### PR TITLE
WAL files start at SequenceNumber::MIN

### DIFF
--- a/durability/wal.rs
+++ b/durability/wal.rs
@@ -225,7 +225,7 @@ impl Files {
         files.sort_unstable_by(|lhs, rhs| lhs.path.cmp(&rhs.path));
 
         if files.is_empty() {
-            files.push(File::open_at(directory.clone(), DurabilitySequenceNumber::MIN.next())?);
+            files.push(File::open_at(directory.clone(), DurabilitySequenceNumber::MIN)?);
         }
 
         let writer = files.last().unwrap().writer()?;

--- a/durability/wal.rs
+++ b/durability/wal.rs
@@ -213,7 +213,7 @@ impl Files {
         Ok(Self { directory, writer, files })
     }
 
-    fn init_files_writer(directory: &PathBuf) -> io::Result<(Vec<File>, BufWriter<std::fs::File>)> {
+    fn init_files_writer(directory: &Path) -> io::Result<(Vec<File>, BufWriter<std::fs::File>)> {
         let mut files: Vec<File> = directory
             .read_dir()?
             .map_ok(|entry| entry.path())
@@ -225,7 +225,7 @@ impl Files {
         files.sort_unstable_by(|lhs, rhs| lhs.path.cmp(&rhs.path));
 
         if files.is_empty() {
-            files.push(File::open_at(directory.clone(), DurabilitySequenceNumber::MIN)?);
+            files.push(File::open_at(directory.to_owned(), DurabilitySequenceNumber::MIN)?);
         }
 
         let writer = files.last().unwrap().writer()?;
@@ -259,7 +259,7 @@ impl Files {
         Ok(())
     }
 
-    fn iter(&self) -> impl Iterator<Item = &File> + DoubleEndedIterator {
+    fn iter(&self) -> impl DoubleEndedIterator<Item = &File> {
         self.files.iter()
     }
 
@@ -461,7 +461,7 @@ impl<'a> FileRecordIterator<'a> {
                 }
             }
         }
-        Ok(Self { reader: Some(reader), file_ref: PhantomData::default() })
+        Ok(Self { reader: Some(reader), file_ref: PhantomData })
     }
 }
 
@@ -689,7 +689,7 @@ mod test {
 
         let found = wal.find_last_type(UnsequencedTestRecord::RECORD_TYPE).unwrap().unwrap();
         assert!(
-            matches!(found, RawRecord { bytes: Cow::Owned(bytes), record_type: UnsequencedTestRecord::RECORD_TYPE, .. } if &bytes == unsequenced_2.bytes())
+            matches!(found, RawRecord { bytes: Cow::Owned(bytes), record_type: UnsequencedTestRecord::RECORD_TYPE, .. } if bytes == unsequenced_2.bytes())
         );
 
         drop(wal);
@@ -698,7 +698,7 @@ mod test {
 
         let found = wal.find_last_type(UnsequencedTestRecord::RECORD_TYPE).unwrap().unwrap();
         assert!(
-            matches!(found, RawRecord { bytes: Cow::Owned(bytes), record_type: UnsequencedTestRecord::RECORD_TYPE, .. } if &bytes == unsequenced_2.bytes())
+            matches!(found, RawRecord { bytes: Cow::Owned(bytes), record_type: UnsequencedTestRecord::RECORD_TYPE, .. } if bytes == unsequenced_2.bytes())
         );
     }
 }

--- a/traversal/executor/instruction/mod.rs
+++ b/traversal/executor/instruction/mod.rs
@@ -7,14 +7,9 @@
 use std::collections::HashMap;
 
 use answer::variable::Variable;
-use concept::{
-    error::ConceptReadError,
-    thing::{thing_manager::ThingManager, ThingAPI},
-    type_::TypeAPI,
-};
+use concept::{error::ConceptReadError, thing::thing_manager::ThingManager};
 use ir::{inference::type_inference::TypeAnnotations, pattern::constraint::Constraint};
 use storage::snapshot::ReadableSnapshot;
-pub use tracing::{error, info, trace, warn};
 
 use crate::{
     executor::{
@@ -31,7 +26,6 @@ use crate::{
     },
     planner::pattern_plan::{Instruction, InstructionAPI},
 };
-use crate::executor::instruction::InstructionExecutor::HasReverse;
 
 mod comparison_executor;
 mod comparison_reverse_executor;

--- a/traversal/tests/executor_has.rs
+++ b/traversal/tests/executor_has.rs
@@ -308,9 +308,7 @@ fn traverse_has_reverse_unbounded_sorted_from() {
     // Plan
     let steps = vec![Step::Intersection(IntersectionStep::new(
         var_age,
-        vec![
-            Instruction::HasReverse(has_age.clone(), IterateBounds::None([])),
-        ],
+        vec![Instruction::HasReverse(has_age.clone(), IterateBounds::None([]))],
         &vec![var_person, var_age],
     ))];
     let pattern_plan = PatternPlan::new(steps, annotated_program.get_entry().context().clone());


### PR DESCRIPTION
## Usage and product changes

Sequenced records in the WAL are numbered starting from 1. Unsequenced records use the number of the last sequenced record in the WAL. 

A problem arises when an unsequenced record is written before any sequenced records (e.g. server restart after WAL had been deleted). In that case the index of the unsequenced record is forced to be zero. However, the WAL shard file still believes it starts at 1, and when the record header does not match that, the shard is believed to be corrupted.

That is not an issue when sharding happens during an unsequenced write, as the new shard filename uses the _record_ sequence number, not the next expected sequence number. That does however mean that during a scan through the WAL, if a shard file starts at the desired sequence number, the previous shard must be scanned as well. (This is already the implemented behaviour.)