### PR TITLE
Introduce IR for schema constraints

### DIFF
--- a/compiler/inference/pattern_type_inference.rs
+++ b/compiler/inference/pattern_type_inference.rs
@@ -875,7 +875,6 @@ pub mod tests {
         }
     }
 
-
     #[test]
     fn type_constraints() {
         // Some version of `$a isa animal, has name $n;`
@@ -894,11 +893,12 @@ pub mod tests {
             let snapshot = storage.clone().open_snapshot_write();
             let mut builder = FunctionalBlock::builder();
             let mut conjunction = builder.conjunction_mut();
-            let (var_animal, var_name, var_animal_type, var_owned_type) = ["animal", "name", "animal_type", "name_type"]
-                .into_iter()
-                .map(|name| conjunction.get_or_declare_variable(name).unwrap())
-                .collect_tuple()
-                .unwrap();
+            let (var_animal, var_name, var_animal_type, var_owned_type) =
+                ["animal", "name", "animal_type", "name_type"]
+                    .into_iter()
+                    .map(|name| conjunction.get_or_declare_variable(name).unwrap())
+                    .collect_tuple()
+                    .unwrap();
 
             conjunction.constraints_mut().add_isa(IsaKind::Subtype, var_animal, var_animal_type).unwrap();
             conjunction.constraints_mut().add_label(var_animal_type, LABEL_CAT).unwrap();
@@ -1118,5 +1118,4 @@ pub mod tests {
             assert_eq!(expected_tig, tig);
         }
     }
-
 }

--- a/compiler/inference/pattern_type_inference.rs
+++ b/compiler/inference/pattern_type_inference.rs
@@ -874,4 +874,249 @@ pub mod tests {
             assert_eq!(expected_graph, tig);
         }
     }
+
+
+    #[test]
+    fn type_constraints() {
+        // Some version of `$a isa animal, has name $n;`
+        let (_tmp_dir, storage) = setup_storage();
+        let (type_manager, thing_manager) = managers();
+        let function_index = HashMapFunctionIndex::empty();
+
+        let ((type_animal, type_cat, type_dog), (type_name, type_catname, type_dogname), _) =
+            setup_types(storage.clone().open_snapshot_write(), &type_manager);
+
+        let all_animals = BTreeSet::from([type_animal.clone(), type_cat.clone(), type_dog.clone()]);
+        let all_names = BTreeSet::from([type_name.clone(), type_catname.clone(), type_dogname.clone()]);
+
+        {
+            // Case 1: $a isa $at; $at type cat; $n isa $nt; $at owns $nt;
+            let snapshot = storage.clone().open_snapshot_write();
+            let mut builder = FunctionalBlock::builder();
+            let mut conjunction = builder.conjunction_mut();
+            let (var_animal, var_name, var_animal_type, var_owned_type) = ["animal", "name", "animal_type", "name_type"]
+                .into_iter()
+                .map(|name| conjunction.get_or_declare_variable(name).unwrap())
+                .collect_tuple()
+                .unwrap();
+
+            conjunction.constraints_mut().add_isa(IsaKind::Subtype, var_animal, var_animal_type).unwrap();
+            conjunction.constraints_mut().add_label(var_animal_type, LABEL_CAT).unwrap();
+            conjunction.constraints_mut().add_isa(IsaKind::Subtype, var_name, var_owned_type).unwrap();
+            conjunction.constraints_mut().add_owns(var_animal_type, var_owned_type).unwrap();
+
+            let block = builder.finish();
+            let constraints = block.conjunction().constraints();
+            let tig =
+                infer_types_for_block(&snapshot, &block, &type_manager, &AnnotatedCommittedFunctions::empty(), None)
+                    .unwrap();
+
+            let expected_tig = TypeInferenceGraph {
+                conjunction: block.conjunction(),
+                vertices: BTreeMap::from([
+                    (var_animal, BTreeSet::from([type_cat.clone()])),
+                    (var_name, BTreeSet::from([type_catname.clone()])),
+                    (var_animal_type, BTreeSet::from([type_cat.clone()])),
+                    (var_owned_type, BTreeSet::from([type_catname.clone()])),
+                ]),
+                edges: vec![
+                    expected_edge(
+                        &constraints[0],
+                        var_animal,
+                        var_animal_type,
+                        vec![(type_cat.clone(), type_cat.clone())],
+                    ),
+                    expected_edge(
+                        &constraints[2],
+                        var_name,
+                        var_owned_type,
+                        vec![(type_catname.clone(), type_catname.clone())],
+                    ),
+                    expected_edge(
+                        &constraints[3],
+                        var_animal_type,
+                        var_owned_type,
+                        vec![(type_cat.clone(), type_catname.clone())],
+                    ),
+                ],
+                nested_disjunctions: Vec::new(),
+                nested_negations: Vec::new(),
+                nested_optionals: Vec::new(),
+            };
+
+            assert_eq!(expected_tig, tig);
+        }
+
+        {
+            // Case 2: $a isa $at; $n isa $nt; $nt type catname; $at owns $nt;
+            let snapshot = storage.clone().open_snapshot_write();
+            let mut builder = FunctionalBlock::builder();
+            let mut conjunction = builder.conjunction_mut();
+            let (var_animal, var_name, var_owner_type, var_name_type) = ["animal", "name", "animal_type", "name_type"]
+                .into_iter()
+                .map(|name| conjunction.get_or_declare_variable(name).unwrap())
+                .collect_tuple()
+                .unwrap();
+
+            conjunction.constraints_mut().add_isa(IsaKind::Subtype, var_animal, var_owner_type).unwrap();
+            conjunction.constraints_mut().add_isa(IsaKind::Subtype, var_name, var_name_type).unwrap();
+            conjunction.constraints_mut().add_label(var_name_type, LABEL_CATNAME).unwrap();
+            conjunction.constraints_mut().add_owns(var_owner_type, var_name_type).unwrap();
+
+            let block = builder.finish();
+
+            let constraints = block.conjunction().constraints();
+            let tig =
+                infer_types_for_block(&snapshot, &block, &type_manager, &AnnotatedCommittedFunctions::empty(), None)
+                    .unwrap();
+
+            let expected_tig = TypeInferenceGraph {
+                conjunction: block.conjunction(),
+                vertices: BTreeMap::from([
+                    (var_animal, BTreeSet::from([type_cat.clone()])),
+                    (var_name, BTreeSet::from([type_catname.clone()])),
+                    (var_owner_type, BTreeSet::from([type_cat.clone()])),
+                    (var_name_type, BTreeSet::from([type_catname.clone()])),
+                ]),
+                edges: vec![
+                    expected_edge(
+                        &constraints[0],
+                        var_animal,
+                        var_owner_type,
+                        vec![(type_cat.clone(), type_cat.clone())],
+                    ),
+                    expected_edge(
+                        &constraints[1],
+                        var_name,
+                        var_name_type,
+                        vec![(type_catname.clone(), type_catname.clone())],
+                    ),
+                    expected_edge(
+                        &constraints[3],
+                        var_owner_type,
+                        var_name_type,
+                        vec![(type_cat.clone(), type_catname.clone())],
+                    ),
+                ],
+                nested_disjunctions: Vec::new(),
+                nested_negations: Vec::new(),
+                nested_optionals: Vec::new(),
+            };
+            assert_eq!(expected_tig, tig);
+        }
+
+        {
+            // Case 3: $a isa $at; $at type cat; $n isa $nt; $nt type dogname; $at owns $nt;
+            let snapshot = storage.clone().open_snapshot_write();
+            let mut builder = FunctionalBlock::builder();
+            let mut conjunction = builder.conjunction_mut();
+            let (var_animal, var_name, var_animal_type, var_name_type) = ["animal", "name", "animal_type", "name_type"]
+                .into_iter()
+                .map(|name| conjunction.get_or_declare_variable(name).unwrap())
+                .collect_tuple()
+                .unwrap();
+
+            conjunction.constraints_mut().add_isa(IsaKind::Subtype, var_animal, var_animal_type).unwrap();
+            conjunction.constraints_mut().add_label(var_animal_type, LABEL_CAT).unwrap();
+            conjunction.constraints_mut().add_isa(IsaKind::Subtype, var_name, var_name_type).unwrap();
+            conjunction.constraints_mut().add_label(var_name_type, LABEL_DOGNAME).unwrap();
+            conjunction.constraints_mut().add_owns(var_animal_type, var_name_type).unwrap();
+
+            let block = builder.finish();
+            let constraints = block.conjunction().constraints();
+            let tig =
+                infer_types_for_block(&snapshot, &block, &type_manager, &AnnotatedCommittedFunctions::empty(), None)
+                    .unwrap();
+
+            let expected_tig = TypeInferenceGraph {
+                conjunction: block.conjunction(),
+                vertices: BTreeMap::from([
+                    (var_animal, BTreeSet::new()),
+                    (var_name, BTreeSet::new()),
+                    (var_animal_type, BTreeSet::new()),
+                    (var_name_type, BTreeSet::new()),
+                ]),
+                edges: vec![
+                    expected_edge(&constraints[0], var_animal, var_animal_type, Vec::new()),
+                    expected_edge(&constraints[2], var_name, var_name_type, Vec::new()),
+                    expected_edge(&constraints[4], var_animal_type, var_name_type, Vec::new()),
+                ],
+                nested_disjunctions: Vec::new(),
+                nested_negations: Vec::new(),
+                nested_optionals: Vec::new(),
+            };
+            assert_eq!(expected_tig, tig);
+        }
+
+        {
+            // Case 4: $a isa! $at; $n isa! $nt; $at owns $nt;
+            let types_a = all_animals.clone();
+            let types_n = all_names.clone();
+            let snapshot = storage.clone().open_snapshot_write();
+            let mut builder = FunctionalBlock::builder();
+            let mut conjunction = builder.conjunction_mut();
+            let (var_animal, var_name, var_animal_type, var_name_type) = ["animal", "name", "animal_type", "name_type"]
+                .into_iter()
+                .map(|name| conjunction.get_or_declare_variable(name).unwrap())
+                .collect_tuple()
+                .unwrap();
+
+            conjunction.constraints_mut().add_isa(IsaKind::Exact, var_animal, var_animal_type).unwrap();
+            conjunction.constraints_mut().add_isa(IsaKind::Exact, var_name, var_name_type).unwrap();
+            conjunction.constraints_mut().add_owns(var_animal_type, var_name_type).unwrap();
+
+            let block = builder.finish();
+            let constraints = block.conjunction().constraints();
+            let tig =
+                infer_types_for_block(&snapshot, &block, &type_manager, &AnnotatedCommittedFunctions::empty(), None)
+                    .unwrap();
+
+            let expected_tig = TypeInferenceGraph {
+                conjunction: block.conjunction(),
+                vertices: BTreeMap::from([
+                    (var_animal, types_a.clone()),
+                    (var_name, types_n.clone()),
+                    (var_animal_type, types_a.clone()),
+                    (var_name_type, types_n.clone()),
+                ]),
+                edges: vec![
+                    expected_edge(
+                        &constraints[0],
+                        var_animal,
+                        var_animal_type,
+                        vec![
+                            (type_cat.clone(), type_cat.clone()),
+                            (type_dog.clone(), type_dog.clone()),
+                            (type_animal.clone(), type_animal.clone()),
+                        ],
+                    ),
+                    expected_edge(
+                        &constraints[1],
+                        var_name,
+                        var_name_type,
+                        vec![
+                            (type_catname.clone(), type_catname.clone()),
+                            (type_dogname.clone(), type_dogname.clone()),
+                            (type_name.clone(), type_name.clone()),
+                        ],
+                    ),
+                    expected_edge(
+                        &constraints[2],
+                        var_animal_type,
+                        var_name_type,
+                        vec![
+                            (type_cat.clone(), type_catname.clone()),
+                            (type_dog.clone(), type_dogname.clone()),
+                            (type_animal.clone(), type_name.clone()),
+                        ],
+                    ),
+                ],
+                nested_disjunctions: Vec::new(),
+                nested_negations: Vec::new(),
+                nested_optionals: Vec::new(),
+            };
+            assert_eq!(expected_tig, tig);
+        }
+    }
+
 }

--- a/compiler/inference/type_seeder.rs
+++ b/compiler/inference/type_seeder.rs
@@ -19,7 +19,10 @@ use encoding::value::value_type::ValueTypeCategory;
 use ir::{
     pattern::{
         conjunction::Conjunction,
-        constraint::{Comparison, Constraint, FunctionCallBinding, Has, Isa, Label, RolePlayer, Sub},
+        constraint::{
+            Comparison, Constraint, FunctionCallBinding, Has, Isa, IsaKind, Label, Owns, Plays, Relates, RolePlayer,
+            Sub,
+        },
         disjunction::Disjunction,
         nested_pattern::NestedPattern,
         variable_category::VariableCategory,
@@ -28,7 +31,6 @@ use ir::{
     program::{block::BlockContext, function::Function, function_signature::FunctionID},
 };
 use itertools::Itertools;
-use ir::pattern::constraint::{IsaKind, Owns, Plays, Relates};
 use storage::snapshot::ReadableSnapshot;
 
 use crate::inference::{
@@ -300,7 +302,7 @@ impl<'this, Snapshot: ReadableSnapshot> TypeSeeder<'this, Snapshot> {
             Constraint::ExpressionBinding(_) | Constraint::FunctionCallBinding(_) | Constraint::Label(_) => false,
             Constraint::Owns(owns) => self.try_propagating_vertex_annotation_impl(owns, vertices)?,
             Constraint::Relates(relates) => self.try_propagating_vertex_annotation_impl(relates, vertices)?,
-            Constraint::Plays(plays)  => self.try_propagating_vertex_annotation_impl(plays, vertices)?,
+            Constraint::Plays(plays) => self.try_propagating_vertex_annotation_impl(plays, vertices)?,
         };
         Ok(any_modified)
     }
@@ -643,7 +645,12 @@ impl BinaryConstraint for Owns<Variable> {
         self.attribute()
     }
 
-    fn annotate_left_to_right_for_type(&self, seeder: &TypeSeeder<'_, impl ReadableSnapshot>, left_type: &TypeAnnotation, collector: &mut BTreeSet<TypeAnnotation>) -> Result<(), ConceptReadError> {
+    fn annotate_left_to_right_for_type(
+        &self,
+        seeder: &TypeSeeder<'_, impl ReadableSnapshot>,
+        left_type: &TypeAnnotation,
+        collector: &mut BTreeSet<TypeAnnotation>,
+    ) -> Result<(), ConceptReadError> {
         let owner = match left_type {
             TypeAnnotation::Entity(entity) => ObjectType::Entity(entity.clone()),
             TypeAnnotation::Relation(relation) => ObjectType::Relation(relation.clone()),
@@ -661,7 +668,12 @@ impl BinaryConstraint for Owns<Variable> {
         Ok(())
     }
 
-    fn annotate_right_to_left_for_type(&self, seeder: &TypeSeeder<'_, impl ReadableSnapshot>, right_type: &TypeAnnotation, collector: &mut BTreeSet<TypeAnnotation>) -> Result<(), ConceptReadError> {
+    fn annotate_right_to_left_for_type(
+        &self,
+        seeder: &TypeSeeder<'_, impl ReadableSnapshot>,
+        right_type: &TypeAnnotation,
+        collector: &mut BTreeSet<TypeAnnotation>,
+    ) -> Result<(), ConceptReadError> {
         let attribute = match right_type {
             TypeAnnotation::Attribute(attribute) => attribute,
             _ => {

--- a/compiler/inference/type_seeder.rs
+++ b/compiler/inference/type_seeder.rs
@@ -28,7 +28,7 @@ use ir::{
     program::{block::BlockContext, function::Function, function_signature::FunctionID},
 };
 use itertools::Itertools;
-use ir::pattern::constraint::{Owns, Plays, Relates};
+use ir::pattern::constraint::{IsaKind, Owns, Plays, Relates};
 use storage::snapshot::ReadableSnapshot;
 
 use crate::inference::{
@@ -698,42 +698,44 @@ impl BinaryConstraint for Isa<Variable> {
         left_type: &TypeAnnotation,
         collector: &mut BTreeSet<TypeAnnotation>,
     ) -> Result<(), ConceptReadError> {
-        match left_type {
-            TypeAnnotation::Attribute(attribute) => {
-                attribute
-                    .get_supertypes(seeder.snapshot, seeder.type_manager)?
-                    .iter()
-                    .map(|subtype| TypeAnnotation::Attribute(subtype.clone().into_owned()))
-                    .for_each(|subtype| {
-                        collector.insert(subtype);
-                    });
-            }
-            TypeAnnotation::Entity(entity) => {
-                entity
-                    .get_supertypes(seeder.snapshot, seeder.type_manager)?
-                    .iter()
-                    .map(|subtype| TypeAnnotation::Entity(subtype.clone().into_owned()))
-                    .for_each(|subtype| {
-                        collector.insert(subtype);
-                    });
-            }
-            TypeAnnotation::Relation(relation) => {
-                relation
-                    .get_supertypes(seeder.snapshot, seeder.type_manager)?
-                    .iter()
-                    .map(|subtype| TypeAnnotation::Relation(subtype.clone().into_owned()))
-                    .for_each(|subtype| {
-                        collector.insert(subtype);
-                    });
-            }
-            TypeAnnotation::RoleType(role_type) => {
-                role_type
-                    .get_supertypes(seeder.snapshot, seeder.type_manager)?
-                    .iter()
-                    .map(|subtype| TypeAnnotation::RoleType(subtype.clone().into_owned()))
-                    .for_each(|subtype| {
-                        collector.insert(subtype);
-                    });
+        if self.isa_kind() == IsaKind::Subtype {
+            match left_type {
+                TypeAnnotation::Attribute(attribute) => {
+                    attribute
+                        .get_supertypes(seeder.snapshot, seeder.type_manager)?
+                        .iter()
+                        .map(|subtype| TypeAnnotation::Attribute(subtype.clone().into_owned()))
+                        .for_each(|subtype| {
+                            collector.insert(subtype);
+                        });
+                }
+                TypeAnnotation::Entity(entity) => {
+                    entity
+                        .get_supertypes(seeder.snapshot, seeder.type_manager)?
+                        .iter()
+                        .map(|subtype| TypeAnnotation::Entity(subtype.clone().into_owned()))
+                        .for_each(|subtype| {
+                            collector.insert(subtype);
+                        });
+                }
+                TypeAnnotation::Relation(relation) => {
+                    relation
+                        .get_supertypes(seeder.snapshot, seeder.type_manager)?
+                        .iter()
+                        .map(|subtype| TypeAnnotation::Relation(subtype.clone().into_owned()))
+                        .for_each(|subtype| {
+                            collector.insert(subtype);
+                        });
+                }
+                TypeAnnotation::RoleType(role_type) => {
+                    role_type
+                        .get_supertypes(seeder.snapshot, seeder.type_manager)?
+                        .iter()
+                        .map(|subtype| TypeAnnotation::RoleType(subtype.clone().into_owned()))
+                        .for_each(|subtype| {
+                            collector.insert(subtype);
+                        });
+                }
             }
         }
         collector.insert(left_type.clone());
@@ -746,42 +748,44 @@ impl BinaryConstraint for Isa<Variable> {
         right_type: &TypeAnnotation,
         collector: &mut BTreeSet<TypeAnnotation>,
     ) -> Result<(), ConceptReadError> {
-        match right_type {
-            TypeAnnotation::Attribute(attribute) => {
-                attribute
-                    .get_subtypes_transitive(seeder.snapshot, seeder.type_manager)?
-                    .iter()
-                    .map(|subtype| TypeAnnotation::Attribute(subtype.clone().into_owned()))
-                    .for_each(|subtype| {
-                        collector.insert(subtype);
-                    });
-            }
-            TypeAnnotation::Entity(entity) => {
-                entity
-                    .get_subtypes_transitive(seeder.snapshot, seeder.type_manager)?
-                    .iter()
-                    .map(|subtype| TypeAnnotation::Entity(subtype.clone().into_owned()))
-                    .for_each(|subtype| {
-                        collector.insert(subtype);
-                    });
-            }
-            TypeAnnotation::Relation(relation) => {
-                relation
-                    .get_subtypes_transitive(seeder.snapshot, seeder.type_manager)?
-                    .iter()
-                    .map(|subtype| TypeAnnotation::Relation(subtype.clone().into_owned()))
-                    .for_each(|subtype| {
-                        collector.insert(subtype);
-                    });
-            }
-            TypeAnnotation::RoleType(role_type) => {
-                role_type
-                    .get_subtypes_transitive(seeder.snapshot, seeder.type_manager)?
-                    .iter()
-                    .map(|subtype| TypeAnnotation::RoleType(subtype.clone().into_owned()))
-                    .for_each(|subtype| {
-                        collector.insert(subtype);
-                    });
+        if self.isa_kind() == IsaKind::Subtype {
+            match right_type {
+                TypeAnnotation::Attribute(attribute) => {
+                    attribute
+                        .get_subtypes_transitive(seeder.snapshot, seeder.type_manager)?
+                        .iter()
+                        .map(|subtype| TypeAnnotation::Attribute(subtype.clone().into_owned()))
+                        .for_each(|subtype| {
+                            collector.insert(subtype);
+                        });
+                }
+                TypeAnnotation::Entity(entity) => {
+                    entity
+                        .get_subtypes_transitive(seeder.snapshot, seeder.type_manager)?
+                        .iter()
+                        .map(|subtype| TypeAnnotation::Entity(subtype.clone().into_owned()))
+                        .for_each(|subtype| {
+                            collector.insert(subtype);
+                        });
+                }
+                TypeAnnotation::Relation(relation) => {
+                    relation
+                        .get_subtypes_transitive(seeder.snapshot, seeder.type_manager)?
+                        .iter()
+                        .map(|subtype| TypeAnnotation::Relation(subtype.clone().into_owned()))
+                        .for_each(|subtype| {
+                            collector.insert(subtype);
+                        });
+                }
+                TypeAnnotation::RoleType(role_type) => {
+                    role_type
+                        .get_subtypes_transitive(seeder.snapshot, seeder.type_manager)?
+                        .iter()
+                        .map(|subtype| TypeAnnotation::RoleType(subtype.clone().into_owned()))
+                        .for_each(|subtype| {
+                            collector.insert(subtype);
+                        });
+                }
             }
         }
         collector.insert(right_type.clone());

--- a/compiler/planner/pattern_plan.rs
+++ b/compiler/planner/pattern_plan.rs
@@ -96,6 +96,9 @@ impl PatternPlan {
                 Constraint::ExpressionBinding(_) => todo!(),
                 Constraint::FunctionCallBinding(_) => todo!(),
                 Constraint::Comparison(_) => todo!(),
+                Constraint::Owns(_) => todo!(),
+                Constraint::Relates(_) => todo!(),
+                Constraint::Plays(_) => todo!(),
             }
         }
 
@@ -151,6 +154,9 @@ impl PatternPlan {
                     Constraint::ExpressionBinding(_) => todo!(),
                     Constraint::FunctionCallBinding(_) => todo!(),
                     Constraint::Comparison(_) => todo!(),
+                    Constraint::Owns(_) => todo!(),
+                    Constraint::Relates(_) => todo!(),
+                    Constraint::Plays(_) => todo!(),
                 }
             }
         }

--- a/concept/type_/type_manager/type_cache/mod.rs
+++ b/concept/type_/type_manager/type_cache/mod.rs
@@ -4,11 +4,9 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-
 mod kind_cache;
 mod selection;
 mod struct_definition_cache;
 mod type_cache;
-
 
 pub use self::type_cache::{TypeCache, TypeCacheCreateError};

--- a/ir/pattern/constraint.rs
+++ b/ir/pattern/constraint.rs
@@ -262,6 +262,9 @@ pub enum Constraint<ID: IrID> {
     ExpressionBinding(ExpressionBinding<ID>),
     FunctionCallBinding(FunctionCallBinding<ID>),
     Comparison(Comparison<ID>),
+    Owns(Owns<ID>),
+    Relates(Relates<ID>),
+    Plays(Plays<ID>),
 }
 
 impl<ID: IrID> Constraint<ID> {
@@ -275,6 +278,9 @@ impl<ID: IrID> Constraint<ID> {
             Constraint::ExpressionBinding(binding) => Box::new(binding.ids_assigned()),
             Constraint::FunctionCallBinding(binding) => Box::new(binding.ids_assigned()),
             Constraint::Comparison(comparison) => Box::new(comparison.ids()),
+            Constraint::Owns(owns) => Box::new(owns.ids()),
+            Constraint::Relates(relates) => Box::new(relates.ids()),
+            Constraint::Plays(plays) => Box::new(plays.ids()),
         }
     }
 
@@ -291,6 +297,9 @@ impl<ID: IrID> Constraint<ID> {
             Constraint::ExpressionBinding(binding) => binding.ids_foreach(function),
             Constraint::FunctionCallBinding(binding) => binding.ids_foreach(function),
             Constraint::Comparison(comparison) => comparison.ids_foreach(function),
+            Constraint::Owns(owns) => owns.ids_foreach(function),
+            Constraint::Relates(relates) => relates.ids_foreach(function),
+            Constraint::Plays(plays) => plays.ids_foreach(function),
         }
     }
 
@@ -388,6 +397,9 @@ impl<ID: IrID> fmt::Display for Constraint<ID> {
             Constraint::ExpressionBinding(constraint) => fmt::Display::fmt(constraint, f),
             Constraint::FunctionCallBinding(constraint) => fmt::Display::fmt(constraint, f),
             Constraint::Comparison(constraint) => fmt::Display::fmt(constraint, f),
+            Constraint::Owns(constraint) => fmt::Display::fmt(constraint, f),
+            Constraint::Relates(constraint) => fmt::Display::fmt(constraint, f),
+            Constraint::Plays(constraint) => fmt::Display::fmt(constraint, f),
         }
     }
 }
@@ -807,3 +819,136 @@ impl<ID: IrID> fmt::Display for Comparison<ID> {
         todo!()
     }
 }
+
+#[derive(Debug, Clone, Eq, PartialEq, Hash)]
+pub struct Owns<ID> {
+    owner: ID,
+    attribute: ID,
+}
+
+impl<ID: IrID> Owns<ID> {
+    fn new(owner: ID, attribute: ID) -> Self {
+        Self { owner,attribute }
+    }
+
+    pub fn owner(&self) -> ID {
+        self.owner
+    }
+
+    pub fn attribute(&self) -> ID {
+        self.attribute
+    }
+
+    pub fn ids(&self) -> impl Iterator<Item = ID> {
+        [self.owner, self.attribute].into_iter()
+    }
+
+    pub fn ids_foreach<F>(&self, mut function: F)
+        where
+            F: FnMut(ID, ConstraintIDSide),
+    {
+        function(self.owner, ConstraintIDSide::Left);
+        function(self.attribute, ConstraintIDSide::Right);
+    }
+}
+
+impl<ID: IrID> From<Owns<ID>> for Constraint<ID> {
+    fn from(val: Owns<ID>) -> Self {
+        Constraint::Owns(val)
+    }
+}
+
+impl<ID: IrID> fmt::Display for Owns<ID> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        todo!()
+    }
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Hash)]
+pub struct Relates<ID> {
+    relation: ID,
+    role_type: ID,
+}
+
+impl<ID: IrID> Relates<ID> {
+    fn new(relation: ID, role: ID) -> Self {
+        Self { relation, role_type: role }
+    }
+
+    pub fn relation(&self) -> ID {
+        self.relation
+    }
+
+    pub fn role_type(&self) -> ID {
+        self.role_type
+    }
+
+    pub fn ids(&self) -> impl Iterator<Item = ID> {
+        [self.relation, self.role_type].into_iter()
+    }
+
+    pub fn ids_foreach<F>(&self, mut function: F)
+        where
+            F: FnMut(ID, ConstraintIDSide),
+    {
+        function(self.relation, ConstraintIDSide::Left);
+        function(self.role_type, ConstraintIDSide::Right);
+    }
+}
+
+impl<ID: IrID> From<Relates<ID>> for Constraint<ID> {
+    fn from(val: Relates<ID>) -> Self {
+        Constraint::Relates(val)
+    }
+}
+
+impl<ID: IrID> fmt::Display for Relates<ID> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        todo!()
+    }
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Hash)]
+pub struct Plays<ID> {
+    player: ID,
+    role_type: ID,
+}
+
+impl<ID: IrID> Plays<ID> {
+    fn new(player: ID, role: ID) -> Self {
+        Self { player, role_type: role }
+    }
+
+    pub fn player(&self) -> ID {
+        self.player
+    }
+
+    pub fn role_type(&self) -> ID {
+        self.role_type
+    }
+
+    pub fn ids(&self) -> impl Iterator<Item = ID> {
+        [self.player, self.role_type].into_iter()
+    }
+
+    pub fn ids_foreach<F>(&self, mut function: F)
+        where
+            F: FnMut(ID, ConstraintIDSide),
+    {
+        function(self.player, ConstraintIDSide::Left);
+        function(self.role_type, ConstraintIDSide::Right);
+    }
+}
+
+impl<ID: IrID> From<Plays<ID>> for Constraint<ID> {
+    fn from(val: Plays<ID>) -> Self {
+        Constraint::Plays(val)
+    }
+}
+
+impl<ID: IrID> fmt::Display for Plays<ID> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        todo!()
+    }
+}
+

--- a/ir/pattern/constraint.rs
+++ b/ir/pattern/constraint.rs
@@ -239,7 +239,11 @@ impl<'cx> ConstraintsBuilder<'cx> {
         Ok(as_ref.as_expression_binding().unwrap())
     }
 
-    pub fn add_owns(&mut self, owner_type: Variable, attribute_type: Variable) -> Result<&Owns<Variable>, PatternDefinitionError> {
+    pub fn add_owns(
+        &mut self,
+        owner_type: Variable,
+        attribute_type: Variable,
+    ) -> Result<&Owns<Variable>, PatternDefinitionError> {
         debug_assert!(
             self.context.is_variable_available(self.constraints.scope, owner_type)
                 && self.context.is_variable_available(self.constraints.scope, attribute_type)
@@ -251,7 +255,11 @@ impl<'cx> ConstraintsBuilder<'cx> {
         Ok(constraint.as_owns().unwrap())
     }
 
-    pub fn add_relates(&mut self, relation_type: Variable, role_type: Variable) -> Result<&Relates<Variable>, PatternDefinitionError> {
+    pub fn add_relates(
+        &mut self,
+        relation_type: Variable,
+        role_type: Variable,
+    ) -> Result<&Relates<Variable>, PatternDefinitionError> {
         debug_assert!(
             self.context.is_variable_available(self.constraints.scope, relation_type)
                 && self.context.is_variable_available(self.constraints.scope, role_type)
@@ -263,7 +271,11 @@ impl<'cx> ConstraintsBuilder<'cx> {
         Ok(constraint.as_relates().unwrap())
     }
 
-    pub fn add_plays(&mut self, player_type: Variable, role_type: Variable) -> Result<&Plays<Variable>, PatternDefinitionError> {
+    pub fn add_plays(
+        &mut self,
+        player_type: Variable,
+        role_type: Variable,
+    ) -> Result<&Plays<Variable>, PatternDefinitionError> {
         debug_assert!(
             self.context.is_variable_available(self.constraints.scope, player_type)
                 && self.context.is_variable_available(self.constraints.scope, role_type)
@@ -889,7 +901,7 @@ pub struct Owns<ID> {
 
 impl<ID: IrID> Owns<ID> {
     fn new(owner: ID, attribute: ID) -> Self {
-        Self { owner,attribute }
+        Self { owner, attribute }
     }
 
     pub fn owner(&self) -> ID {
@@ -905,8 +917,8 @@ impl<ID: IrID> Owns<ID> {
     }
 
     pub fn ids_foreach<F>(&self, mut function: F)
-        where
-            F: FnMut(ID, ConstraintIDSide),
+    where
+        F: FnMut(ID, ConstraintIDSide),
     {
         function(self.owner, ConstraintIDSide::Left);
         function(self.attribute, ConstraintIDSide::Right);
@@ -949,8 +961,8 @@ impl<ID: IrID> Relates<ID> {
     }
 
     pub fn ids_foreach<F>(&self, mut function: F)
-        where
-            F: FnMut(ID, ConstraintIDSide),
+    where
+        F: FnMut(ID, ConstraintIDSide),
     {
         function(self.relation, ConstraintIDSide::Left);
         function(self.role_type, ConstraintIDSide::Right);
@@ -993,8 +1005,8 @@ impl<ID: IrID> Plays<ID> {
     }
 
     pub fn ids_foreach<F>(&self, mut function: F)
-        where
-            F: FnMut(ID, ConstraintIDSide),
+    where
+        F: FnMut(ID, ConstraintIDSide),
     {
         function(self.player, ConstraintIDSide::Left);
         function(self.role_type, ConstraintIDSide::Right);
@@ -1012,4 +1024,3 @@ impl<ID: IrID> fmt::Display for Plays<ID> {
         todo!()
     }
 }
-


### PR DESCRIPTION
## Usage and product changes
Introduce `Owns`, `Relates` & `Plays` constraints into IR &  implement type-inference traits for them.

## Implementation
Introduce `Owns`, `Relates` & `Plays` constraints into IR &  implement type-inference traits for them.

