### PR TITLE
HasReverse executor and refactoring

### DIFF
--- a/common/bytes/byte_array.rs
+++ b/common/bytes/byte_array.rs
@@ -44,7 +44,7 @@ impl<const INLINE_BYTES: usize> ByteArray<INLINE_BYTES> {
     }
 
     pub fn copy(bytes: &[u8]) -> ByteArray<INLINE_BYTES> {
-        if bytes.len() < INLINE_BYTES {
+        if bytes.len() <= INLINE_BYTES {
             ByteArray::Inline(ByteArrayInline::from(bytes))
         } else {
             ByteArray::Boxed(ByteArrayBoxed::from(bytes))
@@ -53,7 +53,7 @@ impl<const INLINE_BYTES: usize> ByteArray<INLINE_BYTES> {
 
     pub fn copy_concat<const N: usize>(slices: [&[u8]; N]) -> ByteArray<INLINE_BYTES> {
         let length: usize = slices.iter().map(|slice| slice.len()).sum();
-        if length < INLINE_BYTES {
+        if length <= INLINE_BYTES {
             ByteArray::Inline(ByteArrayInline::concat(slices))
         } else {
             ByteArray::Boxed(ByteArrayBoxed::concat(slices))

--- a/concept/iterator.rs
+++ b/concept/iterator.rs
@@ -6,6 +6,48 @@
 
 // FIXME: exported macros must provide their own use-declarations or use fully qualified paths
 //        As it stands, this macro requires imports at point of use.
+
+use std::marker::PhantomData;
+use encoding::graph::thing::ThingVertex;
+use lending_iterator::higher_order::Hkt;
+use lending_iterator::LendingIterator;
+use crate::error::ConceptReadError;
+use crate::error::ConceptReadError::SnapshotIterate;
+use crate::thing::{InstanceAPI, ThingAPI};
+
+pub struct InstanceIterator<T: Hkt> {
+    snapshot_iterator: Option<storage::snapshot::iterator::SnapshotRangeIterator>,
+    _ph: PhantomData<T>,
+}
+
+impl<T: Hkt> InstanceIterator<T> {
+    pub(crate) fn new(snapshot_iterator: storage::snapshot::iterator::SnapshotRangeIterator) -> Self {
+        Self { snapshot_iterator: Some(snapshot_iterator), _ph: PhantomData::default() }
+    }
+
+    pub(crate) fn empty() -> Self {
+        Self { snapshot_iterator: None, _ph: PhantomData::default() }
+    }
+}
+
+impl<T> LendingIterator for InstanceIterator<T>
+where
+    T: Hkt,
+    for<'a> <T as Hkt>::HktSelf<'a>: InstanceAPI<'a>,
+{
+    type Item<'a> = Result<T::HktSelf<'a>, ConceptReadError>;
+
+    fn next(&mut self) -> Option<Self::Item<'_>> {
+        self.snapshot_iterator.as_mut()?.next().map(|result| {
+            result
+                .map(|(storage_key, _value_bytes)| T::HktSelf::new(
+                    <T::HktSelf<'_> as ThingAPI<'_>>::Vertex::new(storage_key.into_bytes())
+                ))
+                .map_err(|error| SnapshotIterate { source: error })
+        })
+    }
+}
+
 #[macro_export]
 macro_rules! concept_iterator {
     ($name:ident, $concept_type:ident, $map_fn: expr) => {
@@ -32,11 +74,12 @@ macro_rules! concept_iterator {
             type Item<'a> = Result<$concept_type<'a>, $crate::error::ConceptReadError>;
             fn next(&mut self) -> Option<Self::Item<'_>> {
                 use $crate::error::ConceptReadError::SnapshotIterate;
-                self.snapshot_iterator.as_mut()?.next().map(|result| {
+                                self.snapshot_iterator.as_mut()?.next().map(|result| {
                     result
                         .map(|(storage_key, _value_bytes)| $map_fn(storage_key))
                         .map_err(|error| SnapshotIterate { source: error })
                 })
+
             }
         }
     };

--- a/concept/iterator.rs
+++ b/concept/iterator.rs
@@ -13,7 +13,7 @@ use lending_iterator::higher_order::Hkt;
 use lending_iterator::LendingIterator;
 use crate::error::ConceptReadError;
 use crate::error::ConceptReadError::SnapshotIterate;
-use crate::thing::{InstanceAPI, ThingAPI};
+use crate::thing::{ThingAPI};
 
 pub struct InstanceIterator<T: Hkt> {
     snapshot_iterator: Option<storage::snapshot::iterator::SnapshotRangeIterator>,
@@ -33,7 +33,7 @@ impl<T: Hkt> InstanceIterator<T> {
 impl<T> LendingIterator for InstanceIterator<T>
 where
     T: Hkt,
-    for<'a> <T as Hkt>::HktSelf<'a>: InstanceAPI<'a>,
+    for<'a> <T as Hkt>::HktSelf<'a>: ThingAPI<'a>,
 {
     type Item<'a> = Result<T::HktSelf<'a>, ConceptReadError>;
 

--- a/concept/thing/attribute.rs
+++ b/concept/thing/attribute.rs
@@ -44,7 +44,7 @@ use crate::{
     edge_iterator,
     error::{ConceptReadError, ConceptWriteError}, thing::{object::Object, thing_manager::ThingManager, ThingAPI}, type_::{attribute_type::AttributeType, ObjectTypeAPI, TypeAPI},
 };
-use crate::thing::{HKInstance, InstanceAPI};
+use crate::thing::{HKInstance};
 use crate::type_::type_manager::TypeManager;
 
 #[derive(Debug, Clone)]
@@ -125,6 +125,9 @@ impl<'a> ConceptAPI<'a> for Attribute<'a> {}
 
 impl<'a> ThingAPI<'a> for Attribute<'a> {
     type Vertex<'b> = AttributeVertex<'b>;
+    type TypeAPI<'b> = AttributeType<'b>;
+    const PREFIX_RANGE: (Prefix, Prefix) = (Prefix::ATTRIBUTE_MIN, Prefix::ATTRIBUTE_MAX);
+
 
     fn new(vertex: Self::Vertex<'a>) -> Self {
         Attribute { vertex, value: None }
@@ -172,11 +175,6 @@ impl<'a> ThingAPI<'a> for Attribute<'a> {
 
         Ok(())
     }
-}
-
-impl<'a> InstanceAPI<'a> for Attribute<'a> {
-    type TypeAPI<'b> = AttributeType<'b>;
-    const PREFIX_RANGE: (Prefix, Prefix) = (Prefix::ATTRIBUTE_MIN, Prefix::ATTRIBUTE_MAX);
 
     fn prefix_for_type(
         type_: Self::TypeAPI<'_>,
@@ -215,8 +213,8 @@ impl<'a> Ord for Attribute<'a> {
 }
 
 pub struct AttributeIterator<AllAttributesIterator>
-where
-    AllAttributesIterator: for<'a> LendingIterator<Item<'a>=Result<Attribute<'a>, ConceptReadError>>,
+    where
+        AllAttributesIterator: for<'a> LendingIterator<Item<'a>=Result<Attribute<'a>, ConceptReadError>>,
 {
     independent_attribute_types: Arc<HashSet<AttributeType<'static>>>,
     attributes_iterator: Option<Peekable<AllAttributesIterator>>,
@@ -225,8 +223,8 @@ where
 }
 
 impl<AllAttributesIterator> AttributeIterator<AllAttributesIterator>
-where
-    AllAttributesIterator: for<'a> LendingIterator<Item<'a>=Result<Attribute<'a>, ConceptReadError>>,
+    where
+        AllAttributesIterator: for<'a> LendingIterator<Item<'a>=Result<Attribute<'a>, ConceptReadError>>,
 {
     pub(crate) fn new(
         attributes_iterator: AllAttributesIterator,
@@ -334,8 +332,8 @@ where
 }
 
 impl<Iterator> LendingIterator for AttributeIterator<Iterator>
-where
-    Iterator: for<'a> LendingIterator<Item<'a>=Result<Attribute<'a>, ConceptReadError>>,
+    where
+        Iterator: for<'a> LendingIterator<Item<'a>=Result<Attribute<'a>, ConceptReadError>>,
 {
     type Item<'a> = Result<Attribute<'a>, ConceptReadError>;
 

--- a/concept/thing/attribute.rs
+++ b/concept/thing/attribute.rs
@@ -9,39 +9,43 @@ use std::{
     collections::HashSet,
     fmt::{Display, Formatter},
     hash::{Hash, Hasher},
-    marker::PhantomData,
     sync::Arc,
 };
 
 use bytes::{byte_array::ByteArray, Bytes};
 use encoding::{
+    AsBytes,
     graph::{
-        thing::{edge::ThingEdgeHasReverse, vertex_attribute::AttributeVertex, vertex_object::ObjectVertex},
+        thing::{edge::ThingEdgeHasReverse, vertex_attribute::AttributeVertex},
         type_::vertex::PrefixedTypeVertexEncoding,
         Typed,
     },
-    value::{
+    Keyable, value::{
         decode_value_u64,
-        value::Value,
-        value_struct::{StructIndexEntry, StructIndexEntryKey},
+        value::Value
+        ,
     },
-    AsBytes, Keyable,
 };
+use encoding::graph::thing::ThingVertex;
+use encoding::layout::prefix::Prefix;
 use iterator::State;
-use lending_iterator::LendingIterator;
+use lending_iterator::{LendingIterator, Peekable};
+use lending_iterator::higher_order::Hkt;
 use resource::constants::snapshot::{BUFFER_KEY_INLINE, BUFFER_VALUE_INLINE};
 use storage::{
-    key_value::{StorageKey, StorageKeyReference},
+    key_value::StorageKey,
     snapshot::{iterator::SnapshotRangeIterator, ReadableSnapshot, WritableSnapshot},
 };
 
 use crate::{
+    ByteReference,
+    ConceptAPI,
+    ConceptStatus,
     edge_iterator,
-    error::{ConceptReadError, ConceptWriteError},
-    thing::{object::Object, thing_manager::ThingManager, ThingAPI},
-    type_::{attribute_type::AttributeType, ObjectTypeAPI, TypeAPI},
-    ByteReference, ConceptAPI, ConceptStatus,
+    error::{ConceptReadError, ConceptWriteError}, thing::{object::Object, thing_manager::ThingManager, ThingAPI}, type_::{attribute_type::AttributeType, ObjectTypeAPI, TypeAPI},
 };
+use crate::thing::{HKInstance, InstanceAPI};
+use crate::type_::type_manager::TypeManager;
 
 #[derive(Debug, Clone)]
 pub struct Attribute<'a> {
@@ -50,10 +54,6 @@ pub struct Attribute<'a> {
 }
 
 impl<'a> Attribute<'a> {
-    pub(crate) fn new(vertex: AttributeVertex<'a>) -> Self {
-        Attribute { vertex, value: None }
-    }
-
     pub fn type_(&self) -> AttributeType<'static> {
         AttributeType::build_from_type_id(self.vertex.type_id_())
     }
@@ -102,13 +102,6 @@ impl<'a> Attribute<'a> {
         thing_manager.get_owners_by_type(snapshot, self.as_reference(), owner_type)
     }
 
-    pub fn as_reference(&self) -> Attribute<'_> {
-        Attribute { vertex: self.vertex.as_reference(), value: self.value.clone() }
-    }
-
-    pub(crate) fn vertex<'this: 'a>(&'this self) -> AttributeVertex<'this> {
-        self.vertex.as_reference()
-    }
 
     pub fn next_possible(&self) -> Attribute<'static> {
         let mut bytes = ByteArray::from(self.vertex.bytes());
@@ -116,8 +109,11 @@ impl<'a> Attribute<'a> {
         Attribute::new(AttributeVertex::new(Bytes::Array(bytes)))
     }
 
-    pub(crate) fn into_vertex(self) -> AttributeVertex<'a> {
-        self.vertex
+    pub fn as_reference(&self) -> Attribute<'_> {
+        Attribute {
+            vertex: self.vertex.as_reference(),
+            value: self.value.clone(),
+        }
     }
 
     pub fn into_owned(self) -> Attribute<'static> {
@@ -128,7 +124,19 @@ impl<'a> Attribute<'a> {
 impl<'a> ConceptAPI<'a> for Attribute<'a> {}
 
 impl<'a> ThingAPI<'a> for Attribute<'a> {
-    type VertexType<'b> = AttributeVertex<'b>;
+    type Vertex<'b> = AttributeVertex<'b>;
+
+    fn new(vertex: Self::Vertex<'a>) -> Self {
+        Attribute { vertex, value: None }
+    }
+
+    fn vertex(&self) -> AttributeVertex<'_> {
+        self.vertex.as_reference()
+    }
+
+    fn into_vertex(self) -> AttributeVertex<'a> {
+        self.vertex
+    }
 
     fn set_modified(&self, snapshot: &mut impl WritableSnapshot, thing_manager: &ThingManager) {
         debug_assert_eq!(thing_manager.get_status(snapshot, self.vertex().as_storage_key()), ConceptStatus::Put);
@@ -166,6 +174,26 @@ impl<'a> ThingAPI<'a> for Attribute<'a> {
     }
 }
 
+impl<'a> InstanceAPI<'a> for Attribute<'a> {
+    type TypeAPI<'b> = AttributeType<'b>;
+    const PREFIX_RANGE: (Prefix, Prefix) = (Prefix::ATTRIBUTE_MIN, Prefix::ATTRIBUTE_MAX);
+
+    fn prefix_for_type(
+        type_: Self::TypeAPI<'_>,
+        snapshot: &impl ReadableSnapshot,
+        type_manager: &TypeManager,
+    ) -> Result<Prefix, ConceptReadError> {
+        let value_type = type_.get_value_type(snapshot, type_manager)?.unwrap();
+        Ok(Self::Vertex::value_type_category_to_prefix_type(value_type.category()))
+    }
+}
+
+impl HKInstance for Attribute<'static> {}
+
+impl Hkt for Attribute<'static> {
+    type HktSelf<'a> = Attribute<'a>;
+}
+
 impl<'a> PartialEq<Self> for Attribute<'a> {
     fn eq(&self, other: &Self) -> bool {
         self.vertex().eq(&other.vertex())
@@ -186,56 +214,30 @@ impl<'a> Ord for Attribute<'a> {
     }
 }
 
-/// Attribute iterators handle hiding dependent attributes that were not deleted yet
-trait KeyAttributeExtractor {
-    fn storage_key_to_attribute_vertex<'bytes>(
-        storage_key: StorageKey<'bytes, BUFFER_KEY_INLINE>,
-    ) -> AttributeVertex<'bytes>;
-}
-
-pub struct StandardAttributeExtractor;
-
-impl KeyAttributeExtractor for StandardAttributeExtractor {
-    fn storage_key_to_attribute_vertex<'bytes>(
-        storage_key: StorageKey<'bytes, BUFFER_KEY_INLINE>,
-    ) -> AttributeVertex<'bytes> {
-        AttributeVertex::new(storage_key.into_bytes())
-    }
-}
-
-pub struct StructIndexAttributeExtractor;
-
-impl KeyAttributeExtractor for StructIndexAttributeExtractor {
-    fn storage_key_to_attribute_vertex<'bytes>(
-        storage_key: StorageKey<'bytes, BUFFER_KEY_INLINE>,
-    ) -> AttributeVertex<'bytes> {
-        StructIndexEntry::new(StructIndexEntryKey::new(Bytes::reference(storage_key.bytes())), None).attribute_vertex()
-    }
-}
-
-pub struct AttributeIteratorImpl<AttributeExtractor: KeyAttributeExtractor> {
+pub struct AttributeIterator<AllAttributesIterator>
+where
+    AllAttributesIterator: for<'a> LendingIterator<Item<'a>=Result<Attribute<'a>, ConceptReadError>>,
+{
     independent_attribute_types: Arc<HashSet<AttributeType<'static>>>,
-    attributes_iterator: Option<SnapshotRangeIterator>,
+    attributes_iterator: Option<Peekable<AllAttributesIterator>>,
     has_reverse_iterator: Option<SnapshotRangeIterator>,
     state: State<ConceptReadError>,
-    key_interpreter: PhantomData<AttributeExtractor>,
 }
 
-pub type AttributeIterator = AttributeIteratorImpl<StandardAttributeExtractor>;
-pub type StructIndexToAttributeIterator = AttributeIteratorImpl<StructIndexAttributeExtractor>;
-
-impl<KeyExtractor: KeyAttributeExtractor> AttributeIteratorImpl<KeyExtractor> {
+impl<AllAttributesIterator> AttributeIterator<AllAttributesIterator>
+where
+    AllAttributesIterator: for<'a> LendingIterator<Item<'a>=Result<Attribute<'a>, ConceptReadError>>,
+{
     pub(crate) fn new(
-        attributes_iterator: SnapshotRangeIterator,
+        attributes_iterator: AllAttributesIterator,
         has_reverse_iterator: SnapshotRangeIterator,
         independent_attribute_types: Arc<HashSet<AttributeType<'static>>>,
     ) -> Self {
         Self {
             independent_attribute_types,
-            attributes_iterator: Some(attributes_iterator),
+            attributes_iterator: Some(Peekable::new(attributes_iterator)),
             has_reverse_iterator: Some(has_reverse_iterator),
             state: State::Init,
-            key_interpreter: PhantomData,
         }
     }
 
@@ -245,44 +247,16 @@ impl<KeyExtractor: KeyAttributeExtractor> AttributeIteratorImpl<KeyExtractor> {
             attributes_iterator: None,
             has_reverse_iterator: None,
             state: State::Done,
-            key_interpreter: PhantomData,
         }
-    }
-
-    pub fn peek(&mut self) -> Option<Result<Attribute<'_>, ConceptReadError>> {
-        self.iter_peek().map(|result| {
-            result.map(|(storage_key, _value_bytes)| {
-                Attribute::new(KeyExtractor::storage_key_to_attribute_vertex(StorageKey::Reference(storage_key)))
-            })
-        })
     }
 
     pub fn seek(&mut self) {
         todo!()
     }
 
-    fn iter_peek(&mut self) -> Option<Result<(StorageKeyReference<'_>, ByteReference<'_>), ConceptReadError>> {
-        match &self.state {
-            State::Init | State::ItemUsed => {
-                self.find_next_state();
-                self.iter_peek()
-            }
-            State::ItemReady => self
-                .attributes_iterator
-                .as_mut()
-                .unwrap()
-                .peek()
-                .transpose()
-                .map_err(|err| ConceptReadError::SnapshotIterate { source: err.clone() })
-                .transpose(),
-            State::Error(error) => Some(Err(error.clone())),
-            State::Done => None,
-        }
-    }
-
     fn iter_next(
         &mut self,
-    ) -> Option<Result<(StorageKey<'_, BUFFER_KEY_INLINE>, Bytes<'_, BUFFER_VALUE_INLINE>), ConceptReadError>> {
+    ) -> Option<Result<Attribute<'_>, ConceptReadError>> {
         match &self.state {
             State::Init | State::ItemUsed => {
                 self.find_next_state();
@@ -293,10 +267,7 @@ impl<KeyExtractor: KeyAttributeExtractor> AttributeIteratorImpl<KeyExtractor> {
                     .attributes_iterator
                     .as_mut()
                     .unwrap()
-                    .next()
-                    .transpose()
-                    .map_err(|err| ConceptReadError::SnapshotIterate { source: err.clone() })
-                    .transpose();
+                    .next();
                 let _ = self.has_reverse_iterator.as_mut().unwrap().next();
                 self.state = State::ItemUsed;
                 next
@@ -312,11 +283,9 @@ impl<KeyExtractor: KeyAttributeExtractor> AttributeIteratorImpl<KeyExtractor> {
             let mut advance_attribute = false;
             match self.attributes_iterator.as_mut().unwrap().peek() {
                 None => self.state = State::Done,
-                Some(Ok((key, _))) => {
-                    let attribute_vertex = KeyExtractor::storage_key_to_attribute_vertex(StorageKey::Reference(key));
-                    let independent = self
-                        .independent_attribute_types
-                        .contains(&Attribute::new(attribute_vertex.as_reference()).type_());
+                Some(Ok(attribute)) => {
+                    let attribute_vertex = attribute.vertex();
+                    let independent = self.independent_attribute_types.contains(&attribute.type_());
                     if independent {
                         self.state = State::ItemReady;
                     } else {
@@ -332,7 +301,7 @@ impl<KeyExtractor: KeyAttributeExtractor> AttributeIteratorImpl<KeyExtractor> {
                         }
                     }
                 }
-                Some(Err(err)) => self.state = State::Error(ConceptReadError::SnapshotIterate { source: err.clone() }),
+                Some(Err(err)) => self.state = State::Error(err.clone()),
             }
             if advance_attribute {
                 self.attributes_iterator.as_mut().unwrap().next();
@@ -364,14 +333,14 @@ impl<KeyExtractor: KeyAttributeExtractor> AttributeIteratorImpl<KeyExtractor> {
     }
 }
 
-impl<KeyExtractor: KeyAttributeExtractor + 'static> LendingIterator for AttributeIteratorImpl<KeyExtractor> {
+impl<Iterator> LendingIterator for AttributeIterator<Iterator>
+where
+    Iterator: for<'a> LendingIterator<Item<'a>=Result<Attribute<'a>, ConceptReadError>>,
+{
     type Item<'a> = Result<Attribute<'a>, ConceptReadError>;
+
     fn next(&mut self) -> Option<Self::Item<'_>> {
-        self.iter_next().map(|result| {
-            result.map(|(storage_key, _value_bytes)| {
-                Attribute::new(KeyExtractor::storage_key_to_attribute_vertex(storage_key))
-            })
-        })
+        self.iter_next()
     }
 }
 

--- a/concept/thing/attribute.rs
+++ b/concept/thing/attribute.rs
@@ -128,6 +128,8 @@ impl<'a> Attribute<'a> {
 impl<'a> ConceptAPI<'a> for Attribute<'a> {}
 
 impl<'a> ThingAPI<'a> for Attribute<'a> {
+    type VertexType<'b> = AttributeVertex<'b>;
+
     fn set_modified(&self, snapshot: &mut impl WritableSnapshot, thing_manager: &ThingManager) {
         debug_assert_eq!(thing_manager.get_status(snapshot, self.vertex().as_storage_key()), ConceptStatus::Put);
         // Attributes are always PUT, so we don't have to record a lock on modification

--- a/concept/thing/entity.rs
+++ b/concept/thing/entity.rs
@@ -11,30 +11,29 @@ use std::{
 
 use bytes::{byte_array::ByteArray, Bytes};
 use encoding::{
+    AsBytes,
     graph::{thing::vertex_object::ObjectVertex, type_::vertex::PrefixedTypeVertexEncoding, Typed},
-    layout::prefix::Prefix,
-    AsBytes, Keyable, Prefixed,
+    Keyable, layout::prefix::Prefix, Prefixed,
 };
+use encoding::graph::thing::ThingVertex;
 use iterator::Collector;
+use lending_iterator::higher_order::Hkt;
 use lending_iterator::LendingIterator;
-use resource::constants::snapshot::BUFFER_KEY_INLINE;
-use storage::{
-    key_value::StorageKey,
-    snapshot::{ReadableSnapshot, WritableSnapshot},
-};
+use storage::snapshot::{ReadableSnapshot, WritableSnapshot};
 
 use crate::{
-    concept_iterator,
-    error::{ConceptReadError, ConceptWriteError},
-    thing::{
+    ByteReference,
+    ConceptAPI,
+    ConceptStatus,
+    error::{ConceptReadError, ConceptWriteError}, thing::{
         object::{Object, ObjectAPI},
         relation::{IndexedPlayersIterator, RelationRoleIterator},
         thing_manager::ThingManager,
         ThingAPI,
-    },
-    type_::{entity_type::EntityType, ObjectTypeAPI, Ordering, OwnerAPI, TypeAPI},
-    ByteReference, ConceptAPI, ConceptStatus,
+    }, type_::{entity_type::EntityType, ObjectTypeAPI, Ordering, OwnerAPI, TypeAPI},
 };
+use crate::thing::{HKInstance, InstanceAPI};
+use crate::type_::type_manager::TypeManager;
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Ord, PartialOrd)]
 pub struct Entity<'a> {
@@ -42,17 +41,8 @@ pub struct Entity<'a> {
 }
 
 impl<'a> Entity<'a> {
-    pub fn new(vertex: ObjectVertex<'a>) -> Self {
-        debug_assert_eq!(vertex.prefix(), Prefix::VertexEntity);
-        Entity { vertex }
-    }
-
     pub fn type_(&self) -> EntityType<'static> {
         EntityType::build_from_type_id(self.vertex.type_id_())
-    }
-
-    pub fn as_reference(&self) -> Entity<'_> {
-        Entity { vertex: self.vertex.as_reference() }
     }
 
     pub fn iid(&self) -> ByteReference<'_> {
@@ -81,6 +71,10 @@ impl<'a> Entity<'a> {
         Entity::new(ObjectVertex::new(Bytes::Array(bytes)))
     }
 
+    pub fn as_reference(&self) -> Entity<'_> {
+        Entity { vertex: self.vertex.as_reference() }
+    }
+
     pub fn into_owned(self) -> Entity<'static> {
         Entity { vertex: self.vertex.into_owned() }
     }
@@ -89,7 +83,21 @@ impl<'a> Entity<'a> {
 impl<'a> ConceptAPI<'a> for Entity<'a> {}
 
 impl<'a> ThingAPI<'a> for Entity<'a> {
-    type VertexType<'b> = ObjectVertex<'b>;
+    type Vertex<'b> = ObjectVertex<'b>;
+
+    fn new(vertex: ObjectVertex<'a>) -> Self {
+        debug_assert_eq!(vertex.prefix(), Prefix::VertexEntity);
+        Entity { vertex }
+    }
+
+    fn vertex(&self) -> Self::Vertex<'_> {
+        self.vertex.as_reference()
+    }
+
+    fn into_vertex(self) -> Self::Vertex<'a> {
+        self.vertex
+    }
+
 
     fn set_modified(&self, snapshot: &mut impl WritableSnapshot, thing_manager: &ThingManager) {
         if matches!(self.get_status(snapshot, thing_manager), ConceptStatus::Persisted) {
@@ -153,15 +161,20 @@ impl<'a> ThingAPI<'a> for Entity<'a> {
     }
 }
 
+impl<'a> InstanceAPI<'a> for Entity<'a> {
+    type TypeAPI<'b> = EntityType<'b>;
+    const PREFIX_RANGE: (Prefix, Prefix) = (Prefix::VertexEntity, Prefix::VertexEntity);
+
+    fn prefix_for_type(
+        _type: Self::TypeAPI<'_>,
+        _snapshot: &impl ReadableSnapshot,
+        _type_manager: &TypeManager,
+    ) -> Result<Prefix, ConceptReadError> {
+        Ok(Prefix::VertexEntity)
+    }
+}
+
 impl<'a> ObjectAPI<'a> for Entity<'a> {
-    fn vertex(&self) -> ObjectVertex<'_> {
-        self.vertex.as_reference()
-    }
-
-    fn into_vertex(self) -> ObjectVertex<'a> {
-        self.vertex
-    }
-
     fn type_(&self) -> impl ObjectTypeAPI<'static> {
         self.type_()
     }
@@ -171,11 +184,11 @@ impl<'a> ObjectAPI<'a> for Entity<'a> {
     }
 }
 
-fn storage_key_to_entity(storage_key: StorageKey<'_, BUFFER_KEY_INLINE>) -> Entity<'_> {
-    Entity::new(ObjectVertex::new(storage_key.into_bytes()))
-}
+impl HKInstance for Entity<'static> {}
 
-concept_iterator!(EntityIterator, Entity, storage_key_to_entity);
+impl Hkt for Entity<'static> {
+    type HktSelf<'a> = Entity<'a>;
+}
 
 impl<'a> Display for Entity<'a> {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {

--- a/concept/thing/entity.rs
+++ b/concept/thing/entity.rs
@@ -32,7 +32,7 @@ use crate::{
         ThingAPI,
     }, type_::{entity_type::EntityType, ObjectTypeAPI, Ordering, OwnerAPI, TypeAPI},
 };
-use crate::thing::{HKInstance, InstanceAPI};
+use crate::thing::{HKInstance};
 use crate::type_::type_manager::TypeManager;
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Ord, PartialOrd)]
@@ -84,6 +84,9 @@ impl<'a> ConceptAPI<'a> for Entity<'a> {}
 
 impl<'a> ThingAPI<'a> for Entity<'a> {
     type Vertex<'b> = ObjectVertex<'b>;
+    type TypeAPI<'b> = EntityType<'b>;
+    const PREFIX_RANGE: (Prefix, Prefix) = (Prefix::VertexEntity, Prefix::VertexEntity);
+
 
     fn new(vertex: ObjectVertex<'a>) -> Self {
         debug_assert_eq!(vertex.prefix(), Prefix::VertexEntity);
@@ -159,11 +162,6 @@ impl<'a> ThingAPI<'a> for Entity<'a> {
         thing_manager.delete_entity(snapshot, self);
         Ok(())
     }
-}
-
-impl<'a> InstanceAPI<'a> for Entity<'a> {
-    type TypeAPI<'b> = EntityType<'b>;
-    const PREFIX_RANGE: (Prefix, Prefix) = (Prefix::VertexEntity, Prefix::VertexEntity);
 
     fn prefix_for_type(
         _type: Self::TypeAPI<'_>,

--- a/concept/thing/entity.rs
+++ b/concept/thing/entity.rs
@@ -11,29 +11,29 @@ use std::{
 
 use bytes::{byte_array::ByteArray, Bytes};
 use encoding::{
-    AsBytes,
-    graph::{thing::vertex_object::ObjectVertex, type_::vertex::PrefixedTypeVertexEncoding, Typed},
-    Keyable, layout::prefix::Prefix, Prefixed,
+    graph::{
+        thing::{vertex_object::ObjectVertex, ThingVertex},
+        type_::vertex::PrefixedTypeVertexEncoding,
+        Typed,
+    },
+    layout::prefix::Prefix,
+    AsBytes, Keyable, Prefixed,
 };
-use encoding::graph::thing::ThingVertex;
 use iterator::Collector;
-use lending_iterator::higher_order::Hkt;
-use lending_iterator::LendingIterator;
+use lending_iterator::{higher_order::Hkt, LendingIterator};
 use storage::snapshot::{ReadableSnapshot, WritableSnapshot};
 
 use crate::{
-    ByteReference,
-    ConceptAPI,
-    ConceptStatus,
-    error::{ConceptReadError, ConceptWriteError}, thing::{
+    error::{ConceptReadError, ConceptWriteError},
+    thing::{
         object::{Object, ObjectAPI},
         relation::{IndexedPlayersIterator, RelationRoleIterator},
         thing_manager::ThingManager,
-        ThingAPI,
-    }, type_::{entity_type::EntityType, ObjectTypeAPI, Ordering, OwnerAPI, TypeAPI},
+        HKInstance, ThingAPI,
+    },
+    type_::{entity_type::EntityType, type_manager::TypeManager, ObjectTypeAPI, Ordering, OwnerAPI, TypeAPI},
+    ByteReference, ConceptAPI, ConceptStatus,
 };
-use crate::thing::{HKInstance};
-use crate::type_::type_manager::TypeManager;
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Ord, PartialOrd)]
 pub struct Entity<'a> {
@@ -87,7 +87,6 @@ impl<'a> ThingAPI<'a> for Entity<'a> {
     type TypeAPI<'b> = EntityType<'b>;
     type Owned = Entity<'static>;
     const PREFIX_RANGE: (Prefix, Prefix) = (Prefix::VertexEntity, Prefix::VertexEntity);
-
 
     fn new(vertex: ObjectVertex<'a>) -> Self {
         debug_assert_eq!(vertex.prefix(), Prefix::VertexEntity);
@@ -174,7 +173,6 @@ impl<'a> ThingAPI<'a> for Entity<'a> {
     ) -> Result<Prefix, ConceptReadError> {
         Ok(Prefix::VertexEntity)
     }
-
 }
 
 impl<'a> ObjectAPI<'a> for Entity<'a> {

--- a/concept/thing/entity.rs
+++ b/concept/thing/entity.rs
@@ -85,6 +85,7 @@ impl<'a> ConceptAPI<'a> for Entity<'a> {}
 impl<'a> ThingAPI<'a> for Entity<'a> {
     type Vertex<'b> = ObjectVertex<'b>;
     type TypeAPI<'b> = EntityType<'b>;
+    type Owned = Entity<'static>;
     const PREFIX_RANGE: (Prefix, Prefix) = (Prefix::VertexEntity, Prefix::VertexEntity);
 
 
@@ -101,6 +102,9 @@ impl<'a> ThingAPI<'a> for Entity<'a> {
         self.vertex
     }
 
+    fn into_owned(self) -> Self::Owned {
+        Entity::new(self.vertex.into_owned())
+    }
 
     fn set_modified(&self, snapshot: &mut impl WritableSnapshot, thing_manager: &ThingManager) {
         if matches!(self.get_status(snapshot, thing_manager), ConceptStatus::Persisted) {
@@ -170,6 +174,7 @@ impl<'a> ThingAPI<'a> for Entity<'a> {
     ) -> Result<Prefix, ConceptReadError> {
         Ok(Prefix::VertexEntity)
     }
+
 }
 
 impl<'a> ObjectAPI<'a> for Entity<'a> {

--- a/concept/thing/entity.rs
+++ b/concept/thing/entity.rs
@@ -89,6 +89,8 @@ impl<'a> Entity<'a> {
 impl<'a> ConceptAPI<'a> for Entity<'a> {}
 
 impl<'a> ThingAPI<'a> for Entity<'a> {
+    type VertexType<'b> = ObjectVertex<'b>;
+
     fn set_modified(&self, snapshot: &mut impl WritableSnapshot, thing_manager: &ThingManager) {
         if matches!(self.get_status(snapshot, thing_manager), ConceptStatus::Persisted) {
             thing_manager.lock_existing(snapshot, self.as_reference());

--- a/concept/thing/has.rs
+++ b/concept/thing/has.rs
@@ -9,7 +9,7 @@ use std::fmt::{Display, Formatter};
 use encoding::graph::thing::edge::{ThingEdgeHas, ThingEdgeHasReverse};
 use lending_iterator::higher_order::Hkt;
 
-use crate::thing::{attribute::Attribute, object::Object};
+use crate::thing::{attribute::Attribute, object::Object, ThingAPI};
 
 #[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd)]
 pub enum Has<'a> {

--- a/concept/thing/has.rs
+++ b/concept/thing/has.rs
@@ -22,7 +22,7 @@ impl<'a> Has<'a> {
         Self::Edge(edge)
     }
 
-    fn new_from_edge_reverse(edge: ThingEdgeHasReverse<'a>) -> Self {
+    pub(crate) fn new_from_edge_reverse(edge: ThingEdgeHasReverse<'a>) -> Self {
         Self::EdgeReverse(edge)
     }
 

--- a/concept/thing/mod.rs
+++ b/concept/thing/mod.rs
@@ -37,6 +37,8 @@ pub mod thing_manager;
 pub trait ThingAPI<'a>: Sized + Clone {
     type TypeAPI<'b>: TypeAPI<'b>;
     type Vertex<'b>: ThingVertex<'b>;
+    type Owned: ThingAPI<'static>;
+
     const PREFIX_RANGE: (Prefix, Prefix);
 
     fn new(vertex: Self::Vertex<'a>) -> Self;
@@ -44,6 +46,8 @@ pub trait ThingAPI<'a>: Sized + Clone {
     fn vertex(&self) -> Self::Vertex<'_>;
 
     fn into_vertex(self) -> Self::Vertex<'a>;
+
+    fn into_owned(self) -> Self::Owned;
 
     fn set_modified(&self, snapshot: &mut impl WritableSnapshot, thing_manager: &ThingManager);
 
@@ -70,6 +74,7 @@ pub trait ThingAPI<'a>: Sized + Clone {
 }
 
 pub trait HKInstance: for<'a> Hkt<HktSelf<'a>: ThingAPI<'a>> {
+
 }
 
 // TODO: where do these belong? They're encodings of values we store for keys

--- a/concept/thing/mod.rs
+++ b/concept/thing/mod.rs
@@ -35,7 +35,9 @@ pub mod statistics;
 pub mod thing_manager;
 
 pub trait ThingAPI<'a>: Sized + Clone {
+    type TypeAPI<'b>: TypeAPI<'b>;
     type Vertex<'b>: ThingVertex<'b>;
+    const PREFIX_RANGE: (Prefix, Prefix);
 
     fn new(vertex: Self::Vertex<'a>) -> Self;
 
@@ -59,11 +61,6 @@ pub trait ThingAPI<'a>: Sized + Clone {
         snapshot: &mut impl WritableSnapshot,
         thing_manager: &ThingManager,
     ) -> Result<(), ConceptWriteError>;
-}
-
-pub trait InstanceAPI<'a>: ThingAPI<'a> {
-    type TypeAPI<'b>: TypeAPI<'b>;
-    const PREFIX_RANGE: (Prefix, Prefix);
 
     fn prefix_for_type(
         type_: Self::TypeAPI<'_>,
@@ -72,7 +69,7 @@ pub trait InstanceAPI<'a>: ThingAPI<'a> {
     ) -> Result<Prefix, ConceptReadError>;
 }
 
-pub trait HKInstance: for<'a> Hkt<HktSelf<'a>: InstanceAPI<'a>> {
+pub trait HKInstance: for<'a> Hkt<HktSelf<'a>: ThingAPI<'a>> {
 }
 
 // TODO: where do these belong? They're encodings of values we store for keys

--- a/concept/thing/mod.rs
+++ b/concept/thing/mod.rs
@@ -28,6 +28,8 @@ pub mod statistics;
 pub mod thing_manager;
 
 pub trait ThingAPI<'a> {
+    type VertexType<'b>;
+
     fn set_modified(&self, snapshot: &mut impl WritableSnapshot, thing_manager: &ThingManager);
 
     // TODO: implementers could cache the status in a OnceCell if we do many operations on the same Thing at once

--- a/concept/thing/mod.rs
+++ b/concept/thing/mod.rs
@@ -5,26 +5,24 @@
  */
 
 use std::ops::RangeBounds;
+
 use bytes::{byte_array::ByteArray, Bytes};
 use encoding::{
-    graph::thing::{vertex_attribute::AttributeID, vertex_object::ObjectVertex},
+    graph::thing::{vertex_attribute::AttributeID, vertex_object::ObjectVertex, ThingVertex},
+    layout::prefix::Prefix,
     value::value_type::ValueTypeCategory,
     AsBytes,
 };
-use encoding::graph::thing::ThingVertex;
-use encoding::layout::prefix::Prefix;
 use lending_iterator::higher_order::Hkt;
 use resource::constants::snapshot::BUFFER_VALUE_INLINE;
 use storage::snapshot::{ReadableSnapshot, WritableSnapshot};
 
 use crate::{
     error::{ConceptReadError, ConceptWriteError},
-    thing::thing_manager::ThingManager,
+    thing::{entity::Entity, thing_manager::ThingManager},
+    type_::{type_manager::TypeManager, TypeAPI},
     ConceptStatus,
 };
-use crate::thing::entity::Entity;
-use crate::type_::type_manager::TypeManager;
-use crate::type_::TypeAPI;
 
 pub mod attribute;
 pub mod entity;
@@ -69,13 +67,11 @@ pub trait ThingAPI<'a>: Sized + Clone {
     fn prefix_for_type(
         type_: Self::TypeAPI<'_>,
         snapshot: &impl ReadableSnapshot,
-        type_manager: &TypeManager
+        type_manager: &TypeManager,
     ) -> Result<Prefix, ConceptReadError>;
 }
 
-pub trait HKInstance: for<'a> Hkt<HktSelf<'a>: ThingAPI<'a>> {
-
-}
+pub trait HKInstance: for<'a> Hkt<HktSelf<'a>: ThingAPI<'a>> {}
 
 // TODO: where do these belong? They're encodings of values we store for keys
 pub(crate) fn decode_attribute_ids(

--- a/concept/thing/object.rs
+++ b/concept/thing/object.rs
@@ -35,6 +35,7 @@ use crate::{
     },
     ConceptStatus,
 };
+use crate::thing::HKInstance;
 
 #[derive(Debug, Clone, Eq, PartialEq, Hash)]
 pub enum Object<'a> {
@@ -80,7 +81,9 @@ impl<'a> Object<'a> {
 }
 
 impl<'a> ThingAPI<'a> for Object<'a> {
+    type TypeAPI<'b> = ObjectType<'b>;
     type Vertex<'b> = ObjectVertex<'b>;
+    const PREFIX_RANGE: (Prefix, Prefix) = (Prefix::VertexEntity, Prefix::VertexRelation);
 
     fn new(object_vertex: Self::Vertex<'a>) -> Self {
         match object_vertex.prefix() {
@@ -138,6 +141,17 @@ impl<'a> ThingAPI<'a> for Object<'a> {
         match self {
             Object::Entity(entity) => entity.delete(snapshot, thing_manager),
             Object::Relation(relation) => relation.delete(snapshot, thing_manager),
+        }
+    }
+
+    fn prefix_for_type(
+        type_: Self::TypeAPI<'_>,
+        snapshot: &impl ReadableSnapshot,
+        type_manager: &TypeManager
+    ) -> Result<Prefix, ConceptReadError> {
+        match type_ {
+            ObjectType::Entity(entity) => Entity::prefix_for_type(entity, snapshot, type_manager),
+            ObjectType::Relation(relation) => Relation::prefix_for_type(relation, snapshot, type_manager),
         }
     }
 }
@@ -393,6 +407,8 @@ impl<'a> ObjectAPI<'a> for Object<'a> {
         self.into_owned()
     }
 }
+
+impl HKInstance for Object<'static> { }
 
 impl Hkt for Object<'static> {
     type HktSelf<'a> = Object<'a>;

--- a/concept/thing/object.rs
+++ b/concept/thing/object.rs
@@ -95,6 +95,8 @@ impl<'a> Object<'a> {
 }
 
 impl<'a> ThingAPI<'a> for Object<'a> {
+    type VertexType<'b> = ObjectVertex<'b>;
+
     fn set_modified(&self, snapshot: &mut impl WritableSnapshot, thing_manager: &ThingManager) {
         match self {
             Object::Entity(entity) => entity.set_modified(snapshot, thing_manager),

--- a/concept/thing/relation.rs
+++ b/concept/thing/relation.rs
@@ -8,6 +8,7 @@ use std::{
     collections::HashMap,
     fmt::{Display, Formatter},
 };
+use itertools::Itertools;
 
 use bytes::{byte_array::ByteArray, Bytes};
 use encoding::{
@@ -66,6 +67,8 @@ impl<'a> Relation<'a> {
     }
 
     pub fn type_(&self) -> RelationType<'static> {
+
+
         RelationType::build_from_type_id(self.vertex.type_id_())
     }
 
@@ -320,6 +323,8 @@ impl<'a> Relation<'a> {
 impl<'a> ConceptAPI<'a> for Relation<'a> {}
 
 impl<'a> ThingAPI<'a> for Relation<'a> {
+    type VertexType<'b> = ObjectVertex<'b>;
+
     fn set_modified(&self, snapshot: &mut impl WritableSnapshot, thing_manager: &ThingManager) {
         if matches!(self.get_status(snapshot, thing_manager), ConceptStatus::Persisted) {
             thing_manager.lock_existing(snapshot, self.as_reference());

--- a/concept/thing/relation.rs
+++ b/concept/thing/relation.rs
@@ -45,7 +45,7 @@ use crate::{
         relates::RelatesAnnotation, relation_type::RelationType, role_type::RoleType, TypeAPI,
     },
 };
-use crate::thing::{HKInstance, InstanceAPI};
+use crate::thing::{HKInstance};
 use crate::type_::type_manager::TypeManager;
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
@@ -314,6 +314,8 @@ impl<'a> ConceptAPI<'a> for Relation<'a> {}
 
 impl<'a> ThingAPI<'a> for Relation<'a> {
     type Vertex<'b> = ObjectVertex<'b>;
+    type TypeAPI<'b> = RelationType<'b>;
+    const PREFIX_RANGE: (Prefix, Prefix) = (Prefix::VertexRelation, Prefix::VertexRelation);
 
     fn new(vertex: Self::Vertex<'a>) -> Self {
         debug_assert_eq!(
@@ -427,11 +429,6 @@ impl<'a> ThingAPI<'a> for Relation<'a> {
         }
         Ok(())
     }
-}
-
-impl<'a> InstanceAPI<'a> for Relation<'a> {
-    type TypeAPI<'b> = RelationType<'b>;
-    const PREFIX_RANGE: (Prefix, Prefix) = (Prefix::VertexRelation, Prefix::VertexRelation);
 
     fn prefix_for_type(
         _type: Self::TypeAPI<'_>,

--- a/concept/thing/relation.rs
+++ b/concept/thing/relation.rs
@@ -315,6 +315,7 @@ impl<'a> ConceptAPI<'a> for Relation<'a> {}
 impl<'a> ThingAPI<'a> for Relation<'a> {
     type Vertex<'b> = ObjectVertex<'b>;
     type TypeAPI<'b> = RelationType<'b>;
+    type Owned = Relation<'static>;
     const PREFIX_RANGE: (Prefix, Prefix) = (Prefix::VertexRelation, Prefix::VertexRelation);
 
     fn new(vertex: Self::Vertex<'a>) -> Self {
@@ -332,6 +333,10 @@ impl<'a> ThingAPI<'a> for Relation<'a> {
 
     fn into_vertex(self) -> Self::Vertex<'a> {
         self.vertex
+    }
+
+    fn into_owned(self) -> Self::Owned {
+        Relation::new(self.vertex.into_owned())
     }
 
     fn set_modified(&self, snapshot: &mut impl WritableSnapshot, thing_manager: &ThingManager) {
@@ -437,6 +442,7 @@ impl<'a> ThingAPI<'a> for Relation<'a> {
     ) -> Result<Prefix, ConceptReadError> {
         Ok(Prefix::VertexRelation)
     }
+
 }
 
 impl<'a> ObjectAPI<'a> for Relation<'a> {

--- a/concept/thing/relation.rs
+++ b/concept/thing/relation.rs
@@ -11,19 +11,19 @@ use std::{
 
 use bytes::{byte_array::ByteArray, Bytes};
 use encoding::{
-    AsBytes,
     graph::{
         thing::{
             edge::{ThingEdgeRolePlayer, ThingEdgeRolePlayerIndex},
             vertex_object::ObjectVertex,
+            ThingVertex,
         },
         type_::vertex::PrefixedTypeVertexEncoding,
         Typed,
     },
-    Keyable,
-    layout::prefix::Prefix, Prefixed, value::decode_value_u64,
+    layout::prefix::Prefix,
+    value::decode_value_u64,
+    AsBytes, Keyable, Prefixed,
 };
-use encoding::graph::thing::ThingVertex;
 use lending_iterator::{higher_order::Hkt, LendingIterator};
 use resource::constants::snapshot::{BUFFER_KEY_INLINE, BUFFER_VALUE_INLINE};
 use storage::{
@@ -32,21 +32,19 @@ use storage::{
 };
 
 use crate::{
-    ByteReference,
-    ConceptAPI,
-    ConceptStatus,
     edge_iterator,
-    error::{ConceptReadError, ConceptWriteError}, thing::{
+    error::{ConceptReadError, ConceptWriteError},
+    thing::{
         object::{Object, ObjectAPI},
         thing_manager::ThingManager,
-        ThingAPI,
-    }, type_::{
-        annotation::AnnotationDistinct, Capability, ObjectTypeAPI, Ordering,
-        relates::RelatesAnnotation, relation_type::RelationType, role_type::RoleType, TypeAPI,
+        HKInstance, ThingAPI,
     },
+    type_::{
+        annotation::AnnotationDistinct, relates::RelatesAnnotation, relation_type::RelationType, role_type::RoleType,
+        type_manager::TypeManager, Capability, ObjectTypeAPI, Ordering, TypeAPI,
+    },
+    ByteReference, ConceptAPI, ConceptStatus,
 };
-use crate::thing::{HKInstance};
-use crate::type_::type_manager::TypeManager;
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct Relation<'a> {
@@ -121,7 +119,7 @@ impl<'a> Relation<'a> {
         &self,
         snapshot: &impl ReadableSnapshot,
         thing_manager: &ThingManager,
-    ) -> impl for<'x> LendingIterator<Item<'x>=Result<(RolePlayer<'x>, u64), ConceptReadError>> {
+    ) -> impl for<'x> LendingIterator<Item<'x> = Result<(RolePlayer<'x>, u64), ConceptReadError>> {
         thing_manager.get_role_players(snapshot, self.as_reference())
     }
 
@@ -139,7 +137,7 @@ impl<'a> Relation<'a> {
         snapshot: &impl ReadableSnapshot,
         thing_manager: &ThingManager,
         role_type: RoleType<'static>,
-    ) -> impl for<'x> LendingIterator<Item<'x>=Result<Object<'x>, ConceptReadError>> {
+    ) -> impl for<'x> LendingIterator<Item<'x> = Result<Object<'x>, ConceptReadError>> {
         self.get_players(snapshot, thing_manager).filter_map::<Result<Object<'_>, _>, _>(move |res| match res {
             Ok((roleplayer, _count)) => (roleplayer.role_type() == role_type).then_some(Ok(roleplayer.player)),
             Err(error) => Some(Err(error)),
@@ -442,7 +440,6 @@ impl<'a> ThingAPI<'a> for Relation<'a> {
     ) -> Result<Prefix, ConceptReadError> {
         Ok(Prefix::VertexRelation)
     }
-
 }
 
 impl<'a> ObjectAPI<'a> for Relation<'a> {

--- a/concept/thing/statistics.rs
+++ b/concept/thing/statistics.rs
@@ -23,6 +23,7 @@ use encoding::graph::{
     Typed,
 };
 use serde::{Deserialize, Serialize};
+use encoding::graph::thing::ThingVertex;
 use storage::{
     durability_client::{DurabilityClient, DurabilityClientError, DurabilityRecord, UnsequencedDurabilityRecord},
     isolation_manager::CommitType,
@@ -41,6 +42,7 @@ use crate::{
         role_type::RoleType, TypeAPI,
     },
 };
+use crate::thing::ThingAPI;
 
 type StatisticsEncodingVersion = u64;
 

--- a/concept/thing/statistics.rs
+++ b/concept/thing/statistics.rs
@@ -18,12 +18,12 @@ use encoding::graph::{
         edge::{ThingEdgeHas, ThingEdgeRolePlayer, ThingEdgeRolePlayerIndex},
         vertex_attribute::AttributeVertex,
         vertex_object::ObjectVertex,
+        ThingVertex,
     },
     type_::vertex::{PrefixedTypeVertexEncoding, TypeID, TypeIDUInt},
     Typed,
 };
 use serde::{Deserialize, Serialize};
-use encoding::graph::thing::ThingVertex;
 use storage::{
     durability_client::{DurabilityClient, DurabilityClientError, DurabilityRecord, UnsequencedDurabilityRecord},
     isolation_manager::CommitType,
@@ -36,13 +36,12 @@ use storage::{
 };
 
 use crate::{
-    thing::{attribute::Attribute, entity::Entity, object::Object, relation::Relation},
+    thing::{attribute::Attribute, entity::Entity, object::Object, relation::Relation, ThingAPI},
     type_::{
         attribute_type::AttributeType, entity_type::EntityType, object_type::ObjectType, relation_type::RelationType,
         role_type::RoleType, TypeAPI,
     },
 };
-use crate::thing::ThingAPI;
 
 type StatisticsEncodingVersion = u64;
 

--- a/concept/thing/thing_manager.rs
+++ b/concept/thing/thing_manager.rs
@@ -42,6 +42,7 @@ use encoding::{
 use itertools::Itertools;
 use lending_iterator::LendingIterator;
 use regex::Regex;
+use encoding::graph::thing::ThingVertex;
 use resource::constants::{encoding::StructFieldIDUInt, snapshot::BUFFER_KEY_INLINE};
 use storage::{
     key_range::KeyRange,
@@ -71,6 +72,7 @@ use crate::{
     },
     ConceptStatus,
 };
+use crate::type_::ThingTypeAPI;
 
 pub struct ThingManager {
     vertex_generator: Arc<ThingVertexGenerator>,
@@ -86,6 +88,10 @@ impl ThingManager {
         &self.type_manager
     }
 
+    pub fn get_instances_in<'a, T: ThingTypeAPI<'a>>(&self, snapshot: &impl ReadableSnapshot, thing_type: T) {
+        todo!()
+    }
+
     pub fn get_entities(&self, snapshot: &impl ReadableSnapshot) -> EntityIterator {
         let prefix = ObjectVertex::build_prefix_prefix(Prefix::VertexEntity);
         let snapshot_iterator =
@@ -98,13 +104,13 @@ impl ThingManager {
             ObjectType::Entity(_) => Prefix::VertexEntity,
             ObjectType::Relation(_) => Prefix::VertexRelation,
         };
-        let prefix = ObjectVertex::build_prefix_type(vertex_prefix.prefix_id(), object_type.vertex().type_id_());
+        let prefix = ObjectVertex::build_prefix_type(vertex_prefix, object_type.vertex().type_id_());
         let snapshot_iterator = snapshot.iterate_range(KeyRange::new_within(prefix, vertex_prefix.fixed_width_keys()));
         ObjectIterator::new(snapshot_iterator)
     }
 
     pub fn get_entities_in(&self, snapshot: &impl ReadableSnapshot, entity_type: EntityType<'_>) -> EntityIterator {
-        let prefix = ObjectVertex::build_prefix_type(Prefix::VertexEntity.prefix_id(), entity_type.vertex().type_id_());
+        let prefix = ObjectVertex::build_prefix_type(Prefix::VertexEntity, entity_type.vertex().type_id_());
         let snapshot_iterator =
             snapshot.iterate_range(KeyRange::new_within(prefix, Prefix::VertexEntity.fixed_width_keys()));
         EntityIterator::new(snapshot_iterator)
@@ -123,7 +129,7 @@ impl ThingManager {
         relation_type: RelationType<'_>,
     ) -> RelationIterator {
         let prefix =
-            ObjectVertex::build_prefix_type(Prefix::VertexRelation.prefix_id(), relation_type.vertex().type_id_());
+            ObjectVertex::build_prefix_type(Prefix::VertexRelation, relation_type.vertex().type_id_());
         let snapshot_iterator =
             snapshot.iterate_range(KeyRange::new_within(prefix, Prefix::VertexRelation.fixed_width_keys()));
         RelationIterator::new(snapshot_iterator)

--- a/concept/type_/attribute_type.rs
+++ b/concept/type_/attribute_type.rs
@@ -13,30 +13,33 @@ use encoding::{
     error::{EncodingError, EncodingError::UnexpectedPrefix},
     graph::{
         type_::{
-            vertex::{PrefixedTypeVertexEncoding, TypeVertex, TypeVertexEncoding},
             Kind,
+            vertex::{PrefixedTypeVertexEncoding, TypeVertex, TypeVertexEncoding},
         },
         Typed,
     },
     layout::prefix::{Prefix, Prefix::VertexAttributeType},
-    value::{label::Label, value_type::ValueType},
     Prefixed,
+    value::{label::Label, value_type::ValueType},
 };
 use primitive::maybe_owns::MaybeOwns;
 use storage::snapshot::{ReadableSnapshot, WritableSnapshot};
 
-use super::annotation::{AnnotationCategory, AnnotationRange, AnnotationRegex, AnnotationValues};
 use crate::{
+    ConceptAPI,
     error::{ConceptReadError, ConceptWriteError},
     type_::{
         annotation::{Annotation, AnnotationAbstract, AnnotationError, AnnotationIndependent, DefaultFrom},
+        KindAPI,
         object_type::ObjectType,
         owns::Owns,
-        type_manager::TypeManager,
-        KindAPI, TypeAPI,
+        type_manager::TypeManager, TypeAPI,
     },
-    ConceptAPI,
 };
+use crate::thing::attribute::Attribute;
+use crate::type_::ThingTypeAPI;
+
+use super::annotation::{AnnotationCategory, AnnotationRange, AnnotationRegex, AnnotationValues};
 
 #[derive(Debug, Clone, Eq, PartialEq, Hash, Ord, PartialOrd)]
 pub struct AttributeType<'a> {
@@ -128,6 +131,10 @@ impl<'a> KindAPI<'a> for AttributeType<'a> {
     ) -> Result<MaybeOwns<'m, HashMap<AttributeTypeAnnotation, AttributeType<'static>>>, ConceptReadError> {
         type_manager.get_attribute_type_annotations(snapshot, self.clone().into_owned())
     }
+}
+
+impl<'a> ThingTypeAPI<'a> for AttributeType<'a> {
+    type InstanceType<'b> = Attribute<'b>;
 }
 
 impl<'a> AttributeType<'a> {

--- a/concept/type_/attribute_type.rs
+++ b/concept/type_/attribute_type.rs
@@ -13,33 +13,31 @@ use encoding::{
     error::{EncodingError, EncodingError::UnexpectedPrefix},
     graph::{
         type_::{
-            Kind,
             vertex::{PrefixedTypeVertexEncoding, TypeVertex, TypeVertexEncoding},
+            Kind,
         },
         Typed,
     },
     layout::prefix::{Prefix, Prefix::VertexAttributeType},
-    Prefixed,
     value::{label::Label, value_type::ValueType},
+    Prefixed,
 };
 use primitive::maybe_owns::MaybeOwns;
 use storage::snapshot::{ReadableSnapshot, WritableSnapshot};
 
+use super::annotation::{AnnotationCategory, AnnotationRange, AnnotationRegex, AnnotationValues};
 use crate::{
-    ConceptAPI,
     error::{ConceptReadError, ConceptWriteError},
+    thing::attribute::Attribute,
     type_::{
         annotation::{Annotation, AnnotationAbstract, AnnotationError, AnnotationIndependent, DefaultFrom},
-        KindAPI,
         object_type::ObjectType,
         owns::Owns,
-        type_manager::TypeManager, TypeAPI,
+        type_manager::TypeManager,
+        KindAPI, ThingTypeAPI, TypeAPI,
     },
+    ConceptAPI,
 };
-use crate::thing::attribute::Attribute;
-use crate::type_::ThingTypeAPI;
-
-use super::annotation::{AnnotationCategory, AnnotationRange, AnnotationRegex, AnnotationValues};
 
 #[derive(Debug, Clone, Eq, PartialEq, Hash, Ord, PartialOrd)]
 pub struct AttributeType<'a> {

--- a/concept/type_/entity_type.rs
+++ b/concept/type_/entity_type.rs
@@ -13,14 +13,14 @@ use encoding::{
     error::{EncodingError, EncodingError::UnexpectedPrefix},
     graph::{
         type_::{
-            vertex::{PrefixedTypeVertexEncoding, TypeVertex, TypeVertexEncoding},
             Kind,
+            vertex::{PrefixedTypeVertexEncoding, TypeVertex, TypeVertexEncoding},
         },
         Typed,
     },
     layout::prefix::{Prefix, Prefix::VertexEntityType},
-    value::label::Label,
     Prefixed,
+    value::label::Label,
 };
 use primitive::maybe_owns::MaybeOwns;
 use resource::constants::snapshot::BUFFER_KEY_INLINE;
@@ -31,19 +31,21 @@ use storage::{
 
 use crate::{
     concept_iterator,
+    ConceptAPI,
     error::{ConceptReadError, ConceptWriteError},
     type_::{
         annotation::{Annotation, AnnotationAbstract, AnnotationCategory, AnnotationError, DefaultFrom},
         attribute_type::AttributeType,
+        KindAPI,
         object_type::ObjectType,
-        owns::Owns,
-        plays::Plays,
-        role_type::RoleType,
-        type_manager::TypeManager,
-        KindAPI, ObjectTypeAPI, Ordering, OwnerAPI, PlayerAPI, TypeAPI,
+        ObjectTypeAPI,
+        Ordering,
+        OwnerAPI,
+        owns::Owns, PlayerAPI, plays::Plays, role_type::RoleType, type_manager::TypeManager, TypeAPI,
     },
-    ConceptAPI,
 };
+use crate::thing::entity::Entity;
+use crate::type_::ThingTypeAPI;
 
 #[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
 pub struct EntityType<'a> {
@@ -130,6 +132,10 @@ impl<'a> KindAPI<'a> for EntityType<'a> {
     ) -> Result<MaybeOwns<'m, HashMap<EntityTypeAnnotation, EntityType<'static>>>, ConceptReadError> {
         type_manager.get_entity_type_annotations(snapshot, self.clone().into_owned())
     }
+}
+
+impl<'a> ThingTypeAPI<'a> for EntityType<'a> {
+    type InstanceType<'b> = Entity<'b>;
 }
 
 impl<'a> EntityType<'a> {

--- a/concept/type_/entity_type.rs
+++ b/concept/type_/entity_type.rs
@@ -13,14 +13,14 @@ use encoding::{
     error::{EncodingError, EncodingError::UnexpectedPrefix},
     graph::{
         type_::{
-            Kind,
             vertex::{PrefixedTypeVertexEncoding, TypeVertex, TypeVertexEncoding},
+            Kind,
         },
         Typed,
     },
     layout::prefix::{Prefix, Prefix::VertexEntityType},
-    Prefixed,
     value::label::Label,
+    Prefixed,
 };
 use primitive::maybe_owns::MaybeOwns;
 use resource::constants::snapshot::BUFFER_KEY_INLINE;
@@ -29,18 +29,22 @@ use storage::{
     snapshot::{ReadableSnapshot, WritableSnapshot},
 };
 
-use crate::{concept_iterator, ConceptAPI, error::{ConceptReadError, ConceptWriteError}, type_::{
-    annotation::{Annotation, AnnotationAbstract, AnnotationCategory, AnnotationError, DefaultFrom},
-    attribute_type::AttributeType,
-    KindAPI,
-    object_type::ObjectType,
-    ObjectTypeAPI,
-    Ordering,
-    OwnerAPI,
-    owns::Owns, PlayerAPI, plays::Plays, role_type::RoleType, type_manager::TypeManager, TypeAPI,
-}};
-use crate::thing::entity::Entity;
-use crate::type_::ThingTypeAPI;
+use crate::{
+    concept_iterator,
+    error::{ConceptReadError, ConceptWriteError},
+    thing::entity::Entity,
+    type_::{
+        annotation::{Annotation, AnnotationAbstract, AnnotationCategory, AnnotationError, DefaultFrom},
+        attribute_type::AttributeType,
+        object_type::ObjectType,
+        owns::Owns,
+        plays::Plays,
+        role_type::RoleType,
+        type_manager::TypeManager,
+        KindAPI, ObjectTypeAPI, Ordering, OwnerAPI, PlayerAPI, ThingTypeAPI, TypeAPI,
+    },
+    ConceptAPI,
+};
 
 #[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
 pub struct EntityType<'a> {

--- a/concept/type_/entity_type.rs
+++ b/concept/type_/entity_type.rs
@@ -29,21 +29,16 @@ use storage::{
     snapshot::{ReadableSnapshot, WritableSnapshot},
 };
 
-use crate::{
-    concept_iterator,
-    ConceptAPI,
-    error::{ConceptReadError, ConceptWriteError},
-    type_::{
-        annotation::{Annotation, AnnotationAbstract, AnnotationCategory, AnnotationError, DefaultFrom},
-        attribute_type::AttributeType,
-        KindAPI,
-        object_type::ObjectType,
-        ObjectTypeAPI,
-        Ordering,
-        OwnerAPI,
-        owns::Owns, PlayerAPI, plays::Plays, role_type::RoleType, type_manager::TypeManager, TypeAPI,
-    },
-};
+use crate::{concept_iterator, ConceptAPI, error::{ConceptReadError, ConceptWriteError}, type_::{
+    annotation::{Annotation, AnnotationAbstract, AnnotationCategory, AnnotationError, DefaultFrom},
+    attribute_type::AttributeType,
+    KindAPI,
+    object_type::ObjectType,
+    ObjectTypeAPI,
+    Ordering,
+    OwnerAPI,
+    owns::Owns, PlayerAPI, plays::Plays, role_type::RoleType, type_manager::TypeManager, TypeAPI,
+}};
 use crate::thing::entity::Entity;
 use crate::type_::ThingTypeAPI;
 

--- a/concept/type_/mod.rs
+++ b/concept/type_/mod.rs
@@ -41,7 +41,7 @@ use crate::{
         type_manager::TypeManager,
     },
 };
-use crate::thing::{InstanceAPI, ThingAPI};
+use crate::thing::{ThingAPI};
 
 pub mod annotation;
 pub mod attribute_type;

--- a/concept/type_/mod.rs
+++ b/concept/type_/mod.rs
@@ -9,28 +9,27 @@ use std::{
     hash::Hash,
 };
 
-use serde::{Deserialize, Serialize};
-
 use bytes::{byte_reference::ByteReference, Bytes};
 use encoding::{
-    AsBytes,
     graph::type_::{
-        CapabilityKind,
         edge::TypeEdgeEncoding,
-        Kind,
-        property::{TypeEdgePropertyEncoding, TypeVertexPropertyEncoding}, vertex::{TypeVertex, TypeVertexEncoding},
+        property::{TypeEdgePropertyEncoding, TypeVertexPropertyEncoding},
+        vertex::{TypeVertex, TypeVertexEncoding},
+        CapabilityKind, Kind,
     },
     layout::infix::Infix,
     value::label::Label,
+    AsBytes,
 };
 use lending_iterator::higher_order::Hkt;
 use primitive::maybe_owns::MaybeOwns;
 use resource::constants::snapshot::{BUFFER_KEY_INLINE, BUFFER_VALUE_INLINE};
+use serde::{Deserialize, Serialize};
 use storage::snapshot::{ReadableSnapshot, WritableSnapshot};
 
 use crate::{
-    ConceptAPI,
     error::{ConceptReadError, ConceptWriteError},
+    thing::ThingAPI,
     type_::{
         annotation::{Annotation, AnnotationCardinality},
         attribute_type::AttributeType,
@@ -40,8 +39,8 @@ use crate::{
         role_type::RoleType,
         type_manager::TypeManager,
     },
+    ConceptAPI,
 };
-use crate::thing::{ThingAPI};
 
 pub mod annotation;
 pub mod attribute_type;

--- a/concept/type_/mod.rs
+++ b/concept/type_/mod.rs
@@ -40,6 +40,7 @@ use crate::{
     },
     ConceptAPI,
 };
+use crate::thing::ThingAPI;
 
 pub mod annotation;
 pub mod attribute_type;
@@ -97,6 +98,10 @@ pub trait KindAPI<'a>: TypeAPI<'a> {
 
 pub trait ObjectTypeAPI<'a>: TypeAPI<'a> + OwnerAPI<'a> {
     fn into_owned_object_type(self) -> ObjectType<'static>;
+}
+
+pub trait ThingTypeAPI<'a>: TypeAPI<'a> {
+    type InstanceType<'b>: ThingAPI<'b>;
 }
 
 pub trait OwnerAPI<'a>: TypeAPI<'a> {

--- a/concept/type_/mod.rs
+++ b/concept/type_/mod.rs
@@ -9,38 +9,39 @@ use std::{
     hash::Hash,
 };
 
+use serde::{Deserialize, Serialize};
+
 use bytes::{byte_reference::ByteReference, Bytes};
 use encoding::{
+    AsBytes,
     graph::type_::{
+        CapabilityKind,
         edge::TypeEdgeEncoding,
-        property::{TypeEdgePropertyEncoding, TypeVertexPropertyEncoding},
-        vertex::{TypeVertex, TypeVertexEncoding},
-        CapabilityKind, Kind,
+        Kind,
+        property::{TypeEdgePropertyEncoding, TypeVertexPropertyEncoding}, vertex::{TypeVertex, TypeVertexEncoding},
     },
     layout::infix::Infix,
     value::label::Label,
-    AsBytes,
 };
+use lending_iterator::higher_order::Hkt;
 use primitive::maybe_owns::MaybeOwns;
 use resource::constants::snapshot::{BUFFER_KEY_INLINE, BUFFER_VALUE_INLINE};
-use serde::{Deserialize, Serialize};
 use storage::snapshot::{ReadableSnapshot, WritableSnapshot};
 
 use crate::{
+    ConceptAPI,
     error::{ConceptReadError, ConceptWriteError},
     type_::{
         annotation::{Annotation, AnnotationCardinality},
         attribute_type::AttributeType,
         object_type::ObjectType,
-        owns::{Owns, OwnsAnnotation},
-        plays::{Plays, PlaysAnnotation},
-        relates::RelatesAnnotation,
+        owns::Owns,
+        plays::Plays,
         role_type::RoleType,
         type_manager::TypeManager,
     },
-    ConceptAPI,
 };
-use crate::thing::ThingAPI;
+use crate::thing::{InstanceAPI, ThingAPI};
 
 pub mod annotation;
 pub mod attribute_type;

--- a/concept/type_/relation_type.rs
+++ b/concept/type_/relation_type.rs
@@ -13,14 +13,14 @@ use encoding::{
     error::{EncodingError, EncodingError::UnexpectedPrefix},
     graph::{
         type_::{
-            vertex::{PrefixedTypeVertexEncoding, TypeVertex, TypeVertexEncoding},
             Kind,
+            vertex::{PrefixedTypeVertexEncoding, TypeVertex, TypeVertexEncoding},
         },
         Typed,
     },
     layout::prefix::{Prefix, Prefix::VertexRelationType},
-    value::label::Label,
     Prefixed,
+    value::label::Label,
 };
 use primitive::maybe_owns::MaybeOwns;
 use resource::constants::snapshot::BUFFER_KEY_INLINE;
@@ -31,22 +31,24 @@ use storage::{
 
 use crate::{
     concept_iterator,
+    ConceptAPI,
     error::{ConceptReadError, ConceptWriteError},
     type_::{
         annotation::{
             Annotation, AnnotationAbstract, AnnotationCascade, AnnotationCategory, AnnotationError, DefaultFrom,
         },
         attribute_type::AttributeType,
+        KindAPI,
         object_type::ObjectType,
+        ObjectTypeAPI,
+        Ordering,
+        OwnerAPI,
         owns::Owns,
-        plays::Plays,
-        relates::Relates,
-        role_type::RoleType,
-        type_manager::TypeManager,
-        KindAPI, ObjectTypeAPI, Ordering, OwnerAPI, PlayerAPI, TypeAPI,
+        PlayerAPI, plays::Plays, relates::Relates, role_type::RoleType, type_manager::TypeManager, TypeAPI,
     },
-    ConceptAPI,
 };
+use crate::thing::relation::Relation;
+use crate::type_::ThingTypeAPI;
 
 #[derive(Debug, Clone, Eq, PartialEq, Hash, Ord, PartialOrd)]
 pub struct RelationType<'a> {
@@ -128,6 +130,10 @@ impl<'a> KindAPI<'a> for RelationType<'a> {
     ) -> Result<MaybeOwns<'m, HashMap<RelationTypeAnnotation, RelationType<'static>>>, ConceptReadError> {
         type_manager.get_relation_type_annotations(snapshot, self.clone().into_owned())
     }
+}
+
+impl<'a> ThingTypeAPI<'a> for RelationType<'a> {
+    type InstanceType<'b> = Relation<'b>;
 }
 
 impl<'a> ObjectTypeAPI<'a> for RelationType<'a> {

--- a/concept/type_/relation_type.rs
+++ b/concept/type_/relation_type.rs
@@ -13,14 +13,14 @@ use encoding::{
     error::{EncodingError, EncodingError::UnexpectedPrefix},
     graph::{
         type_::{
-            Kind,
             vertex::{PrefixedTypeVertexEncoding, TypeVertex, TypeVertexEncoding},
+            Kind,
         },
         Typed,
     },
     layout::prefix::{Prefix, Prefix::VertexRelationType},
-    Prefixed,
     value::label::Label,
+    Prefixed,
 };
 use primitive::maybe_owns::MaybeOwns;
 use resource::constants::snapshot::BUFFER_KEY_INLINE;
@@ -29,21 +29,25 @@ use storage::{
     snapshot::{ReadableSnapshot, WritableSnapshot},
 };
 
-use crate::{concept_iterator, ConceptAPI, error::{ConceptReadError, ConceptWriteError}, type_::{
-    annotation::{
-        Annotation, AnnotationAbstract, AnnotationCascade, AnnotationCategory, AnnotationError, DefaultFrom,
+use crate::{
+    concept_iterator,
+    error::{ConceptReadError, ConceptWriteError},
+    thing::relation::Relation,
+    type_::{
+        annotation::{
+            Annotation, AnnotationAbstract, AnnotationCascade, AnnotationCategory, AnnotationError, DefaultFrom,
+        },
+        attribute_type::AttributeType,
+        object_type::ObjectType,
+        owns::Owns,
+        plays::Plays,
+        relates::Relates,
+        role_type::RoleType,
+        type_manager::TypeManager,
+        KindAPI, ObjectTypeAPI, Ordering, OwnerAPI, PlayerAPI, ThingTypeAPI, TypeAPI,
     },
-    attribute_type::AttributeType,
-    KindAPI,
-    object_type::ObjectType,
-    ObjectTypeAPI,
-    Ordering,
-    OwnerAPI,
-    owns::Owns,
-    PlayerAPI, plays::Plays, relates::Relates, role_type::RoleType, type_manager::TypeManager, TypeAPI,
-}};
-use crate::thing::relation::Relation;
-use crate::type_::ThingTypeAPI;
+    ConceptAPI,
+};
 
 #[derive(Debug, Clone, Eq, PartialEq, Hash, Ord, PartialOrd)]
 pub struct RelationType<'a> {

--- a/concept/type_/relation_type.rs
+++ b/concept/type_/relation_type.rs
@@ -29,24 +29,19 @@ use storage::{
     snapshot::{ReadableSnapshot, WritableSnapshot},
 };
 
-use crate::{
-    concept_iterator,
-    ConceptAPI,
-    error::{ConceptReadError, ConceptWriteError},
-    type_::{
-        annotation::{
-            Annotation, AnnotationAbstract, AnnotationCascade, AnnotationCategory, AnnotationError, DefaultFrom,
-        },
-        attribute_type::AttributeType,
-        KindAPI,
-        object_type::ObjectType,
-        ObjectTypeAPI,
-        Ordering,
-        OwnerAPI,
-        owns::Owns,
-        PlayerAPI, plays::Plays, relates::Relates, role_type::RoleType, type_manager::TypeManager, TypeAPI,
+use crate::{concept_iterator, ConceptAPI, error::{ConceptReadError, ConceptWriteError}, type_::{
+    annotation::{
+        Annotation, AnnotationAbstract, AnnotationCascade, AnnotationCategory, AnnotationError, DefaultFrom,
     },
-};
+    attribute_type::AttributeType,
+    KindAPI,
+    object_type::ObjectType,
+    ObjectTypeAPI,
+    Ordering,
+    OwnerAPI,
+    owns::Owns,
+    PlayerAPI, plays::Plays, relates::Relates, role_type::RoleType, type_manager::TypeManager, TypeAPI,
+}};
 use crate::thing::relation::Relation;
 use crate::type_::ThingTypeAPI;
 

--- a/concept/type_/role_type.rs
+++ b/concept/type_/role_type.rs
@@ -31,20 +31,15 @@ use storage::{
 };
 
 use super::Ordering;
-use crate::{
-    concept_iterator,
-    error::{ConceptReadError, ConceptWriteError},
-    type_::{
-        annotation::{Annotation, AnnotationAbstract, AnnotationCategory, AnnotationError, DefaultFrom},
-        object_type::ObjectType,
-        plays::Plays,
-        relates::Relates,
-        relation_type::RelationType,
-        type_manager::TypeManager,
-        KindAPI, TypeAPI,
-    },
-    ConceptAPI,
-};
+use crate::{error::{ConceptReadError, ConceptWriteError}, type_::{
+    annotation::{Annotation, AnnotationAbstract, AnnotationCategory, AnnotationError, DefaultFrom},
+    object_type::ObjectType,
+    plays::Plays,
+    relates::Relates,
+    relation_type::RelationType,
+    type_manager::TypeManager,
+    KindAPI, TypeAPI,
+}, ConceptAPI, concept_iterator};
 
 #[derive(Debug, Clone, Eq, PartialEq, Hash, Ord, PartialOrd)]
 pub struct RoleType<'a> {

--- a/concept/type_/role_type.rs
+++ b/concept/type_/role_type.rs
@@ -31,15 +31,20 @@ use storage::{
 };
 
 use super::Ordering;
-use crate::{error::{ConceptReadError, ConceptWriteError}, type_::{
-    annotation::{Annotation, AnnotationAbstract, AnnotationCategory, AnnotationError, DefaultFrom},
-    object_type::ObjectType,
-    plays::Plays,
-    relates::Relates,
-    relation_type::RelationType,
-    type_manager::TypeManager,
-    KindAPI, TypeAPI,
-}, ConceptAPI, concept_iterator};
+use crate::{
+    concept_iterator,
+    error::{ConceptReadError, ConceptWriteError},
+    type_::{
+        annotation::{Annotation, AnnotationAbstract, AnnotationCategory, AnnotationError, DefaultFrom},
+        object_type::ObjectType,
+        plays::Plays,
+        relates::Relates,
+        relation_type::RelationType,
+        type_manager::TypeManager,
+        KindAPI, TypeAPI,
+    },
+    ConceptAPI,
+};
 
 #[derive(Debug, Clone, Eq, PartialEq, Hash, Ord, PartialOrd)]
 pub struct RoleType<'a> {

--- a/concept/type_/type_manager/validation/operation_time_validation.rs
+++ b/concept/type_/type_manager/validation/operation_time_validation.rs
@@ -20,6 +20,7 @@ use encoding::{
     value::{label::Label, value_type::ValueType},
 };
 use itertools::Itertools;
+use encoding::graph::thing::ThingVertex;
 use lending_iterator::LendingIterator;
 use storage::{key_range::KeyRange, snapshot::ReadableSnapshot};
 
@@ -1485,7 +1486,7 @@ impl OperationTimeValidation {
             .map_err(SchemaValidationError::ConceptRead)?
             .relation();
         let prefix =
-            ObjectVertex::build_prefix_type(Prefix::VertexRelation.prefix_id(), relation_type.vertex().type_id_());
+            ObjectVertex::build_prefix_type(Prefix::VertexRelation, relation_type.vertex().type_id_());
         let snapshot_iterator =
             snapshot.iterate_range(KeyRange::new_within(prefix, Prefix::VertexRelation.fixed_width_keys()));
         let mut relation_iterator = RelationIterator::new(snapshot_iterator);

--- a/concept/type_/type_manager/validation/operation_time_validation.rs
+++ b/concept/type_/type_manager/validation/operation_time_validation.rs
@@ -12,7 +12,7 @@ use std::{
 use encoding::{
     graph::{
         definition::definition_key::DefinitionKey,
-        thing::{edge::ThingEdgeRolePlayer, vertex_object::ObjectVertex},
+        thing::{edge::ThingEdgeRolePlayer, vertex_object::ObjectVertex, ThingVertex},
         type_::CapabilityKind,
         Typed,
     },
@@ -20,16 +20,11 @@ use encoding::{
     value::{label::Label, value_type::ValueType},
 };
 use itertools::Itertools;
-use encoding::graph::thing::ThingVertex;
 use lending_iterator::LendingIterator;
 use storage::{key_range::KeyRange, snapshot::ReadableSnapshot};
 
 use crate::{
-    thing::{
-        object::ObjectAPI,
-        relation::{ RolePlayerIterator},
-        thing_manager::ThingManager,
-    },
+    thing::{object::ObjectAPI, relation::RolePlayerIterator, thing_manager::ThingManager, ThingAPI},
     type_::{
         annotation::{
             Annotation, AnnotationCardinality, AnnotationCategory, AnnotationRange, AnnotationRegex, AnnotationValues,
@@ -70,7 +65,6 @@ use crate::{
         Capability, KindAPI, ObjectTypeAPI, Ordering, TypeAPI,
     },
 };
-use crate::thing::ThingAPI;
 
 macro_rules! object_type_match {
     ($obj_var:ident, $block:block) => {
@@ -1434,7 +1428,7 @@ impl OperationTimeValidation {
             None => Ok(()),
             Some(Ok(_)) => Err(SchemaValidationError::CannotDeleteTypeWithExistingInstances(get_label_or_schema_err(
                 snapshot,
-                entity_type
+                entity_type,
             )?)),
             Some(Err(concept_read_error)) => Err(SchemaValidationError::ConceptRead(concept_read_error)),
         }

--- a/encoding/encoding.rs
+++ b/encoding/encoding.rs
@@ -77,7 +77,6 @@ pub trait Keyable<'a, const INLINE_SIZE: usize>: AsBytes<'a, INLINE_SIZE> + Size
 }
 
 pub trait Prefixed<'a, const INLINE_SIZE: usize>: AsBytes<'a, INLINE_SIZE> {
-    const LENGTH_PREFIX_PREFIX: usize = PrefixID::LENGTH;
     const RANGE_PREFIX: Range<usize> = 0..PrefixID::LENGTH;
 
     fn prefix(&'a self) -> Prefix {

--- a/encoding/encoding.rs
+++ b/encoding/encoding.rs
@@ -77,6 +77,7 @@ pub trait Keyable<'a, const INLINE_SIZE: usize>: AsBytes<'a, INLINE_SIZE> + Size
 }
 
 pub trait Prefixed<'a, const INLINE_SIZE: usize>: AsBytes<'a, INLINE_SIZE> {
+    const LENGTH_PREFIX_PREFIX: usize = PrefixID::LENGTH;
     const RANGE_PREFIX: Range<usize> = 0..PrefixID::LENGTH;
 
     fn prefix(&'a self) -> Prefix {

--- a/encoding/graph/thing/edge.rs
+++ b/encoding/graph/thing/edge.rs
@@ -26,6 +26,7 @@ use crate::{
     value::value_type::ValueTypeCategory,
     AsBytes, EncodingKeyspace, Keyable, Prefixed,
 };
+use crate::graph::thing::{THING_VERTEX_LENGTH_PREFIX_TYPE, ThingVertex};
 
 ///
 /// [has][object][Attribute8|Attribute17]
@@ -42,10 +43,10 @@ impl<'a> ThingEdgeHas<'a> {
     const PREFIX: Prefix = Prefix::EdgeHas;
     pub const FIXED_WIDTH_ENCODING: bool = Self::PREFIX.fixed_width_keys();
 
-    pub const LENGTH_PREFIX_FROM_TYPE: usize = PrefixID::LENGTH + ObjectVertex::LENGTH_PREFIX_TYPE;
+    pub const LENGTH_PREFIX_FROM_TYPE: usize = PrefixID::LENGTH + THING_VERTEX_LENGTH_PREFIX_TYPE;
     pub const LENGTH_PREFIX_FROM_OBJECT: usize = PrefixID::LENGTH + ObjectVertex::LENGTH;
     pub const LENGTH_PREFIX_FROM_OBJECT_TO_TYPE: usize =
-        PrefixID::LENGTH + ObjectVertex::LENGTH + AttributeVertex::LENGTH_PREFIX_TYPE;
+        PrefixID::LENGTH + ObjectVertex::LENGTH + THING_VERTEX_LENGTH_PREFIX_TYPE;
 
     pub fn new(bytes: Bytes<'a, BUFFER_KEY_INLINE>) -> Self {
         debug_assert_eq!(bytes.bytes()[Self::RANGE_PREFIX], Self::PREFIX.prefix_id().bytes());
@@ -127,7 +128,7 @@ impl<'a> ThingEdgeHas<'a> {
     }
 
     const fn range_from_type() -> Range<usize> {
-        Self::RANGE_PREFIX.end..Self::RANGE_PREFIX.end + ObjectVertex::LENGTH_PREFIX_TYPE
+        Self::RANGE_PREFIX.end..Self::RANGE_PREFIX.end + THING_VERTEX_LENGTH_PREFIX_TYPE
     }
 
     const fn range_from() -> Range<usize> {
@@ -183,13 +184,13 @@ impl<'a> ThingEdgeHasReverse<'a> {
 
     const INDEX_FROM_PREFIX: usize = PrefixID::LENGTH;
     pub const LENGTH_PREFIX_FROM_PREFIX: usize = PrefixID::LENGTH + AttributeVertex::LENGTH_PREFIX_PREFIX;
-    pub const LENGTH_PREFIX_FROM_TYPE: usize = PrefixID::LENGTH + AttributeVertex::LENGTH_PREFIX_TYPE;
+    pub const LENGTH_PREFIX_FROM_TYPE: usize = PrefixID::LENGTH + THING_VERTEX_LENGTH_PREFIX_TYPE;
     pub const LENGTH_BOUND_PREFIX_FROM: usize =
-        PrefixID::LENGTH + AttributeVertex::LENGTH_PREFIX_TYPE + AttributeID::max_length();
+        PrefixID::LENGTH + THING_VERTEX_LENGTH_PREFIX_TYPE + AttributeID::max_length();
     pub const LENGTH_BOUND_PREFIX_FROM_TO_TYPE: usize = PrefixID::LENGTH
-        + AttributeVertex::LENGTH_PREFIX_TYPE
+        + THING_VERTEX_LENGTH_PREFIX_TYPE
         + AttributeID::max_length()
-        + ObjectVertex::LENGTH_PREFIX_TYPE;
+        + THING_VERTEX_LENGTH_PREFIX_TYPE;
 
     pub fn new(bytes: Bytes<'a, BUFFER_KEY_INLINE>) -> ThingEdgeHasReverse<'a> {
         debug_assert_eq!(bytes.bytes()[Self::RANGE_PREFIX], Self::PREFIX.prefix_id().bytes());
@@ -294,7 +295,7 @@ impl<'a> ThingEdgeHasReverse<'a> {
         let prefix = PrefixID::new([byte]);
         let id_encoding_length =
             AttributeVertex::prefix_type_to_value_id_encoding_length(Prefix::from_prefix_id(prefix));
-        AttributeVertex::LENGTH_PREFIX_TYPE + id_encoding_length
+        THING_VERTEX_LENGTH_PREFIX_TYPE + id_encoding_length
     }
 
     fn keyspace_for_from(attribute: AttributeVertex<'_>) -> EncodingKeyspace {

--- a/encoding/graph/thing/edge.rs
+++ b/encoding/graph/thing/edge.rs
@@ -183,7 +183,7 @@ impl<'a> ThingEdgeHasReverse<'a> {
     pub const FIXED_WIDTH_ENCODING: bool = Self::PREFIX.fixed_width_keys();
 
     const INDEX_FROM_PREFIX: usize = PrefixID::LENGTH;
-    pub const LENGTH_PREFIX_FROM_PREFIX: usize = PrefixID::LENGTH + AttributeVertex::LENGTH_PREFIX_PREFIX;
+    pub const LENGTH_PREFIX_FROM_PREFIX: usize = PrefixID::LENGTH + PrefixID::LENGTH;
     pub const LENGTH_PREFIX_FROM_TYPE: usize = PrefixID::LENGTH + THING_VERTEX_LENGTH_PREFIX_TYPE;
     pub const LENGTH_BOUND_PREFIX_FROM: usize =
         PrefixID::LENGTH + THING_VERTEX_LENGTH_PREFIX_TYPE + AttributeID::max_length();
@@ -212,7 +212,7 @@ impl<'a> ThingEdgeHasReverse<'a> {
     ) -> StorageKey<'static, { ThingEdgeHasReverse::LENGTH_PREFIX_FROM_PREFIX }> {
         let mut bytes = ByteArray::zeros(Self::LENGTH_PREFIX_FROM_PREFIX);
         bytes.bytes_mut()[Self::RANGE_PREFIX].copy_from_slice(&Self::PREFIX.prefix_id().bytes());
-        bytes.bytes_mut()[Self::RANGE_PREFIX.end..Self::RANGE_PREFIX.end + AttributeVertex::LENGTH_PREFIX_PREFIX]
+        bytes.bytes_mut()[Self::RANGE_PREFIX.end..Self::RANGE_PREFIX.end + PrefixID::LENGTH]
             .copy_from_slice(&from_prefix.prefix_id().bytes);
         StorageKey::new_owned(Self::keyspace_for_from_prefix(from_prefix), bytes)
     }
@@ -223,7 +223,7 @@ impl<'a> ThingEdgeHasReverse<'a> {
     ) -> StorageKey<'static, { ThingEdgeHasReverse::LENGTH_PREFIX_FROM_TYPE }> {
         let mut bytes = ByteArray::zeros(Self::LENGTH_PREFIX_FROM_TYPE);
         bytes.bytes_mut()[Self::RANGE_PREFIX].copy_from_slice(&Self::PREFIX.prefix_id().bytes());
-        let from_prefix_end = Self::RANGE_PREFIX.end + AttributeVertex::LENGTH_PREFIX_PREFIX;
+        let from_prefix_end = Self::RANGE_PREFIX.end + PrefixID::LENGTH;
         bytes.bytes_mut()[Self::RANGE_PREFIX.end..from_prefix_end].copy_from_slice(&from_prefix.prefix_id().bytes);
         let from_type_id_end = from_prefix_end + TypeID::LENGTH;
         bytes.bytes_mut()[from_prefix_end..from_type_id_end].copy_from_slice(&from_type_id.bytes());

--- a/encoding/graph/thing/edge.rs
+++ b/encoding/graph/thing/edge.rs
@@ -18,6 +18,7 @@ use crate::{
         thing::{
             vertex_attribute::{AttributeID, AttributeVertex},
             vertex_object::ObjectVertex,
+            ThingVertex, THING_VERTEX_LENGTH_PREFIX_TYPE,
         },
         type_::vertex::{TypeID, TypeVertex},
         Typed,
@@ -26,7 +27,6 @@ use crate::{
     value::value_type::ValueTypeCategory,
     AsBytes, EncodingKeyspace, Keyable, Prefixed,
 };
-use crate::graph::thing::{THING_VERTEX_LENGTH_PREFIX_TYPE, ThingVertex};
 
 ///
 /// [has][object][Attribute8|Attribute17]

--- a/encoding/graph/thing/edge.rs
+++ b/encoding/graph/thing/edge.rs
@@ -82,16 +82,13 @@ impl<'a> ThingEdgeHas<'a> {
 
     pub fn prefix_from_object_to_type(
         from: ObjectVertex,
-        to_value_type_category: ValueTypeCategory,
-        to_type: TypeVertex,
+        to_vertex_prefix: Prefix,
+        to_type_id: TypeID,
     ) -> StorageKey<'static, { ThingEdgeHas::LENGTH_PREFIX_FROM_OBJECT_TO_TYPE }> {
         let mut bytes = ByteArray::zeros(Self::LENGTH_PREFIX_FROM_OBJECT_TO_TYPE);
         bytes.bytes_mut()[Self::RANGE_PREFIX].copy_from_slice(&Self::PREFIX.prefix_id().bytes());
         bytes.bytes_mut()[Self::range_from()].copy_from_slice(from.bytes().bytes());
-        let to_prefix = AttributeVertex::build_prefix_type(
-            AttributeVertex::value_type_category_to_prefix_type(to_value_type_category),
-            to_type.type_id_(),
-        );
+        let to_prefix = AttributeVertex::build_prefix_type(to_vertex_prefix, to_type_id);
         let to_type_range = Self::range_from().end..Self::range_from().end + to_prefix.length();
         bytes.bytes_mut()[to_type_range].copy_from_slice(to_prefix.bytes());
         StorageKey::new_owned(Self::KEYSPACE, bytes)
@@ -167,9 +164,9 @@ impl<'a> Keyable<'a, BUFFER_KEY_INLINE> for ThingEdgeHas<'a> {
 }
 
 ///
-/// [has_reverse][8 byte ID][object]
+/// [has_reverse][attribute, 8 byte ID][object]
 /// OR
-/// [has_reverse][17 byte ID][object]
+/// [has_reverse][attribute, 16 byte ID][object]
 ///
 /// Note that these are represented here together, but should go to different keyspaces due to different prefix lengths
 ///
@@ -217,7 +214,7 @@ impl<'a> ThingEdgeHasReverse<'a> {
         StorageKey::new_owned(Self::keyspace_for_from_prefix(from_prefix), bytes)
     }
 
-    pub fn prefix_from_type(
+    pub fn prefix_from_type_with_category(
         from_prefix: Prefix,
         from_type_id: TypeID,
     ) -> StorageKey<'static, { ThingEdgeHasReverse::LENGTH_PREFIX_FROM_TYPE }> {

--- a/encoding/graph/thing/mod.rs
+++ b/encoding/graph/thing/mod.rs
@@ -4,8 +4,43 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
+use std::ops::Range;
+use bytes::byte_array::ByteArray;
+use bytes::Bytes;
+use resource::constants::snapshot::BUFFER_KEY_INLINE;
+use storage::key_value::StorageKey;
+use crate::graph::type_::vertex::{TypeID, TypeVertex};
+use crate::layout::prefix::{Prefix, PrefixID};
+use crate::{EncodingKeyspace, Prefixed};
+use crate::graph::thing::vertex_object::ObjectVertex;
+use crate::graph::Typed;
+
 pub mod edge;
 pub mod property;
 pub mod vertex_attribute;
 pub mod vertex_generator;
 pub mod vertex_object;
+
+
+const THING_VERTEX_LENGTH_PREFIX_TYPE: usize = PrefixID::LENGTH + TypeID::LENGTH;
+
+pub trait ThingVertex<'a>: Prefixed<'a, BUFFER_KEY_INLINE> + Typed<'a, BUFFER_KEY_INLINE> {
+    const KEYSPACE: EncodingKeyspace;
+
+    fn build_prefix_prefix(prefix: Prefix) -> StorageKey<'static, THING_VERTEX_LENGTH_PREFIX_TYPE> {
+        let mut array = ByteArray::zeros(THING_VERTEX_LENGTH_PREFIX_TYPE);
+        array.bytes_mut()[Self::RANGE_PREFIX].copy_from_slice(&prefix.prefix_id().bytes());
+        StorageKey::new(Self::KEYSPACE, Bytes::Array(array))
+    }
+
+    fn build_prefix_type(
+        prefix: Prefix,
+        type_id: TypeID,
+    ) -> StorageKey<'static, THING_VERTEX_LENGTH_PREFIX_TYPE> {
+        debug_assert!(prefix == Prefix::VertexEntity || prefix == Prefix::VertexRelation);
+        let mut array = ByteArray::zeros(THING_VERTEX_LENGTH_PREFIX_TYPE);
+        array.bytes_mut()[Self::RANGE_PREFIX].copy_from_slice(&prefix.prefix_id().bytes());
+        array.bytes_mut()[Self::RANGE_TYPE_ID].copy_from_slice(&type_id.bytes());
+        StorageKey::new(Self::KEYSPACE, Bytes::Array(array))
+    }
+}

--- a/encoding/graph/thing/mod.rs
+++ b/encoding/graph/thing/mod.rs
@@ -4,22 +4,21 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-use bytes::byte_array::ByteArray;
-use bytes::Bytes;
+use bytes::{byte_array::ByteArray, Bytes};
 use resource::constants::snapshot::BUFFER_KEY_INLINE;
 use storage::key_value::StorageKey;
 
-use crate::{EncodingKeyspace, Prefixed};
-use crate::graph::type_::vertex::TypeID;
-use crate::graph::Typed;
-use crate::layout::prefix::{Prefix, PrefixID};
+use crate::{
+    graph::{type_::vertex::TypeID, Typed},
+    layout::prefix::{Prefix, PrefixID},
+    EncodingKeyspace, Prefixed,
+};
 
 pub mod edge;
 pub mod property;
 pub mod vertex_attribute;
 pub mod vertex_generator;
 pub mod vertex_object;
-
 
 const THING_VERTEX_LENGTH_PREFIX_TYPE: usize = PrefixID::LENGTH + TypeID::LENGTH;
 
@@ -34,13 +33,11 @@ pub trait ThingVertex<'a>: Prefixed<'a, BUFFER_KEY_INLINE> + Typed<'a, BUFFER_KE
         StorageKey::new(Self::KEYSPACE, Bytes::Array(array))
     }
 
-    fn build_prefix_type(
-        prefix: Prefix,
-        type_id: TypeID,
-    ) -> StorageKey<'static, THING_VERTEX_LENGTH_PREFIX_TYPE> {
+    fn build_prefix_type(prefix: Prefix, type_id: TypeID) -> StorageKey<'static, THING_VERTEX_LENGTH_PREFIX_TYPE> {
         debug_assert!(
-            prefix == Prefix::VertexEntity || prefix == Prefix::VertexRelation ||
-                (prefix.prefix_id().bytes() >= Prefix::ATTRIBUTE_MIN.prefix_id().bytes
+            prefix == Prefix::VertexEntity
+                || prefix == Prefix::VertexRelation
+                || (prefix.prefix_id().bytes() >= Prefix::ATTRIBUTE_MIN.prefix_id().bytes
                     && prefix.prefix_id().bytes() < Prefix::ATTRIBUTE_MAX.prefix_id().bytes)
         );
         let mut array = ByteArray::zeros(THING_VERTEX_LENGTH_PREFIX_TYPE);

--- a/encoding/graph/thing/mod.rs
+++ b/encoding/graph/thing/mod.rs
@@ -4,16 +4,16 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-use std::ops::Range;
 use bytes::byte_array::ByteArray;
 use bytes::Bytes;
 use resource::constants::snapshot::BUFFER_KEY_INLINE;
 use storage::key_value::StorageKey;
-use crate::graph::type_::vertex::{TypeID, TypeVertex};
-use crate::layout::prefix::{Prefix, PrefixID};
+
 use crate::{EncodingKeyspace, Prefixed};
-use crate::graph::thing::vertex_object::ObjectVertex;
+use crate::graph::thing::vertex_attribute::AttributeVertex;
+use crate::graph::type_::vertex::TypeID;
 use crate::graph::Typed;
+use crate::layout::prefix::{Prefix, PrefixID};
 
 pub mod edge;
 pub mod property;
@@ -26,6 +26,8 @@ const THING_VERTEX_LENGTH_PREFIX_TYPE: usize = PrefixID::LENGTH + TypeID::LENGTH
 
 pub trait ThingVertex<'a>: Prefixed<'a, BUFFER_KEY_INLINE> + Typed<'a, BUFFER_KEY_INLINE> {
     const KEYSPACE: EncodingKeyspace;
+
+    fn new(bytes: Bytes<'a, BUFFER_KEY_INLINE>) -> Self;
 
     fn build_prefix_prefix(prefix: Prefix) -> StorageKey<'static, THING_VERTEX_LENGTH_PREFIX_TYPE> {
         let mut array = ByteArray::zeros(THING_VERTEX_LENGTH_PREFIX_TYPE);

--- a/encoding/graph/thing/property.rs
+++ b/encoding/graph/thing/property.rs
@@ -11,14 +11,17 @@ use resource::constants::snapshot::BUFFER_KEY_INLINE;
 use storage::key_value::StorageKey;
 
 use crate::{
-    graph::{thing::vertex_object::ObjectVertex, type_::vertex::TypeVertex, Typed},
+    graph::{
+        thing::{vertex_object::ObjectVertex, ThingVertex},
+        type_::vertex::TypeVertex,
+        Typed,
+    },
     layout::{
         infix::{Infix, InfixID},
         prefix::{Prefix, PrefixID},
     },
     AsBytes, EncodingKeyspace, Keyable, Prefixed,
 };
-use crate::graph::thing::ThingVertex;
 
 trait ObjectVertexPropertyFactory {
     fn infix(&self) -> Infix;

--- a/encoding/graph/thing/property.rs
+++ b/encoding/graph/thing/property.rs
@@ -18,6 +18,7 @@ use crate::{
     },
     AsBytes, EncodingKeyspace, Keyable, Prefixed,
 };
+use crate::graph::thing::ThingVertex;
 
 trait ObjectVertexPropertyFactory {
     fn infix(&self) -> Infix;

--- a/encoding/graph/thing/vertex_attribute.rs
+++ b/encoding/graph/thing/vertex_attribute.rs
@@ -10,7 +10,7 @@ use std::{
     sync::Arc,
 };
 
-use bytes::{byte_array::ByteArray, byte_reference::ByteReference, Bytes, util::HexBytesFormatter};
+use bytes::{byte_array::ByteArray, byte_reference::ByteReference, util::HexBytesFormatter, Bytes};
 use primitive::either::Either;
 use resource::constants::snapshot::BUFFER_KEY_INLINE;
 use storage::{
@@ -20,10 +20,14 @@ use storage::{
 };
 
 use crate::{
-    AsBytes,
-    EncodingKeyspace,
-    graph::{common::value_hasher::HashedID, type_::vertex::TypeID, Typed},
-    Keyable, layout::prefix::Prefix, Prefixed, value::{
+    graph::{
+        common::value_hasher::HashedID,
+        thing::{ThingVertex, THING_VERTEX_LENGTH_PREFIX_TYPE},
+        type_::vertex::TypeID,
+        Typed,
+    },
+    layout::prefix::Prefix,
+    value::{
         boolean_bytes::BooleanBytes,
         date_bytes::DateBytes,
         date_time_bytes::DateTimeBytes,
@@ -37,8 +41,8 @@ use crate::{
         value_type::{ValueType, ValueTypeCategory},
         ValueEncodable,
     },
+    AsBytes, EncodingKeyspace, Keyable, Prefixed,
 };
-use crate::graph::thing::{THING_VERTEX_LENGTH_PREFIX_TYPE, ThingVertex};
 
 #[derive(Clone, Debug, PartialEq, Eq, Ord, PartialOrd, Hash)]
 pub struct AttributeVertex<'a> {
@@ -46,7 +50,6 @@ pub struct AttributeVertex<'a> {
 }
 
 impl<'a> AttributeVertex<'a> {
-
     pub fn build(value_type_category: ValueTypeCategory, type_id: TypeID, attribute_id: AttributeID) -> Self {
         let mut bytes = ByteArray::zeros(THING_VERTEX_LENGTH_PREFIX_TYPE + attribute_id.length());
         bytes.bytes_mut()[Self::RANGE_PREFIX]
@@ -170,7 +173,6 @@ impl<'a> ThingVertex<'a> for AttributeVertex<'a> {
         AttributeVertex { bytes }
     }
 }
-
 
 impl<'a> Keyable<'a, BUFFER_KEY_INLINE> for AttributeVertex<'a> {
     fn keyspace(&self) -> EncodingKeyspace {

--- a/encoding/graph/thing/vertex_attribute.rs
+++ b/encoding/graph/thing/vertex_attribute.rs
@@ -23,7 +23,7 @@ use crate::{
     AsBytes,
     EncodingKeyspace,
     graph::{common::value_hasher::HashedID, type_::vertex::TypeID, Typed},
-    Keyable, layout::prefix::{Prefix, PrefixID}, Prefixed, value::{
+    Keyable, layout::prefix::Prefix, Prefixed, value::{
         boolean_bytes::BooleanBytes,
         date_bytes::DateBytes,
         date_time_bytes::DateTimeBytes,
@@ -46,10 +46,6 @@ pub struct AttributeVertex<'a> {
 }
 
 impl<'a> AttributeVertex<'a> {
-    pub fn new(bytes: Bytes<'a, BUFFER_KEY_INLINE>) -> Self {
-        debug_assert!(bytes.length() > THING_VERTEX_LENGTH_PREFIX_TYPE);
-        AttributeVertex { bytes }
-    }
 
     pub fn build(value_type_category: ValueTypeCategory, type_id: TypeID, attribute_id: AttributeID) -> Self {
         let mut bytes = ByteArray::zeros(THING_VERTEX_LENGTH_PREFIX_TYPE + attribute_id.length());
@@ -168,6 +164,11 @@ impl<'a> Typed<'a, BUFFER_KEY_INLINE> for AttributeVertex<'a> {}
 
 impl<'a> ThingVertex<'a> for AttributeVertex<'a> {
     const KEYSPACE: EncodingKeyspace = EncodingKeyspace::Data;
+
+    fn new(bytes: Bytes<'a, BUFFER_KEY_INLINE>) -> Self {
+        debug_assert!(bytes.length() > THING_VERTEX_LENGTH_PREFIX_TYPE);
+        AttributeVertex { bytes }
+    }
 }
 
 

--- a/encoding/graph/thing/vertex_generator.rs
+++ b/encoding/graph/thing/vertex_generator.rs
@@ -40,6 +40,7 @@ use crate::{
     },
     AsBytes, Keyable, Prefixed,
 };
+use crate::graph::thing::ThingVertex;
 
 pub struct ThingVertexGenerator {
     entity_ids: Box<[AtomicU64]>,

--- a/encoding/graph/thing/vertex_generator.rs
+++ b/encoding/graph/thing/vertex_generator.rs
@@ -27,6 +27,7 @@ use crate::{
         thing::{
             vertex_attribute::{AttributeID, AttributeVertex, LongAttributeID, StringAttributeID},
             vertex_object::{ObjectID, ObjectVertex},
+            ThingVertex,
         },
         type_::vertex::{build_type_vertex_prefix_key, TypeID, TypeIDUInt, TypeVertex},
         Typed,
@@ -40,7 +41,6 @@ use crate::{
     },
     AsBytes, Keyable, Prefixed,
 };
-use crate::graph::thing::ThingVertex;
 
 pub struct ThingVertexGenerator {
     entity_ids: Box<[AtomicU64]>,

--- a/encoding/graph/thing/vertex_object.rs
+++ b/encoding/graph/thing/vertex_object.rs
@@ -118,7 +118,7 @@ impl<'a> Prefixed<'a, BUFFER_KEY_INLINE> for ObjectVertex<'a> {}
 impl<'a> Typed<'a, BUFFER_KEY_INLINE> for ObjectVertex<'a> {}
 
 impl<'a> ThingVertex<'a> for ObjectVertex<'a> {
-    const KEYSPACE: EncodingKeyspace = EncodingKeyspace::Schema;
+    const KEYSPACE: EncodingKeyspace = EncodingKeyspace::Data;
 
     fn new(bytes: Bytes<'a, BUFFER_KEY_INLINE>) -> ObjectVertex<'a> {
         debug_assert_eq!(bytes.length(), Self::LENGTH);

--- a/encoding/graph/thing/vertex_object.rs
+++ b/encoding/graph/thing/vertex_object.rs
@@ -10,7 +10,7 @@ use std::{
     ops::Range,
 };
 
-use bytes::{byte_array::ByteArray, byte_reference::ByteReference, util::HexBytesFormatter, Bytes};
+use bytes::{byte_array::ByteArray, byte_reference::ByteReference, Bytes, util::HexBytesFormatter};
 use resource::constants::snapshot::BUFFER_KEY_INLINE;
 use storage::{
     key_value::{StorageKey, StorageKeyReference},
@@ -18,12 +18,12 @@ use storage::{
 };
 
 use crate::{
+    AsBytes,
+    EncodingKeyspace,
     graph::{
         type_::vertex::{TypeID, TypeVertex},
         Typed,
-    },
-    layout::prefix::{Prefix, PrefixID},
-    AsBytes, EncodingKeyspace, Keyable, Prefixed,
+    }, Keyable, layout::prefix::{Prefix, PrefixID}, Prefixed,
 };
 use crate::graph::thing::{THING_VERTEX_LENGTH_PREFIX_TYPE, ThingVertex};
 
@@ -36,11 +36,6 @@ impl<'a> ObjectVertex<'a> {
     pub const FIXED_WIDTH_ENCODING: bool = true;
 
     pub const LENGTH: usize = PrefixID::LENGTH + TypeID::LENGTH + ObjectID::LENGTH;
-
-    pub fn new(bytes: Bytes<'a, BUFFER_KEY_INLINE>) -> ObjectVertex<'a> {
-        debug_assert_eq!(bytes.length(), Self::LENGTH);
-        ObjectVertex { bytes }
-    }
 
     pub fn build_entity(type_id: TypeID, object_id: ObjectID) -> Self {
         let mut array = ByteArray::zeros(Self::LENGTH);
@@ -124,6 +119,11 @@ impl<'a> Typed<'a, BUFFER_KEY_INLINE> for ObjectVertex<'a> {}
 
 impl<'a> ThingVertex<'a> for ObjectVertex<'a> {
     const KEYSPACE: EncodingKeyspace = EncodingKeyspace::Schema;
+
+    fn new(bytes: Bytes<'a, BUFFER_KEY_INLINE>) -> ObjectVertex<'a> {
+        debug_assert_eq!(bytes.length(), Self::LENGTH);
+        ObjectVertex { bytes }
+    }
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]

--- a/encoding/graph/thing/vertex_object.rs
+++ b/encoding/graph/thing/vertex_object.rs
@@ -10,7 +10,7 @@ use std::{
     ops::Range,
 };
 
-use bytes::{byte_array::ByteArray, byte_reference::ByteReference, Bytes, util::HexBytesFormatter};
+use bytes::{byte_array::ByteArray, byte_reference::ByteReference, util::HexBytesFormatter, Bytes};
 use resource::constants::snapshot::BUFFER_KEY_INLINE;
 use storage::{
     key_value::{StorageKey, StorageKeyReference},
@@ -18,14 +18,14 @@ use storage::{
 };
 
 use crate::{
-    AsBytes,
-    EncodingKeyspace,
     graph::{
+        thing::{ThingVertex, THING_VERTEX_LENGTH_PREFIX_TYPE},
         type_::vertex::{TypeID, TypeVertex},
         Typed,
-    }, Keyable, layout::prefix::{Prefix, PrefixID}, Prefixed,
+    },
+    layout::prefix::{Prefix, PrefixID},
+    AsBytes, EncodingKeyspace, Keyable, Prefixed,
 };
-use crate::graph::thing::{THING_VERTEX_LENGTH_PREFIX_TYPE, ThingVertex};
 
 #[derive(Debug, Clone, PartialEq, Eq, Ord, PartialOrd, Hash)]
 pub struct ObjectVertex<'a> {

--- a/encoding/layout/prefix.rs
+++ b/encoding/layout/prefix.rs
@@ -182,6 +182,7 @@ impl Prefix {
            DefinitionStruct => [20], true;
            DefinitionFunction => [21], true;
 
+           // All objects are stored consecutively for iteration
            VertexEntity => [30], true;
            VertexRelation => [31], true;
 

--- a/ir/inference/mod.rs
+++ b/ir/inference/mod.rs
@@ -161,6 +161,7 @@ pub mod tests {
             durability_client::WALClient,
             snapshot::{CommittableSnapshot, WritableSnapshot},
         };
+
         pub(crate) const LABEL_ANIMAL: &str = "animal";
         pub(crate) const LABEL_CAT: &str = "cat";
         pub(crate) const LABEL_DOG: &str = "dog";

--- a/ir/inference/pattern_type_inference.rs
+++ b/ir/inference/pattern_type_inference.rs
@@ -310,7 +310,6 @@ impl<'this> NestedTypeInferenceGraphDisjunction<'this> {
 
 #[cfg(test)]
 pub mod tests {
-
     use std::collections::{BTreeMap, BTreeSet};
 
     use answer::{variable::Variable, Type as TypeAnnotation};

--- a/ir/inference/type_seeder.rs
+++ b/ir/inference/type_seeder.rs
@@ -319,14 +319,10 @@ impl<'this, Snapshot: ReadableSnapshot> TypeSeeder<'this, Snapshot> {
             Constraint::Isa(isa) => self.try_propagating_vertex_annotation_impl(isa, vertices)?,
             Constraint::Sub(sub) => self.try_propagating_vertex_annotation_impl(sub, vertices)?,
             Constraint::RolePlayer(role_player) => {
-                if role_player.role_type.is_some() {
-                    let relation_role = RelationRoleEdge { role_player };
-                    let player_role = PlayerRoleEdge { role_player };
-                    self.try_propagating_vertex_annotation_impl(&relation_role, vertices)?
-                        || self.try_propagating_vertex_annotation_impl(&player_role, vertices)?
-                } else {
-                    todo!("Can we always have a role-player variable?")
-                }
+                let relation_role = RelationRoleEdge { role_player };
+                let player_role = PlayerRoleEdge { role_player };
+                self.try_propagating_vertex_annotation_impl(&relation_role, vertices)?
+                    || self.try_propagating_vertex_annotation_impl(&player_role, vertices)?
             }
             Constraint::Has(has) => self.try_propagating_vertex_annotation_impl(has, vertices)?,
             Constraint::Comparison(cmp) => self.try_propagating_vertex_annotation_impl(cmp, vertices)?,
@@ -446,14 +442,10 @@ impl<'this, Snapshot: ReadableSnapshot> TypeSeeder<'this, Snapshot> {
                 Constraint::Isa(isa) => edges.push(self.seed_edge(constraint, isa, vertices)?),
                 Constraint::Sub(sub) => edges.push(self.seed_edge(constraint, sub, vertices)?),
                 Constraint::RolePlayer(role_player) => {
-                    if role_player.role_type.is_some() {
-                        let relation_role = RelationRoleEdge { role_player };
-                        let player_role = PlayerRoleEdge { role_player };
-                        edges.push(self.seed_edge(constraint, &relation_role, vertices)?);
-                        edges.push(self.seed_edge(constraint, &player_role, vertices)?);
-                    } else {
-                        todo!("Can we always have a role-player variable?")
-                    }
+                    let relation_role = RelationRoleEdge { role_player };
+                    let player_role = PlayerRoleEdge { role_player };
+                    edges.push(self.seed_edge(constraint, &relation_role, vertices)?);
+                    edges.push(self.seed_edge(constraint, &player_role, vertices)?);
                 }
                 Constraint::Has(has) => edges.push(self.seed_edge(constraint, has, vertices)?),
                 Constraint::Comparison(cmp) => edges.push(self.seed_edge(constraint, cmp, vertices)?),
@@ -954,7 +946,7 @@ impl<'graph> BinaryConstraint for PlayerRoleEdge<'graph> {
     }
 
     fn right(&self) -> Variable {
-        self.role_player.role_type.unwrap()
+        self.role_player.role_type
     }
 
     fn annotate_left_to_right_for_type(
@@ -1012,7 +1004,7 @@ impl<'graph> BinaryConstraint for RelationRoleEdge<'graph> {
     }
 
     fn right(&self) -> Variable {
-        self.role_player.role_type.unwrap()
+        self.role_player.role_type
     }
 
     fn annotate_left_to_right_for_type(

--- a/ir/pattern/constraint.rs
+++ b/ir/pattern/constraint.rs
@@ -143,20 +143,17 @@ impl<'cx> ConstraintsBuilder<'cx> {
         &mut self,
         relation: Variable,
         player: Variable,
-        role_type: Option<Variable>,
+        role_type: Variable,
     ) -> Result<&RolePlayer<Variable>, PatternDefinitionError> {
         debug_assert!(
             self.context.is_variable_available(self.constraints.scope, relation)
                 && self.context.is_variable_available(self.constraints.scope, player)
-                && !role_type
-                    .is_some_and(|role_type| !self.context.is_variable_available(self.constraints.scope, role_type))
+                && self.context.is_variable_available(self.constraints.scope, role_type)
         );
         let role_player = Constraint::from(RolePlayer::new(relation, player, role_type));
         self.context.set_variable_category(relation, VariableCategory::Object, role_player.clone())?;
         self.context.set_variable_category(player, VariableCategory::Object, role_player.clone())?;
-        if let Some(role_type) = role_type {
-            self.context.set_variable_category(role_type, VariableCategory::Type, role_player.clone())?;
-        }
+        self.context.set_variable_category(role_type, VariableCategory::Type, role_player.clone())?;
         let constraint = self.constraints.add_constraint(role_player);
         Ok(constraint.as_role_player().unwrap())
     }

--- a/ir/pattern/negation.rs
+++ b/ir/pattern/negation.rs
@@ -9,7 +9,6 @@ use std::fmt;
 use crate::{
     pattern::{
         conjunction::{Conjunction, ConjunctionBuilder},
-        optional::Optional,
         Scope, ScopeId,
     },
     program::block::BlockContext,

--- a/ir/program/function.rs
+++ b/ir/program/function.rs
@@ -6,19 +6,13 @@
 
 use std::{
     collections::{BTreeSet, HashMap, HashSet},
-    error::Error,
-    fmt,
     fmt::Display,
     sync::Arc,
 };
 
 use answer::{variable::Variable, Type};
-use storage::snapshot::{iterator::SnapshotIteratorError, SnapshotGetError};
 
-use crate::{
-    program::{block::FunctionalBlock, function_signature::FunctionID},
-    PatternDefinitionError,
-};
+use crate::program::block::FunctionalBlock;
 
 pub type PlaceholderTypeQLReturnOperation = String;
 

--- a/ir/tests/program.rs
+++ b/ir/tests/program.rs
@@ -4,7 +4,6 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-
 use encoding::{
     graph::definition::definition_key::{DefinitionID, DefinitionKey},
     layout::prefix::Prefix,

--- a/ir/translator/constraints.rs
+++ b/ir/translator/constraints.rs
@@ -217,11 +217,12 @@ fn add_typeql_relation(
             typeql::statement::thing::RolePlayer::Typed(type_, var) => {
                 let player = register_typeql_var(constraints, var)?;
                 let type_ = register_typeql_type_var_any(constraints, type_)?;
-                constraints.add_role_player(relation, player, Some(type_))?;
+                constraints.add_role_player(relation, player, type_)?;
             }
             typeql::statement::thing::RolePlayer::Untyped(var) => {
                 let player = register_typeql_var(constraints, var)?;
-                constraints.add_role_player(relation, player, None)?;
+                let role_type = constraints.create_anonymous_variable()?;
+                constraints.add_role_player(relation, player, role_type)?;
             }
         }
     }

--- a/storage/key_range.rs
+++ b/storage/key_range.rs
@@ -84,12 +84,12 @@ impl<T: Prefix> KeyRange<T> {
         match &self.end {
             RangeEnd::SameAsStart => value.starts_with(self.start()),
             RangeEnd::Inclusive(e) => value.cmp(e) == Ordering::Less || value.starts_with(e),
-            RangeEnd::Exclusive(e) => value.cmp(e) == Ordering::Less,
+            RangeEnd::Exclusive(e) => value.cmp(e) == Ordering::Less || *value == self.start,
             RangeEnd::Unbounded => true,
         }
     }
 
-    fn end_value(&self) -> Option<&T> {
+    pub(crate) fn end_value(&self) -> Option<&T> {
         match &self.end {
             RangeEnd::SameAsStart => Some(self.start()),
             RangeEnd::Inclusive(value) => Some(value),

--- a/storage/keyspace/iterator.rs
+++ b/storage/keyspace/iterator.rs
@@ -5,9 +5,9 @@
  */
 
 use std::cmp::{max, Ordering};
-use itertools::Itertools;
 
 use bytes::{byte_array::ByteArray, Bytes};
+use itertools::Itertools;
 use lending_iterator::{
     adaptors::{SeekableMap, TakeWhile},
     LendingIterator, Peekable, Seekable,
@@ -58,24 +58,23 @@ impl KeyspaceRangeIterator {
 
         let keyspace_name = keyspace.name();
 
-        let max_required_length = range.end_value()
+        let max_required_length = range
+            .end_value()
             .map(|bytes| max(bytes.length(), range.start().length()))
             .unwrap_or(range.start().length());
 
         // TODO: this Box and copy for comparison shouldn't be necessary
         let range_iterator = iterator
-            .take_while(Box::new(move |res: &Result<(&[u8], &[u8]), rocksdb::Error>| {
-                match res {
-                    Ok((key, _)) => {
-                        let copy = if key.len() > max_required_length {
-                            ByteArray::copy(&key[0..max_required_length])
-                        }  else {
-                            ByteArray::copy(key)
-                        };
-                        range.within_end(&copy)
-                    }
-                    Err(_) => true,
+            .take_while(Box::new(move |res: &Result<(&[u8], &[u8]), rocksdb::Error>| match res {
+                Ok((key, _)) => {
+                    let copy = if key.len() > max_required_length {
+                        ByteArray::copy(&key[0..max_required_length])
+                    } else {
+                        ByteArray::copy(key)
+                    };
+                    range.within_end(&copy)
                 }
+                Err(_) => true,
             }) as Box<_>)
             .map(error_mapper(keyspace_name))
             .into_seekable(identity as _, raw_iterator::compare_key as _);

--- a/storage/keyspace/iterator.rs
+++ b/storage/keyspace/iterator.rs
@@ -4,7 +4,8 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-use std::cmp::Ordering;
+use std::cmp::{max, Ordering};
+use itertools::Itertools;
 
 use bytes::{byte_array::ByteArray, Bytes};
 use lending_iterator::{
@@ -57,10 +58,24 @@ impl KeyspaceRangeIterator {
 
         let keyspace_name = keyspace.name();
 
+        let max_required_length = range.end_value()
+            .map(|bytes| max(bytes.length(), range.start().length()))
+            .unwrap_or(range.start().length());
+
+        // TODO: this Box and copy for comparison shouldn't be necessary
         let range_iterator = iterator
-            .take_while(Box::new(move |res: &Result<(&[u8], &[u8]), rocksdb::Error>| match res {
-                Ok((key, _)) => range.within_end(&ByteArray::copy(key)),
-                Err(_) => true,
+            .take_while(Box::new(move |res: &Result<(&[u8], &[u8]), rocksdb::Error>| {
+                match res {
+                    Ok((key, _)) => {
+                        let copy = if key.len() > max_required_length {
+                            ByteArray::copy(&key[0..max_required_length])
+                        }  else {
+                            ByteArray::copy(key)
+                        };
+                        range.within_end(&copy)
+                    }
+                    Err(_) => true,
+                }
             }) as Box<_>)
             .map(error_mapper(keyspace_name))
             .into_seekable(identity as _, raw_iterator::compare_key as _);

--- a/tests/behaviour/steps/lib.rs
+++ b/tests/behaviour/steps/lib.rs
@@ -17,9 +17,15 @@ use std::{
 use ::concept::thing::{attribute::Attribute, object::Object};
 use cucumber::{gherkin::Feature, StatsWriter, World};
 use database::Database;
+use futures::{
+    future::Either,
+    stream::{self, StreamExt},
+};
 use itertools::Itertools;
 use server::typedb;
 use storage::durability_client::WALClient;
+use thing_util::ObjectWithKey;
+use transaction_context::ActiveTransaction;
 
 mod assert;
 mod concept;
@@ -27,13 +33,6 @@ mod connection;
 mod params;
 mod transaction_context;
 mod util;
-
-use futures::{
-    future::Either,
-    stream::{self, StreamExt},
-};
-use thing_util::ObjectWithKey;
-use transaction_context::ActiveTransaction;
 
 mod thing_util {
     use concept::thing::{attribute::Attribute, object::Object};

--- a/traversal/executor/instruction/has_reverse_executor.rs
+++ b/traversal/executor/instruction/has_reverse_executor.rs
@@ -4,18 +4,214 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-use ir::pattern::constraint::Has;
+use std::cmp::Ordering;
+use std::collections::{BTreeMap, HashSet};
+use std::sync::Arc;
 
+use answer::Type;
+use concept::error::ConceptReadError;
+use concept::thing::attribute::Attribute;
+use concept::thing::thing_manager::ThingManager;
+use lending_iterator::LendingIterator;
+use resource::constants::traversal::CONSTANT_CONCEPT_LIMIT;
+use storage::snapshot::ReadableSnapshot;
+
+use crate::executor::batch::ImmutableRow;
+use crate::executor::instruction::{BinaryIterateMode, VariableModes};
+use crate::executor::instruction::has_executor::HasFilterFn;
+use crate::executor::instruction::iterator::TupleIterator;
+use crate::executor::instruction::tuple::TuplePositions;
 use crate::executor::VariablePosition;
 
 pub(crate) struct HasReverseIteratorExecutor {
-    has: Has<VariablePosition>,
+    has: ir::pattern::constraint::Has<VariablePosition>,
+    iterate_mode: BinaryIterateMode,
+    variable_modes: VariableModes,
+    tuple_positions: TuplePositions,
+    attribute_owner_types: Arc<BTreeMap<Type, Vec<Type>>>,
+    owner_types: Arc<HashSet<Type>>,
+    filter_fn: Arc<HasFilterFn>,
+    attribute_cache: Option<Vec<Attribute<'static>>>,
 }
 
 impl HasReverseIteratorExecutor {
-    pub(crate) fn new(has: Has<VariablePosition>) -> HasReverseIteratorExecutor {
-        Self { has }
+    pub(crate) fn new<Snapshot: ReadableSnapshot>(
+        has: ir::pattern::constraint::Has<VariablePosition>,
+        variable_modes: VariableModes,
+        sort_by: Option<VariablePosition>,
+        attribute_owner_types: Arc<BTreeMap<Type, Vec<Type>>>, // vecs are in sorted order
+        owner_types: Arc<HashSet<Type>>,
+        snapshot: &Snapshot,
+        thing_manager: &ThingManager,
+    ) -> Result<Self, ConceptReadError> {
+        debug_assert!(attribute_owner_types.len() > 0);
+        debug_assert!(!variable_modes.fully_bound());
+        let iterate_mode = BinaryIterateMode::new(has.clone(), true, &variable_modes, sort_by);
+        let filter_fn = match iterate_mode {
+            BinaryIterateMode::Unbound => Arc::new({
+                let att_owner_types = attribute_owner_types.clone();
+                let owner_types = owner_types.clone();
+                move |result: &Result<(concept::thing::has::Has<'_>, u64), ConceptReadError>| match result {
+                    Ok((has, _)) => {
+                        att_owner_types.contains_key(&Type::Attribute(has.attribute().type_()))
+                            && owner_types.contains(&Type::from(has.owner().type_()))
+                    }
+                    Err(_) => true,
+                }
+            }) as Arc<HasFilterFn>,
+            BinaryIterateMode::UnboundInverted | BinaryIterateMode::BoundFrom => Arc::new({
+                let owner_types = owner_types.clone();
+                move |result: &Result<(concept::thing::has::Has<'_>, u64), ConceptReadError>| match result {
+                    Ok((has, _)) => owner_types.contains(&Type::from(has.owner().type_())),
+                    Err(_) => true,
+                }
+            }) as Arc<HasFilterFn>,
+        };
+        let output_tuple_positions = if iterate_mode.is_inverted() {
+            TuplePositions::Pair([has.owner(), has.attribute()])
+        } else {
+            TuplePositions::Pair([has.attribute(), has.owner()])
+        };
+
+        let owner_cache = if matches!(iterate_mode, BinaryIterateMode::UnboundInverted) {
+            let mut cache = Vec::new();
+            for attr_type in attribute_owner_types.keys() {
+                for attr in thing_manager
+                    .get_attributes_in(snapshot, attr_type.as_attribute_type())?
+                    .map_static(|result| result.map(|attr| attr.clone().into_owned()))
+                    .into_iter() {
+                    cache.push(attr?);
+                }
+            }
+            debug_assert!(cache.len() < CONSTANT_CONCEPT_LIMIT);
+            Some(cache)
+        } else {
+            None
+        };
+        todo!()
+        //
+        // Ok(Self {
+        //     has,
+        //     iterate_mode,
+        //     variable_modes,
+        //     tuple_positions: output_tuple_positions,
+        //     owner_attribute_types,
+        //     attribute_types,
+        //     filter_fn,
+        //     owner_cache,
+        // })
+    }
+
+    pub(crate) fn get_iterator<Snapshot: ReadableSnapshot>(
+        &self,
+        snapshot: &Snapshot,
+        thing_manager: &ThingManager,
+        row: ImmutableRow<'_>,
+    ) -> Result<TupleIterator, ConceptReadError> {
+        // match self.iterate_mode {
+        // BinaryIterateMode::Unbound => {
+        //     let first_from_type = self.owner_attribute_types.first_key_value().unwrap().0;
+        //     let last_key_from_type = self.owner_attribute_types.last_key_value().unwrap().0;
+        //     let key_range =
+        //         KeyRange::new_inclusive(first_from_type.as_object_type(), last_key_from_type.as_object_type());
+        //     let filter_fn = self.filter_fn.has_both_filter();
+        //     // TODO: we could cache the range byte arrays computed inside the thing_manager, for this case
+        //     let iterator: Filter<HasIterator, Arc<crate::executor::instruction::has_executor::HasFilterBothFn>> = thing_manager
+        //         .get_has_from_type_range_unordered(snapshot, key_range)
+        //         .filter::<_, crate::executor::instruction::has_executor::HasFilterBothFn>(filter_fn);
+        //     let as_tuples: Map<Filter<HasIterator, Arc<crate::executor::instruction::has_executor::HasFilterBothFn>>, crate::executor::instruction::has_executor::HasToTupleFn, TupleResult> =
+        //         iterator.map::<Result<Tuple<'_>, _>, _>(has_to_tuple_owner_attribute);
+        //     Ok(TupleIterator::HasUnbounded(SortedTupleIterator::new(
+        //         as_tuples,
+        //         self.tuple_positions.clone(),
+        //         &self.variable_modes,
+        //     )))
+        // }
+        // BinaryIterateMode::UnboundInverted => {
+        //     debug_assert!(self.owner_cache.is_some());
+        //     if let Some([iter]) = self.owner_cache.as_deref() {
+        //         // no heap allocs needed if there is only 1 iterator
+        //         let iterator = iter
+        //             .get_has_types_range_unordered(
+        //                 snapshot,
+        //                 thing_manager,
+        //                 // TODO: this should be just the types owned by the one instance's type in the cache!
+        //                 self.attribute_types.iter().map(|t| t.as_attribute_type()),
+        //             )?
+        //             .filter::<_, crate::executor::instruction::has_executor::HasFilterAttributeFn>(self.filter_fn.has_attribute_filter());
+        //         let as_tuples: HasUnboundedSortedAttributeSingle =
+        //             iterator.map::<Result<Tuple<'_>, _>, _>(has_to_tuple_attribute_owner);
+        //         Ok(TupleIterator::HasUnboundedInvertedSingle(SortedTupleIterator::new(
+        //             as_tuples,
+        //             self.tuple_positions.clone(),
+        //             &self.variable_modes,
+        //         )))
+        //     } else {
+        //         // // TODO: we could create a reusable space for these temporarily held iterators so we don't have allocate again before the merging iterator
+        //         let mut iterators: Vec<Peekable<HasIterator>> =
+        //             Vec::with_capacity(self.owner_cache.as_ref().unwrap().len());
+        //         for iter in self.owner_cache.as_ref().unwrap().iter().map(|object| {
+        //             object.get_has_types_range_unordered(
+        //                 snapshot,
+        //                 thing_manager,
+        //                 self.attribute_types.iter().map(|t| t.as_attribute_type()),
+        //             )
+        //         }) {
+        //             iterators.push(Peekable::new(iter?))
+        //         }
+        //
+        //         // note: this will always have to heap alloc, if we use don't have a re-usable/small-vec'ed priority queue somewhere
+        //         let merged: KMergeBy<HasIterator, crate::executor::instruction::has_executor::HasOrderByAttributeFn> =
+        //             KMergeBy::new(iterators, Self::compare_has_by_attribute_then_owner);
+        //         let filtered: Filter<KMergeBy<HasIterator, crate::executor::instruction::has_executor::HasOrderByAttributeFn>, Arc<crate::executor::instruction::has_executor::HasFilterAttributeFn>> =
+        //             merged.filter::<_, crate::executor::instruction::has_executor::HasFilterAttributeFn>(self.filter_fn.has_attribute_filter());
+        //         let as_tuples: HasUnboundedSortedAttributeMerged =
+        //             filtered.map::<Result<Tuple<'_>, _>, _>(has_to_tuple_attribute_owner);
+        //         Ok(TupleIterator::HasUnboundedInvertedMerged(SortedTupleIterator::new(
+        //             as_tuples,
+        //             self.tuple_positions.clone(),
+        //             &self.variable_modes,
+        //         )))
+        //     }
+        // }
+        // BinaryIterateMode::BoundFrom => {
+        //     debug_assert!(row.width() > self.has.owner().as_usize());
+        //     let owner = row.get(self.has.owner());
+        //     let iterator = match owner {
+        //         VariableValue::Thing(Thing::Entity(entity)) => entity.get_has_types_range_unordered(
+        //             snapshot,
+        //             thing_manager,
+        //             self.attribute_types.iter().map(|t| t.as_attribute_type()),
+        //         )?,
+        //         VariableValue::Thing(Thing::Relation(relation)) => relation.get_has_types_range_unordered(
+        //             snapshot,
+        //             thing_manager,
+        //             self.attribute_types.iter().map(|t| t.as_attribute_type()),
+        //         )?,
+        //         _ => unreachable!("Has owner must be an entity or relation."),
+        //     };
+        //     let filtered = iterator.filter::<_, crate::executor::instruction::has_executor::HasFilterAttributeFn>(self.filter_fn.has_attribute_filter());
+        //     let as_tuples: HasBoundedSortedAttribute =
+        //         filtered.map::<Result<Tuple<'_>, _>, _>(has_to_tuple_owner_attribute);
+        //     Ok(TupleIterator::HasBounded(SortedTupleIterator::new(
+        //         as_tuples,
+        //         self.tuple_positions.clone(),
+        //         &self.variable_modes,
+        //     )))
+        // }
+        todo!()
+    }
+
+    fn compare_has_by_attribute_then_owner<'a, 'b>(
+        pair: (&'a Result<(concept::thing::has::Has<'a>, u64), ConceptReadError>, &'b Result<(concept::thing::has::Has<'b>, u64), ConceptReadError>),
+    ) -> Ordering {
+        let (result_1, result_2) = pair;
+        match (result_1, result_2) {
+            (Ok((has_1, _)), Ok((has_2, _))) => {
+                has_1.attribute().cmp(&has_2.attribute()).then(has_1.owner().cmp(&has_2.owner()))
+            }
+            _ => Ordering::Equal,
+        }
     }
 }
 
-impl HasReverseIteratorExecutor {}

--- a/traversal/executor/instruction/has_reverse_executor.rs
+++ b/traversal/executor/instruction/has_reverse_executor.rs
@@ -11,16 +11,21 @@ use std::sync::Arc;
 use answer::Type;
 use concept::error::ConceptReadError;
 use concept::thing::attribute::Attribute;
+use concept::thing::has::Has;
+use concept::thing::object::{HasIterator, HasReverseIterator};
 use concept::thing::thing_manager::ThingManager;
-use lending_iterator::LendingIterator;
+use lending_iterator::adaptors::{Filter, Map};
+use lending_iterator::{AsHkt, LendingIterator, Peekable};
+use lending_iterator::kmerge::KMergeBy;
 use resource::constants::traversal::CONSTANT_CONCEPT_LIMIT;
+use storage::key_range::KeyRange;
 use storage::snapshot::ReadableSnapshot;
 
 use crate::executor::batch::ImmutableRow;
 use crate::executor::instruction::{BinaryIterateMode, VariableModes};
-use crate::executor::instruction::has_executor::HasFilterFn;
-use crate::executor::instruction::iterator::TupleIterator;
-use crate::executor::instruction::tuple::TuplePositions;
+use crate::executor::instruction::has_executor::{HasFilterFn, HasOrderingFn};
+use crate::executor::instruction::iterator::{inverted_instances_cache, SortedTupleIterator, TupleIterator};
+use crate::executor::instruction::tuple::{has_to_tuple_attribute_owner, has_to_tuple_owner_attribute, HasToTupleFn, Tuple, TuplePositions, TupleResult};
 use crate::executor::VariablePosition;
 
 pub(crate) struct HasReverseIteratorExecutor {
@@ -33,6 +38,19 @@ pub(crate) struct HasReverseIteratorExecutor {
     filter_fn: Arc<HasFilterFn>,
     attribute_cache: Option<Vec<Attribute<'static>>>,
 }
+
+pub(crate) type HasReverseUnboundedSortedAttribute =
+Map<Filter<HasReverseIterator, Arc<HasFilterFn>>, HasToTupleFn, AsHkt![TupleResult<'_>]>;
+pub(crate) type HasReverseUnboundedSortedOwnerMerged = Map<
+    Filter<KMergeBy<HasReverseIterator, HasOrderingFn>, Arc<HasFilterFn>>,
+    HasToTupleFn,
+    AsHkt![TupleResult<'_>],
+>;
+pub(crate) type HasReverseUnboundedSortedOwnerSingle =
+Map<Filter<HasReverseIterator, Arc<HasFilterFn>>, HasToTupleFn, AsHkt![TupleResult<'_>]>;
+pub(crate) type HasReverseBoundedSortedOwner =
+Map<Filter<HasReverseIterator, Arc<HasFilterFn>>, HasToTupleFn, AsHkt![TupleResult<'_>]>;
+
 
 impl HasReverseIteratorExecutor {
     pub(crate) fn new<Snapshot: ReadableSnapshot>(
@@ -48,24 +66,12 @@ impl HasReverseIteratorExecutor {
         debug_assert!(!variable_modes.fully_bound());
         let iterate_mode = BinaryIterateMode::new(has.clone(), true, &variable_modes, sort_by);
         let filter_fn = match iterate_mode {
-            BinaryIterateMode::Unbound => Arc::new({
-                let att_owner_types = attribute_owner_types.clone();
-                let owner_types = owner_types.clone();
-                move |result: &Result<(concept::thing::has::Has<'_>, u64), ConceptReadError>| match result {
-                    Ok((has, _)) => {
-                        att_owner_types.contains_key(&Type::Attribute(has.attribute().type_()))
-                            && owner_types.contains(&Type::from(has.owner().type_()))
-                    }
-                    Err(_) => true,
-                }
-            }) as Arc<HasFilterFn>,
-            BinaryIterateMode::UnboundInverted | BinaryIterateMode::BoundFrom => Arc::new({
-                let owner_types = owner_types.clone();
-                move |result: &Result<(concept::thing::has::Has<'_>, u64), ConceptReadError>| match result {
-                    Ok((has, _)) => owner_types.contains(&Type::from(has.owner().type_())),
-                    Err(_) => true,
-                }
-            }) as Arc<HasFilterFn>,
+            BinaryIterateMode::Unbound => {
+                Self::create_has_filter_attributes_owners(attribute_owner_types.clone(), owner_types.clone())
+            }
+            BinaryIterateMode::UnboundInverted | BinaryIterateMode::BoundFrom => {
+                Self::create_has_filter_owners(owner_types.clone())
+            }
         };
         let output_tuple_positions = if iterate_mode.is_inverted() {
             TuplePositions::Pair([has.owner(), has.attribute()])
@@ -73,33 +79,23 @@ impl HasReverseIteratorExecutor {
             TuplePositions::Pair([has.attribute(), has.owner()])
         };
 
-        let owner_cache = if matches!(iterate_mode, BinaryIterateMode::UnboundInverted) {
-            let mut cache = Vec::new();
-            for attr_type in attribute_owner_types.keys() {
-                for attr in thing_manager
-                    .get_attributes_in(snapshot, attr_type.as_attribute_type())?
-                    .map_static(|result| result.map(|attr| attr.clone().into_owned()))
-                    .into_iter() {
-                    cache.push(attr?);
-                }
-            }
-            debug_assert!(cache.len() < CONSTANT_CONCEPT_LIMIT);
-            Some(cache)
+        let attribute_cache = if matches!(iterate_mode, BinaryIterateMode::UnboundInverted) {
+            Some(inverted_instances_cache(
+                attribute_owner_types.keys().map(|type_| type_.as_attribute_type()), snapshot, thing_manager,
+            )?)
         } else {
             None
         };
-        todo!()
-        //
-        // Ok(Self {
-        //     has,
-        //     iterate_mode,
-        //     variable_modes,
-        //     tuple_positions: output_tuple_positions,
-        //     owner_attribute_types,
-        //     attribute_types,
-        //     filter_fn,
-        //     owner_cache,
-        // })
+        Ok(Self {
+            has,
+            iterate_mode,
+            variable_modes,
+            tuple_positions: output_tuple_positions,
+            attribute_owner_types,
+            owner_types,
+            filter_fn,
+            attribute_cache,
+        })
     }
 
     pub(crate) fn get_iterator<Snapshot: ReadableSnapshot>(
@@ -108,107 +104,143 @@ impl HasReverseIteratorExecutor {
         thing_manager: &ThingManager,
         row: ImmutableRow<'_>,
     ) -> Result<TupleIterator, ConceptReadError> {
-        // match self.iterate_mode {
-        // BinaryIterateMode::Unbound => {
-        //     let first_from_type = self.owner_attribute_types.first_key_value().unwrap().0;
-        //     let last_key_from_type = self.owner_attribute_types.last_key_value().unwrap().0;
-        //     let key_range =
-        //         KeyRange::new_inclusive(first_from_type.as_object_type(), last_key_from_type.as_object_type());
-        //     let filter_fn = self.filter_fn.has_both_filter();
-        //     // TODO: we could cache the range byte arrays computed inside the thing_manager, for this case
-        //     let iterator: Filter<HasIterator, Arc<crate::executor::instruction::has_executor::HasFilterBothFn>> = thing_manager
-        //         .get_has_from_type_range_unordered(snapshot, key_range)
-        //         .filter::<_, crate::executor::instruction::has_executor::HasFilterBothFn>(filter_fn);
-        //     let as_tuples: Map<Filter<HasIterator, Arc<crate::executor::instruction::has_executor::HasFilterBothFn>>, crate::executor::instruction::has_executor::HasToTupleFn, TupleResult> =
-        //         iterator.map::<Result<Tuple<'_>, _>, _>(has_to_tuple_owner_attribute);
-        //     Ok(TupleIterator::HasUnbounded(SortedTupleIterator::new(
-        //         as_tuples,
-        //         self.tuple_positions.clone(),
-        //         &self.variable_modes,
-        //     )))
-        // }
-        // BinaryIterateMode::UnboundInverted => {
-        //     debug_assert!(self.owner_cache.is_some());
-        //     if let Some([iter]) = self.owner_cache.as_deref() {
-        //         // no heap allocs needed if there is only 1 iterator
-        //         let iterator = iter
-        //             .get_has_types_range_unordered(
-        //                 snapshot,
-        //                 thing_manager,
-        //                 // TODO: this should be just the types owned by the one instance's type in the cache!
-        //                 self.attribute_types.iter().map(|t| t.as_attribute_type()),
-        //             )?
-        //             .filter::<_, crate::executor::instruction::has_executor::HasFilterAttributeFn>(self.filter_fn.has_attribute_filter());
-        //         let as_tuples: HasUnboundedSortedAttributeSingle =
-        //             iterator.map::<Result<Tuple<'_>, _>, _>(has_to_tuple_attribute_owner);
-        //         Ok(TupleIterator::HasUnboundedInvertedSingle(SortedTupleIterator::new(
-        //             as_tuples,
-        //             self.tuple_positions.clone(),
-        //             &self.variable_modes,
-        //         )))
-        //     } else {
-        //         // // TODO: we could create a reusable space for these temporarily held iterators so we don't have allocate again before the merging iterator
-        //         let mut iterators: Vec<Peekable<HasIterator>> =
-        //             Vec::with_capacity(self.owner_cache.as_ref().unwrap().len());
-        //         for iter in self.owner_cache.as_ref().unwrap().iter().map(|object| {
-        //             object.get_has_types_range_unordered(
-        //                 snapshot,
-        //                 thing_manager,
-        //                 self.attribute_types.iter().map(|t| t.as_attribute_type()),
-        //             )
-        //         }) {
-        //             iterators.push(Peekable::new(iter?))
-        //         }
-        //
-        //         // note: this will always have to heap alloc, if we use don't have a re-usable/small-vec'ed priority queue somewhere
-        //         let merged: KMergeBy<HasIterator, crate::executor::instruction::has_executor::HasOrderByAttributeFn> =
-        //             KMergeBy::new(iterators, Self::compare_has_by_attribute_then_owner);
-        //         let filtered: Filter<KMergeBy<HasIterator, crate::executor::instruction::has_executor::HasOrderByAttributeFn>, Arc<crate::executor::instruction::has_executor::HasFilterAttributeFn>> =
-        //             merged.filter::<_, crate::executor::instruction::has_executor::HasFilterAttributeFn>(self.filter_fn.has_attribute_filter());
-        //         let as_tuples: HasUnboundedSortedAttributeMerged =
-        //             filtered.map::<Result<Tuple<'_>, _>, _>(has_to_tuple_attribute_owner);
-        //         Ok(TupleIterator::HasUnboundedInvertedMerged(SortedTupleIterator::new(
-        //             as_tuples,
-        //             self.tuple_positions.clone(),
-        //             &self.variable_modes,
-        //         )))
-        //     }
-        // }
-        // BinaryIterateMode::BoundFrom => {
-        //     debug_assert!(row.width() > self.has.owner().as_usize());
-        //     let owner = row.get(self.has.owner());
-        //     let iterator = match owner {
-        //         VariableValue::Thing(Thing::Entity(entity)) => entity.get_has_types_range_unordered(
-        //             snapshot,
-        //             thing_manager,
-        //             self.attribute_types.iter().map(|t| t.as_attribute_type()),
-        //         )?,
-        //         VariableValue::Thing(Thing::Relation(relation)) => relation.get_has_types_range_unordered(
-        //             snapshot,
-        //             thing_manager,
-        //             self.attribute_types.iter().map(|t| t.as_attribute_type()),
-        //         )?,
-        //         _ => unreachable!("Has owner must be an entity or relation."),
-        //     };
-        //     let filtered = iterator.filter::<_, crate::executor::instruction::has_executor::HasFilterAttributeFn>(self.filter_fn.has_attribute_filter());
-        //     let as_tuples: HasBoundedSortedAttribute =
-        //         filtered.map::<Result<Tuple<'_>, _>, _>(has_to_tuple_owner_attribute);
-        //     Ok(TupleIterator::HasBounded(SortedTupleIterator::new(
-        //         as_tuples,
-        //         self.tuple_positions.clone(),
-        //         &self.variable_modes,
-        //     )))
-        // }
-        todo!()
+        match self.iterate_mode {
+            BinaryIterateMode::Unbound => {
+                let attribute_types_in_range = self.attribute_owner_types.keys()
+                    .map(|type_| type_.as_attribute_type());
+                let filter_fn = self.filter_fn.clone();
+                // TODO: we could cache the range byte arrays computed inside the thing_manager, for this case
+                let iterator: Filter<HasReverseIterator, Arc<HasFilterFn>> = thing_manager
+                    .get_has_from_attribute_type_range(snapshot, attribute_types_in_range)?
+                    .filter::<_, HasFilterFn>(filter_fn);
+                let as_tuples: Map<Filter<HasReverseIterator, Arc<HasFilterFn>>, HasToTupleFn, TupleResult> =
+                    iterator.map::<Result<Tuple<'_>, _>, _>(has_to_tuple_attribute_owner);
+                Ok(TupleIterator::HasReverseUnbounded(SortedTupleIterator::new(
+                    as_tuples,
+                    self.tuple_positions.clone(),
+                    &self.variable_modes,
+                )))
+            }
+            BinaryIterateMode::UnboundInverted => {
+                debug_assert!(self.attribute_cache.is_some());
+                if let Some([attr]) = self.attribute_cache.as_deref() {
+                    let (min_owner_type, max_owner_type) = Self::min_max_types(self.owner_types.iter());
+                    let type_range = KeyRange::new_inclusive(min_owner_type.as_object_type(), max_owner_type.as_object_type());
+                    // no heap allocs needed if there is only 1 iterator
+                    let iterator = attr
+                        .get_owners_by_type_range(
+                            snapshot,
+                            thing_manager,
+                            type_range,
+                        )
+                        .filter::<_, HasFilterFn>(self.filter_fn.clone());
+                    let as_tuples: HasReverseUnboundedSortedOwnerSingle =
+                        iterator.map::<Result<Tuple<'_>, _>, _>(has_to_tuple_owner_attribute);
+                    Ok(TupleIterator::HasReverseUnboundedInvertedSingle(SortedTupleIterator::new(
+                        as_tuples,
+                        self.tuple_positions.clone(),
+                        &self.variable_modes,
+                    )))
+                } else {
+                    // // TODO: we could create a reusable space for these temporarily held iterators so we don't have allocate again before the merging iterator
+                    let mut iterators: Vec<Peekable<HasReverseIterator>> =
+                        Vec::with_capacity(self.attribute_cache.as_ref().unwrap().len());
+                    let (min_owner_type, max_owner_type) = Self::min_max_types(self.owner_types.iter());
+                    let type_range = KeyRange::new_inclusive(min_owner_type.as_object_type(), max_owner_type.as_object_type());
+                    for iter in self.attribute_cache.as_ref().unwrap().iter().map(|attribute| {
+                        attribute.get_owners_by_type_range(
+                            snapshot,
+                            thing_manager,
+                            type_range.clone(),
+                        )
+                    }) {
+                        iterators.push(Peekable::new(iter))
+                    }
+
+                    // note: this will always have to heap alloc, if we use don't have a re-usable/small-vec'ed priority queue somewhere
+                    let merged: KMergeBy<HasReverseIterator, HasOrderingFn> =
+                        KMergeBy::new(iterators, Self::compare_has_by_owner_then_attribute);
+                    let filtered: Filter<KMergeBy<HasReverseIterator, HasOrderingFn>, Arc<HasFilterFn>> =
+                        merged.filter::<_, HasFilterFn>(self.filter_fn.clone());
+                    let as_tuples: HasReverseUnboundedSortedOwnerMerged =
+                        filtered.map::<Result<Tuple<'_>, _>, _>(has_to_tuple_owner_attribute);
+                    Ok(TupleIterator::HasReverseUnboundedInvertedMerged(SortedTupleIterator::new(
+                        as_tuples,
+                        self.tuple_positions.clone(),
+                        &self.variable_modes,
+                    )))
+                }
+            }
+            BinaryIterateMode::BoundFrom => {
+                debug_assert!(row.width() > self.has.attribute().as_usize());
+                let attribute = row.get(self.has.attribute());
+                let (min_owner_type, max_owner_type) = Self::min_max_types(self.owner_types.iter());
+                let type_range = KeyRange::new_inclusive(min_owner_type.as_object_type(), max_owner_type.as_object_type());
+                let iterator = attribute.as_thing().as_attribute().get_owners_by_type_range(
+                    snapshot,
+                    thing_manager,
+                    type_range
+                );
+                let filtered = iterator.filter::<_, HasFilterFn>(self.filter_fn.clone());
+                let as_tuples: HasReverseBoundedSortedOwner =
+                    filtered.map::<Result<Tuple<'_>, _>, _>(has_to_tuple_attribute_owner);
+                Ok(TupleIterator::HasReverseBounded(SortedTupleIterator::new(
+                    as_tuples,
+                    self.tuple_positions.clone(),
+                    &self.variable_modes,
+                )))
+            }
+        }
     }
 
-    fn compare_has_by_attribute_then_owner<'a, 'b>(
-        pair: (&'a Result<(concept::thing::has::Has<'a>, u64), ConceptReadError>, &'b Result<(concept::thing::has::Has<'b>, u64), ConceptReadError>),
+    fn min_max_types<'a>(types: impl Iterator<Item=&'a Type>) -> (Type, Type) {
+        let mut min = None;
+        let mut max = None;
+        for type_ in types {
+            if min.is_none() || min.as_ref().is_some_and(|min_type| min_type > type_) {
+                min = Some(type_.clone())
+            };
+            if max.is_none() || max.as_ref().is_some_and(|max_type| max_type < type_) {
+                max = Some(type_.clone())
+            };
+        }
+        debug_assert!(min.is_some() && max.is_some());
+        (min.unwrap(), max.unwrap())
+    }
+
+    fn create_has_filter_attributes_owners(
+        attributes_owner_types: Arc<BTreeMap<Type, Vec<Type>>>,
+        owner_types: Arc<HashSet<Type>>,
+    ) -> Arc<HasFilterFn> {
+        Arc::new({
+            move |result: &Result<(Has<'_>, u64), ConceptReadError>| match result {
+                Ok((has, _)) => {
+                    attributes_owner_types.contains_key(&Type::from(has.attribute().type_()))
+                        && owner_types.contains(&Type::from(has.owner().type_()))
+                }
+                Err(_) => true,
+            }
+        }) as Arc<HasFilterFn>
+    }
+
+    fn create_has_filter_owners(
+        owner_types: Arc<HashSet<Type>>
+    ) -> Arc<HasFilterFn> {
+        Arc::new({
+            move |result: &Result<(Has<'_>, u64), ConceptReadError>| match result {
+                Ok((has, _)) => owner_types.contains(&Type::from(has.owner().type_())),
+                Err(_) => true,
+            }
+        }) as Arc<HasFilterFn>
+    }
+
+    fn compare_has_by_owner_then_attribute<'a, 'b>(
+        pair: (&'a Result<(Has<'a>, u64), ConceptReadError>, &'b Result<(Has<'b>, u64), ConceptReadError>),
     ) -> Ordering {
         let (result_1, result_2) = pair;
         match (result_1, result_2) {
             (Ok((has_1, _)), Ok((has_2, _))) => {
-                has_1.attribute().cmp(&has_2.attribute()).then(has_1.owner().cmp(&has_2.owner()))
+                has_1.owner().cmp(&has_2.owner()).then(has_1.attribute().cmp(&has_2.attribute()))
             }
             _ => Ordering::Equal,
         }

--- a/traversal/executor/instruction/has_reverse_executor.rs
+++ b/traversal/executor/instruction/has_reverse_executor.rs
@@ -4,29 +4,37 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-use std::cmp::Ordering;
-use std::collections::{BTreeMap, HashSet};
-use std::sync::Arc;
+use std::{
+    cmp::Ordering,
+    collections::{BTreeMap, HashSet},
+    sync::Arc,
+};
 
 use answer::Type;
-use concept::error::ConceptReadError;
-use concept::thing::attribute::Attribute;
-use concept::thing::has::Has;
-use concept::thing::object::{HasIterator, HasReverseIterator};
-use concept::thing::thing_manager::ThingManager;
-use lending_iterator::adaptors::{Filter, Map};
-use lending_iterator::{AsHkt, LendingIterator, Peekable};
-use lending_iterator::kmerge::KMergeBy;
-use resource::constants::traversal::CONSTANT_CONCEPT_LIMIT;
-use storage::key_range::KeyRange;
-use storage::snapshot::ReadableSnapshot;
+use concept::{
+    error::ConceptReadError,
+    thing::{attribute::Attribute, has::Has, object::HasReverseIterator, thing_manager::ThingManager},
+};
+use lending_iterator::{
+    adaptors::{Filter, Map},
+    kmerge::KMergeBy,
+    AsHkt, LendingIterator, Peekable,
+};
+use storage::{key_range::KeyRange, snapshot::ReadableSnapshot};
 
-use crate::executor::batch::ImmutableRow;
-use crate::executor::instruction::{BinaryIterateMode, VariableModes};
-use crate::executor::instruction::has_executor::{HasFilterFn, HasOrderingFn};
-use crate::executor::instruction::iterator::{inverted_instances_cache, SortedTupleIterator, TupleIterator};
-use crate::executor::instruction::tuple::{has_to_tuple_attribute_owner, has_to_tuple_owner_attribute, HasToTupleFn, Tuple, TuplePositions, TupleResult};
-use crate::executor::VariablePosition;
+use crate::executor::{
+    batch::ImmutableRow,
+    instruction::{
+        has_executor::{HasFilterFn, HasOrderingFn},
+        iterator::{inverted_instances_cache, SortedTupleIterator, TupleIterator},
+        tuple::{
+            has_to_tuple_attribute_owner, has_to_tuple_owner_attribute, HasToTupleFn, Tuple, TuplePositions,
+            TupleResult,
+        },
+        BinaryIterateMode, VariableModes,
+    },
+    VariablePosition,
+};
 
 pub(crate) struct HasReverseIteratorExecutor {
     has: ir::pattern::constraint::Has<VariablePosition>,
@@ -40,17 +48,13 @@ pub(crate) struct HasReverseIteratorExecutor {
 }
 
 pub(crate) type HasReverseUnboundedSortedAttribute =
-Map<Filter<HasReverseIterator, Arc<HasFilterFn>>, HasToTupleFn, AsHkt![TupleResult<'_>]>;
-pub(crate) type HasReverseUnboundedSortedOwnerMerged = Map<
-    Filter<KMergeBy<HasReverseIterator, HasOrderingFn>, Arc<HasFilterFn>>,
-    HasToTupleFn,
-    AsHkt![TupleResult<'_>],
->;
+    Map<Filter<HasReverseIterator, Arc<HasFilterFn>>, HasToTupleFn, AsHkt![TupleResult<'_>]>;
+pub(crate) type HasReverseUnboundedSortedOwnerMerged =
+    Map<Filter<KMergeBy<HasReverseIterator, HasOrderingFn>, Arc<HasFilterFn>>, HasToTupleFn, AsHkt![TupleResult<'_>]>;
 pub(crate) type HasReverseUnboundedSortedOwnerSingle =
-Map<Filter<HasReverseIterator, Arc<HasFilterFn>>, HasToTupleFn, AsHkt![TupleResult<'_>]>;
+    Map<Filter<HasReverseIterator, Arc<HasFilterFn>>, HasToTupleFn, AsHkt![TupleResult<'_>]>;
 pub(crate) type HasReverseBoundedSortedOwner =
-Map<Filter<HasReverseIterator, Arc<HasFilterFn>>, HasToTupleFn, AsHkt![TupleResult<'_>]>;
-
+    Map<Filter<HasReverseIterator, Arc<HasFilterFn>>, HasToTupleFn, AsHkt![TupleResult<'_>]>;
 
 impl HasReverseIteratorExecutor {
     pub(crate) fn new<Snapshot: ReadableSnapshot>(
@@ -81,7 +85,9 @@ impl HasReverseIteratorExecutor {
 
         let attribute_cache = if matches!(iterate_mode, BinaryIterateMode::UnboundInverted) {
             Some(inverted_instances_cache(
-                attribute_owner_types.keys().map(|type_| type_.as_attribute_type()), snapshot, thing_manager,
+                attribute_owner_types.keys().map(|type_| type_.as_attribute_type()),
+                snapshot,
+                thing_manager,
             )?)
         } else {
             None
@@ -106,8 +112,7 @@ impl HasReverseIteratorExecutor {
     ) -> Result<TupleIterator, ConceptReadError> {
         match self.iterate_mode {
             BinaryIterateMode::Unbound => {
-                let attribute_types_in_range = self.attribute_owner_types.keys()
-                    .map(|type_| type_.as_attribute_type());
+                let attribute_types_in_range = self.attribute_owner_types.keys().map(|type_| type_.as_attribute_type());
                 let filter_fn = self.filter_fn.clone();
                 // TODO: we could cache the range byte arrays computed inside the thing_manager, for this case
                 let iterator: Filter<HasReverseIterator, Arc<HasFilterFn>> = thing_manager
@@ -125,14 +130,11 @@ impl HasReverseIteratorExecutor {
                 debug_assert!(self.attribute_cache.is_some());
                 if let Some([attr]) = self.attribute_cache.as_deref() {
                     let (min_owner_type, max_owner_type) = Self::min_max_types(self.owner_types.iter());
-                    let type_range = KeyRange::new_inclusive(min_owner_type.as_object_type(), max_owner_type.as_object_type());
+                    let type_range =
+                        KeyRange::new_inclusive(min_owner_type.as_object_type(), max_owner_type.as_object_type());
                     // no heap allocs needed if there is only 1 iterator
                     let iterator = attr
-                        .get_owners_by_type_range(
-                            snapshot,
-                            thing_manager,
-                            type_range,
-                        )
+                        .get_owners_by_type_range(snapshot, thing_manager, type_range)
                         .filter::<_, HasFilterFn>(self.filter_fn.clone());
                     let as_tuples: HasReverseUnboundedSortedOwnerSingle =
                         iterator.map::<Result<Tuple<'_>, _>, _>(has_to_tuple_owner_attribute);
@@ -146,13 +148,10 @@ impl HasReverseIteratorExecutor {
                     let mut iterators: Vec<Peekable<HasReverseIterator>> =
                         Vec::with_capacity(self.attribute_cache.as_ref().unwrap().len());
                     let (min_owner_type, max_owner_type) = Self::min_max_types(self.owner_types.iter());
-                    let type_range = KeyRange::new_inclusive(min_owner_type.as_object_type(), max_owner_type.as_object_type());
+                    let type_range =
+                        KeyRange::new_inclusive(min_owner_type.as_object_type(), max_owner_type.as_object_type());
                     for iter in self.attribute_cache.as_ref().unwrap().iter().map(|attribute| {
-                        attribute.get_owners_by_type_range(
-                            snapshot,
-                            thing_manager,
-                            type_range.clone(),
-                        )
+                        attribute.get_owners_by_type_range(snapshot, thing_manager, type_range.clone())
                     }) {
                         iterators.push(Peekable::new(iter))
                     }
@@ -175,12 +174,10 @@ impl HasReverseIteratorExecutor {
                 debug_assert!(row.width() > self.has.attribute().as_usize());
                 let attribute = row.get(self.has.attribute());
                 let (min_owner_type, max_owner_type) = Self::min_max_types(self.owner_types.iter());
-                let type_range = KeyRange::new_inclusive(min_owner_type.as_object_type(), max_owner_type.as_object_type());
-                let iterator = attribute.as_thing().as_attribute().get_owners_by_type_range(
-                    snapshot,
-                    thing_manager,
-                    type_range
-                );
+                let type_range =
+                    KeyRange::new_inclusive(min_owner_type.as_object_type(), max_owner_type.as_object_type());
+                let iterator =
+                    attribute.as_thing().as_attribute().get_owners_by_type_range(snapshot, thing_manager, type_range);
                 let filtered = iterator.filter::<_, HasFilterFn>(self.filter_fn.clone());
                 let as_tuples: HasReverseBoundedSortedOwner =
                     filtered.map::<Result<Tuple<'_>, _>, _>(has_to_tuple_attribute_owner);
@@ -193,7 +190,7 @@ impl HasReverseIteratorExecutor {
         }
     }
 
-    fn min_max_types<'a>(types: impl Iterator<Item=&'a Type>) -> (Type, Type) {
+    fn min_max_types<'a>(types: impl Iterator<Item = &'a Type>) -> (Type, Type) {
         let mut min = None;
         let mut max = None;
         for type_ in types {
@@ -223,9 +220,7 @@ impl HasReverseIteratorExecutor {
         }) as Arc<HasFilterFn>
     }
 
-    fn create_has_filter_owners(
-        owner_types: Arc<HashSet<Type>>
-    ) -> Arc<HasFilterFn> {
+    fn create_has_filter_owners(owner_types: Arc<HashSet<Type>>) -> Arc<HasFilterFn> {
         Arc::new({
             move |result: &Result<(Has<'_>, u64), ConceptReadError>| match result {
                 Ok((has, _)) => owner_types.contains(&Type::from(has.owner().type_())),
@@ -246,4 +241,3 @@ impl HasReverseIteratorExecutor {
         }
     }
 }
-

--- a/traversal/executor/instruction/isa_reverse_executor.rs
+++ b/traversal/executor/instruction/isa_reverse_executor.rs
@@ -12,14 +12,14 @@ use std::{
 use answer::Type;
 use concept::{
     error::ConceptReadError,
+    iterator::InstanceIterator,
     thing::{
         attribute::{Attribute, AttributeIterator},
-        entity::{Entity},
-        relation::{Relation},
+        entity::Entity,
+        relation::Relation,
         thing_manager::ThingManager,
     },
 };
-use concept::iterator::InstanceIterator;
 use ir::pattern::constraint::Isa;
 use lending_iterator::{adaptors::Map, AsHkt, LendingIterator};
 use resource::constants::traversal::CONSTANT_CONCEPT_LIMIT;
@@ -33,11 +33,10 @@ use crate::executor::{
             isa_attribute_to_tuple_thing_type, isa_entity_to_tuple_thing_type, isa_relation_to_tuple_thing_type,
             TuplePositions, TupleResult,
         },
-        VariableModes,
+        BinaryIterateMode, VariableModes,
     },
     VariablePosition,
 };
-use crate::executor::instruction::BinaryIterateMode;
 
 pub(crate) struct IsaReverseExecutor {
     isa: Isa<VariablePosition>,
@@ -49,7 +48,8 @@ pub(crate) struct IsaReverseExecutor {
     type_cache: Option<Arc<HashSet<Type>>>,
 }
 
-pub(crate) type IsaUnboundedSortedThingEntitySingle = Map<InstanceIterator<AsHkt![Entity<'_>]>, EntityToTupleFn, AsHkt![TupleResult<'_>]>;
+pub(crate) type IsaUnboundedSortedThingEntitySingle =
+    Map<InstanceIterator<AsHkt![Entity<'_>]>, EntityToTupleFn, AsHkt![TupleResult<'_>]>;
 pub(crate) type IsaUnboundedSortedThingRelationSingle =
     Map<InstanceIterator<AsHkt![Relation<'_>]>, RelationToTupleFn, AsHkt![TupleResult<'_>]>;
 pub(crate) type IsaUnboundedSortedThingAttributeSingle =

--- a/traversal/executor/instruction/isa_reverse_executor.rs
+++ b/traversal/executor/instruction/isa_reverse_executor.rs
@@ -14,11 +14,12 @@ use concept::{
     error::ConceptReadError,
     thing::{
         attribute::{Attribute, AttributeIterator},
-        entity::{Entity, EntityIterator},
-        relation::{Relation, RelationIterator},
+        entity::{Entity},
+        relation::{Relation},
         thing_manager::ThingManager,
     },
 };
+use concept::iterator::InstanceIterator;
 use ir::pattern::constraint::Isa;
 use lending_iterator::{adaptors::Map, AsHkt, LendingIterator};
 use resource::constants::traversal::CONSTANT_CONCEPT_LIMIT;
@@ -48,11 +49,11 @@ pub(crate) struct IsaReverseExecutor {
     type_cache: Option<Arc<HashSet<Type>>>,
 }
 
-pub(crate) type IsaUnboundedSortedThingEntitySingle = Map<EntityIterator, EntityToTupleFn, AsHkt![TupleResult<'_>]>;
+pub(crate) type IsaUnboundedSortedThingEntitySingle = Map<InstanceIterator<AsHkt![Entity<'_>]>, EntityToTupleFn, AsHkt![TupleResult<'_>]>;
 pub(crate) type IsaUnboundedSortedThingRelationSingle =
-    Map<RelationIterator, RelationToTupleFn, AsHkt![TupleResult<'_>]>;
+    Map<InstanceIterator<AsHkt![Relation<'_>]>, RelationToTupleFn, AsHkt![TupleResult<'_>]>;
 pub(crate) type IsaUnboundedSortedThingAttributeSingle =
-    Map<AttributeIterator, AttributeToTupleFn, AsHkt![TupleResult<'_>]>;
+    Map<AttributeIterator<InstanceIterator<AsHkt![Attribute<'_>]>>, AttributeToTupleFn, AsHkt![TupleResult<'_>]>;
 
 type EntityToTupleFn = for<'a> fn(Result<Entity<'a>, ConceptReadError>) -> TupleResult<'a>;
 type RelationToTupleFn = for<'a> fn(Result<Relation<'a>, ConceptReadError>) -> TupleResult<'a>;

--- a/traversal/executor/instruction/isa_reverse_executor.rs
+++ b/traversal/executor/instruction/isa_reverse_executor.rs
@@ -48,12 +48,6 @@ pub(crate) struct IsaReverseExecutor {
     type_cache: Option<Arc<HashSet<Type>>>,
 }
 
-enum IterateMode {
-    UnboundSortedFrom,
-    UnboundSortedTo,
-    BoundFromSortedTo,
-}
-
 pub(crate) type IsaUnboundedSortedThingEntitySingle = Map<EntityIterator, EntityToTupleFn, AsHkt![TupleResult<'_>]>;
 pub(crate) type IsaUnboundedSortedThingRelationSingle =
     Map<RelationIterator, RelationToTupleFn, AsHkt![TupleResult<'_>]>;

--- a/traversal/executor/instruction/iterator.rs
+++ b/traversal/executor/instruction/iterator.rs
@@ -5,10 +5,13 @@
  */
 
 use std::{cmp::Ordering, iter::Iterator, ops::Range};
+use answer::Type;
 
 use answer::variable_value::VariableValue;
 use concept::error::ConceptReadError;
+use concept::type_::{KindAPI, ThingTypeAPI};
 use lending_iterator::{LendingIterator, Peekable};
+use resource::constants::traversal::CONSTANT_CONCEPT_LIMIT;
 
 use crate::executor::{
     batch::Row,
@@ -354,6 +357,26 @@ impl<Iterator: for<'a> LendingIterator<Item<'a> = TupleResult<'a>>> TupleIterato
     fn positions(&self) -> &TuplePositions {
         &self.positions
     }
+}
+
+fn inverted_instances_cache<'a, T: ThingTypeAPI<'a>>(type_: T) {
+    todo!()
+    // let mut cache = Vec::new();
+    // match type_.into() {
+    //     Type::Entity(_) => {}
+    //     Type::Relation(_) => {}
+    //     Type::Attribute(_) => {}
+    //     Type::RoleType(_) => unreachable!("Cannot retrieve instances of role type"),
+    // }
+    // for attr_type in attribute_owner_types.keys() {
+    //     for attr in thing_manager
+    //         .get_attributes_in(snapshot, attr_type.as_attribute_type())?
+    //         .map_static(|result| result.map(|attr| attr.clone().into_owned()))
+    //         .into_iter() {
+    //         cache.push(attr?);
+    //     }
+    // }
+    // debug_assert!(cache.len() < CONSTANT_CONCEPT_LIMIT);
 }
 
 fn first_unbound(variable_modes: &VariableModes, positions: &TuplePositions) -> TupleIndex {

--- a/traversal/executor/instruction/iterator.rs
+++ b/traversal/executor/instruction/iterator.rs
@@ -7,11 +7,11 @@
 use std::{cmp::Ordering, iter::Iterator, ops::Range};
 
 use answer::variable_value::VariableValue;
-use concept::error::ConceptReadError;
-use concept::thing::{HKInstance, ThingAPI};
-use concept::thing::thing_manager::ThingManager;
-use lending_iterator::{LendingIterator, Peekable};
-use lending_iterator::higher_order::Hkt;
+use concept::{
+    error::ConceptReadError,
+    thing::{thing_manager::ThingManager, HKInstance, ThingAPI},
+};
+use lending_iterator::{higher_order::Hkt, LendingIterator, Peekable};
 use resource::constants::traversal::CONSTANT_CONCEPT_LIMIT;
 use storage::snapshot::ReadableSnapshot;
 
@@ -22,6 +22,10 @@ use crate::executor::{
             HasBoundedSortedAttribute, HasUnboundedSortedAttributeMerged, HasUnboundedSortedAttributeSingle,
             HasUnboundedSortedOwner,
         },
+        has_reverse_executor::{
+            HasReverseBoundedSortedOwner, HasReverseUnboundedSortedAttribute, HasReverseUnboundedSortedOwnerMerged,
+            HasReverseUnboundedSortedOwnerSingle,
+        },
         isa_reverse_executor::{
             IsaUnboundedSortedThingAttributeSingle, IsaUnboundedSortedThingEntitySingle,
             IsaUnboundedSortedThingRelationSingle,
@@ -30,7 +34,6 @@ use crate::executor::{
         VariableMode, VariableModes,
     },
 };
-use crate::executor::instruction::has_reverse_executor::{HasReverseBoundedSortedOwner, HasReverseUnboundedSortedAttribute, HasReverseUnboundedSortedOwnerMerged, HasReverseUnboundedSortedOwnerSingle};
 
 // TODO: the 'check' can deduplicate against all relevant variables as soon as an anonymous variable is no longer relevant.
 //       if the deduplicated answer leads to an answer, we should not re-emit it again (we will rediscover the same answers)
@@ -64,58 +67,64 @@ macro_rules! dispatch_tuple_iterator {
 
 impl TupleIterator {
     pub(crate) fn write_values(&mut self, row: &mut Row<'_>) {
-        dispatch_tuple_iterator!(self, [
-            IsaEntityInvertedSingle,
-            IsaRelationInvertedSingle,
-            IsaAttributeInvertedSingle,
-
-            HasUnbounded,
-            HasUnboundedInvertedSingle,
-            HasUnboundedInvertedMerged,
-            HasBounded,
-
-            HasReverseUnbounded,
-            HasReverseUnboundedInvertedSingle,
-            HasReverseUnboundedInvertedMerged,
-            HasReverseBounded,
-        ], iter.write_values(row))
+        dispatch_tuple_iterator!(
+            self,
+            [
+                IsaEntityInvertedSingle,
+                IsaRelationInvertedSingle,
+                IsaAttributeInvertedSingle,
+                HasUnbounded,
+                HasUnboundedInvertedSingle,
+                HasUnboundedInvertedMerged,
+                HasBounded,
+                HasReverseUnbounded,
+                HasReverseUnboundedInvertedSingle,
+                HasReverseUnboundedInvertedMerged,
+                HasReverseBounded,
+            ],
+            iter.write_values(row)
+        )
     }
 
     pub(crate) fn peek(&mut self) -> Option<Result<&Tuple<'_>, ConceptReadError>> {
-        let value = dispatch_tuple_iterator!(self, [
-            IsaEntityInvertedSingle,
-            IsaRelationInvertedSingle,
-            IsaAttributeInvertedSingle,
-
-            HasUnbounded,
-            HasUnboundedInvertedSingle,
-            HasUnboundedInvertedMerged,
-            HasBounded,
-
-            HasReverseUnbounded,
-            HasReverseUnboundedInvertedSingle,
-            HasReverseUnboundedInvertedMerged,
-            HasReverseBounded,
-        ], iter.peek());
+        let value = dispatch_tuple_iterator!(
+            self,
+            [
+                IsaEntityInvertedSingle,
+                IsaRelationInvertedSingle,
+                IsaAttributeInvertedSingle,
+                HasUnbounded,
+                HasUnboundedInvertedSingle,
+                HasUnboundedInvertedMerged,
+                HasBounded,
+                HasReverseUnbounded,
+                HasReverseUnboundedInvertedSingle,
+                HasReverseUnboundedInvertedMerged,
+                HasReverseBounded,
+            ],
+            iter.peek()
+        );
         value.map(|result| result.as_ref().map_err(|err| err.clone()))
     }
 
     pub(crate) fn advance_past(&mut self) -> Result<usize, ConceptReadError> {
-        dispatch_tuple_iterator!(self, [
-            IsaEntityInvertedSingle,
-            IsaRelationInvertedSingle,
-            IsaAttributeInvertedSingle,
-
-            HasUnbounded,
-            HasUnboundedInvertedSingle,
-            HasUnboundedInvertedMerged,
-            HasBounded,
-
-            HasReverseUnbounded,
-            HasReverseUnboundedInvertedSingle,
-            HasReverseUnboundedInvertedMerged,
-            HasReverseBounded,
-        ], iter.advance_past())
+        dispatch_tuple_iterator!(
+            self,
+            [
+                IsaEntityInvertedSingle,
+                IsaRelationInvertedSingle,
+                IsaAttributeInvertedSingle,
+                HasUnbounded,
+                HasUnboundedInvertedSingle,
+                HasUnboundedInvertedMerged,
+                HasBounded,
+                HasReverseUnbounded,
+                HasReverseUnboundedInvertedSingle,
+                HasReverseUnboundedInvertedMerged,
+                HasReverseBounded,
+            ],
+            iter.advance_past()
+        )
     }
 
     pub(crate) fn advance_until_index_is(
@@ -123,75 +132,83 @@ impl TupleIterator {
         index: TupleIndex,
         value: &VariableValue<'_>,
     ) -> Result<Option<Ordering>, ConceptReadError> {
-        dispatch_tuple_iterator!(self, [
-            IsaEntityInvertedSingle,
-            IsaRelationInvertedSingle,
-            IsaAttributeInvertedSingle,
-
-            HasUnbounded,
-            HasUnboundedInvertedSingle,
-            HasUnboundedInvertedMerged,
-            HasBounded,
-
-            HasReverseUnbounded,
-            HasReverseUnboundedInvertedSingle,
-            HasReverseUnboundedInvertedMerged,
-            HasReverseBounded,
-        ], iter.skip_until_value(index, value))
+        dispatch_tuple_iterator!(
+            self,
+            [
+                IsaEntityInvertedSingle,
+                IsaRelationInvertedSingle,
+                IsaAttributeInvertedSingle,
+                HasUnbounded,
+                HasUnboundedInvertedSingle,
+                HasUnboundedInvertedMerged,
+                HasBounded,
+                HasReverseUnbounded,
+                HasReverseUnboundedInvertedSingle,
+                HasReverseUnboundedInvertedMerged,
+                HasReverseBounded,
+            ],
+            iter.skip_until_value(index, value)
+        )
     }
 
     pub(crate) fn advance_single(&mut self) -> Result<(), ConceptReadError> {
-        dispatch_tuple_iterator!(self, [
-            IsaEntityInvertedSingle,
-            IsaRelationInvertedSingle,
-            IsaAttributeInvertedSingle,
-
-            HasUnbounded,
-            HasUnboundedInvertedSingle,
-            HasUnboundedInvertedMerged,
-            HasBounded,
-
-            HasReverseUnbounded,
-            HasReverseUnboundedInvertedSingle,
-            HasReverseUnboundedInvertedMerged,
-            HasReverseBounded,
-        ], iter.advance_single())
+        dispatch_tuple_iterator!(
+            self,
+            [
+                IsaEntityInvertedSingle,
+                IsaRelationInvertedSingle,
+                IsaAttributeInvertedSingle,
+                HasUnbounded,
+                HasUnboundedInvertedSingle,
+                HasUnboundedInvertedMerged,
+                HasBounded,
+                HasReverseUnbounded,
+                HasReverseUnboundedInvertedSingle,
+                HasReverseUnboundedInvertedMerged,
+                HasReverseBounded,
+            ],
+            iter.advance_single()
+        )
     }
 
     pub(crate) fn peek_first_unbound_value(&mut self) -> Option<Result<&VariableValue<'_>, ConceptReadError>> {
-        dispatch_tuple_iterator!(self, [
-            IsaEntityInvertedSingle,
-            IsaRelationInvertedSingle,
-            IsaAttributeInvertedSingle,
-
-            HasUnbounded,
-            HasUnboundedInvertedSingle,
-            HasUnboundedInvertedMerged,
-            HasBounded,
-
-            HasReverseUnbounded,
-            HasReverseUnboundedInvertedSingle,
-            HasReverseUnboundedInvertedMerged,
-            HasReverseBounded,
-        ], iter.peek_first_unbound_value())
+        dispatch_tuple_iterator!(
+            self,
+            [
+                IsaEntityInvertedSingle,
+                IsaRelationInvertedSingle,
+                IsaAttributeInvertedSingle,
+                HasUnbounded,
+                HasUnboundedInvertedSingle,
+                HasUnboundedInvertedMerged,
+                HasBounded,
+                HasReverseUnbounded,
+                HasReverseUnboundedInvertedSingle,
+                HasReverseUnboundedInvertedMerged,
+                HasReverseBounded,
+            ],
+            iter.peek_first_unbound_value()
+        )
     }
 
     pub(crate) fn first_unbound_index(&self) -> TupleIndex {
-        dispatch_tuple_iterator!(self, [
-            IsaEntityInvertedSingle,
-            IsaRelationInvertedSingle,
-            IsaAttributeInvertedSingle,
-
-            HasUnbounded,
-            HasUnboundedInvertedSingle,
-            HasUnboundedInvertedMerged,
-            HasBounded,
-
-            HasReverseUnbounded,
-            HasReverseUnboundedInvertedSingle,
-            HasReverseUnboundedInvertedMerged,
-            HasReverseBounded,
-        ], iter.first_unbound_index())
+        dispatch_tuple_iterator!(
+            self,
+            [
+                IsaEntityInvertedSingle,
+                IsaRelationInvertedSingle,
+                IsaAttributeInvertedSingle,
+                HasUnbounded,
+                HasUnboundedInvertedSingle,
+                HasUnboundedInvertedMerged,
+                HasBounded,
+                HasReverseUnbounded,
+                HasReverseUnboundedInvertedSingle,
+                HasReverseUnboundedInvertedMerged,
+                HasReverseBounded,
+            ],
+            iter.first_unbound_index()
+        )
     }
 }
 
@@ -208,7 +225,7 @@ pub(crate) trait TupleIteratorAPI {
     fn positions(&self) -> &TuplePositions;
 }
 
-pub(crate) struct SortedTupleIterator<Iterator: for<'a> LendingIterator<Item<'a>=TupleResult<'a>>> {
+pub(crate) struct SortedTupleIterator<Iterator: for<'a> LendingIterator<Item<'a> = TupleResult<'a>>> {
     iterator: Peekable<Iterator>,
     positions: TuplePositions,
     tuple_length: usize,
@@ -217,7 +234,7 @@ pub(crate) struct SortedTupleIterator<Iterator: for<'a> LendingIterator<Item<'a>
     enumerate_or_count_range: Range<TupleIndex>,
 }
 
-impl<Iterator: for<'a> LendingIterator<Item<'a>=TupleResult<'a>>> SortedTupleIterator<Iterator> {
+impl<Iterator: for<'a> LendingIterator<Item<'a> = TupleResult<'a>>> SortedTupleIterator<Iterator> {
     pub(crate) fn new(iterator: Iterator, tuple_positions: TuplePositions, variable_modes: &VariableModes) -> Self {
         let first_unbound = first_unbound(variable_modes, &tuple_positions);
         let enumerate_range = enumerated_range(variable_modes, &tuple_positions);
@@ -313,7 +330,7 @@ impl<Iterator: for<'a> LendingIterator<Item<'a>=TupleResult<'a>>> SortedTupleIte
     }
 }
 
-impl<Iterator: for<'a> LendingIterator<Item<'a>=TupleResult<'a>>> TupleIteratorAPI for SortedTupleIterator<Iterator> {
+impl<Iterator: for<'a> LendingIterator<Item<'a> = TupleResult<'a>>> TupleIteratorAPI for SortedTupleIterator<Iterator> {
     fn write_values(&mut self, row: &mut Row<'_>) {
         debug_assert!(self.peek().is_some() && self.peek().unwrap().is_ok());
         // note: can't use self.peek() since it will cause mut and immutable reference to self
@@ -414,12 +431,12 @@ impl<Iterator: for<'a> LendingIterator<Item<'a>=TupleResult<'a>>> TupleIteratorA
 
 // TODO: this method and assertion on size would make more sense constructing a dedicated type, instead returning Vec
 pub(crate) fn inverted_instances_cache<'a, T: HKInstance>(
-    types: impl Iterator<Item=<T::HktSelf<'a> as ThingAPI<'a>>::TypeAPI<'a>>,
+    types: impl Iterator<Item = <T::HktSelf<'a> as ThingAPI<'a>>::TypeAPI<'a>>,
     snapshot: &impl ReadableSnapshot,
     thing_manager: &ThingManager,
 ) -> Result<Vec<T>, ConceptReadError>
-    where
-        for<'b> <T as Hkt>::HktSelf<'b>: ThingAPI<'b, Owned=T>
+where
+    for<'b> <T as Hkt>::HktSelf<'b>: ThingAPI<'b, Owned = T>,
 {
     let mut cache = Vec::new();
     for type_ in types {

--- a/traversal/executor/instruction/iterator.rs
+++ b/traversal/executor/instruction/iterator.rs
@@ -17,7 +17,7 @@ use crate::executor::{
             HasBoundedSortedAttribute, HasUnboundedSortedAttributeMerged, HasUnboundedSortedAttributeSingle,
             HasUnboundedSortedOwner,
         },
-        isa_executor::{
+        isa_reverse_executor::{
             IsaUnboundedSortedThingAttributeSingle, IsaUnboundedSortedThingEntitySingle,
             IsaUnboundedSortedThingRelationSingle,
         },

--- a/traversal/executor/instruction/mod.rs
+++ b/traversal/executor/instruction/mod.rs
@@ -240,9 +240,9 @@ impl BinaryIterateMode {
         debug_assert!(!var_modes.fully_bound());
 
         let default_sort_variable_for_direction = if in_reverse_direction {
-            constraint.id_right();
+            constraint.right_id()
         } else {
-            constraint.id_left();
+            constraint.left_id()
         };
 
         if var_modes.fully_unbound() {
@@ -262,6 +262,10 @@ impl BinaryIterateMode {
         } else {
             BinaryIterateMode::BoundFrom
         }
+    }
+
+    pub(crate) fn is_inverted(&self) -> bool {
+        matches!(self, Self::UnboundInverted)
     }
 }
 

--- a/traversal/executor/instruction/mod.rs
+++ b/traversal/executor/instruction/mod.rs
@@ -12,10 +12,9 @@ use concept::{
     thing::{thing_manager::ThingManager, ThingAPI},
     type_::TypeAPI,
 };
-use ir::inference::type_inference::TypeAnnotations;
+use ir::{inference::type_inference::TypeAnnotations, pattern::constraint::Constraint};
 use storage::snapshot::ReadableSnapshot;
 pub use tracing::{error, info, trace, warn};
-use ir::pattern::constraint::{Constraint, ConstraintIDSide};
 
 use crate::{
     executor::{
@@ -24,8 +23,8 @@ use crate::{
             comparison_executor::ComparisonIteratorExecutor,
             comparison_reverse_executor::ComparisonReverseIteratorExecutor,
             function_call_binding_executor::FunctionCallBindingIteratorExecutor, has_executor::HasExecutor,
-            has_reverse_executor::HasReverseIteratorExecutor, isa_reverse_executor::IsaReverseExecutor, iterator::TupleIterator,
-            role_player_executor::RolePlayerIteratorExecutor,
+            has_reverse_executor::HasReverseIteratorExecutor, isa_reverse_executor::IsaReverseExecutor,
+            iterator::TupleIterator, role_player_executor::RolePlayerIteratorExecutor,
             role_player_reverse_executor::RolePlayerReverseIteratorExecutor,
         },
         VariablePosition,
@@ -220,12 +219,11 @@ impl VariableModes {
     }
 }
 
-
 #[derive(Debug, Copy, Clone)]
 pub(crate) enum BinaryIterateMode {
-    Unbound, // [x, y] in standard order
+    Unbound,         // [x, y] in standard order
     UnboundInverted, // [x, y] in [y, x] sort order
-    BoundFrom, // [X, y], where X is bound
+    BoundFrom,       // [X, y], where X is bound
 }
 
 impl BinaryIterateMode {
@@ -239,11 +237,8 @@ impl BinaryIterateMode {
         debug_assert!(constraint.ids_count() == 2);
         debug_assert!(!var_modes.fully_bound());
 
-        let default_sort_variable_for_direction = if in_reverse_direction {
-            constraint.right_id()
-        } else {
-            constraint.left_id()
-        };
+        let default_sort_variable_for_direction =
+            if in_reverse_direction { constraint.right_id() } else { constraint.left_id() };
 
         if var_modes.fully_unbound() {
             match sort_by {

--- a/traversal/executor/instruction/role_player_executor.rs
+++ b/traversal/executor/instruction/role_player_executor.rs
@@ -31,32 +31,32 @@ enum TernaryIterateMode {
     BoundFromBoundTo,
 }
 
-impl TernaryIterateMode {
-    fn new(
-        has: &ir::pattern::constraint::RolePlayer<VariablePosition>,
-        var_modes: &VariableModes,
-        sort_by: Option<VariablePosition>,
-    ) -> TernaryIterateMode {
-        debug_assert!(!var_modes.fully_bound());
-        if var_modes.fully_unbound() {
-            match sort_by {
-                None => {
-                    // arbitrarily pick from sorted
-                    TernaryIterateMode::Unbound
-                }
-                Some(variable) => {
-                    if has.owner() == variable {
-                        TernaryIterateMode::UnboundSortedFrom
-                    } else {
-                        TernaryIterateMode::UnboundSortedTo
-                    }
-                }
-            }
-        } else {
-            TernaryIterateMode::BoundFromSortedTo
-        }
-    }
-}
+// impl TernaryIterateMode {
+//     fn new(
+//         has: &ir::pattern::constraint::RolePlayer<VariablePosition>,
+//         var_modes: &VariableModes,
+//         sort_by: Option<VariablePosition>,
+//     ) -> TernaryIterateMode {
+//         debug_assert!(!var_modes.fully_bound());
+//         if var_modes.fully_unbound() {
+//             match sort_by {
+//                 None => {
+//                     // arbitrarily pick from sorted
+//                     TernaryIterateMode::Unbound
+//                 }
+//                 Some(variable) => {
+//                     if has.owner() == variable {
+//                         TernaryIterateMode::UnboundSortedFrom
+//                     } else {
+//                         TernaryIterateMode::UnboundSortedTo
+//                     }
+//                 }
+//             }
+//         } else {
+//             TernaryIterateMode::BoundFromSortedTo
+//         }
+//     }
+// }
 
 impl RolePlayerIteratorExecutor {
     pub(crate) fn new(
@@ -64,8 +64,7 @@ impl RolePlayerIteratorExecutor {
         var_modes: VariableModes,
         sort_by: Option<VariablePosition>,
     ) -> RolePlayerIteratorExecutor {
-        let iterate_mode = IterateMode::new()
-        Self { role_player, iterate_mode, variable_modes }
+        todo!()
     }
 }
 

--- a/traversal/executor/instruction/role_player_executor.rs
+++ b/traversal/executor/instruction/role_player_executor.rs
@@ -4,17 +4,68 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-use ir::pattern::constraint::RolePlayer;
 
+use std::collections::{BTreeMap, HashSet};
+use std::sync::Arc;
+use answer::Type;
+use concept::thing::object::Object;
+use crate::executor::instruction::VariableModes;
 use crate::executor::VariablePosition;
 
 pub(crate) struct RolePlayerIteratorExecutor {
-    role_player: RolePlayer<VariablePosition>,
+    role_player: ir::pattern::constraint::RolePlayer<VariablePosition>,
+
+    iterate_mode: TernaryIterateMode,
+    variable_modes: VariableModes,
+    // owner_attribute_types: Arc<BTreeMap<Type, Vec<Type>>>,
+    // attribute_types: Arc<HashSet<Type>>,
+    // filter_fn: crate::executor::instruction::has_executor::HasExecutorFilter,
+    // owner_cache: Option<Vec<Object<'static>>>,
+}
+
+#[derive(Debug, Copy, Clone)]
+enum TernaryIterateMode {
+    Unbound,
+    UnboundInverted,
+    BoundFrom,
+    BoundFromBoundTo,
+}
+
+impl TernaryIterateMode {
+    fn new(
+        has: &ir::pattern::constraint::RolePlayer<VariablePosition>,
+        var_modes: &VariableModes,
+        sort_by: Option<VariablePosition>,
+    ) -> TernaryIterateMode {
+        debug_assert!(!var_modes.fully_bound());
+        if var_modes.fully_unbound() {
+            match sort_by {
+                None => {
+                    // arbitrarily pick from sorted
+                    TernaryIterateMode::Unbound
+                }
+                Some(variable) => {
+                    if has.owner() == variable {
+                        TernaryIterateMode::UnboundSortedFrom
+                    } else {
+                        TernaryIterateMode::UnboundSortedTo
+                    }
+                }
+            }
+        } else {
+            TernaryIterateMode::BoundFromSortedTo
+        }
+    }
 }
 
 impl RolePlayerIteratorExecutor {
-    pub(crate) fn new(role_player: RolePlayer<VariablePosition>) -> RolePlayerIteratorExecutor {
-        Self { role_player }
+    pub(crate) fn new(
+        role_player: ir::pattern::constraint::RolePlayer<VariablePosition>,
+        var_modes: VariableModes,
+        sort_by: Option<VariablePosition>,
+    ) -> RolePlayerIteratorExecutor {
+        let iterate_mode = IterateMode::new()
+        Self { role_player, iterate_mode, variable_modes }
     }
 }
 

--- a/traversal/executor/instruction/role_player_executor.rs
+++ b/traversal/executor/instruction/role_player_executor.rs
@@ -4,13 +4,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-
-use std::collections::{BTreeMap, HashSet};
-use std::sync::Arc;
-use answer::Type;
-use concept::thing::object::Object;
-use crate::executor::instruction::VariableModes;
-use crate::executor::VariablePosition;
+use crate::executor::{instruction::VariableModes, VariablePosition};
 
 pub(crate) struct RolePlayerIteratorExecutor {
     role_player: ir::pattern::constraint::RolePlayer<VariablePosition>,

--- a/traversal/executor/instruction/role_player_reverse_executor.rs
+++ b/traversal/executor/instruction/role_player_reverse_executor.rs
@@ -6,7 +6,7 @@
 
 use ir::pattern::constraint::RolePlayer;
 
-use crate::executor::{batch::Row, VariablePosition};
+use crate::executor::VariablePosition;
 
 pub(crate) struct RolePlayerReverseIteratorExecutor {
     role_player: RolePlayer<VariablePosition>,

--- a/traversal/executor/instruction/tuple.rs
+++ b/traversal/executor/instruction/tuple.rs
@@ -153,6 +153,7 @@ pub(crate) fn isa_attribute_to_tuple_thing_type<'a>(
         Err(err) => Err(err),
     }
 }
+pub(crate) type HasToTupleFn = for<'a> fn(Result<(Has<'a>, u64), ConceptReadError>) -> TupleResult<'a>;
 
 pub(crate) fn has_to_tuple_owner_attribute<'a>(result: Result<(Has<'a>, u64), ConceptReadError>) -> TupleResult<'a> {
     match result {

--- a/traversal/executor/instruction/tuple.rs
+++ b/traversal/executor/instruction/tuple.rs
@@ -64,6 +64,7 @@ impl Hkt for Tuple<'static> {
     type HktSelf<'a> = Tuple<'a>;
 }
 
+#[derive(Debug, Clone)]
 pub(crate) enum TuplePositions {
     Single([VariablePosition; 1]),
     Pair([VariablePosition; 2]),

--- a/traversal/executor/instruction/tuple.rs
+++ b/traversal/executor/instruction/tuple.rs
@@ -4,8 +4,6 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-use std::ops::Range;
-
 use answer::variable_value::VariableValue;
 use concept::{
     error::ConceptReadError,
@@ -13,9 +11,7 @@ use concept::{
 };
 use lending_iterator::higher_order::Hkt;
 
-use crate::executor::{
-    VariablePosition,
-};
+use crate::executor::VariablePosition;
 
 #[derive(Debug, Clone)]
 pub(crate) enum Tuple<'a> {

--- a/traversal/executor/pattern_executor.rs
+++ b/traversal/executor/pattern_executor.rs
@@ -47,12 +47,13 @@ impl PatternExecutor {
         let mut step_executors = Vec::with_capacity(steps.len());
         for step in steps {
             for variable in step.unbound_variables() {
-                let previous =
-                    variable_positions.insert(*variable, VariablePosition::new(variable_positions.len() as u32));
+                let previous = variable_positions
+                    .insert(*variable, VariablePosition::new(variable_positions.len() as u32));
                 debug_assert_eq!(previous, Option::None);
             }
-            let executor =
-                StepExecutor::new(step, &context, &variable_positions, type_annotations, snapshot, thing_manager)?;
+            let executor = StepExecutor::new(
+                step, &context, &variable_positions, type_annotations, snapshot, thing_manager
+            )?;
             step_executors.push(executor)
         }
         let mut variable_positions_index = vec![Variable::new(0); variable_positions.len()];

--- a/traversal/executor/pattern_executor.rs
+++ b/traversal/executor/pattern_executor.rs
@@ -47,13 +47,12 @@ impl PatternExecutor {
         let mut step_executors = Vec::with_capacity(steps.len());
         for step in steps {
             for variable in step.unbound_variables() {
-                let previous = variable_positions
-                    .insert(*variable, VariablePosition::new(variable_positions.len() as u32));
+                let previous =
+                    variable_positions.insert(*variable, VariablePosition::new(variable_positions.len() as u32));
                 debug_assert_eq!(previous, Option::None);
             }
-            let executor = StepExecutor::new(
-                step, &context, &variable_positions, type_annotations, snapshot, thing_manager
-            )?;
+            let executor =
+                StepExecutor::new(step, &context, &variable_positions, type_annotations, snapshot, thing_manager)?;
             step_executors.push(executor)
         }
         let mut variable_positions_index = vec![Variable::new(0); variable_positions.len()];

--- a/traversal/executor/program_executor.rs
+++ b/traversal/executor/program_executor.rs
@@ -9,7 +9,6 @@ use std::{collections::HashMap, sync::Arc};
 use answer::variable::Variable;
 use concept::{error::ConceptReadError, thing::thing_manager::ThingManager};
 use encoding::graph::definition::definition_key::DefinitionKey;
-use ir::inference::type_inference::TypeAnnotations;
 use lending_iterator::LendingIterator;
 use storage::snapshot::ReadableSnapshot;
 

--- a/traversal/lib.rs
+++ b/traversal/lib.rs
@@ -3,5 +3,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
+extern crate core;
+
 pub mod executor;
 pub mod planner;

--- a/traversal/planner/pattern_plan.rs
+++ b/traversal/planner/pattern_plan.rs
@@ -4,10 +4,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-use std::{
-    collections::{HashMap, HashSet},
-    fmt,
-};
+use std::collections::HashMap;
 
 use answer::variable::Variable;
 use concept::thing::statistics::Statistics;

--- a/traversal/planner/program_plan.rs
+++ b/traversal/planner/program_plan.rs
@@ -21,7 +21,7 @@ impl ProgramPlan {
     pub fn new(
         entry: PatternPlan,
         entry_annotations: TypeAnnotations,
-        functions: HashMap<DefinitionKey<'static>, FunctionPlan>
+        functions: HashMap<DefinitionKey<'static>, FunctionPlan>,
     ) -> Self {
         Self { entry, entry_annotations, functions }
     }

--- a/traversal/tests/executor_has.rs
+++ b/traversal/tests/executor_has.rs
@@ -9,7 +9,7 @@ use std::{borrow::Cow, collections::HashMap, sync::Arc};
 use concept::{
     error::ConceptReadError,
     thing::object::ObjectAPI,
-    type_::{annotation::AnnotationCardinality, Ordering, OwnerAPI, owns::OwnsAnnotation},
+    type_::{annotation::AnnotationCardinality, owns::OwnsAnnotation, Ordering, OwnerAPI},
 };
 use encoding::{
     graph::type_::Kind,
@@ -26,8 +26,8 @@ use ir::{
 use lending_iterator::LendingIterator;
 use storage::{
     durability_client::WALClient,
-    MVCCStorage,
     snapshot::{CommittableSnapshot, ReadSnapshot, WriteSnapshot},
+    MVCCStorage,
 };
 use traversal::{
     executor::{batch::ImmutableRow, program_executor::ProgramExecutor},
@@ -161,7 +161,8 @@ fn traverse_has_unbounded_sorted_from() {
     ))];
     // TODO: incorporate the filter
     let pattern_plan = PatternPlan::new(steps, annotated_program.get_entry().context().clone());
-    let program_plan = ProgramPlan::new(pattern_plan, annotated_program.get_entry_annotations().clone(), HashMap::new());
+    let program_plan =
+        ProgramPlan::new(pattern_plan, annotated_program.get_entry_annotations().clone(), HashMap::new());
 
     // Executor
     let executor = {
@@ -229,7 +230,8 @@ fn traverse_has_unbounded_sorted_to_merged() {
         &vec![var_person, var_attribute],
     ))];
     let pattern_plan = PatternPlan::new(steps, annotated_program.get_entry().context().clone());
-    let program_plan = ProgramPlan::new(pattern_plan, annotated_program.get_entry_annotations().clone(), HashMap::new());
+    let program_plan =
+        ProgramPlan::new(pattern_plan, annotated_program.get_entry_annotations().clone(), HashMap::new());
 
     // Executor
     let executor = {

--- a/traversal/tests/executor_isa.rs
+++ b/traversal/tests/executor_isa.rs
@@ -6,9 +6,8 @@
 
 use std::{collections::HashMap, sync::Arc};
 
-use answer::variable_value::VariableValue;
 use concept::{error::ConceptReadError, thing::object::ObjectAPI, type_::OwnerAPI};
-use encoding::{graph::type_::Kind, value::label::Label};
+use encoding::value::label::Label;
 use ir::{
     inference::type_inference::infer_types,
     pattern::constraint::IsaKind,
@@ -18,13 +17,13 @@ use ir::program::program::CompiledSchemaFunctions;
 use lending_iterator::LendingIterator;
 use storage::{
     durability_client::WALClient,
-    snapshot::{CommittableSnapshot, ReadSnapshot, WriteSnapshot},
     MVCCStorage,
+    snapshot::{CommittableSnapshot, ReadSnapshot, WriteSnapshot},
 };
 use traversal::{
     executor::{batch::ImmutableRow, program_executor::ProgramExecutor},
     planner::{
-        pattern_plan::{Instruction, IterateBounds, PatternPlan, IntersectionStep, Step},
+        pattern_plan::{Instruction, IntersectionStep, IterateBounds, PatternPlan, Step},
         program_plan::ProgramPlan,
     },
 };

--- a/traversal/tests/executor_rp.rs
+++ b/traversal/tests/executor_rp.rs
@@ -202,7 +202,8 @@ fn traverse_rp_unbounded_sorted_from() {
     ))];
 
     let pattern_plan = PatternPlan::new(steps, annotated_program.get_entry().context().clone());
-    let program_plan = ProgramPlan::new(pattern_plan, annotated_program.get_entry_annotations().clone(), HashMap::new());
+    let program_plan =
+        ProgramPlan::new(pattern_plan, annotated_program.get_entry_annotations().clone(), HashMap::new());
 
     // Executor
     let executor = {
@@ -271,7 +272,8 @@ fn traverse_has_unbounded_sorted_to_merged() {
         &vec![var_person, var_attribute],
     ))];
     let pattern_plan = PatternPlan::new(steps, annotated_program.get_entry().context().clone());
-    let program_plan = ProgramPlan::new(pattern_plan, annotated_program.get_entry_annotations().clone(), HashMap::new());
+    let program_plan =
+        ProgramPlan::new(pattern_plan, annotated_program.get_entry_annotations().clone(), HashMap::new());
 
     // Executor
     let executor = {

--- a/traversal/tests/select.rs
+++ b/traversal/tests/select.rs
@@ -172,7 +172,8 @@ fn anonymous_vars_not_enumerated_or_counted() {
         &vec![var_person],
     ))];
     let pattern_plan = PatternPlan::new(steps, annotated_program.get_entry().context().clone());
-    let program_plan = ProgramPlan::new(pattern_plan, annotated_program.get_entry_annotations().clone(), HashMap::new());
+    let program_plan =
+        ProgramPlan::new(pattern_plan, annotated_program.get_entry_annotations().clone(), HashMap::new());
 
     // Executor
     let executor = {
@@ -248,7 +249,8 @@ fn unselected_named_vars_counted() {
         &vec![var_person],
     ))];
     let pattern_plan = PatternPlan::new(steps, annotated_program.get_entry().context().clone());
-    let program_plan = ProgramPlan::new(pattern_plan, annotated_program.get_entry_annotations().clone(), HashMap::new());
+    let program_plan =
+        ProgramPlan::new(pattern_plan, annotated_program.get_entry_annotations().clone(), HashMap::new());
 
     // Executor
     let executor = {
@@ -335,7 +337,8 @@ fn cartesian_named_counted_checked() {
         &vec![var_person, var_age],
     ))];
     let pattern_plan = PatternPlan::new(steps, annotated_program.get_entry().context().clone());
-    let program_plan = ProgramPlan::new(pattern_plan, annotated_program.get_entry_annotations().clone(), HashMap::new());
+    let program_plan =
+        ProgramPlan::new(pattern_plan, annotated_program.get_entry_annotations().clone(), HashMap::new());
 
     // Executor
     let executor = {


### PR DESCRIPTION
## Usage and product changes

Implement Has reverse executor, refactor the Has executor into methods for reuse. We also implement higher-kinded traits for `Thing`s, and refactor the `get_instances/get_instances_in` set of APIs in the ThingManager.
