### PR TITLE
Purge root types

### DIFF
--- a/concept/benches/bench_thing_write.rs
+++ b/concept/benches/bench_thing_write.rs
@@ -90,11 +90,11 @@ fn create_schema(
     {
         let type_manager =
             Rc::new(TypeManager::new(definition_key_generator.clone(), type_vertex_generator.clone(), None));
-        let age_type = type_manager.create_attribute_type(&mut snapshot, AGE_LABEL.get().unwrap(), false).unwrap();
+        let age_type = type_manager.create_attribute_type(&mut snapshot, AGE_LABEL.get().unwrap()).unwrap();
         age_type.set_value_type(&mut snapshot, &type_manager, ValueType::Long).unwrap();
-        let name_type = type_manager.create_attribute_type(&mut snapshot, NAME_LABEL.get().unwrap(), false).unwrap();
+        let name_type = type_manager.create_attribute_type(&mut snapshot, NAME_LABEL.get().unwrap()).unwrap();
         name_type.set_value_type(&mut snapshot, &type_manager, ValueType::String).unwrap();
-        let person_type = type_manager.create_entity_type(&mut snapshot, PERSON_LABEL.get().unwrap(), false).unwrap();
+        let person_type = type_manager.create_entity_type(&mut snapshot, PERSON_LABEL.get().unwrap()).unwrap();
         person_type.set_owns(&mut snapshot, &type_manager, age_type, Ordering::Unordered).unwrap();
         person_type.set_owns(&mut snapshot, &type_manager, name_type, Ordering::Unordered).unwrap();
     }
@@ -121,8 +121,6 @@ fn criterion_benchmark(c: &mut Criterion) {
         let definition_key_generator = Arc::new(DefinitionKeyGenerator::new());
         let type_vertex_generator = Arc::new(TypeVertexGenerator::new());
         let thing_vertex_generator = Arc::new(ThingVertexGenerator::new());
-        TypeManager::initialise_types(storage.clone(), definition_key_generator.clone(), type_vertex_generator.clone())
-            .unwrap();
         create_schema(storage.clone(), definition_key_generator.clone(), type_vertex_generator.clone());
         let schema_cache = Arc::new(TypeCache::new(storage.clone(), storage.read_watermark()).unwrap());
         b.iter(|| {

--- a/concept/error.rs
+++ b/concept/error.rs
@@ -4,7 +4,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-use std::{cmp::Ordering, error::Error, fmt, sync::Arc};
+use std::{error::Error, fmt, sync::Arc};
 
 use encoding::{
     error::EncodingError,

--- a/concept/lib.rs
+++ b/concept/lib.rs
@@ -8,7 +8,6 @@
 #![deny(elided_lifetimes_in_paths)]
 
 use bytes::byte_reference::ByteReference;
-use storage::key_value::StorageKeyReference;
 
 pub mod error;
 pub mod iterator;

--- a/concept/tests/test_thing.rs
+++ b/concept/tests/test_thing.rs
@@ -68,17 +68,13 @@ fn thing_create_iterate() {
     let storage = Arc::new(
         MVCCStorage::<WALClient>::create::<EncodingKeyspace>("storage", &storage_path, WALClient::new(wal)).unwrap(),
     );
-    let definition_key_generator = Arc::new(DefinitionKeyGenerator::new());
-    let type_vertex_generator = Arc::new(TypeVertexGenerator::new());
-    TypeManager::initialise_types(storage.clone(), definition_key_generator.clone(), type_vertex_generator.clone())
-        .unwrap();
 
     let mut snapshot: WriteSnapshot<WALClient> = storage.clone().open_snapshot_write();
     {
         let (type_manager, thing_manager) = load_managers(storage.clone());
 
         let person_label = Label::build("person");
-        let person_type = type_manager.create_entity_type(&mut snapshot, &person_label, false).unwrap();
+        let person_type = type_manager.create_entity_type(&mut snapshot, &person_label).unwrap();
 
         let _person_1 = thing_manager.create_entity(&mut snapshot, person_type.clone()).unwrap();
         let _person_2 = thing_manager.create_entity(&mut snapshot, person_type.clone()).unwrap();
@@ -106,10 +102,6 @@ fn attribute_create() {
     let storage = Arc::new(
         MVCCStorage::<WALClient>::create::<EncodingKeyspace>("storage", &storage_path, WALClient::new(wal)).unwrap(),
     );
-    let definition_key_generator = Arc::new(DefinitionKeyGenerator::new());
-    let type_vertex_generator = Arc::new(TypeVertexGenerator::new());
-    TypeManager::initialise_types(storage.clone(), definition_key_generator.clone(), type_vertex_generator.clone())
-        .unwrap();
 
     let age_label = Label::build("age");
     let name_label = Label::build("name");
@@ -120,12 +112,12 @@ fn attribute_create() {
     let mut snapshot: WriteSnapshot<WALClient> = storage.clone().open_snapshot_write();
     {
         let (type_manager, thing_manager) = load_managers(storage.clone());
-        let age_type = type_manager.create_attribute_type(&mut snapshot, &age_label, false).unwrap();
+        let age_type = type_manager.create_attribute_type(&mut snapshot, &age_label).unwrap();
         age_type.set_value_type(&mut snapshot, &type_manager, ValueType::Long).unwrap();
         age_type
             .set_annotation(&mut snapshot, &type_manager, AttributeTypeAnnotation::Independent(AnnotationIndependent))
             .unwrap();
-        let name_type = type_manager.create_attribute_type(&mut snapshot, &name_label, false).unwrap();
+        let name_type = type_manager.create_attribute_type(&mut snapshot, &name_label).unwrap();
         name_type.set_value_type(&mut snapshot, &type_manager, ValueType::String).unwrap();
         name_type
             .set_annotation(&mut snapshot, &type_manager, AttributeTypeAnnotation::Independent(AnnotationIndependent))
@@ -170,10 +162,6 @@ fn has() {
     let storage = Arc::new(
         MVCCStorage::<WALClient>::create::<EncodingKeyspace>("storage", &storage_path, WALClient::new(wal)).unwrap(),
     );
-    let definition_key_generator = Arc::new(DefinitionKeyGenerator::new());
-    let type_vertex_generator = Arc::new(TypeVertexGenerator::new());
-    TypeManager::initialise_types(storage.clone(), definition_key_generator.clone(), type_vertex_generator.clone())
-        .unwrap();
 
     let age_label = Label::build("age");
     let name_label = Label::build("name");
@@ -186,18 +174,18 @@ fn has() {
     {
         let (type_manager, thing_manager) = load_managers(storage.clone());
 
-        let age_type = type_manager.create_attribute_type(&mut snapshot, &age_label, false).unwrap();
+        let age_type = type_manager.create_attribute_type(&mut snapshot, &age_label).unwrap();
         age_type.set_value_type(&mut snapshot, &type_manager, ValueType::Long).unwrap();
         age_type
             .set_annotation(&mut snapshot, &type_manager, AttributeTypeAnnotation::Independent(AnnotationIndependent))
             .unwrap();
-        let name_type = type_manager.create_attribute_type(&mut snapshot, &name_label, false).unwrap();
+        let name_type = type_manager.create_attribute_type(&mut snapshot, &name_label).unwrap();
         name_type.set_value_type(&mut snapshot, &type_manager, ValueType::String).unwrap();
         name_type
             .set_annotation(&mut snapshot, &type_manager, AttributeTypeAnnotation::Independent(AnnotationIndependent))
             .unwrap();
 
-        let person_type = type_manager.create_entity_type(&mut snapshot, &person_label, false).unwrap();
+        let person_type = type_manager.create_entity_type(&mut snapshot, &person_label).unwrap();
         person_type.set_owns(&mut snapshot, &type_manager, age_type.clone(), Ordering::Unordered).unwrap();
         person_type.set_owns(&mut snapshot, &type_manager, name_type.clone(), Ordering::Unordered).unwrap();
 
@@ -240,10 +228,6 @@ fn attribute_cleanup_on_concurrent_detach() {
     let storage = Arc::new(
         MVCCStorage::<WALClient>::create::<EncodingKeyspace>("storage", &storage_path, WALClient::new(wal)).unwrap(),
     );
-    let definition_key_generator = Arc::new(DefinitionKeyGenerator::new());
-    let type_vertex_generator = Arc::new(TypeVertexGenerator::new());
-    TypeManager::initialise_types(storage.clone(), definition_key_generator.clone(), type_vertex_generator.clone())
-        .unwrap();
 
     let age_label = Label::build("age");
     let name_label = Label::build("name");
@@ -256,12 +240,12 @@ fn attribute_cleanup_on_concurrent_detach() {
     let mut snapshot: WriteSnapshot<WALClient> = storage.clone().open_snapshot_write();
     {
         let (type_manager, thing_manager) = load_managers(storage.clone());
-        let age_type = type_manager.create_attribute_type(&mut snapshot, &age_label, false).unwrap();
+        let age_type = type_manager.create_attribute_type(&mut snapshot, &age_label).unwrap();
         age_type.set_value_type(&mut snapshot, &type_manager, ValueType::Long).unwrap();
-        let name_type = type_manager.create_attribute_type(&mut snapshot, &name_label, false).unwrap();
+        let name_type = type_manager.create_attribute_type(&mut snapshot, &name_label).unwrap();
         name_type.set_value_type(&mut snapshot, &type_manager, ValueType::String).unwrap();
 
-        let person_type = type_manager.create_entity_type(&mut snapshot, &person_label, false).unwrap();
+        let person_type = type_manager.create_entity_type(&mut snapshot, &person_label).unwrap();
         let owns_age = person_type.set_owns(&mut snapshot, &type_manager, age_type.clone(), Ordering::Ordered).unwrap();
         owns_age.set_annotation(&mut snapshot, &type_manager, OwnsAnnotation::Distinct(AnnotationDistinct)).unwrap();
 
@@ -384,11 +368,6 @@ fn role_player_distinct() {
         MVCCStorage::<WALClient>::create::<EncodingKeyspace>("storage", &storage_path, WALClient::new(wal)).unwrap(),
     );
 
-    let definition_key_generator = Arc::new(DefinitionKeyGenerator::new());
-    let type_vertex_generator = Arc::new(TypeVertexGenerator::new());
-    TypeManager::initialise_types(storage.clone(), definition_key_generator.clone(), type_vertex_generator.clone())
-        .unwrap();
-
     let employment_label = Label::build("employment");
     let employee_role = "employee";
     let employer_role = "employer";
@@ -399,7 +378,7 @@ fn role_player_distinct() {
     {
         let (type_manager, thing_manager) = load_managers(storage.clone());
 
-        let employment_type = type_manager.create_relation_type(&mut snapshot, &employment_label, false).unwrap();
+        let employment_type = type_manager.create_relation_type(&mut snapshot, &employment_label).unwrap();
         employment_type.create_relates(&mut snapshot, &type_manager, employee_role, Ordering::Ordered).unwrap();
         let employee_relates =
             employment_type.get_relates_of_role(&snapshot, &type_manager, employee_role).unwrap().unwrap();
@@ -430,8 +409,8 @@ fn role_player_distinct() {
             .unwrap();
         let employer_type = employer_relates.role();
 
-        let person_type = type_manager.create_entity_type(&mut snapshot, &person_label, false).unwrap();
-        let company_type = type_manager.create_entity_type(&mut snapshot, &company_label, false).unwrap();
+        let person_type = type_manager.create_entity_type(&mut snapshot, &person_label).unwrap();
+        let company_type = type_manager.create_entity_type(&mut snapshot, &company_label).unwrap();
         person_type.set_plays(&mut snapshot, &type_manager, employee_type.clone()).unwrap();
         company_type.set_plays(&mut snapshot, &type_manager, employee_type.clone()).unwrap();
 
@@ -510,11 +489,6 @@ fn role_player_duplicates() {
         MVCCStorage::<WALClient>::create::<EncodingKeyspace>("storage", &storage_path, WALClient::new(wal)).unwrap(),
     );
 
-    let definition_key_generator = Arc::new(DefinitionKeyGenerator::new());
-    let type_vertex_generator = Arc::new(TypeVertexGenerator::new());
-    TypeManager::initialise_types(storage.clone(), definition_key_generator.clone(), type_vertex_generator.clone())
-        .unwrap();
-
     let list_label = Label::build("list");
     let entry_role_label = "entry";
     let owner_role_label = "owner";
@@ -524,7 +498,7 @@ fn role_player_duplicates() {
     let mut snapshot: WriteSnapshot<WALClient> = storage.clone().open_snapshot_write();
     {
         let (type_manager, thing_manager) = load_managers(storage.clone());
-        let list_type = type_manager.create_relation_type(&mut snapshot, &list_label, false).unwrap();
+        let list_type = type_manager.create_relation_type(&mut snapshot, &list_label).unwrap();
         list_type.create_relates(&mut snapshot, &type_manager, entry_role_label, Ordering::Unordered).unwrap();
         let entry_relates = list_type.get_relates_of_role(&snapshot, &type_manager, entry_role_label).unwrap().unwrap();
         entry_relates
@@ -539,8 +513,8 @@ fn role_player_duplicates() {
         let owner_type =
             list_type.get_relates_of_role(&snapshot, &type_manager, owner_role_label).unwrap().unwrap().role();
 
-        let resource_type = type_manager.create_entity_type(&mut snapshot, &resource_label, false).unwrap();
-        let group_type = type_manager.create_entity_type(&mut snapshot, &group_label, false).unwrap();
+        let resource_type = type_manager.create_entity_type(&mut snapshot, &resource_label).unwrap();
+        let group_type = type_manager.create_entity_type(&mut snapshot, &group_label).unwrap();
         resource_type.set_plays(&mut snapshot, &type_manager, entry_type.clone()).unwrap();
         group_type.set_plays(&mut snapshot, &type_manager, owner_type.clone()).unwrap();
 
@@ -688,18 +662,13 @@ fn attribute_string_write_read() {
         MVCCStorage::<WALClient>::create::<EncodingKeyspace>("storage", &storage_path, WALClient::new(wal)).unwrap(),
     );
 
-    let definition_key_generator = Arc::new(DefinitionKeyGenerator::new());
-    let type_vertex_generator = Arc::new(TypeVertexGenerator::new());
-    TypeManager::initialise_types(storage.clone(), definition_key_generator.clone(), type_vertex_generator.clone())
-        .unwrap();
-
     let (type_manager, thing_manager) = load_managers(storage.clone());
     let attr_label = Label::build("test_string_attr");
     let short_string = "short".to_owned();
     let long_string = "this string is 33 characters long".to_owned();
     let attr_type = {
         let mut snapshot: WriteSnapshot<WALClient> = storage.clone().open_snapshot_write();
-        let attr_type = type_manager.create_attribute_type(&mut snapshot, &attr_label, false).unwrap();
+        let attr_type = type_manager.create_attribute_type(&mut snapshot, &attr_label).unwrap();
         attr_type.set_value_type(&mut snapshot, &type_manager, ValueType::String).unwrap();
         attr_type
             .set_annotation(&mut snapshot, &type_manager, AttributeTypeAnnotation::Independent(AnnotationIndependent))
@@ -760,11 +729,6 @@ fn attribute_struct_write_read() {
         MVCCStorage::<WALClient>::create::<EncodingKeyspace>("storage", &storage_path, WALClient::new(wal)).unwrap(),
     );
 
-    let definition_key_generator = Arc::new(DefinitionKeyGenerator::new());
-    let type_vertex_generator = Arc::new(TypeVertexGenerator::new());
-    TypeManager::initialise_types(storage.clone(), definition_key_generator.clone(), type_vertex_generator.clone())
-        .unwrap();
-
     let (type_manager, thing_manager) = load_managers(storage.clone());
 
     let attr_label = Label::build("struct_test_attr");
@@ -779,7 +743,7 @@ fn attribute_struct_write_read() {
     let struct_key = {
         let mut snapshot: WriteSnapshot<WALClient> = storage.clone().open_snapshot_write();
         let struct_key = define_struct(&mut snapshot, &type_manager, struct_name, fields);
-        let attr_type = type_manager.create_attribute_type(&mut snapshot, &attr_label, false).unwrap();
+        let attr_type = type_manager.create_attribute_type(&mut snapshot, &attr_label).unwrap();
         attr_type
             .set_annotation(&mut snapshot, &type_manager, AttributeTypeAnnotation::Independent(AnnotationIndependent))
             .unwrap();
@@ -815,13 +779,11 @@ fn attribute_struct_write_read() {
             .unwrap()
             .map_static(|result| result.unwrap().into_owned())
             .collect();
-        let mut attr = attr_vec.get(0).unwrap().clone();
+        let mut attr = attr_vec.first().unwrap().clone();
         let value_0 = attr.get_value(&snapshot, &thing_manager).unwrap();
         match value_0 {
-            Value::Struct(v) => {
-                assert_eq!(struct_value, *v);
-            }
-            _ => assert!(false, "Wrong data type"),
+            Value::Struct(v) => assert_eq!(struct_value, *v),
+            _ => panic!("Wrong data type"),
         }
 
         let attr_by_id = thing_manager
@@ -843,11 +805,6 @@ fn read_attribute_struct_by_field() {
         MVCCStorage::<WALClient>::create::<EncodingKeyspace>("storage", &storage_path, WALClient::new(wal)).unwrap(),
     );
 
-    let definition_key_generator = Arc::new(DefinitionKeyGenerator::new());
-    let type_vertex_generator = Arc::new(TypeVertexGenerator::new());
-    TypeManager::initialise_types(storage.clone(), definition_key_generator.clone(), type_vertex_generator.clone())
-        .unwrap();
-
     let (type_manager, thing_manager) = load_managers(storage.clone());
 
     let attr_label = Label::build("index_test_attr");
@@ -868,7 +825,7 @@ fn read_attribute_struct_by_field() {
     let (attr_type, struct_key, struct_def) = {
         let mut snapshot = storage.clone().open_snapshot_write();
         let struct_key = define_struct(&mut snapshot, &type_manager, struct_spec.0, struct_spec.1);
-        let attr_type = type_manager.create_attribute_type(&mut snapshot, &attr_label, false).unwrap();
+        let attr_type = type_manager.create_attribute_type(&mut snapshot, &attr_label).unwrap();
         attr_type.set_value_type(&mut snapshot, &type_manager, ValueType::Struct(struct_key.clone())).unwrap();
         attr_type
             .set_annotation(&mut snapshot, &type_manager, AttributeTypeAnnotation::Independent(AnnotationIndependent))
@@ -913,7 +870,7 @@ fn read_attribute_struct_by_field() {
                 attr_by_field.push(res.as_ref().unwrap().clone().into_owned());
             }
             assert_eq!(1, attr_by_field.len());
-            assert_eq!(attr, attr_by_field.get(0).unwrap());
+            assert_eq!(attr, attr_by_field.first().unwrap());
         }
         snapshot.close_resources();
     };
@@ -927,11 +884,6 @@ fn attribute_struct_errors() {
     let storage = Arc::new(
         MVCCStorage::<WALClient>::create::<EncodingKeyspace>("storage", &storage_path, WALClient::new(wal)).unwrap(),
     );
-
-    let definition_key_generator = Arc::new(DefinitionKeyGenerator::new());
-    let type_vertex_generator = Arc::new(TypeVertexGenerator::new());
-    TypeManager::initialise_types(storage.clone(), definition_key_generator.clone(), type_vertex_generator.clone())
-        .unwrap();
 
     let (type_manager, _) = load_managers(storage.clone());
 
@@ -985,12 +937,12 @@ fn attribute_struct_errors() {
             )
             .unwrap_err();
             assert!(
-                err.len() == 1 && matches!(err.get(0).unwrap(), EncodingError::StructFieldValueTypeMismatch { .. })
+                err.len() == 1 && matches!(err.first().unwrap(), EncodingError::StructFieldValueTypeMismatch { .. })
             );
         }
         {
             let err = StructValue::build(struct_key.clone(), struct_def.clone(), HashMap::from([])).unwrap_err();
-            assert!(err.len() == 1 && matches!(err.get(0).unwrap(), EncodingError::StructMissingRequiredField { .. }));
+            assert!(err.len() == 1 && matches!(err.first().unwrap(), EncodingError::StructMissingRequiredField { .. }));
         }
         snapshot.close_resources();
     }

--- a/concept/tests/test_thing.rs
+++ b/concept/tests/test_thing.rs
@@ -855,7 +855,7 @@ fn read_attribute_struct_by_field() {
 
         for (val, attr) in std::iter::zip(field_values, attrs.iter()) {
             let field_path = type_manager
-                .resolve_struct_field(&snapshot, &vec!["f_nested", "nested_string"], struct_def.clone())
+                .resolve_struct_field(&snapshot, &["f_nested", "nested_string"], struct_def.clone())
                 .unwrap();
             let mut attr_by_field_iterator = thing_manager
                 .get_attributes_by_struct_field(
@@ -908,19 +908,19 @@ fn attribute_struct_errors() {
         let snapshot = storage.clone().open_snapshot_write();
         let struct_def = type_manager.get_struct_definition(&snapshot, struct_key.clone()).unwrap();
         assert!(matches!(
-            type_manager.resolve_struct_field(&snapshot, &vec!["non-existant"], struct_def.clone()),
+            type_manager.resolve_struct_field(&snapshot, &["non-existant"], struct_def.clone()),
             Err(ConceptReadError::Encoding { source: EncodingError::StructFieldUnresolvable { .. } })
         ));
         assert!(matches!(
             type_manager.resolve_struct_field(
                 &snapshot,
-                &vec!["f_nested", "nested_string", "but-strings-arent-structs"],
+                &["f_nested", "nested_string", "but-strings-arent-structs"],
                 struct_def.clone()
             ),
             Err(ConceptReadError::Encoding { source: EncodingError::IndexingIntoNonStructField { .. } })
         ));
         assert!(matches!(
-            type_manager.resolve_struct_field(&snapshot, &vec![], struct_def.clone()),
+            type_manager.resolve_struct_field(&snapshot, &[], struct_def.clone()),
             Err(ConceptReadError::Encoding { source: EncodingError::StructPathIncomplete { .. } })
         ));
     };

--- a/concept/type_/attribute_type.rs
+++ b/concept/type_/attribute_type.rs
@@ -136,14 +136,6 @@ impl<'a> ThingTypeAPI<'a> for AttributeType<'a> {
 }
 
 impl<'a> AttributeType<'a> {
-    pub fn is_root(
-        &self,
-        snapshot: &impl ReadableSnapshot,
-        type_manager: &TypeManager,
-    ) -> Result<bool, ConceptReadError> {
-        type_manager.get_attribute_type_is_root(snapshot, self.clone().into_owned())
-    }
-
     pub fn get_value_type(
         &self,
         snapshot: &impl ReadableSnapshot,
@@ -177,11 +169,7 @@ impl<'a> AttributeType<'a> {
         type_manager: &TypeManager,
         label: &Label<'_>,
     ) -> Result<(), ConceptWriteError> {
-        if self.is_root(snapshot, type_manager)? {
-            Err(ConceptWriteError::RootModification) // TODO: Move into TypeManager?
-        } else {
-            type_manager.set_label(snapshot, self.clone().into_owned(), label)
-        }
+        type_manager.set_label(snapshot, self.clone().into_owned(), label)
     }
 
     pub fn get_supertype(

--- a/concept/type_/attribute_type.rs
+++ b/concept/type_/attribute_type.rs
@@ -84,7 +84,7 @@ impl<'a> TypeAPI<'a> for AttributeType<'a> {
         Self::from_vertex(vertex).unwrap()
     }
 
-    fn vertex<'this>(&'this self) -> TypeVertex<'this> {
+    fn vertex(&self) -> TypeVertex<'_> {
         self.vertex.as_reference()
     }
 

--- a/concept/type_/entity_type.rs
+++ b/concept/type_/entity_type.rs
@@ -80,7 +80,7 @@ impl<'a> TypeAPI<'a> for EntityType<'a> {
         Self::from_vertex(vertex).unwrap()
     }
 
-    fn vertex<'this>(&'this self) -> TypeVertex<'this> {
+    fn vertex(&self) -> TypeVertex<'_> {
         self.vertex.as_reference()
     }
 

--- a/concept/type_/entity_type.rs
+++ b/concept/type_/entity_type.rs
@@ -138,25 +138,13 @@ impl<'a> ThingTypeAPI<'a> for EntityType<'a> {
 }
 
 impl<'a> EntityType<'a> {
-    pub fn is_root(
-        &self,
-        snapshot: &impl ReadableSnapshot,
-        type_manager: &TypeManager,
-    ) -> Result<bool, ConceptReadError> {
-        type_manager.get_entity_type_is_root(snapshot, self.clone().into_owned())
-    }
-
     pub fn set_label(
         &self,
         snapshot: &mut impl WritableSnapshot,
         type_manager: &TypeManager,
         label: &Label<'_>,
     ) -> Result<(), ConceptWriteError> {
-        if self.is_root(snapshot, type_manager)? {
-            Err(ConceptWriteError::RootModification)
-        } else {
-            type_manager.set_label(snapshot, self.clone().into_owned(), label)
-        }
+        type_manager.set_label(snapshot, self.clone().into_owned(), label)
     }
 
     pub fn get_supertype(

--- a/concept/type_/mod.rs
+++ b/concept/type_/mod.rs
@@ -148,13 +148,13 @@ pub trait OwnerAPI<'a>: TypeAPI<'a> {
         Ok(self.get_owns_attribute(snapshot, type_manager, attribute_type)?.is_some())
     }
 
-    fn get_owns_attribute_transitive<'m>(
+    fn get_owns_attribute_transitive(
         &self,
         snapshot: &impl ReadableSnapshot,
-        type_manager: &'m TypeManager,
+        type_manager: &TypeManager,
         attribute_type: AttributeType<'static>,
     ) -> Result<Option<Owns<'static>>, ConceptReadError> {
-        Ok(self.get_owns(snapshot, type_manager)?.get(&attribute_type).map(|owns| owns.clone()))
+        Ok(self.get_owns(snapshot, type_manager)?.get(&attribute_type).cloned())
     }
 
     fn has_owns_attribute_transitive(
@@ -274,16 +274,16 @@ pub trait Capability<'a>:
         type_manager: &'this TypeManager,
     ) -> Result<MaybeOwns<'this, HashMap<Self::AnnotationType, Self>>, ConceptReadError>;
 
-    fn get_cardinality<'this>(
-        &'this self,
+    fn get_cardinality(
+        &self,
         snapshot: &impl ReadableSnapshot,
         type_manager: &TypeManager,
     ) -> Result<AnnotationCardinality, ConceptReadError> {
         type_manager.get_cardinality(snapshot, self.clone())
     }
 
-    fn get_default_cardinality<'this>(
-        &'this self,
+    fn get_default_cardinality(
+        &self,
         snapshot: &impl ReadableSnapshot,
         type_manager: &TypeManager,
     ) -> Result<AnnotationCardinality, ConceptReadError>;

--- a/concept/type_/relation_type.rs
+++ b/concept/type_/relation_type.rs
@@ -142,25 +142,13 @@ impl<'a> ObjectTypeAPI<'a> for RelationType<'a> {
 }
 
 impl<'a> RelationType<'a> {
-    pub fn is_root(
-        &self,
-        snapshot: &impl ReadableSnapshot,
-        type_manager: &TypeManager,
-    ) -> Result<bool, ConceptReadError> {
-        type_manager.get_relation_type_is_root(snapshot, self.clone().into_owned())
-    }
-
     pub fn set_label(
         &self,
         snapshot: &mut impl WritableSnapshot,
         type_manager: &TypeManager,
         label: &Label<'_>,
     ) -> Result<(), ConceptWriteError> {
-        if self.is_root(snapshot, type_manager)? {
-            Err(ConceptWriteError::RootModification)
-        } else {
-            type_manager.set_relation_type_label(snapshot, self.clone().into_owned(), label)
-        }
+        type_manager.set_relation_type_label(snapshot, self.clone().into_owned(), label)
     }
 
     pub fn get_supertype(

--- a/concept/type_/relation_type.rs
+++ b/concept/type_/relation_type.rs
@@ -84,7 +84,7 @@ impl<'a> TypeAPI<'a> for RelationType<'a> {
         Self::from_vertex(vertex).unwrap()
     }
 
-    fn vertex<'this>(&'this self) -> TypeVertex<'this> {
+    fn vertex(&self) -> TypeVertex<'_> {
         self.vertex.as_reference()
     }
 

--- a/concept/type_/role_type.rs
+++ b/concept/type_/role_type.rs
@@ -182,25 +182,13 @@ impl<'a> KindAPI<'a> for RoleType<'a> {
 }
 
 impl<'a> RoleType<'a> {
-    pub fn is_root(
-        &self,
-        snapshot: &impl ReadableSnapshot,
-        type_manager: &TypeManager,
-    ) -> Result<bool, ConceptReadError> {
-        type_manager.get_role_type_is_root(snapshot, self.clone().into_owned())
-    }
-
     pub fn set_name(
         &self,
         snapshot: &mut impl WritableSnapshot,
         type_manager: &TypeManager,
         name: &str,
     ) -> Result<(), ConceptWriteError> {
-        if self.is_root(snapshot, type_manager)? {
-            Err(ConceptWriteError::RootModification) // TODO: Move into TypeManager?
-        } else {
-            type_manager.set_role_type_name(snapshot, self.clone().into_owned(), name)
-        }
+        type_manager.set_role_type_name(snapshot, self.clone().into_owned(), name)
     }
 
     pub fn get_supertype(

--- a/concept/type_/role_type.rs
+++ b/concept/type_/role_type.rs
@@ -134,7 +134,7 @@ impl<'a> TypeAPI<'a> for RoleType<'a> {
         Self::from_vertex(vertex).unwrap()
     }
 
-    fn vertex<'this>(&'this self) -> TypeVertex<'this> {
+    fn vertex(&self) -> TypeVertex<'_> {
         self.vertex.as_reference()
     }
 

--- a/concept/type_/type_manager.rs
+++ b/concept/type_/type_manager.rs
@@ -179,25 +179,6 @@ macro_rules! get_subtypes_transitive_methods {
     }
 }
 
-macro_rules! get_type_is_root_methods {
-    ($(
-        fn $method_name:ident() -> $type_:ident = $cache_method:ident;
-    )*) => {
-        $(
-            pub(crate) fn $method_name(
-                &self, snapshot: &impl ReadableSnapshot, type_: $type_<'static>
-            ) -> Result<bool, ConceptReadError> {
-                if let Some(cache) = &self.type_cache {
-                    Ok(cache.$cache_method(type_))
-                } else {
-                    let type_label = TypeReader::get_label(snapshot, type_)?.unwrap();
-                    Ok(TypeReader::check_type_is_root(&type_label, $type_::ROOT_KIND))
-                }
-            }
-        )*
-    }
-}
-
 macro_rules! get_type_label_methods {
     ($(
         fn $method_name:ident() -> $type_:ident = $cache_method:ident;
@@ -306,7 +287,7 @@ impl TypeManager {
     pub fn resolve_struct_field(
         &self,
         snapshot: &impl ReadableSnapshot,
-        fields_path: &Vec<&str>,
+        fields_path: &[&str],
         definition: StructDefinition,
     ) -> Result<Vec<StructFieldIDUInt>, ConceptReadError> {
         let mut resolved: Vec<StructFieldIDUInt> = Vec::with_capacity(fields_path.len());
@@ -328,7 +309,7 @@ impl TypeManager {
                             Err(ConceptReadError::Encoding {
                                 source: EncodingError::IndexingIntoNonStructField {
                                     struct_name: definition.name,
-                                    field_path: fields_path.clone().into_iter().map(|str| str.to_owned()).collect(),
+                                    field_path: fields_path.iter().map(|&str| str.to_owned()).collect(),
                                 },
                             })
                         };
@@ -338,7 +319,7 @@ impl TypeManager {
                 return Err(ConceptReadError::Encoding {
                     source: EncodingError::StructFieldUnresolvable {
                         struct_name: definition.name,
-                        field_path: fields_path.clone().into_iter().map(|str| str.to_owned()).collect(),
+                        field_path: fields_path.iter().map(|&str| str.to_owned()).collect(),
                     },
                 });
             }
@@ -347,7 +328,7 @@ impl TypeManager {
         Err(ConceptReadError::Encoding {
             source: EncodingError::StructPathIncomplete {
                 struct_name: definition.name,
-                field_path: fields_path.clone().into_iter().map(|str| str.to_owned()).collect(),
+                field_path: fields_path.iter().map(|&str| str.to_owned()).collect(),
             },
         })
     }

--- a/concept/type_/type_manager/type_cache/kind_cache.rs
+++ b/concept/type_/type_manager/type_cache/kind_cache.rs
@@ -92,7 +92,6 @@ pub(crate) struct RelatesCache {
 pub(crate) struct CommonTypeCache<T: KindAPI<'static>> {
     pub(super) type_: T,
     pub(super) label: Label<'static>,
-    pub(super) is_root: bool,
     pub(super) annotations_declared: HashSet<T::AnnotationType>,
     pub(super) annotations: HashMap<T::AnnotationType, T>,
     // TODO: Should these all be sets instead of vec?
@@ -312,7 +311,6 @@ impl<T: KindAPI<'static, SelfStatic = T>> CommonTypeCache<T> {
         Snapshot: ReadableSnapshot,
     {
         let label = TypeReader::get_label(snapshot, type_.clone()).unwrap().unwrap();
-        let is_root = TypeReader::check_type_is_root(&label, T::ROOT_KIND);
         let annotations_declared = TypeReader::get_type_annotations_declared(snapshot, type_.clone()).unwrap();
         let annotations = TypeReader::get_type_annotations(snapshot, type_.clone()).unwrap();
         let supertype = TypeReader::get_supertype(snapshot, type_.clone()).unwrap();
@@ -322,7 +320,6 @@ impl<T: KindAPI<'static, SelfStatic = T>> CommonTypeCache<T> {
         CommonTypeCache {
             type_,
             label,
-            is_root,
             annotations_declared,
             annotations,
             supertype,

--- a/concept/type_/type_manager/validation/mod.rs
+++ b/concept/type_/type_manager/validation/mod.rs
@@ -10,7 +10,6 @@ use encoding::{
     graph::type_::{CapabilityKind, Kind},
     value::{label::Label, value_type::ValueType},
 };
-use storage::snapshot::ReadableSnapshot;
 
 use crate::{
     error::ConceptReadError,
@@ -22,7 +21,7 @@ use crate::{
         object_type::ObjectType,
         relation_type::RelationType,
         role_type::RoleType,
-        Capability, Ordering, TypeAPI,
+        Ordering,
     },
 };
 
@@ -34,8 +33,6 @@ mod validation;
 #[derive(Debug, Clone)]
 pub enum SchemaValidationError {
     ConceptRead(ConceptReadError),
-    RootTypesAreImmutable,
-    RootHasBeenCorrupted(Label<'static>),
     LabelShouldBeUnique(Label<'static>),
     StructNameShouldBeUnique(String),
     StructShouldHaveAtLeastOneField(String),
@@ -168,8 +165,6 @@ impl Error for SchemaValidationError {
     fn source(&self) -> Option<&(dyn Error + 'static)> {
         match self {
             Self::ConceptRead(source) => Some(source),
-            Self::RootTypesAreImmutable => None,
-            Self::RootHasBeenCorrupted(_) => None,
             Self::LabelShouldBeUnique(_) => None,
             Self::StructNameShouldBeUnique(_) => None,
             Self::StructShouldHaveAtLeastOneField(_) => None,

--- a/database/database.rs
+++ b/database/database.rs
@@ -15,7 +15,6 @@ use std::{
 use concept::{
     error::ConceptWriteError,
     thing::statistics::{Statistics, StatisticsError},
-    type_::type_manager::TypeManager,
 };
 use durability::wal::{WALError, WAL};
 use encoding::{
@@ -78,7 +77,7 @@ impl Database<WALClient> {
     }
 
     fn create(path: &Path, name: impl AsRef<str>) -> Result<Database<WALClient>, DatabaseOpenError> {
-        use DatabaseOpenError::{DirectoryCreate, Encoding, SchemaInitialise, StorageOpen, WALOpen};
+        use DatabaseOpenError::{DirectoryCreate, Encoding, StorageOpen, WALOpen};
 
         let name = name.as_ref();
 
@@ -97,8 +96,6 @@ impl Database<WALClient> {
         let thing_vertex_generator =
             Arc::new(ThingVertexGenerator::load(storage.clone()).map_err(|err| Encoding { source: err })?);
         let statistics = Statistics::new(storage.read_watermark());
-        TypeManager::initialise_types(storage.clone(), definition_key_generator.clone(), type_vertex_generator.clone())
-            .map_err(|err| SchemaInitialise { source: err })?;
 
         Ok(Database::<WALClient> {
             name: name.to_owned(),
@@ -114,8 +111,7 @@ impl Database<WALClient> {
 
     fn load(path: &Path, name: impl AsRef<str>) -> Result<Database<WALClient>, DatabaseOpenError> {
         use DatabaseOpenError::{
-            CheckpointCreate, CheckpointLoad, DurabilityRead, Encoding, SchemaInitialise, StatisticsInitialise,
-            StorageOpen, WALOpen,
+            CheckpointCreate, CheckpointLoad, DurabilityRead, Encoding, StatisticsInitialise, StorageOpen, WALOpen,
         };
 
         let wal = WAL::load(path).map_err(|err| WALOpen { source: err })?;
@@ -133,8 +129,6 @@ impl Database<WALClient> {
         let type_vertex_generator = Arc::new(TypeVertexGenerator::new());
         let thing_vertex_generator =
             Arc::new(ThingVertexGenerator::load(storage.clone()).map_err(|err| Encoding { source: err })?);
-        TypeManager::initialise_types(storage.clone(), definition_key_generator.clone(), type_vertex_generator.clone())
-            .map_err(|err| SchemaInitialise { source: err })?;
 
         let mut statistics = storage
             .durability()
@@ -184,7 +178,7 @@ impl Database<WALClient> {
     pub fn reset(&mut self) -> Result<(), DatabaseResetError> {
         use DatabaseResetError::{
             CorruptionDefinitionKeyGeneratorInUse, CorruptionStorageReset, CorruptionTypeVertexGeneratorInUse,
-            SchemaInitialise, TypeVertexGeneratorInUse,
+            TypeVertexGeneratorInUse,
         };
 
         let mut locked_schema = self.schema.write().unwrap();
@@ -217,13 +211,6 @@ impl Database<WALClient> {
 
         let schema = Arc::get_mut(&mut *locked_schema).unwrap();
         schema.thing_statistics.reset(self.storage.read_watermark());
-
-        TypeManager::initialise_types(
-            self.storage.clone(),
-            self.definition_key_generator.clone(),
-            self.type_vertex_generator.clone(),
-        )
-        .map_err(|err| SchemaInitialise { source: err })?;
 
         Ok(())
     }

--- a/database/tests/database.rs
+++ b/database/tests/database.rs
@@ -4,10 +4,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-use std::sync::Arc;
-
-use database::{transaction::TransactionRead, Database};
-use encoding::graph::type_::Kind;
+use database::Database;
 use storage::durability_client::WALClient;
 use test_utils::{create_tmp_dir, init_logging};
 
@@ -18,12 +15,7 @@ fn create_delete_database() {
     dbg!(database_path.exists());
     let db_result = Database::<WALClient>::open(&database_path.join("create_delete"));
     assert!(db_result.is_ok(), "{:?}", db_result.unwrap_err());
-    let db = Arc::new(db_result.unwrap());
-
-    let txn = TransactionRead::open(db.clone());
-    let types = txn.type_manager;
-    let root_entity_type = types.get_entity_type(&txn.snapshot, &Kind::Entity.root_label());
-    eprintln!("Root entity type: {:?}", root_entity_type);
-    // let delete_result = db.delete();
-    // assert!(delete_result.is_ok());
+    let db = db_result.unwrap();
+    let delete_result = db.delete();
+    assert!(delete_result.is_ok());
 }

--- a/encoding/graph/type_/mod.rs
+++ b/encoding/graph/type_/mod.rs
@@ -6,8 +6,6 @@
 
 use std::fmt::{Display, Formatter, Result};
 
-use crate::value::label::Label;
-
 pub mod edge;
 pub mod index;
 pub mod property;
@@ -23,27 +21,19 @@ pub enum Kind {
 }
 
 impl Kind {
-    const fn all_kinds() -> [Kind; 4] {
-        [Kind::Entity, Kind::Attribute, Kind::Relation, Kind::Role]
-    }
-
-    pub const fn root_label(&self) -> Label {
+    pub const fn name(&self) -> &'static str {
         match self {
-            Kind::Entity => Label::new_static("entity"),
-            Kind::Attribute => Label::new_static("attribute"),
-            Kind::Relation => Label::new_static("relation"),
-            Kind::Role => Label::new_static_scoped("role", "relation", "relation:role"),
+            Kind::Entity => "entity",
+            Kind::Attribute => "attribute",
+            Kind::Relation => "relation",
+            Kind::Role => "relation:role",
         }
-    }
-
-    pub fn is_root_label(label: &Label) -> bool {
-        Kind::all_kinds().iter().any(|kind| kind.root_label() == *label)
     }
 }
 
 impl std::fmt::Debug for Kind {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        write!(f, "Kind[{}]", self.root_label().name)
+        write!(f, "Kind[{}]", self.name())
     }
 }
 
@@ -55,24 +45,23 @@ pub enum CapabilityKind {
 }
 
 impl CapabilityKind {
-    const fn all_kinds() -> [CapabilityKind; 3] {
-        [CapabilityKind::Relates, CapabilityKind::Plays, CapabilityKind::Owns]
+    fn name(&self) -> &'static str {
+        match self {
+            CapabilityKind::Relates => "relates",
+            CapabilityKind::Plays => "plays",
+            CapabilityKind::Owns => "owns",
+        }
     }
 }
 
 impl Display for CapabilityKind {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result {
-        let str = match self {
-            CapabilityKind::Relates => "relates",
-            CapabilityKind::Plays => "plays",
-            CapabilityKind::Owns => "owns",
-        };
-        write!(f, "{}", str)
+        write!(f, "{}", self.name())
     }
 }
 
 impl std::fmt::Debug for CapabilityKind {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result {
-        write!(f, "CapabilityKind[{}]", self.to_string())
+        write!(f, "CapabilityKind[{}]", self)
     }
 }

--- a/ir/inference/type_inference.rs
+++ b/ir/inference/type_inference.rs
@@ -435,7 +435,7 @@ pub mod tests {
 
             let mut builder = FunctionalBlock::builder();
             let mut conjunction = builder.conjunction_mut();
-            let mut context = BlockContext::new();
+            let context = BlockContext::new();
             let var_animal = conjunction.get_or_declare_variable("animal").unwrap();
 
             let callee_signature = FunctionSignature::new(

--- a/ir/program/block.rs
+++ b/ir/program/block.rs
@@ -31,7 +31,7 @@ pub struct FunctionalBlock {
 }
 
 impl FunctionalBlock {
-    pub fn builder<'func>() -> FunctionalBlockBuilder {
+    pub fn builder() -> FunctionalBlockBuilder {
         FunctionalBlockBuilder::new()
     }
 

--- a/tests/behaviour/steps/concept/type_/owns.rs
+++ b/tests/behaviour/steps/concept/type_/owns.rs
@@ -462,7 +462,7 @@ pub async fn get_owns_set_ordering(
         let attr_type =
             tx.type_manager.get_attribute_type(&tx.snapshot, &attr_type_label.into_typedb()).unwrap().unwrap();
         let owns = object_type.get_owns_attribute(&tx.snapshot, &tx.type_manager, attr_type).unwrap().unwrap();
-        let res = owns.set_ordering(&mut tx.snapshot, &tx.type_manager, ordering.into_typedb().into());
+        let res = owns.set_ordering(&mut tx.snapshot, &tx.type_manager, ordering.into_typedb());
         may_error.check_concept_write_without_read_errors(&res);
     });
 }
@@ -481,6 +481,6 @@ pub async fn get_owns_get_ordering(
         let attr_type =
             tx.type_manager.get_attribute_type(&tx.snapshot, &attr_type_label.into_typedb()).unwrap().unwrap();
         let owns = object_type.get_owns_attribute(&tx.snapshot, &tx.type_manager, attr_type).unwrap().unwrap();
-        assert_eq!(owns.get_ordering(&tx.snapshot, &tx.type_manager).unwrap(), ordering.into_typedb().into());
+        assert_eq!(owns.get_ordering(&tx.snapshot, &tx.type_manager).unwrap(), ordering.into_typedb());
     });
 }

--- a/tests/behaviour/steps/concept/type_/plays.rs
+++ b/tests/behaviour/steps/concept/type_/plays.rs
@@ -4,7 +4,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-use concept::type_::{annotation, plays::PlaysAnnotation, Capability, Ordering, OwnerAPI, PlayerAPI, TypeAPI};
+use concept::type_::{annotation, plays::PlaysAnnotation, Capability, PlayerAPI, TypeAPI};
 use cucumber::gherkin::Step;
 use itertools::Itertools;
 use macro_rules_attribute::apply;
@@ -134,8 +134,8 @@ pub async fn get_plays_set_override(
             tx.type_manager.get_role_type(&tx.snapshot, &overridden_role_label.into_typedb()).unwrap().unwrap();
         let overridden_plays_opt =
             player_supertype.get_plays_role(&tx.snapshot, &tx.type_manager, overridden_role_type).unwrap();
-        if let Some(overridden_plays) = overridden_plays_opt.as_ref() {
-            let res = plays.set_override(&mut tx.snapshot, &tx.type_manager, overridden_plays_opt.unwrap());
+        if let Some(overridden_plays) = overridden_plays_opt {
+            let res = plays.set_override(&mut tx.snapshot, &tx.type_manager, overridden_plays);
             may_error.check_concept_write_without_read_errors(&res);
         } else {
             assert!(may_error.expects_error());

--- a/tests/behaviour/steps/concept/type_/relation_type.rs
+++ b/tests/behaviour/steps/concept/type_/relation_type.rs
@@ -15,9 +15,7 @@ use macro_rules_attribute::apply;
 use crate::{
     concept::type_::BehaviourConceptTestExecutionError,
     generic_step, params,
-    params::{
-        Annotation, AnnotationCategory, ContainsOrDoesnt, ExistsOrDoesnt, IsEmptyOrNot, Label, MayError, RootLabel,
-    },
+    params::{Annotation, AnnotationCategory, ContainsOrDoesnt, ExistsOrDoesnt, IsEmptyOrNot, Label, MayError},
     transaction_context::{with_read_tx, with_schema_tx},
     util, Context,
 };

--- a/tests/behaviour/steps/concept/type_/struct_definition.rs
+++ b/tests/behaviour/steps/concept/type_/struct_definition.rs
@@ -4,20 +4,14 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-use std::ascii::escape_default;
-
-use concept::type_::{object_type::ObjectType, PlayerAPI};
 use cucumber::gherkin::Step;
-use encoding::graph::type_::Kind;
 use macro_rules_attribute::apply;
 
 use crate::{
     generic_step, params,
-    params::{
-        check_boolean, Annotation, ContainsOrDoesnt, ExistsOrDoesnt, Label, MayError, Optional, RootLabel, ValueType,
-    },
-    transaction_context::{with_read_tx, with_schema_tx, with_write_tx},
-    util, with_type, Context,
+    params::{check_boolean, ContainsOrDoesnt, ExistsOrDoesnt, Label, MayError, Optional, ValueType},
+    transaction_context::{with_read_tx, with_schema_tx},
+    util, Context,
 };
 
 #[apply(generic_step)]

--- a/tests/behaviour/steps/concept/type_/thing_type.rs
+++ b/tests/behaviour/steps/concept/type_/thing_type.rs
@@ -4,11 +4,9 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-use std::ascii::escape_default;
-
 use concept::type_::{
     annotation, attribute_type::AttributeTypeAnnotation, entity_type::EntityTypeAnnotation, object_type::ObjectType,
-    relation_type::RelationTypeAnnotation, KindAPI, PlayerAPI, TypeAPI,
+    relation_type::RelationTypeAnnotation, KindAPI, TypeAPI,
 };
 use cucumber::gherkin::Step;
 use encoding::{graph::type_::Kind, value::value_type::ValueType};
@@ -16,7 +14,7 @@ use itertools::Itertools;
 use macro_rules_attribute::apply;
 
 use crate::{
-    generic_step, params,
+    generic_step,
     params::{
         Annotation, AnnotationCategory, ContainsOrDoesnt, ExistsOrDoesnt, IsEmptyOrNot, Label, MayError, RootLabel,
     },
@@ -98,25 +96,19 @@ pub async fn type_create(context: &mut Context, root_label: RootLabel, type_labe
     with_schema_tx!(context, |tx| {
         match root_label.into_typedb() {
             Kind::Entity => {
-                may_error.check_concept_write_without_read_errors(&tx.type_manager.create_entity_type(
-                    &mut tx.snapshot,
-                    &type_label.into_typedb(),
-                    false,
-                ));
+                may_error.check_concept_write_without_read_errors(
+                    &tx.type_manager.create_entity_type(&mut tx.snapshot, &type_label.into_typedb()),
+                );
             }
             Kind::Relation => {
-                may_error.check_concept_write_without_read_errors(&tx.type_manager.create_relation_type(
-                    &mut tx.snapshot,
-                    &type_label.into_typedb(),
-                    false,
-                ));
+                may_error.check_concept_write_without_read_errors(
+                    &tx.type_manager.create_relation_type(&mut tx.snapshot, &type_label.into_typedb()),
+                );
             }
             Kind::Attribute => {
-                may_error.check_concept_write_without_read_errors(&tx.type_manager.create_attribute_type(
-                    &mut tx.snapshot,
-                    &type_label.into_typedb(),
-                    false,
-                ));
+                may_error.check_concept_write_without_read_errors(
+                    &tx.type_manager.create_attribute_type(&mut tx.snapshot, &type_label.into_typedb()),
+                );
             }
             Kind::Role => unreachable!("Can only address roles through relation(relation_label) get role(role_name)"),
         }
@@ -228,8 +220,7 @@ pub async fn type_unset_annotation(
 ) {
     with_write_tx!(context, |tx| {
         with_type!(tx, root_label, type_label, type_, {
-            let res =
-                type_.unset_annotation(&mut tx.snapshot, &tx.type_manager, annotation_category.into_typedb().into());
+            let res = type_.unset_annotation(&mut tx.snapshot, &tx.type_manager, annotation_category.into_typedb());
             may_error.check_concept_write_without_read_errors(&res);
         });
     });

--- a/tests/behaviour/steps/params.rs
+++ b/tests/behaviour/steps/params.rs
@@ -4,23 +4,32 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-use std::{borrow::Cow, convert::Infallible, error::Error, fmt, str::FromStr, sync::Arc};
+use std::{borrow::Cow, convert::Infallible, fmt, str::FromStr, sync::Arc};
 
-use chrono::{DateTime, FixedOffset, NaiveDate, NaiveDateTime, NaiveTime};
+use chrono::{FixedOffset, NaiveDate, NaiveDateTime, NaiveTime};
 use chrono_tz::Tz;
-use concept::type_::{
-    annotation::{
-        Annotation as TypeDBAnnotation, AnnotationAbstract, AnnotationCardinality, AnnotationCascade,
-        AnnotationCategory as TypeDBAnnotationCategory, AnnotationIndependent, AnnotationKey, AnnotationRegex,
+use concept::{
+    error::ConceptWriteError,
+    type_::{
+        annotation::{
+            Annotation as TypeDBAnnotation, AnnotationAbstract, AnnotationCardinality, AnnotationCascade,
+            AnnotationCategory as TypeDBAnnotationCategory, AnnotationDistinct, AnnotationIndependent, AnnotationKey,
+            AnnotationRange, AnnotationRegex, AnnotationUnique, AnnotationValues,
+        },
+        object_type::ObjectType,
+        type_manager::{validation::SchemaValidationError, TypeManager},
     },
-    object_type::ObjectType,
 };
 use cucumber::Parameter;
 use encoding::{
     graph::type_::Kind as TypeDBTypeKind,
-    value::{label::Label as TypeDBLabel, value::Value as TypeDBValue, value_type::ValueType as TypeDBValueType},
+    value::{
+        decimal_value::Decimal, label::Label as TypeDBLabel, value::Value as TypeDBValue,
+        value_type::ValueType as TypeDBValueType,
+    },
 };
 use itertools::Itertools;
+use storage::snapshot::ReadableSnapshot;
 
 use crate::assert::assert_matches;
 
@@ -95,16 +104,6 @@ macro_rules! check_boolean {
     };
 }
 pub(crate) use check_boolean;
-use concept::{
-    error::ConceptWriteError,
-    type_::{
-        annotation::{AnnotationDistinct, AnnotationRange, AnnotationUnique, AnnotationValues},
-        type_manager::{validation::SchemaValidationError, TypeManager},
-    },
-};
-use database::transaction::SchemaCommitError;
-use encoding::value::decimal_value::Decimal;
-use storage::snapshot::ReadableSnapshot;
 
 impl FromStr for Boolean {
     type Err = String;

--- a/traversal/executor/batch.rs
+++ b/traversal/executor/batch.rs
@@ -7,6 +7,7 @@
 use std::{
     borrow::Cow,
     fmt::{Display, Formatter},
+    vec,
 };
 
 use answer::variable_value::VariableValue;
@@ -178,8 +179,7 @@ impl<'a> ImmutableRow<'a> {
     }
 
     pub fn into_owned(self) -> ImmutableRow<'static> {
-        let cloned: Vec<VariableValue<'static>> =
-            self.row.into_iter().map(|value| value.clone().into_owned()).collect();
+        let cloned: Vec<VariableValue<'static>> = self.row.iter().map(|value| value.clone().into_owned()).collect();
         ImmutableRow { row: Cow::Owned(cloned), multiplicity: self.multiplicity }
     }
 
@@ -188,8 +188,11 @@ impl<'a> ImmutableRow<'a> {
     }
 }
 
-impl ImmutableRow<'static> {
-    pub fn into_iter(self) -> impl Iterator<Item = VariableValue<'static>> {
+impl IntoIterator for ImmutableRow<'static> {
+    type Item = VariableValue<'static>;
+    type IntoIter = vec::IntoIter<VariableValue<'static>>;
+    fn into_iter(self) -> Self::IntoIter {
+        #[allow(clippy::unnecessary_to_owned)]
         self.row.into_owned().into_iter()
     }
 }
@@ -200,6 +203,7 @@ impl<'a> Display for ImmutableRow<'a> {
         for value in self.row.as_ref() {
             write!(f, "{value}  ")?
         }
-        write!(f, "]\n")
+        writeln!(f, "]")?;
+        Ok(())
     }
 }

--- a/traversal/planner/pattern_plan.rs
+++ b/traversal/planner/pattern_plan.rs
@@ -255,7 +255,7 @@ impl IntersectionStep {
             instructions,
             unbound_variables: unbound,
             bound_variables: bound,
-            selected_variables: selected_variables.clone(),
+            selected_variables: selected_variables.to_owned(),
         }
     }
 
@@ -277,7 +277,7 @@ impl UnsortedJoinStep {
     pub fn new(
         iterate_instruction: Instruction,
         check_instructions: Vec<Instruction>,
-        selected_variables: &Vec<Variable>,
+        selected_variables: &[Variable],
     ) -> Self {
         let mut bound = Vec::with_capacity(check_instructions.len() * 2);
         let mut unbound = Vec::with_capacity(5);
@@ -303,7 +303,7 @@ impl UnsortedJoinStep {
             check_instructions,
             unbound_variables: unbound,
             bound_variables: bound,
-            selected_variables: selected_variables.clone(),
+            selected_variables: selected_variables.to_owned(),
         }
     }
 
@@ -380,7 +380,7 @@ impl Instruction {
         found
     }
 
-    fn bound_vars_foreach(&self, mut apply: impl FnMut(Variable) -> ()) {
+    fn bound_vars_foreach(&self, mut apply: impl FnMut(Variable)) {
         match self {
             Instruction::Isa(_, bounds) => bounds.bounds().iter().cloned().for_each(apply),
             Instruction::Has(_, bounds) | Instruction::HasReverse(_, bounds) => {
@@ -435,7 +435,7 @@ impl InstructionAPI for Instruction {
             Instruction::Has(has, _) | Instruction::HasReverse(has, _) => has.clone().into(),
             Instruction::RolePlayer(rp, _) | Instruction::RolePlayerReverse(rp, _) => rp.clone().into(),
             Instruction::FunctionCallBinding(call) => call.clone().into(),
-            Instruction::ComparisonGenerator(cmp)
+            | Instruction::ComparisonGenerator(cmp)
             | Instruction::ComparisonGeneratorReverse(cmp)
             | Instruction::ComparisonCheck(cmp) => cmp.clone().into(),
             Instruction::ExpressionBinding(binding) => binding.clone().into(),

--- a/traversal/tests/common.rs
+++ b/traversal/tests/common.rs
@@ -25,11 +25,6 @@ pub fn setup_storage() -> (TempDir, Arc<MVCCStorage<WALClient>>) {
     let storage = Arc::new(
         MVCCStorage::<WALClient>::create::<EncodingKeyspace>("storage", &storage_path, WALClient::new(wal)).unwrap(),
     );
-
-    let definition_key_generator = Arc::new(DefinitionKeyGenerator::new());
-    let type_vertex_generator = Arc::new(TypeVertexGenerator::new());
-    TypeManager::initialise_types(storage.clone(), definition_key_generator.clone(), type_vertex_generator.clone())
-        .unwrap();
     (storage_path, storage)
 }
 

--- a/traversal/tests/executor.rs
+++ b/traversal/tests/executor.rs
@@ -43,10 +43,10 @@ fn test_planning_traversal() {
     let mut snapshot: WriteSnapshot<WALClient> = storage.clone().open_snapshot_write();
     let (type_manager, thing_manager) = load_managers(storage.clone());
 
-    let person_type = type_manager.create_entity_type(&mut snapshot, &PERSON_LABEL, false).unwrap();
-    let age_type = type_manager.create_attribute_type(&mut snapshot, &AGE_LABEL, false).unwrap();
+    let person_type = type_manager.create_entity_type(&mut snapshot, &PERSON_LABEL).unwrap();
+    let age_type = type_manager.create_attribute_type(&mut snapshot, &AGE_LABEL).unwrap();
     age_type.set_value_type(&mut snapshot, &type_manager, ValueType::Long).unwrap();
-    let name_type = type_manager.create_attribute_type(&mut snapshot, &NAME_LABEL, false).unwrap();
+    let name_type = type_manager.create_attribute_type(&mut snapshot, &NAME_LABEL).unwrap();
     name_type.set_value_type(&mut snapshot, &type_manager, ValueType::String).unwrap();
     person_type.set_owns(&mut snapshot, &type_manager, age_type.clone(), Ordering::Unordered).unwrap();
     person_type.set_owns(&mut snapshot, &type_manager, name_type.clone(), Ordering::Unordered).unwrap();

--- a/traversal/tests/executor_isa.rs
+++ b/traversal/tests/executor_isa.rs
@@ -11,14 +11,16 @@ use encoding::value::label::Label;
 use ir::{
     inference::type_inference::infer_types,
     pattern::constraint::IsaKind,
-    program::{block::FunctionalBlock, program::Program},
+    program::{
+        block::FunctionalBlock,
+        program::{CompiledSchemaFunctions, Program},
+    },
 };
-use ir::program::program::CompiledSchemaFunctions;
 use lending_iterator::LendingIterator;
 use storage::{
     durability_client::WALClient,
-    MVCCStorage,
     snapshot::{CommittableSnapshot, ReadSnapshot, WriteSnapshot},
+    MVCCStorage,
 };
 use traversal::{
     executor::{batch::ImmutableRow, program_executor::ProgramExecutor},
@@ -40,9 +42,9 @@ fn setup_database(storage: Arc<MVCCStorage<WALClient>>) {
     let mut snapshot: WriteSnapshot<WALClient> = storage.clone().open_snapshot_write();
     let (type_manager, thing_manager) = load_managers(storage.clone());
 
-    let animal_type = type_manager.create_entity_type(&mut snapshot, &ANIMAL_LABEL, false).unwrap();
-    let dog_type = type_manager.create_entity_type(&mut snapshot, &DOG_LABEL, false).unwrap();
-    let cat_type = type_manager.create_entity_type(&mut snapshot, &CAT_LABEL, false).unwrap();
+    let animal_type = type_manager.create_entity_type(&mut snapshot, &ANIMAL_LABEL).unwrap();
+    let dog_type = type_manager.create_entity_type(&mut snapshot, &DOG_LABEL).unwrap();
+    let cat_type = type_manager.create_entity_type(&mut snapshot, &CAT_LABEL).unwrap();
     dog_type.set_supertype(&mut snapshot, &type_manager, animal_type.clone()).unwrap();
     cat_type.set_supertype(&mut snapshot, &type_manager, animal_type.clone()).unwrap();
 
@@ -71,19 +73,15 @@ fn traverse_isa_unbounded_sorted_thing() {
     // IR
     let mut block = FunctionalBlock::builder();
     let mut conjunction = block.conjunction_mut();
-    let var_dog_type = conjunction.get_or_declare_variable(&"dog_type").unwrap();
-    let var_dog = conjunction.get_or_declare_variable(&"dog").unwrap();
+    let var_dog_type = conjunction.get_or_declare_variable("dog_type").unwrap();
+    let var_dog = conjunction.get_or_declare_variable("dog").unwrap();
 
     // add all constraints to make type inference return correct types, though we only plan Has's
     let isa = conjunction.constraints_mut().add_isa(IsaKind::Subtype, var_dog, var_dog_type).unwrap().clone();
     conjunction.constraints_mut().add_label(var_dog_type, DOG_LABEL.scoped_name().as_str()).unwrap();
+    let filter = block.add_filter(vec!["dog"]).unwrap().clone();
     let program = Program::new(block.finish(), Vec::new());
-
-    let annotated_program = {
-        let snapshot: ReadSnapshot<WALClient> = storage.clone().open_snapshot_read();
-        let (type_manager, _) = load_managers(storage.clone());
-        infer_types(program, &snapshot, &type_manager, Arc::new(CompiledSchemaFunctions::empty())).unwrap()
-    };
+    let schema_cache = CompiledSchemaFunctions::new(Box::new([]), Box::new([]));
 
     // Plan
     let steps = vec![Step::Intersection(IntersectionStep::new(
@@ -93,13 +91,21 @@ fn traverse_isa_unbounded_sorted_thing() {
     ))];
     // TODO: incorporate the filter
     let pattern_plan = PatternPlan::new(steps, annotated_program.get_entry().context().clone());
-    let program_plan = ProgramPlan::new(pattern_plan, annotated_program.get_entry_annotations().clone(), HashMap::new());
+    let program_plan =
+        ProgramPlan::new(pattern_plan, annotated_program.get_entry_annotations().clone(), HashMap::new());
+
+    let annotated_program = {
+        let snapshot: ReadSnapshot<WALClient> = storage.clone().open_snapshot_read();
+        let (type_manager, _) = load_managers(storage.clone());
+        infer_types(program, &snapshot, &type_manager, Arc::new(schema_cache)).unwrap()
+    };
 
     // Executor
     let executor = {
         let snapshot: ReadSnapshot<WALClient> = storage.clone().open_snapshot_read();
         let (_, thing_manager) = load_managers(storage.clone());
-        ProgramExecutor::new(program_plan, &snapshot, &thing_manager).unwrap()
+        ProgramExecutor::new(program_plan, annotated_program.get_entry_annotations(), &snapshot, &thing_manager)
+            .unwrap()
     };
 
     {
@@ -114,9 +120,91 @@ fn traverse_isa_unbounded_sorted_thing() {
         assert_eq!(rows.len(), 3);
 
         for row in rows {
-            let r = row.unwrap();
-            assert_eq!(r.get_multiplicity(), 1);
+            let row = row.unwrap();
+            assert_eq!(row.get_multiplicity(), 1);
+            print!("{}", row);
+        }
+    }
+}
+
+#[test]
+fn traverse_has_unbounded_sorted_to_merged() {
+    let (_tmp_dir, storage) = setup_storage();
+
+    setup_database(storage.clone());
+
+    // query:
+    //   match
+    //    $person has $attribute;
+
+    // IR
+    let mut block = FunctionalBlock::builder();
+    let mut conjunction = block.conjunction_mut();
+    let var_person_type = conjunction.get_or_declare_variable("person_type").unwrap();
+    let var_attribute_type = conjunction.get_or_declare_variable("attr_type").unwrap();
+    let var_person = conjunction.get_or_declare_variable("person").unwrap();
+    let var_attribute = conjunction.get_or_declare_variable("attr").unwrap();
+    let has_attribute = conjunction.constraints_mut().add_has(var_person, var_attribute).unwrap().clone();
+    conjunction.constraints_mut().add_isa(IsaKind::Subtype, var_person, var_person_type).unwrap();
+    conjunction.constraints_mut().add_isa(IsaKind::Subtype, var_attribute, var_attribute_type).unwrap();
+    conjunction.constraints_mut().add_label(var_person_type, ANIMAL_LABEL.scoped_name().as_str()).unwrap();
+    let program = Program::new(block.finish(), Vec::new());
+    let schema_cache = CompiledSchemaFunctions::new(Box::new([]), Box::new([]));
+
+    // Plan
+    let steps = vec![Step::SortedJoin(SortedJoinStep::new(
+        var_attribute,
+        vec![Instruction::Has(has_attribute.clone(), IterateBounds::None([]))],
+        &vec![var_person, var_attribute],
+    ))];
+    let pattern_plan = PatternPlan::new(steps, program.entry().context().clone());
+    let program_plan = ProgramPlan::new(pattern_plan, HashMap::new());
+
+    let annotated_program = {
+        let snapshot: ReadSnapshot<WALClient> = storage.clone().open_snapshot_read();
+        let (type_manager, _) = load_managers(storage.clone());
+        infer_types(program, &snapshot, &type_manager, Arc::new(schema_cache)).unwrap()
+    };
+
+    // Executor
+    let executor = {
+        let snapshot: ReadSnapshot<WALClient> = storage.clone().open_snapshot_read();
+        let (_, thing_manager) = load_managers(storage.clone());
+        ProgramExecutor::new(program_plan, annotated_program.get_entry_annotations(), &snapshot, &thing_manager)
+            .unwrap()
+    };
+
+    {
+        let snapshot: Arc<ReadSnapshot<WALClient>> = Arc::new(storage.clone().open_snapshot_read());
+        let (_, thing_manager) = load_managers(storage.clone());
+        let thing_manager = Arc::new(thing_manager);
+
+        let variable_positions = executor.entry_variable_positions().clone();
+
+        let iterator = executor.into_iterator(snapshot, thing_manager);
+
+        let rows: Vec<Result<ImmutableRow<'static>, ConceptReadError>> =
+            iterator.map_static(|row| row.map(|row| row.into_owned()).map_err(|err| err.clone())).collect();
+
+        // person 1 - has age 1, has age 2, has age 3, has name 1, has name 2 => 5 answers
+        // person 2 - has age 1, has age 4, has age 5 => 3 answers
+        // person 3 - has age 4, has name 3 => 2 answers
+
+        assert_eq!(rows.len(), 10);
+
+        for row in &rows {
+            let r = row.as_ref().unwrap();
+            debug_assert_eq!(r.get_multiplicity(), 1);
             print!("{}", r);
+        }
+
+        let attribute_position = variable_positions[&var_attribute];
+        let mut last_attribute = rows[0].as_ref().unwrap().get(attribute_position);
+        for row in &rows {
+            let row = row.as_ref().unwrap();
+            let attribute = &row.get(attribute_position);
+            assert!(last_attribute <= attribute, "{} <= {} failed", &last_attribute, &attribute);
+            last_attribute = attribute;
         }
     }
 }


### PR DESCRIPTION
## Usage and product changes

`entity`, `relation`, and `attribute` are promoted to keywords (á la `struct`) and no longer have corresponding root types. That means that they are no longer a part of the type hierarchy.