### PR TITLE
Rename roleplayer edge to links + plan

### DIFF
--- a/answer/lib.rs
+++ b/answer/lib.rs
@@ -72,6 +72,13 @@ impl Type {
         }
     }
 
+    pub fn as_role_type(&self) -> RoleType<'static> {
+        match self {
+            Type::RoleType(role) => role.clone().into_owned(),
+            _ => panic!("Type is not an Role type."),
+        }
+    }
+
     pub fn next_possible(&self) -> Self {
         match self {
             Type::Entity(entity) => {

--- a/compiler/inference/pattern_type_inference.rs
+++ b/compiler/inference/pattern_type_inference.rs
@@ -90,13 +90,13 @@ impl<'this> TypeInferenceGraph<'this> {
     ) {
         let TypeInferenceGraph { vertices, edges, nested_disjunctions, nested_negations, nested_optionals, .. } = self;
 
-        let mut combine_role_player_edges = HashMap::new();
+        let mut combine_links_edges = HashMap::new();
         edges.into_iter().for_each(|edge| {
             let TypeInferenceEdge { constraint, left_to_right, right_to_left, .. } = edge;
-            if let Constraint::RolePlayer(rp) = edge.constraint {
-                if let Some((other_left_right, other_right_left)) = combine_role_player_edges.remove(&edge.right) {
+            if let Constraint::Links(links) = edge.constraint {
+                if let Some((other_left_right, other_right_left)) = combine_links_edges.remove(&edge.right) {
                     let lrf_annotation = {
-                        if edge.left == rp.relation() {
+                        if edge.left == links.relation() {
                             LeftRightFilteredAnnotations::build(
                                 left_to_right,
                                 right_to_left,
@@ -115,7 +115,7 @@ impl<'this> TypeInferenceGraph<'this> {
                     constraint_annotations
                         .insert(constraint.clone(), ConstraintTypeAnnotations::LeftRightFiltered(lrf_annotation));
                 } else {
-                    combine_role_player_edges.insert(edge.right, (left_to_right, right_to_left));
+                    combine_links_edges.insert(edge.right, (left_to_right, right_to_left));
                 }
             } else {
                 let lr_annotations = LeftRightAnnotations::build(left_to_right, right_to_left);
@@ -791,8 +791,8 @@ pub mod tests {
 
             conjunction.constraints_mut().add_isa(IsaKind::Subtype, var_fears, var_fears_type).unwrap();
             conjunction.constraints_mut().add_label(var_fears_type, LABEL_FEARS).unwrap();
-            conjunction.constraints_mut().add_role_player(var_fears, var_has_fear, var_role_has_fear).unwrap();
-            conjunction.constraints_mut().add_role_player(var_fears, var_is_feared, var_role_is_feared).unwrap();
+            conjunction.constraints_mut().add_links(var_fears, var_has_fear, var_role_has_fear).unwrap();
+            conjunction.constraints_mut().add_links(var_fears, var_is_feared, var_role_is_feared).unwrap();
 
             conjunction.constraints_mut().add_sub(var_role_has_fear, var_role_has_fear_type).unwrap();
             conjunction.constraints_mut().add_label(var_role_has_fear_type, "fears:has-fear").unwrap();

--- a/compiler/inference/type_inference.rs
+++ b/compiler/inference/type_inference.rs
@@ -102,7 +102,7 @@ pub mod tests {
     };
     use ir::{
         pattern::{
-            constraint::{Constraint, IsaKind, RolePlayer},
+            constraint::{Constraint, IsaKind, Links},
             variable_category::{VariableCategory, VariableOptionality},
         },
         program::{
@@ -158,8 +158,8 @@ pub mod tests {
         let type_player_1 = Type::Relation(RelationType::build_from_type_id(TypeID::build(2)));
 
         let dummy = FunctionalBlock::builder().finish();
-        let constraint1 = Constraint::RolePlayer(RolePlayer::new(var_relation, var_player, var_role_type));
-        let constraint2 = Constraint::RolePlayer(RolePlayer::new(var_relation, var_player, var_role_type));
+        let constraint1 = Constraint::Links(Links::new(var_relation, var_player, var_role_type));
+        let constraint2 = Constraint::Links(Links::new(var_relation, var_player, var_role_type));
         let nested1 = TypeInferenceGraph {
             conjunction: dummy.conjunction(),
             vertices: BTreeMap::from([

--- a/compiler/planner/pattern_plan.rs
+++ b/compiler/planner/pattern_plan.rs
@@ -156,7 +156,7 @@ impl PatternPlan {
                     Constraint::Label(_) | Constraint::Sub(_) | Constraint::Isa(_) => todo!(),
                     Constraint::Links(rp) => {
                         if bound_variables.len() >= 2 {
-                            continue; // TODO verify
+                            todo!()
                         }
                         let planner = elements[index].as_links().unwrap();
                         let selected_variables = &[rp.relation(), rp.player(), rp.role_type()];
@@ -200,7 +200,7 @@ impl PatternPlan {
                     }
                     Constraint::Has(has) => {
                         if bound_variables.len() == 2 {
-                            continue; // TODO verify
+                            todo!()
                         }
                         let planner = elements[index].as_has().unwrap();
                         let selected_variables = &[has.owner(), has.attribute()];

--- a/compiler/planner/pattern_plan.rs
+++ b/compiler/planner/pattern_plan.rs
@@ -63,7 +63,10 @@ impl PatternPlan {
 
         for (variable, category) in context.variable_categories() {
             match category {
-                VariableCategory::Type | VariableCategory::ThingType | VariableCategory::RoleType => (), // ignore for now
+                VariableCategory::Type | VariableCategory::ThingType => (), // ignore for now
+                VariableCategory::RoleType => {
+                    variable_index.insert(variable, elements.len());
+                }
                 VariableCategory::Thing | VariableCategory::Object | VariableCategory::Attribute => {
                     let planner = ThingPlanner::from_variable(variable, type_annotations, statistics);
                     variable_index.insert(variable, elements.len());

--- a/compiler/planner/vertex/mod.rs
+++ b/compiler/planner/vertex/mod.rs
@@ -8,7 +8,8 @@ use std::{collections::HashMap, ops::Deref};
 
 use answer::variable::Variable;
 use concept::thing::statistics::Statistics;
-use ir::pattern::constraint::Has;
+use ir::pattern::constraint::{Has, RolePlayer};
+use itertools::Itertools;
 
 use crate::inference::type_annotations::TypeAnnotations;
 
@@ -18,8 +19,9 @@ const ADVANCE_ITERATOR_RELATIVE_COST: f64 = 1.0;
 // FIXME name
 #[derive(Debug)]
 pub(super) enum PlannerVertex {
-    Has(HasPlanner),
     Thing(ThingPlanner),
+    Has(HasPlanner),
+    RolePlayer(RolePlayerPlanner),
 }
 
 impl PlannerVertex {
@@ -33,6 +35,13 @@ impl PlannerVertex {
     pub(super) fn as_has(&self) -> Option<&HasPlanner> {
         match self {
             Self::Has(v) => Some(v),
+            _ => None,
+        }
+    }
+
+    pub(super) fn as_role_player(&self) -> Option<&RolePlayerPlanner> {
+        match self {
+            Self::RolePlayer(v) => Some(v),
             _ => None,
         }
     }
@@ -53,8 +62,9 @@ pub(super) trait Costed {
 impl Costed for PlannerVertex {
     fn cost(&self, inputs: &[usize], elements: &[PlannerVertex]) -> VertexCost {
         match self {
-            Self::Has(inner) => inner.cost(inputs, elements),
             Self::Thing(inner) => inner.cost(inputs, elements),
+            Self::Has(inner) => inner.cost(inputs, elements),
+            Self::RolePlayer(inner) => inner.cost(inputs, elements),
         }
     }
 }
@@ -110,7 +120,7 @@ pub(super) struct HasPlanner {
     pub owner: usize,
     pub attribute: usize,
     expected_size: f64,
-    expected_unbound_size: f64,   // TODO encode direction
+    expected_unbound_size: f64,
     pub unbound_is_forward: bool, //FIXME
 }
 
@@ -178,6 +188,112 @@ impl Costed for HasPlanner {
             (true, true) => self.expected_size / owner.expected_size / attribute.expected_size,
             (true, false) => self.expected_size / owner.expected_size,
             (false, true) => self.expected_size / attribute.expected_size,
+            (false, false) => self.expected_size,
+        };
+
+        VertexCost { per_input, per_output, branching_factor }
+    }
+}
+
+#[derive(Debug)]
+pub(super) struct RolePlayerPlanner {
+    pub relation: usize,
+    pub player: usize,
+    pub role: usize,
+    expected_size: f64,
+    expected_unbound_size: f64,
+    pub unbound_is_forward: bool, //FIXME
+}
+
+impl RolePlayerPlanner {
+    pub(crate) fn from_constraint(
+        constraint: &RolePlayer<Variable>,
+        variable_index: &HashMap<Variable, usize>,
+        type_annotations: &TypeAnnotations,
+        statistics: &Statistics,
+    ) -> Self {
+        let relation = constraint.relation();
+        let player = constraint.player();
+        let role = constraint.role_type();
+
+        let relation_types = type_annotations.variable_annotations_of(relation).unwrap().deref();
+        let player_types = type_annotations.variable_annotations_of(player).unwrap().deref();
+
+        let constraint_types =
+            type_annotations.constraint_annotations_of(constraint.clone().into()).unwrap().as_left_right_filtered();
+
+        let expected_size = constraint_types
+            .filters_on_left()
+            .iter()
+            .flat_map(|(relation, roles)| {
+                roles.iter().cartesian_product(player_types).flat_map(|(role, player)| {
+                    statistics
+                        .relation_role_player_counts
+                        .get(&relation.as_relation_type())?
+                        .get(&role.as_role_type())?
+                        .get(&player.as_object_type())
+                })
+            })
+            .sum::<u64>() as f64;
+
+        let unbound_forward_size = relation_types
+            .iter()
+            .filter_map(|relation| {
+                Some(statistics.relation_role_player_counts.get(&relation.as_relation_type())?.values().flat_map(
+                    |player_to_count| {
+                        player_types.iter().filter_map(|player| player_to_count.get(&player.as_object_type()))
+                    },
+                ))
+            })
+            .flatten()
+            .sum::<u64>() as f64;
+
+        let unbound_backward_size = player_types
+            .iter()
+            .filter_map(|player| {
+                Some(statistics.role_player_relation_counts.get(&player.as_object_type())?.values().flat_map(
+                    |relation_to_count| {
+                        relation_types.iter().filter_map(|relation| relation_to_count.get(&relation.as_relation_type()))
+                    },
+                ))
+            })
+            .flatten()
+            .sum::<u64>() as f64;
+
+        let expected_unbound_size = f64::min(unbound_forward_size, unbound_backward_size);
+        let unbound_is_forward = unbound_forward_size <= unbound_backward_size;
+
+        Self {
+            relation: variable_index[&relation],
+            player: variable_index[&player],
+            role: variable_index[&role],
+            expected_size,
+            expected_unbound_size,
+            unbound_is_forward,
+        }
+    }
+}
+
+impl Costed for RolePlayerPlanner {
+    fn cost(&self, inputs: &[usize], elements: &[PlannerVertex]) -> VertexCost {
+        let is_relation_bound = inputs.contains(&self.relation);
+        let is_player_bound = inputs.contains(&self.player);
+
+        let per_input = OPEN_ITERATOR_RELATIVE_COST;
+
+        let per_output = match (is_relation_bound, is_player_bound) {
+            (true, true) => 0.0,
+            (false, false) => ADVANCE_ITERATOR_RELATIVE_COST * self.expected_unbound_size / self.expected_size,
+            (true, false) | (false, true) => ADVANCE_ITERATOR_RELATIVE_COST,
+        };
+
+        let relation = elements[self.relation].as_thing().unwrap();
+        let player = elements[self.player].as_thing().unwrap();
+
+        let branching_factor = match (is_relation_bound, is_player_bound) {
+            (true, true) => self.expected_size / relation.expected_size / player.expected_size,
+            (true, false) => self.expected_size / relation.expected_size,
+            (false, true) => self.expected_size / player.expected_size,
             (false, false) => self.expected_size,
         };
 

--- a/concept/tests/test_statistics.rs
+++ b/concept/tests/test_statistics.rs
@@ -52,7 +52,7 @@ macro_rules! assert_statistics_eq {
             role_player_counts: lhs_role_player_counts,
             relation_role_counts: lhs_relation_role_counts,
             relation_role_player_counts: lhs_relation_role_player_counts,
-            role_player_relation_counts: lhs_role_player_relation_counts,
+            player_role_relation_counts: lhs_player_role_relation_counts,
             player_index_counts: lhs_player_index_counts,
             ..
         } = $lhs;
@@ -77,7 +77,7 @@ macro_rules! assert_statistics_eq {
             role_player_counts: rhs_role_player_counts,
             relation_role_counts: rhs_relation_role_counts,
             relation_role_player_counts: rhs_relation_role_player_counts,
-            role_player_relation_counts: rhs_role_player_relation_counts,
+            player_role_relation_counts: rhs_player_role_relation_counts,
             player_index_counts: rhs_player_index_counts,
             ..
         } = $rhs;
@@ -93,7 +93,7 @@ macro_rules! assert_statistics_eq {
                 (lhs_entity_counts, lhs_relation_counts, lhs_attribute_counts, lhs_role_counts),
                 (lhs_has_attribute_counts, lhs_attribute_owner_counts),
                 (lhs_role_player_counts, lhs_relation_role_counts, lhs_player_index_counts),
-                (lhs_relation_role_player_counts, lhs_role_player_relation_counts),
+                (lhs_relation_role_player_counts, lhs_player_role_relation_counts),
             ),
             (
                 rhs_sequence_number,
@@ -102,7 +102,7 @@ macro_rules! assert_statistics_eq {
                 (rhs_entity_counts, rhs_relation_counts, rhs_attribute_counts, rhs_role_counts),
                 (rhs_has_attribute_counts, rhs_attribute_owner_counts),
                 (rhs_role_player_counts, rhs_relation_role_counts, rhs_player_index_counts),
-                (rhs_relation_role_player_counts, rhs_role_player_relation_counts),
+                (rhs_relation_role_player_counts, rhs_player_role_relation_counts),
             )
         );
     };
@@ -178,7 +178,7 @@ fn read_statistics(storage: Arc<MVCCStorage<WALClient>>, thing_manager: ThingMan
                 .entry(player.type_())
                 .or_default() += count;
             *statistics
-                .role_player_relation_counts
+                .player_role_relation_counts
                 .entry(player.type_())
                 .or_default()
                 .entry(role.clone())

--- a/concept/tests/test_statistics.rs
+++ b/concept/tests/test_statistics.rs
@@ -51,6 +51,8 @@ macro_rules! assert_statistics_eq {
             attribute_owner_counts: lhs_attribute_owner_counts,
             role_player_counts: lhs_role_player_counts,
             relation_role_counts: lhs_relation_role_counts,
+            relation_role_player_counts: lhs_relation_role_player_counts,
+            role_player_relation_counts: lhs_role_player_relation_counts,
             player_index_counts: lhs_player_index_counts,
             ..
         } = $lhs;
@@ -74,6 +76,8 @@ macro_rules! assert_statistics_eq {
             attribute_owner_counts: rhs_attribute_owner_counts,
             role_player_counts: rhs_role_player_counts,
             relation_role_counts: rhs_relation_role_counts,
+            relation_role_player_counts: rhs_relation_role_player_counts,
+            role_player_relation_counts: rhs_role_player_relation_counts,
             player_index_counts: rhs_player_index_counts,
             ..
         } = $rhs;
@@ -89,6 +93,7 @@ macro_rules! assert_statistics_eq {
                 (lhs_entity_counts, lhs_relation_counts, lhs_attribute_counts, lhs_role_counts),
                 (lhs_has_attribute_counts, lhs_attribute_owner_counts),
                 (lhs_role_player_counts, lhs_relation_role_counts, lhs_player_index_counts),
+                (lhs_relation_role_player_counts, lhs_role_player_relation_counts),
             ),
             (
                 rhs_sequence_number,
@@ -97,6 +102,7 @@ macro_rules! assert_statistics_eq {
                 (rhs_entity_counts, rhs_relation_counts, rhs_attribute_counts, rhs_role_counts),
                 (rhs_has_attribute_counts, rhs_attribute_owner_counts),
                 (rhs_role_player_counts, rhs_relation_role_counts, rhs_player_index_counts),
+                (rhs_relation_role_player_counts, rhs_role_player_relation_counts),
             )
         );
     };
@@ -163,6 +169,22 @@ fn read_statistics(storage: Arc<MVCCStorage<WALClient>>, thing_manager: ThingMan
             *statistics.relation_role_counts.entry(relation.type_()).or_default().entry(role.clone()).or_default() +=
                 count;
             *statistics.role_player_counts.entry(player.type_()).or_default().entry(role.clone()).or_default() += count;
+            *statistics
+                .relation_role_player_counts
+                .entry(relation.type_())
+                .or_default()
+                .entry(role.clone())
+                .or_default()
+                .entry(player.type_())
+                .or_default() += count;
+            *statistics
+                .role_player_relation_counts
+                .entry(player.type_())
+                .or_default()
+                .entry(role.clone())
+                .or_default()
+                .entry(relation.type_())
+                .or_default() += count;
             *this_relation_players.entry(player.type_()).or_default() += 1;
         }
         for (player_1, count_1) in &this_relation_players {

--- a/concept/thing/entity.rs
+++ b/concept/thing/entity.rs
@@ -159,7 +159,7 @@ impl<'a> ThingAPI<'a> for Entity<'a> {
             .try_collect::<Vec<_>, _>()
             .map_err(|err| ConceptWriteError::ConceptRead { source: err })?;
         for (relation, role) in relations_roles {
-            thing_manager.unset_role_player(snapshot, relation, self.as_reference(), role)?;
+            thing_manager.unset_links(snapshot, relation, self.as_reference(), role)?;
         }
 
         thing_manager.delete_entity(snapshot, self);

--- a/concept/thing/relation.rs
+++ b/concept/thing/relation.rs
@@ -488,7 +488,7 @@ fn storage_key_to_role_player<'a>(
 ) -> (RolePlayer<'a>, u64) {
     let edge = ThingEdgeRolePlayer::new(storage_key.into_bytes());
     let role_type = RoleType::build_from_type_id(edge.role_id());
-    (RolePlayer { player: Object::new(edge.into_to()), role_type }, decode_value_u64(value.as_reference()))
+    (RolePlayer { player: Object::new(edge.into_player()), role_type }, decode_value_u64(value.as_reference()))
 }
 
 impl Hkt for RolePlayer<'static> {
@@ -507,7 +507,7 @@ fn storage_key_to_relation_role<'a>(
 ) -> (Relation<'a>, RoleType<'static>, u64) {
     let edge = ThingEdgeRolePlayer::new(storage_key.into_bytes());
     let role_type = RoleType::build_from_type_id(edge.role_id());
-    (Relation::new(edge.into_from()), role_type, decode_value_u64(value.as_reference()))
+    (Relation::new(edge.into_relation()), role_type, decode_value_u64(value.as_reference()))
 }
 
 edge_iterator!(

--- a/concept/thing/relation.rs
+++ b/concept/thing/relation.rs
@@ -13,7 +13,7 @@ use bytes::{byte_array::ByteArray, Bytes};
 use encoding::{
     graph::{
         thing::{
-            edge::{ThingEdgeRolePlayer, ThingEdgeRolePlayerIndex},
+            edge::{ThingEdgeLinks, ThingEdgeRolePlayerIndex},
             vertex_object::ObjectVertex,
             ThingVertex,
         },
@@ -108,8 +108,8 @@ impl<'a> Relation<'a> {
 
     pub fn has_players(&self, snapshot: &impl ReadableSnapshot, thing_manager: &ThingManager) -> bool {
         match self.get_status(snapshot, thing_manager) {
-            ConceptStatus::Inserted => thing_manager.has_role_players(snapshot, self.as_reference(), true),
-            ConceptStatus::Persisted => thing_manager.has_role_players(snapshot, self.as_reference(), false),
+            ConceptStatus::Inserted => thing_manager.has_links(snapshot, self.as_reference(), true),
+            ConceptStatus::Persisted => thing_manager.has_links(snapshot, self.as_reference(), false),
             ConceptStatus::Put => unreachable!("Encountered a `put` relation"),
             ConceptStatus::Deleted => unreachable!("Cannot operate on a deleted concept."),
         }
@@ -185,14 +185,9 @@ impl<'a> Relation<'a> {
         let relates_annotations = relates.get_annotations(snapshot, thing_manager.type_manager()).unwrap();
         let distinct = relates_annotations.contains_key(&RelatesAnnotation::Distinct(AnnotationDistinct));
         if distinct {
-            thing_manager.put_role_player_unordered(
-                snapshot,
-                self.as_reference(),
-                player.as_reference(),
-                role_type.clone(),
-            )
+            thing_manager.put_links_unordered(snapshot, self.as_reference(), player.as_reference(), role_type.clone())
         } else {
-            thing_manager.increment_role_player(snapshot, self.as_reference(), player.as_reference(), role_type.clone())
+            thing_manager.increment_links_count(snapshot, self.as_reference(), player.as_reference(), role_type.clone())
         }
     }
 
@@ -233,17 +228,12 @@ impl<'a> Relation<'a> {
         // 2. Delete existing but no-longer necessary has, and add new ones, with the correct counts (!)
         for player in old_counts.keys() {
             if !new_counts.contains_key(player) {
-                thing_manager.unset_role_player(
-                    snapshot,
-                    self.as_reference(),
-                    player.as_reference(),
-                    role_type.clone(),
-                )?;
+                thing_manager.unset_links(snapshot, self.as_reference(), player.as_reference(), role_type.clone())?;
             }
         }
         for (player, count) in new_counts {
             if old_counts.get(&player) != Some(&count) {
-                thing_manager.set_role_player_count(
+                thing_manager.set_links_count(
                     snapshot,
                     self.as_reference(),
                     player.as_reference(),
@@ -254,7 +244,7 @@ impl<'a> Relation<'a> {
         }
 
         // 3. Overwrite owned list
-        thing_manager.set_role_players_ordered(snapshot, self.as_reference(), role_type, new_players)?;
+        thing_manager.set_links_ordered(snapshot, self.as_reference(), role_type, new_players)?;
         Ok(())
     }
 
@@ -281,9 +271,9 @@ impl<'a> Relation<'a> {
         let distinct = relates_annotations.contains_key(&RelatesAnnotation::Distinct(AnnotationDistinct));
         if distinct {
             debug_assert_eq!(delete_count, 1);
-            thing_manager.unset_role_player(snapshot, self.as_reference(), player.as_reference(), role_type.clone())
+            thing_manager.unset_links(snapshot, self.as_reference(), player.as_reference(), role_type.clone())
         } else {
-            thing_manager.decrement_role_player(
+            thing_manager.decrement_links_count(
                 snapshot,
                 self.as_reference(),
                 player.as_reference(),
@@ -406,7 +396,7 @@ impl<'a> ThingAPI<'a> for Relation<'a> {
             .try_collect::<Vec<_>, _>()
             .map_err(|error| ConceptWriteError::ConceptRead { source: error })?
         {
-            thing_manager.unset_role_player(snapshot, relation, self.as_reference(), role)?;
+            thing_manager.unset_links(snapshot, relation, self.as_reference(), role)?;
         }
 
         let players = self
@@ -420,7 +410,7 @@ impl<'a> ThingAPI<'a> for Relation<'a> {
         for (role, player) in players {
             // TODO: Deleting one player at a time, each of which will delete parts of the relation index, isn't optimal
             //       Instead, we could delete the players, then delete the entire index at once, if there is one
-            thing_manager.unset_role_player(snapshot, self.as_reference(), player, role)?;
+            thing_manager.unset_links(snapshot, self.as_reference(), player, role)?;
         }
 
         debug_assert_eq!(self.get_indexed_players(snapshot, thing_manager).count(), 0);
@@ -482,13 +472,14 @@ impl<'a> RolePlayer<'a> {
     }
 }
 
-fn storage_key_to_role_player<'a>(
+fn storage_key_links_edge_to_role_player<'a>(
     storage_key: StorageKey<'a, BUFFER_KEY_INLINE>,
     value: Bytes<'a, BUFFER_VALUE_INLINE>,
 ) -> (RolePlayer<'a>, u64) {
-    let edge = ThingEdgeRolePlayer::new(storage_key.into_bytes());
+    let edge = ThingEdgeLinks::new(storage_key.into_bytes());
     let role_type = RoleType::build_from_type_id(edge.role_id());
-    (RolePlayer { player: Object::new(edge.into_player()), role_type }, decode_value_u64(value.as_reference()))
+    let player = Object::new(edge.into_player());
+    (RolePlayer { player, role_type }, decode_value_u64(value.as_reference()))
 }
 
 impl Hkt for RolePlayer<'static> {
@@ -498,14 +489,14 @@ impl Hkt for RolePlayer<'static> {
 edge_iterator!(
     RolePlayerIterator;
     'a -> (RolePlayer<'a>, u64);
-    storage_key_to_role_player
+    storage_key_links_edge_to_role_player
 );
 
-fn storage_key_to_relation_role<'a>(
+fn storage_key_links_edge_to_relation_role<'a>(
     storage_key: StorageKey<'a, BUFFER_KEY_INLINE>,
     value: Bytes<'a, BUFFER_VALUE_INLINE>,
 ) -> (Relation<'a>, RoleType<'static>, u64) {
-    let edge = ThingEdgeRolePlayer::new(storage_key.into_bytes());
+    let edge = ThingEdgeLinks::new(storage_key.into_bytes());
     let role_type = RoleType::build_from_type_id(edge.role_id());
     (Relation::new(edge.into_relation()), role_type, decode_value_u64(value.as_reference()))
 }
@@ -513,14 +504,14 @@ fn storage_key_to_relation_role<'a>(
 edge_iterator!(
     RelationRoleIterator;
     'a -> (Relation<'a>, RoleType<'static>, u64);
-    storage_key_to_relation_role
+    storage_key_links_edge_to_relation_role
 );
 
-fn storage_key_to_relation_role_player<'a>(
+fn storage_key_links_edge_to_relation_role_player<'a>(
     storage_key: StorageKey<'a, BUFFER_KEY_INLINE>,
     value: Bytes<'a, BUFFER_VALUE_INLINE>,
 ) -> (Relation<'a>, RolePlayer<'a>, u64) {
-    let edge = ThingEdgeRolePlayer::new(storage_key.into_bytes());
+    let edge = ThingEdgeLinks::new(storage_key.into_bytes());
     let relation = Relation::new(edge.relation().into_owned());
     let role_type = RoleType::build_from_type_id(edge.role_id());
     let player = Object::new(edge.into_player());
@@ -529,9 +520,9 @@ fn storage_key_to_relation_role_player<'a>(
 }
 
 edge_iterator!(
-    RelationRolePlayerIterator;
+    LinksIterator;
     'a -> (Relation<'a>, RolePlayer<'a>, u64);
-    storage_key_to_relation_role_player
+    storage_key_links_edge_to_relation_role_player
 );
 
 fn storage_key_to_indexed_players<'a>(

--- a/concept/type_/type_manager/type_reader.rs
+++ b/concept/type_/type_manager/type_reader.rs
@@ -527,7 +527,7 @@ impl TypeReader {
                     | Infix::PropertyOrdering
                     | Infix::PropertyOverride
                     | Infix::PropertyHasOrder
-                    | Infix::PropertyRolePlayerOrder => {
+                    | Infix::PropertyLinksOrder => {
                         unreachable!("Retrieved unexpected infixes while reading annotations.")
                     }
                 };
@@ -597,7 +597,7 @@ impl TypeReader {
                     | Infix::PropertyOrdering
                     | Infix::PropertyOverride
                     | Infix::PropertyHasOrder
-                    | Infix::PropertyRolePlayerOrder => {
+                    | Infix::PropertyLinksOrder => {
                         unreachable!("Retrieved unexpected infixes while reading annotations.")
                     }
                 }

--- a/concept/type_/type_manager/validation/operation_time_validation.rs
+++ b/concept/type_/type_manager/validation/operation_time_validation.rs
@@ -9,11 +9,9 @@ use std::collections::{HashMap, HashSet};
 use encoding::{
     graph::{
         definition::definition_key::DefinitionKey,
-        thing::{edge::ThingEdgeRolePlayer, vertex_object::ObjectVertex, ThingVertex},
+        thing::edge::ThingEdgeLinks,
         type_::{CapabilityKind, Kind},
-        Typed,
     },
-    layout::prefix::Prefix,
     value::{label::Label, value_type::ValueType},
 };
 use itertools::Itertools;
@@ -1473,12 +1471,12 @@ impl OperationTimeValidation {
         let mut relation_iterator = _thing_manager.get_relations(snapshot);
         while let Some(result) = relation_iterator.next() {
             let relation_instance = result.map_err(SchemaValidationError::ConceptRead)?;
-            let prefix = ThingEdgeRolePlayer::prefix_from_relation(relation_instance.into_vertex());
+            let prefix = ThingEdgeLinks::prefix_from_relation(relation_instance.into_vertex());
             let mut role_player_iterator = RolePlayerIterator::new(
-                snapshot.iterate_range(KeyRange::new_within(prefix, ThingEdgeRolePlayer::FIXED_WIDTH_ENCODING)),
+                snapshot.iterate_range(KeyRange::new_within(prefix, ThingEdgeLinks::FIXED_WIDTH_ENCODING)),
             );
             match role_player_iterator.next() {
-                None => {}
+                None => (),
                 Some(Ok(_)) => {
                     let role_type_clone = role_type.clone();
                     Err(SchemaValidationError::CannotDeleteTypeWithExistingInstances(get_label_or_schema_err(

--- a/encoding/graph/thing/edge.rs
+++ b/encoding/graph/thing/edge.rs
@@ -364,14 +364,14 @@ impl<'a> Keyable<'a, BUFFER_KEY_INLINE> for ThingEdgeHasReverse<'a> {
 /// OR
 /// [rp_reverse][object][relation][role_id]
 ///
-pub struct ThingEdgeRolePlayer<'a> {
+pub struct ThingEdgeLinks<'a> {
     bytes: Bytes<'a, BUFFER_KEY_INLINE>,
 }
 
-impl<'a> ThingEdgeRolePlayer<'a> {
+impl<'a> ThingEdgeLinks<'a> {
     const KEYSPACE: EncodingKeyspace = EncodingKeyspace::Data;
-    const PREFIX: Prefix = Prefix::EdgeRolePlayer;
-    const PREFIX_REVERSE: Prefix = Prefix::EdgeRolePlayerReverse;
+    const PREFIX: Prefix = Prefix::EdgeLinks;
+    const PREFIX_REVERSE: Prefix = Prefix::EdgeLinksReverse;
     pub const FIXED_WIDTH_ENCODING: bool = Self::PREFIX.fixed_width_keys();
     pub const FIXED_WIDTH_ENCODING_REVERSE: bool = Self::PREFIX_REVERSE.fixed_width_keys();
 
@@ -387,21 +387,21 @@ impl<'a> ThingEdgeRolePlayer<'a> {
 
     pub fn new(bytes: Bytes<'a, BUFFER_KEY_INLINE>) -> Self {
         debug_assert_eq!(bytes.length(), Self::LENGTH);
-        let edge = ThingEdgeRolePlayer { bytes };
+        let edge = ThingEdgeLinks { bytes };
         debug_assert!(edge.prefix() == Self::PREFIX || edge.prefix() == Self::PREFIX_REVERSE);
         edge
     }
 
-    pub fn build_role_player(relation: ObjectVertex<'_>, player: ObjectVertex<'_>, role_type: TypeVertex<'_>) -> Self {
+    pub fn build_links(relation: ObjectVertex<'_>, player: ObjectVertex<'_>, role_type: TypeVertex<'_>) -> Self {
         let mut bytes = ByteArray::zeros(Self::LENGTH);
         bytes.bytes_mut()[Self::RANGE_PREFIX].copy_from_slice(&Self::PREFIX.prefix_id().bytes());
         bytes.bytes_mut()[Self::RANGE_FROM].copy_from_slice(relation.bytes().bytes());
         bytes.bytes_mut()[Self::RANGE_TO].copy_from_slice(player.bytes().bytes());
         bytes.bytes_mut()[Self::RANGE_ROLE_ID].copy_from_slice(&role_type.type_id_().bytes());
-        ThingEdgeRolePlayer { bytes: Bytes::Array(bytes) }
+        ThingEdgeLinks { bytes: Bytes::Array(bytes) }
     }
 
-    pub fn build_role_player_reverse(
+    pub fn build_links_reverse(
         player: ObjectVertex<'_>,
         relation: ObjectVertex<'_>,
         role_type: TypeVertex<'_>,
@@ -411,12 +411,12 @@ impl<'a> ThingEdgeRolePlayer<'a> {
         bytes.bytes_mut()[Self::RANGE_FROM].copy_from_slice(player.bytes().bytes());
         bytes.bytes_mut()[Self::RANGE_TO].copy_from_slice(relation.bytes().bytes());
         bytes.bytes_mut()[Self::RANGE_ROLE_ID].copy_from_slice(&role_type.type_id_().bytes());
-        ThingEdgeRolePlayer { bytes: Bytes::Array(bytes) }
+        ThingEdgeLinks { bytes: Bytes::Array(bytes) }
     }
 
     pub fn prefix_from_relation_type(
         relation_type: TypeVertex<'_>,
-    ) -> StorageKey<'static, { ThingEdgeRolePlayer::LENGTH_PREFIX_FROM_TYPE }> {
+    ) -> StorageKey<'static, { ThingEdgeLinks::LENGTH_PREFIX_FROM_TYPE }> {
         let mut bytes = ByteArray::zeros(Self::LENGTH_PREFIX_FROM_TYPE);
         bytes.bytes_mut()[Self::RANGE_PREFIX].copy_from_slice(&Self::PREFIX.prefix_id().bytes());
         bytes.bytes_mut()[Self::range_from_type()]
@@ -426,7 +426,7 @@ impl<'a> ThingEdgeRolePlayer<'a> {
 
     pub fn prefix_from_relation(
         relation: ObjectVertex<'_>,
-    ) -> StorageKey<'static, { ThingEdgeRolePlayer::LENGTH_PREFIX_FROM }> {
+    ) -> StorageKey<'static, { ThingEdgeLinks::LENGTH_PREFIX_FROM }> {
         let mut bytes = ByteArray::zeros(Self::LENGTH_PREFIX_FROM);
         bytes.bytes_mut()[Self::RANGE_PREFIX].copy_from_slice(&Self::PREFIX.prefix_id().bytes());
         bytes.bytes_mut()[Self::RANGE_FROM].copy_from_slice(relation.bytes().bytes());
@@ -436,7 +436,7 @@ impl<'a> ThingEdgeRolePlayer<'a> {
     pub fn prefix_from_relation_player_type(
         relation: ObjectVertex<'_>,
         player_type: TypeVertex<'_>,
-    ) -> StorageKey<'static, { ThingEdgeRolePlayer::LENGTH_PREFIX_FROM_TO_TYPE }> {
+    ) -> StorageKey<'static, { ThingEdgeLinks::LENGTH_PREFIX_FROM_TO_TYPE }> {
         let mut bytes = ByteArray::zeros(Self::LENGTH_PREFIX_FROM_TO_TYPE);
         bytes.bytes_mut()[Self::RANGE_PREFIX].copy_from_slice(&Self::PREFIX.prefix_id().bytes());
         bytes.bytes_mut()[Self::RANGE_FROM].copy_from_slice(relation.bytes().bytes());
@@ -448,7 +448,7 @@ impl<'a> ThingEdgeRolePlayer<'a> {
     pub fn prefix_from_relation_player(
         relation: ObjectVertex<'_>,
         player: ObjectVertex<'_>,
-    ) -> StorageKey<'static, { ThingEdgeRolePlayer::LENGTH_PREFIX_FROM_TO }> {
+    ) -> StorageKey<'static, { ThingEdgeLinks::LENGTH_PREFIX_FROM_TO }> {
         let mut bytes = ByteArray::zeros(Self::LENGTH_PREFIX_FROM_TO);
         bytes.bytes_mut()[Self::RANGE_PREFIX].copy_from_slice(&Self::PREFIX.prefix_id().bytes());
         bytes.bytes_mut()[Self::RANGE_FROM].copy_from_slice(relation.bytes().bytes());
@@ -458,7 +458,7 @@ impl<'a> ThingEdgeRolePlayer<'a> {
 
     pub fn prefix_reverse_from_player(
         player: ObjectVertex<'_>,
-    ) -> StorageKey<'static, { ThingEdgeRolePlayer::LENGTH_PREFIX_FROM }> {
+    ) -> StorageKey<'static, { ThingEdgeLinks::LENGTH_PREFIX_FROM }> {
         let mut bytes = ByteArray::zeros(Self::LENGTH_PREFIX_FROM);
         bytes.bytes_mut()[Self::RANGE_PREFIX].copy_from_slice(&Self::PREFIX_REVERSE.prefix_id().bytes());
         bytes.bytes_mut()[Self::RANGE_FROM].copy_from_slice(player.bytes().bytes());
@@ -467,7 +467,7 @@ impl<'a> ThingEdgeRolePlayer<'a> {
 
     pub fn prefix_reverse_from_player_type(
         player_type: TypeVertex<'_>,
-    ) -> StorageKey<'static, { ThingEdgeRolePlayer::LENGTH_PREFIX_FROM }> {
+    ) -> StorageKey<'static, { ThingEdgeLinks::LENGTH_PREFIX_FROM }> {
         let mut bytes = ByteArray::zeros(Self::LENGTH_PREFIX_FROM_TYPE);
         bytes.bytes_mut()[Self::RANGE_PREFIX].copy_from_slice(&Self::PREFIX_REVERSE.prefix_id().bytes());
         bytes.bytes_mut()[Self::range_from_type()]
@@ -478,7 +478,7 @@ impl<'a> ThingEdgeRolePlayer<'a> {
     pub fn prefix_reverse_from_player_relation_type(
         player: ObjectVertex<'_>,
         relation_type: TypeVertex<'_>,
-    ) -> StorageKey<'static, { ThingEdgeRolePlayer::LENGTH_PREFIX_FROM_TO_TYPE }> {
+    ) -> StorageKey<'static, { ThingEdgeLinks::LENGTH_PREFIX_FROM_TO_TYPE }> {
         let mut bytes = ByteArray::zeros(Self::LENGTH_PREFIX_FROM_TO_TYPE);
         bytes.bytes_mut()[Self::RANGE_PREFIX].copy_from_slice(&Self::PREFIX_REVERSE.prefix_id().bytes());
         bytes.bytes_mut()[Self::RANGE_FROM].copy_from_slice(player.bytes().bytes());
@@ -490,7 +490,7 @@ impl<'a> ThingEdgeRolePlayer<'a> {
     pub fn prefix_reverse_from_player_relation(
         player: ObjectVertex<'_>,
         relation: ObjectVertex<'_>,
-    ) -> StorageKey<'static, { ThingEdgeRolePlayer::LENGTH_PREFIX_FROM_TO }> {
+    ) -> StorageKey<'static, { ThingEdgeLinks::LENGTH_PREFIX_FROM_TO }> {
         let mut bytes = ByteArray::zeros(Self::LENGTH_PREFIX_FROM_TO);
         bytes.bytes_mut()[Self::RANGE_PREFIX].copy_from_slice(&Self::PREFIX_REVERSE.prefix_id().bytes());
         bytes.bytes_mut()[Self::RANGE_FROM].copy_from_slice(player.bytes().bytes());
@@ -514,13 +514,13 @@ impl<'a> ThingEdgeRolePlayer<'a> {
         Self::LENGTH_PREFIX_FROM..Self::LENGTH_PREFIX_FROM + THING_VERTEX_LENGTH_PREFIX_TYPE
     }
 
-    pub fn is_role_player(key: StorageKeyReference<'_>) -> bool {
+    pub fn is_links(key: StorageKeyReference<'_>) -> bool {
         key.keyspace_id() == Self::KEYSPACE.id()
             && key.bytes().len() == Self::LENGTH
             && key.bytes()[Self::RANGE_PREFIX] == Self::PREFIX.prefix_id().bytes()
     }
 
-    pub fn is_role_player_reverse(key: StorageKeyReference<'_>) -> bool {
+    pub fn is_links_reverse(key: StorageKeyReference<'_>) -> bool {
         key.keyspace_id() == Self::KEYSPACE.id()
             && key.bytes().len() == Self::LENGTH
             && key.bytes()[Self::RANGE_PREFIX] == Self::PREFIX_REVERSE.prefix_id().bytes()
@@ -586,7 +586,7 @@ impl<'a> ThingEdgeRolePlayer<'a> {
     }
 }
 
-impl<'a> AsBytes<'a, BUFFER_KEY_INLINE> for ThingEdgeRolePlayer<'a> {
+impl<'a> AsBytes<'a, BUFFER_KEY_INLINE> for ThingEdgeLinks<'a> {
     fn bytes(&'a self) -> ByteReference<'a> {
         self.bytes.as_reference()
     }
@@ -596,9 +596,9 @@ impl<'a> AsBytes<'a, BUFFER_KEY_INLINE> for ThingEdgeRolePlayer<'a> {
     }
 }
 
-impl<'a> Prefixed<'a, BUFFER_KEY_INLINE> for ThingEdgeRolePlayer<'a> {}
+impl<'a> Prefixed<'a, BUFFER_KEY_INLINE> for ThingEdgeLinks<'a> {}
 
-impl<'a> Keyable<'a, BUFFER_KEY_INLINE> for ThingEdgeRolePlayer<'a> {
+impl<'a> Keyable<'a, BUFFER_KEY_INLINE> for ThingEdgeLinks<'a> {
     fn keyspace(&self) -> EncodingKeyspace {
         Self::KEYSPACE
     }

--- a/encoding/graph/thing/property.rs
+++ b/encoding/graph/thing/property.rs
@@ -23,56 +23,23 @@ use crate::{
     AsBytes, EncodingKeyspace, Keyable, Prefixed,
 };
 
-trait ObjectVertexPropertyFactory {
-    fn infix(&self) -> Infix;
-
-    fn create<'a>(&self, bytes: Bytes<'a, BUFFER_KEY_INLINE>) -> ObjectVertexProperty<'a> {
-        let property = ObjectVertexProperty::new(bytes);
-        debug_assert_eq!(property.infix(), self.infix());
-        property
-    }
-
-    fn matches(&self, bytes: Bytes<'_, BUFFER_KEY_INLINE>) -> bool {
-        Prefix::from_prefix_id(PrefixID::new([bytes.bytes()[0]])) == ObjectVertexProperty::PREFIX
-            && self.create(bytes).infix() == self.infix()
-    }
+pub fn build_object_vertex_property_has_order(
+    object_vertex: ObjectVertex,
+    attribute_type: TypeVertex,
+) -> ObjectVertexProperty<'static> {
+    debug_assert_eq!(attribute_type.prefix(), Prefix::VertexAttributeType);
+    let suffix: Bytes<'_, BUFFER_KEY_INLINE> = Bytes::Array(ByteArray::copy(&attribute_type.type_id_().bytes()));
+    ObjectVertexProperty::build_suffixed(object_vertex, Infix::PropertyHasOrder, suffix)
 }
 
-pub struct HasOrderPropertyFactory {}
-
-impl HasOrderPropertyFactory {
-    pub fn build(&self, object_vertex: ObjectVertex, attribute_type: TypeVertex) -> ObjectVertexProperty<'static> {
-        debug_assert_eq!(attribute_type.prefix(), Prefix::VertexAttributeType);
-        let suffix: Bytes<'_, BUFFER_KEY_INLINE> = Bytes::Array(ByteArray::copy(&attribute_type.type_id_().bytes()));
-        ObjectVertexProperty::build_suffixed(object_vertex, self.infix(), suffix)
-    }
+pub fn build_object_vertex_property_links_order(
+    object_vertex: ObjectVertex,
+    role_type: TypeVertex,
+) -> ObjectVertexProperty<'static> {
+    debug_assert_eq!(role_type.prefix(), Prefix::VertexRoleType);
+    let suffix: Bytes<'_, BUFFER_KEY_INLINE> = Bytes::Array(ByteArray::copy(&role_type.type_id_().bytes()));
+    ObjectVertexProperty::build_suffixed(object_vertex, Infix::PropertyLinksOrder, suffix)
 }
-
-impl ObjectVertexPropertyFactory for HasOrderPropertyFactory {
-    fn infix(&self) -> Infix {
-        Infix::PropertyHasOrder
-    }
-}
-
-pub const HAS_ORDER_PROPERTY_FACTORY: HasOrderPropertyFactory = HasOrderPropertyFactory {};
-
-pub struct RolePlayerOrderPropertyFactory {}
-
-impl RolePlayerOrderPropertyFactory {
-    pub fn build(&self, object_vertex: ObjectVertex, role_type: TypeVertex) -> ObjectVertexProperty<'static> {
-        debug_assert_eq!(role_type.prefix(), Prefix::VertexRoleType);
-        let suffix: Bytes<'_, BUFFER_KEY_INLINE> = Bytes::Array(ByteArray::copy(&role_type.type_id_().bytes()));
-        ObjectVertexProperty::build_suffixed(object_vertex, self.infix(), suffix)
-    }
-}
-
-impl ObjectVertexPropertyFactory for RolePlayerOrderPropertyFactory {
-    fn infix(&self) -> Infix {
-        Infix::PropertyRolePlayerOrder
-    }
-}
-
-pub const ROLE_PLAYER_ORDER_PROPERTY_FACTORY: RolePlayerOrderPropertyFactory = RolePlayerOrderPropertyFactory {};
 
 #[derive(Debug, Clone, PartialEq, Eq, Ord, PartialOrd)]
 pub struct ObjectVertexProperty<'a> {

--- a/encoding/layout/infix.rs
+++ b/encoding/layout/infix.rs
@@ -43,7 +43,7 @@ pub enum Infix {
 
     // Data properties
     PropertyHasOrder,
-    PropertyRolePlayerOrder,
+    PropertyLinksOrder,
 }
 
 macro_rules! infix_functions {
@@ -95,6 +95,6 @@ impl Infix {
         _PropertyAnnotationLast => [99];
 
         PropertyHasOrder => [100];
-        PropertyRolePlayerOrder => [101]
+        PropertyLinksOrder => [101]
     );
 }

--- a/encoding/layout/prefix.rs
+++ b/encoding/layout/prefix.rs
@@ -56,8 +56,8 @@ pub enum Prefix {
 
     EdgeHas,
     EdgeHasReverse,
-    EdgeRolePlayer,
-    EdgeRolePlayerReverse,
+    EdgeLinks,
+    EdgeLinksReverse,
     EdgeRolePlayerIndex,
 
     DefinitionStruct,
@@ -164,8 +164,8 @@ impl Prefix {
 
            EdgeHas => [130], false;
            EdgeHasReverse => [131], false;
-           EdgeRolePlayer => [132], true;
-           EdgeRolePlayerReverse => [133], true;
+           EdgeLinks => [132], true;
+           EdgeLinksReverse => [133], true;
            EdgeRolePlayerIndex => [140], true;
 
            PropertyTypeVertex => [160], true;

--- a/executor/instruction/has_executor.rs
+++ b/executor/instruction/has_executor.rs
@@ -77,10 +77,10 @@ impl HasExecutor {
         thing_manager: &ThingManager,
     ) -> Result<Self, ConceptReadError> {
         debug_assert!(!variable_modes.all_inputs());
-        let owner_attribute_types = has.edge_types();
+        let owner_attribute_types = has.owner_to_attribute_types().clone();
         debug_assert!(owner_attribute_types.len() > 0);
-        let attribute_types = has.end_types();
-        let has = has.constraint;
+        let attribute_types = has.attribute_types().clone();
+        let has = has.has;
         let iterate_mode = BinaryIterateMode::new(has.owner(), has.attribute(), &variable_modes, sort_by);
         let filter_fn = match iterate_mode {
             BinaryIterateMode::Unbound => Self::create_has_filter_owners_attributes(owner_attribute_types.clone()),

--- a/executor/instruction/has_reverse_executor.rs
+++ b/executor/instruction/has_reverse_executor.rs
@@ -67,10 +67,10 @@ impl HasReverseExecutor {
         thing_manager: &ThingManager,
     ) -> Result<Self, ConceptReadError> {
         debug_assert!(!variable_modes.all_inputs());
-        let attribute_owner_types = has_reverse.edge_types();
+        let attribute_owner_types = has_reverse.attribute_to_owner_types().clone();
         debug_assert!(!attribute_owner_types.is_empty());
-        let owner_types = has_reverse.end_types();
-        let has = has_reverse.constraint;
+        let owner_types = has_reverse.owner_types().clone();
+        let has = has_reverse.has;
         let iterate_mode = BinaryIterateMode::new(has.attribute(), has.owner(), &variable_modes, sort_by);
         let filter_fn = match iterate_mode {
             BinaryIterateMode::Unbound => Self::create_has_filter_attributes_owners(attribute_owner_types.clone()),

--- a/executor/instruction/isa_reverse_executor.rs
+++ b/executor/instruction/isa_reverse_executor.rs
@@ -64,9 +64,9 @@ impl IsaReverseExecutor {
         variable_modes: VariableModes,
         sort_by: Option<VariablePosition>,
     ) -> Self {
-        let thing_types = isa_reverse.types();
+        let thing_types = isa_reverse.types().clone();
         debug_assert!(thing_types.len() > 0);
-        let isa = isa_reverse.constraint;
+        let isa = isa_reverse.isa;
         let iterate_mode = BinaryIterateMode::new(isa.type_(), isa.thing(), &variable_modes, sort_by);
         let type_cache = if iterate_mode == BinaryIterateMode::UnboundInverted {
             let cache = thing_types.clone();

--- a/executor/instruction/iterator.rs
+++ b/executor/instruction/iterator.rs
@@ -30,15 +30,14 @@ use crate::{
             IsaUnboundedSortedThingAttributeSingle, IsaUnboundedSortedThingEntitySingle,
             IsaUnboundedSortedThingRelationSingle,
         },
-        role_player_executor::{
-            RolePlayerBoundedRelationPlayer, RolePlayerBoundedRelationSortedPlayer,
-            RolePlayerUnboundedSortedPlayerMerged, RolePlayerUnboundedSortedPlayerSingle,
-            RolePlayerUnboundedSortedRelation,
+        links_executor::{
+            LinksBoundedRelationPlayer, LinksBoundedRelationSortedPlayer, LinksUnboundedSortedPlayerMerged,
+            LinksUnboundedSortedPlayerSingle, LinksUnboundedSortedRelation,
         },
-        role_player_reverse_executor::{
-            RolePlayerReverseBoundedPlayerRelation, RolePlayerReverseBoundedPlayerSortedRelation,
-            RolePlayerReverseUnboundedSortedPlayer, RolePlayerReverseUnboundedSortedRelationMerged,
-            RolePlayerReverseUnboundedSortedRelationSingle,
+        links_reverse_executor::{
+            LinksReverseBoundedPlayerRelation, LinksReverseBoundedPlayerSortedRelation,
+            LinksReverseUnboundedSortedPlayer, LinksReverseUnboundedSortedRelationMerged,
+            LinksReverseUnboundedSortedRelationSingle,
         },
         tuple::{Tuple, TupleIndex, TuplePositions, TupleResult},
         VariableMode, VariableModes,
@@ -101,17 +100,17 @@ pub(crate) enum TupleIterator {
     HasReverseUnboundedInvertedMerged(SortedTupleIterator<HasReverseUnboundedSortedOwnerMerged>),
     HasReverseBounded(SortedTupleIterator<HasReverseBoundedSortedOwner>),
 
-    RolePlayerUnbounded(SortedTupleIterator<RolePlayerUnboundedSortedRelation>),
-    RolePlayerUnboundedInvertedSingle(SortedTupleIterator<RolePlayerUnboundedSortedPlayerSingle>),
-    RolePlayerUnboundedInvertedMerged(SortedTupleIterator<RolePlayerUnboundedSortedPlayerMerged>),
-    RolePlayerBoundedRelation(SortedTupleIterator<RolePlayerBoundedRelationSortedPlayer>),
-    RolePlayerBoundedRelationPlayer(SortedTupleIterator<RolePlayerBoundedRelationPlayer>),
+    LinksUnbounded(SortedTupleIterator<LinksUnboundedSortedRelation>),
+    LinksUnboundedInvertedSingle(SortedTupleIterator<LinksUnboundedSortedPlayerSingle>),
+    LinksUnboundedInvertedMerged(SortedTupleIterator<LinksUnboundedSortedPlayerMerged>),
+    LinksBoundedRelation(SortedTupleIterator<LinksBoundedRelationSortedPlayer>),
+    LinksBoundedRelationPlayer(SortedTupleIterator<LinksBoundedRelationPlayer>),
 
-    RolePlayerReverseUnbounded(SortedTupleIterator<RolePlayerReverseUnboundedSortedPlayer>),
-    RolePlayerReverseUnboundedInvertedSingle(SortedTupleIterator<RolePlayerReverseUnboundedSortedRelationSingle>),
-    RolePlayerReverseUnboundedInvertedMerged(SortedTupleIterator<RolePlayerReverseUnboundedSortedRelationMerged>),
-    RolePlayerReverseBoundedPlayer(SortedTupleIterator<RolePlayerReverseBoundedPlayerSortedRelation>),
-    RolePlayerReverseBoundedPlayerRelation(SortedTupleIterator<RolePlayerReverseBoundedPlayerRelation>),
+    LinksReverseUnbounded(SortedTupleIterator<LinksReverseUnboundedSortedPlayer>),
+    LinksReverseUnboundedInvertedSingle(SortedTupleIterator<LinksReverseUnboundedSortedRelationSingle>),
+    LinksReverseUnboundedInvertedMerged(SortedTupleIterator<LinksReverseUnboundedSortedRelationMerged>),
+    LinksReverseBoundedPlayer(SortedTupleIterator<LinksReverseBoundedPlayerSortedRelation>),
+    LinksReverseBoundedPlayerRelation(SortedTupleIterator<LinksReverseBoundedPlayerRelation>),
 }
 
 impl {

--- a/executor/instruction/mod.rs
+++ b/executor/instruction/mod.rs
@@ -21,7 +21,7 @@ use crate::{
         comparison_reverse_executor::ComparisonReverseIteratorExecutor,
         function_call_binding_executor::FunctionCallBindingIteratorExecutor, has_executor::HasExecutor,
         has_reverse_executor::HasReverseExecutor, isa_reverse_executor::IsaReverseExecutor, iterator::TupleIterator,
-        role_player_executor::RolePlayerExecutor, role_player_reverse_executor::RolePlayerReverseExecutor,
+        links_executor::LinksExecutor, links_reverse_executor::LinksReverseExecutor,
     },
     VariablePosition,
 };
@@ -33,8 +33,8 @@ mod has_executor;
 mod has_reverse_executor;
 mod isa_reverse_executor;
 pub(crate) mod iterator;
-mod role_player_executor;
-mod role_player_reverse_executor;
+mod links_executor;
+mod links_reverse_executor;
 pub(crate) mod tuple;
 
 pub(crate) enum InstructionExecutor {
@@ -43,8 +43,8 @@ pub(crate) enum InstructionExecutor {
     Has(HasExecutor),
     HasReverse(HasReverseExecutor),
 
-    RolePlayer(RolePlayerExecutor),
-    RolePlayerReverse(RolePlayerReverseExecutor),
+    Links(LinksExecutor),
+    LinksReverse(LinksReverseExecutor),
 
     // RolePlayerIndex(RolePlayerIndexExecutor),
     FunctionCallBinding(FunctionCallBindingIteratorExecutor),
@@ -87,25 +87,25 @@ impl InstructionExecutor {
                 )?;
                 Ok(Self::HasReverse(executor))
             }
-            ConstraintInstruction::RolePlayer(role_player) => {
-                let executor = RolePlayerExecutor::new(
-                    role_player.map(positions),
+            ConstraintInstruction::Links(links) => {
+                let executor = LinksExecutor::new(
+                    links.map(positions),
                     variable_modes,
                     sort_by_position,
                     snapshot,
                     thing_manager,
                 )?;
-                Ok(Self::RolePlayer(executor))
+                Ok(Self::Links(executor))
             }
-            ConstraintInstruction::RolePlayerReverse(role_player_reverse) => {
-                let executor = RolePlayerReverseExecutor::new(
-                    role_player_reverse.map(positions),
+            ConstraintInstruction::LinksReverse(links_reverse) => {
+                let executor = LinksReverseExecutor::new(
+                    links_reverse.map(positions),
                     variable_modes,
                     sort_by_position,
                     snapshot,
                     thing_manager,
                 )?;
-                Ok(Self::RolePlayerReverse(executor))
+                Ok(Self::LinksReverse(executor))
             }
             ConstraintInstruction::FunctionCallBinding(function_call) => {
                 todo!()
@@ -135,8 +135,8 @@ impl InstructionExecutor {
             InstructionExecutor::IsaReverse(executor) => executor.get_iterator(snapshot, thing_manager, row),
             InstructionExecutor::Has(executor) => executor.get_iterator(snapshot, thing_manager, row),
             InstructionExecutor::HasReverse(executor) => executor.get_iterator(snapshot, thing_manager, row),
-            InstructionExecutor::RolePlayer(executor) => executor.get_iterator(snapshot, thing_manager, row),
-            InstructionExecutor::RolePlayerReverse(executor) => executor.get_iterator(snapshot, thing_manager, row),
+            InstructionExecutor::Links(executor) => executor.get_iterator(snapshot, thing_manager, row),
+            InstructionExecutor::LinksReverse(executor) => executor.get_iterator(snapshot, thing_manager, row),
             InstructionExecutor::FunctionCallBinding(executor) => todo!(),
             InstructionExecutor::Comparison(executor) => todo!(),
             InstructionExecutor::ComparisonReverse(executor) => todo!(),
@@ -292,8 +292,8 @@ impl TernaryIterateMode {
 //     Has(HasCheckExecutor),
 //     HasReverse(HasReverseCheckExecutor),
 //
-//     RolePlayer(RolePlayerCheckExecutor),
-//     RolePlayerReverse(RolePlayerReverseCheckExecutor),
+//     Links(LinksCheckExecutor),
+//     LinksReverse(LinksReverseCheckExecutor),
 //
 //     // RolePlayerIndex(RolePlayerIndexExecutor),
 //

--- a/executor/instruction/tuple.rs
+++ b/executor/instruction/tuple.rs
@@ -162,10 +162,10 @@ pub(crate) fn has_to_tuple_attribute_owner(result: Result<(Has<'_>, u64), Concep
     Ok(Tuple::Pair([VariableValue::Thing(attribute.into()), VariableValue::Thing(owner.into())]))
 }
 
-pub(crate) type RelationRolePlayerToTupleFn =
+pub(crate) type LinksToTupleFn =
     for<'a> fn(Result<(Relation<'a>, RolePlayer<'a>, u64), ConceptReadError>) -> TupleResult<'a>;
 
-pub(crate) fn relation_role_player_to_tuple_relation_player_role<'a>(
+pub(crate) fn links_to_tuple_relation_player_role<'a>(
     result: Result<(Relation<'a>, RolePlayer<'a>, u64), ConceptReadError>,
 ) -> TupleResult<'a> {
     let (rel, rp, count) = result?;
@@ -177,7 +177,7 @@ pub(crate) fn relation_role_player_to_tuple_relation_player_role<'a>(
     ]))
 }
 
-pub(crate) fn relation_role_player_to_tuple_player_relation_role<'a>(
+pub(crate) fn links_to_tuple_player_relation_role<'a>(
     result: Result<(Relation<'a>, RolePlayer<'a>, u64), ConceptReadError>,
 ) -> TupleResult<'a> {
     let (rel, rp, count) = result?;

--- a/executor/tests/BUILD
+++ b/executor/tests/BUILD
@@ -38,9 +38,9 @@ rust_test(
 )
 
 rust_test(
-    name = "test_execute_rp",
-    crate_root = "execute_rp.rs",
-    srcs = ["execute_rp.rs", "common.rs"],
+    name = "test_execute_links",
+    crate_root = "execute_links.rs",
+    srcs = ["execute_links.rs", "common.rs"],
     deps = deps,
 )
 

--- a/executor/tests/compile_execute.rs
+++ b/executor/tests/compile_execute.rs
@@ -12,7 +12,10 @@ use compiler::{
 };
 use concept::{
     thing::{object::ObjectAPI, statistics::Statistics},
-    type_::{annotation::AnnotationCardinality, owns::OwnsAnnotation, Ordering, OwnerAPI},
+    type_::{
+        annotation::AnnotationCardinality, owns::OwnsAnnotation, relates::RelatesAnnotation, Ordering, OwnerAPI,
+        PlayerAPI,
+    },
 };
 use encoding::value::{label::Label, value::Value, value_type::ValueType};
 use executor::program_executor::ProgramExecutor;
@@ -31,9 +34,12 @@ mod common;
 const PERSON_LABEL: Label = Label::new_static("person");
 const AGE_LABEL: Label = Label::new_static("age");
 const NAME_LABEL: Label = Label::new_static("name");
+const MEMBERSHIP_LABEL: Label = Label::new_static("membership");
+const MEMBERSHIP_MEMBER_LABEL: Label = Label::new_static_scoped("member", "membership", "membership:member");
+const MEMBERSHIP_GROUP_LABEL: Label = Label::new_static_scoped("group", "membership", "membership:group");
 
 #[test]
-fn test_planning_traversal() {
+fn test_has_planning_traversal() {
     let (_tmp_dir, storage) = setup_storage();
     let mut snapshot = storage.clone().open_snapshot_write();
     let (type_manager, thing_manager) = load_managers(storage.clone());
@@ -134,6 +140,127 @@ fn test_planning_traversal() {
             .unwrap();
 
         assert_eq!(rows.len(), 7);
+
+        for row in rows {
+            for value in row {
+                print!("{}, ", value);
+            }
+            println!()
+        }
+    }
+}
+
+#[test]
+fn test_links_planning_traversal() {
+    let (_tmp_dir, storage) = setup_storage();
+    let mut snapshot = storage.clone().open_snapshot_write();
+    let (type_manager, thing_manager) = load_managers(storage.clone());
+
+    const CARDINALITY_ANY: AnnotationCardinality = AnnotationCardinality::new(0, None);
+    const OWNS_CARDINALITY_ANY: OwnsAnnotation = OwnsAnnotation::Cardinality(CARDINALITY_ANY);
+    const RELATES_CARDINALITY_ANY: RelatesAnnotation = RelatesAnnotation::Cardinality(CARDINALITY_ANY);
+
+    let person_type = type_manager.create_entity_type(&mut snapshot, &PERSON_LABEL).unwrap();
+    let membership_type = type_manager.create_relation_type(&mut snapshot, &MEMBERSHIP_LABEL).unwrap();
+
+    let name_type = type_manager.create_attribute_type(&mut snapshot, &NAME_LABEL).unwrap();
+    name_type.set_value_type(&mut snapshot, &type_manager, ValueType::String).unwrap();
+
+    let person_owns_name =
+        person_type.set_owns(&mut snapshot, &type_manager, name_type.clone(), Ordering::Unordered).unwrap();
+    person_owns_name.set_annotation(&mut snapshot, &type_manager, OWNS_CARDINALITY_ANY).unwrap();
+
+    let relates_member = membership_type
+        .create_relates(&mut snapshot, &type_manager, MEMBERSHIP_MEMBER_LABEL.name().as_str(), Ordering::Unordered)
+        .unwrap();
+    relates_member.set_annotation(&mut snapshot, &type_manager, RELATES_CARDINALITY_ANY).unwrap();
+    let membership_member_type = relates_member.role();
+
+    person_type.set_plays(&mut snapshot, &type_manager, membership_member_type.clone()).unwrap();
+
+    let person = [
+        thing_manager.create_entity(&mut snapshot, person_type.clone()).unwrap(),
+        thing_manager.create_entity(&mut snapshot, person_type.clone()).unwrap(),
+        thing_manager.create_entity(&mut snapshot, person_type.clone()).unwrap(),
+    ];
+
+    let membership = [
+        thing_manager.create_relation(&mut snapshot, membership_type.clone()).unwrap(),
+        thing_manager.create_relation(&mut snapshot, membership_type.clone()).unwrap(),
+    ];
+
+    let name = [
+        thing_manager.create_attribute(&mut snapshot, name_type.clone(), Value::String(Cow::Borrowed("John"))).unwrap(),
+        thing_manager
+            .create_attribute(&mut snapshot, name_type.clone(), Value::String(Cow::Borrowed("Alice")))
+            .unwrap(),
+        thing_manager
+            .create_attribute(&mut snapshot, name_type.clone(), Value::String(Cow::Borrowed("Leila")))
+            .unwrap(),
+    ];
+
+    person[0].set_has_unordered(&mut snapshot, &thing_manager, name[0].clone()).unwrap();
+    person[1].set_has_unordered(&mut snapshot, &thing_manager, name[1].clone()).unwrap();
+    person[2].set_has_unordered(&mut snapshot, &thing_manager, name[2].clone()).unwrap();
+
+    membership[0]
+        .add_player(
+            &mut snapshot,
+            &thing_manager,
+            membership_member_type.clone(),
+            person[0].clone().into_owned_object(),
+        )
+        .unwrap();
+    membership[1]
+        .add_player(
+            &mut snapshot,
+            &thing_manager,
+            membership_member_type.clone(),
+            person[2].clone().into_owned_object(),
+        )
+        .unwrap();
+
+    let finalise_result = thing_manager.finalise(&mut snapshot);
+    assert!(finalise_result.is_ok());
+    snapshot.commit().unwrap();
+
+    let mut statistics = Statistics::new(SequenceNumber::new(0));
+    statistics.may_synchronise(&storage).unwrap();
+
+    let query = "match $person isa person, has name $name; $membership isa membership, links ($person);";
+    let match_ = typeql::parse_query(query).unwrap().into_pipeline().stages.remove(0).into_match();
+
+    // IR
+    let empty_function_index = HashMapFunctionIndex::empty();
+    let builder = translate_match(&empty_function_index, &match_).unwrap();
+    // builder.add_limit(3);
+    // builder.add_filter(vec!["person", "age"]).unwrap();
+    let block = builder.finish();
+
+    // Executor
+    let snapshot = storage.clone().open_snapshot_read();
+    let (type_manager, thing_manager) = load_managers(storage.clone());
+    let program = Program::new(block, Vec::new());
+    let annotated_program =
+        infer_types(program, &snapshot, &type_manager, Arc::new(AnnotatedCommittedFunctions::empty())).unwrap();
+    let pattern_plan = PatternPlan::from_block(&annotated_program, &statistics);
+    let program_plan = ProgramPlan::new(pattern_plan, annotated_program.entry_annotations().clone(), HashMap::new());
+    let executor = ProgramExecutor::new(&program_plan, &snapshot, &thing_manager).unwrap();
+
+    {
+        let snapshot = Arc::new(storage.clone().open_snapshot_read());
+        let (_, thing_manager) = load_managers(storage.clone());
+        let thing_manager = Arc::new(thing_manager);
+
+        let iterator = executor.into_iterator(snapshot, thing_manager);
+
+        let rows = iterator
+            .map_static(|row| row.map(|row| row.into_owned()).map_err(|err| err.clone()))
+            .into_iter()
+            .try_collect::<_, Vec<_>, _>()
+            .unwrap();
+
+        assert_eq!(rows.len(), 2);
 
         for row in rows {
             for value in row {

--- a/executor/tests/compile_execute.rs
+++ b/executor/tests/compile_execute.rs
@@ -125,28 +125,21 @@ fn test_has_planning_traversal() {
     let pattern_plan = PatternPlan::from_block(&annotated_program, &statistics);
     let program_plan = ProgramPlan::new(pattern_plan, annotated_program.entry_annotations().clone(), HashMap::new());
     let executor = ProgramExecutor::new(&program_plan, &snapshot, &thing_manager).unwrap();
+    let iterator = executor.into_iterator(Arc::new(snapshot), Arc::new(thing_manager));
 
-    {
-        let snapshot = Arc::new(storage.clone().open_snapshot_read());
-        let (_, thing_manager) = load_managers(storage.clone());
-        let thing_manager = Arc::new(thing_manager);
+    let rows = iterator
+        .map_static(|row| row.map(|row| row.into_owned()).map_err(|err| err.clone()))
+        .into_iter()
+        .try_collect::<_, Vec<_>, _>()
+        .unwrap();
 
-        let iterator = executor.into_iterator(snapshot, thing_manager);
+    assert_eq!(rows.len(), 7);
 
-        let rows = iterator
-            .map_static(|row| row.map(|row| row.into_owned()).map_err(|err| err.clone()))
-            .into_iter()
-            .try_collect::<_, Vec<_>, _>()
-            .unwrap();
-
-        assert_eq!(rows.len(), 7);
-
-        for row in rows {
-            for value in row {
-                print!("{}, ", value);
-            }
-            println!()
+    for row in rows {
+        for value in row {
+            print!("{}, ", value);
         }
+        println!()
     }
 }
 
@@ -246,27 +239,20 @@ fn test_links_planning_traversal() {
     let pattern_plan = PatternPlan::from_block(&annotated_program, &statistics);
     let program_plan = ProgramPlan::new(pattern_plan, annotated_program.entry_annotations().clone(), HashMap::new());
     let executor = ProgramExecutor::new(&program_plan, &snapshot, &thing_manager).unwrap();
+    let iterator = executor.into_iterator(Arc::new(snapshot), Arc::new(thing_manager));
 
-    {
-        let snapshot = Arc::new(storage.clone().open_snapshot_read());
-        let (_, thing_manager) = load_managers(storage.clone());
-        let thing_manager = Arc::new(thing_manager);
+    let rows = iterator
+        .map_static(|row| row.map(|row| row.into_owned()).map_err(|err| err.clone()))
+        .into_iter()
+        .try_collect::<_, Vec<_>, _>()
+        .unwrap();
 
-        let iterator = executor.into_iterator(snapshot, thing_manager);
+    assert_eq!(rows.len(), 2);
 
-        let rows = iterator
-            .map_static(|row| row.map(|row| row.into_owned()).map_err(|err| err.clone()))
-            .into_iter()
-            .try_collect::<_, Vec<_>, _>()
-            .unwrap();
-
-        assert_eq!(rows.len(), 2);
-
-        for row in rows {
-            for value in row {
-                print!("{}, ", value);
-            }
-            println!()
+    for row in rows {
+        for value in row {
+            print!("{}, ", value);
         }
+        println!()
     }
 }

--- a/executor/tests/execute_links.rs
+++ b/executor/tests/execute_links.rs
@@ -57,6 +57,7 @@ fn setup_database(storage: Arc<MVCCStorage<WALClient>>) {
     let group_type = type_manager.create_entity_type(&mut snapshot, &GROUP_LABEL).unwrap();
 
     let membership_type = type_manager.create_relation_type(&mut snapshot, &MEMBERSHIP_LABEL).unwrap();
+
     let relates_member = membership_type
         .create_relates(&mut snapshot, &type_manager, MEMBERSHIP_MEMBER_LABEL.name().as_str(), Ordering::Unordered)
         .unwrap();

--- a/executor/tests/execute_links.rs
+++ b/executor/tests/execute_links.rs
@@ -9,7 +9,7 @@ use std::{borrow::Cow, collections::HashMap, sync::Arc};
 use compiler::{
     inference::{annotated_functions::AnnotatedCommittedFunctions, type_inference::infer_types},
     instruction::constraint::instructions::{
-        ConstraintInstruction, Inputs, IsaReverseInstruction, RolePlayerInstruction, RolePlayerReverseInstruction,
+        ConstraintInstruction, Inputs, IsaReverseInstruction, LinksInstruction, LinksReverseInstruction,
     },
     planner::{
         pattern_plan::{IntersectionStep, PatternPlan, Step},
@@ -145,7 +145,7 @@ fn setup_database(storage: Arc<MVCCStorage<WALClient>>) {
 }
 
 #[test]
-fn traverse_rp_unbounded_sorted_from() {
+fn traverse_links_unbounded_sorted_from() {
     let (_tmp_dir, storage) = setup_storage();
 
     setup_database(storage.clone());
@@ -168,16 +168,13 @@ fn traverse_rp_unbounded_sorted_from() {
     let var_group = conjunction.get_or_declare_variable("group").unwrap();
     let var_membership = conjunction.get_or_declare_variable("membership").unwrap();
 
-    let rp_membership_person = conjunction
+    let links_membership_person = conjunction
         .constraints_mut()
-        .add_role_player(var_membership, var_person, var_membership_member_type)
+        .add_links(var_membership, var_person, var_membership_member_type)
         .unwrap()
         .clone();
-    let rp_membership_group = conjunction
-        .constraints_mut()
-        .add_role_player(var_membership, var_group, var_membership_group_type)
-        .unwrap()
-        .clone();
+    let links_membership_group =
+        conjunction.constraints_mut().add_links(var_membership, var_group, var_membership_group_type).unwrap().clone();
 
     conjunction.constraints_mut().add_isa(IsaKind::Subtype, var_person, var_person_type).unwrap();
     conjunction.constraints_mut().add_isa(IsaKind::Subtype, var_group, var_group_type).unwrap();
@@ -205,13 +202,13 @@ fn traverse_rp_unbounded_sorted_from() {
     let steps = vec![Step::Intersection(IntersectionStep::new(
         var_membership,
         vec![
-            ConstraintInstruction::RolePlayer(RolePlayerInstruction::new(
-                rp_membership_person.clone(),
+            ConstraintInstruction::Links(LinksInstruction::new(
+                links_membership_person,
                 Inputs::None([]),
                 annotated_program.entry_annotations(),
             )),
-            ConstraintInstruction::RolePlayer(RolePlayerInstruction::new(
-                rp_membership_group.clone(),
+            ConstraintInstruction::Links(LinksInstruction::new(
+                links_membership_group,
                 Inputs::None([]),
                 annotated_program.entry_annotations(),
             )),
@@ -238,7 +235,7 @@ fn traverse_rp_unbounded_sorted_from() {
 }
 
 #[test]
-fn traverse_rp_unbounded_sorted_to() {
+fn traverse_links_unbounded_sorted_to() {
     let (_tmp_dir, storage) = setup_storage();
 
     setup_database(storage.clone());
@@ -261,9 +258,9 @@ fn traverse_rp_unbounded_sorted_to() {
     let var_group = conjunction.get_or_declare_variable("group").unwrap();
     let var_membership = conjunction.get_or_declare_variable("membership").unwrap();
 
-    let rp_membership_person = conjunction
+    let links_membership_person = conjunction
         .constraints_mut()
-        .add_role_player(var_membership, var_person, var_membership_member_type)
+        .add_links(var_membership, var_person, var_membership_member_type)
         .unwrap()
         .clone();
 
@@ -292,8 +289,8 @@ fn traverse_rp_unbounded_sorted_to() {
     // Plan
     let steps = vec![Step::Intersection(IntersectionStep::new(
         var_person,
-        vec![ConstraintInstruction::RolePlayer(RolePlayerInstruction::new(
-            rp_membership_person.clone(),
+        vec![ConstraintInstruction::Links(LinksInstruction::new(
+            links_membership_person,
             Inputs::None([]),
             annotated_program.entry_annotations(),
         ))],
@@ -319,7 +316,7 @@ fn traverse_rp_unbounded_sorted_to() {
 }
 
 #[test]
-fn traverse_rp_bounded_relation() {
+fn traverse_links_bounded_relation() {
     let (_tmp_dir, storage) = setup_storage();
 
     setup_database(storage.clone());
@@ -342,9 +339,9 @@ fn traverse_rp_bounded_relation() {
     let var_group = conjunction.get_or_declare_variable("group").unwrap();
     let var_membership = conjunction.get_or_declare_variable("membership").unwrap();
 
-    let rp_membership_person = conjunction
+    let links_membership_person = conjunction
         .constraints_mut()
-        .add_role_player(var_membership, var_person, var_membership_member_type)
+        .add_links(var_membership, var_person, var_membership_member_type)
         .unwrap()
         .clone();
 
@@ -384,8 +381,8 @@ fn traverse_rp_bounded_relation() {
         )),
         Step::Intersection(IntersectionStep::new(
             var_person,
-            vec![ConstraintInstruction::RolePlayer(RolePlayerInstruction::new(
-                rp_membership_person.clone(),
+            vec![ConstraintInstruction::Links(LinksInstruction::new(
+                links_membership_person,
                 Inputs::Single([var_membership]),
                 annotated_program.entry_annotations(),
             ))],
@@ -412,7 +409,7 @@ fn traverse_rp_bounded_relation() {
 }
 
 #[test]
-fn traverse_rp_bounded_relation_player() {
+fn traverse_links_bounded_relation_player() {
     let (_tmp_dir, storage) = setup_storage();
 
     setup_database(storage.clone());
@@ -435,9 +432,9 @@ fn traverse_rp_bounded_relation_player() {
     let var_group = conjunction.get_or_declare_variable("group").unwrap();
     let var_membership = conjunction.get_or_declare_variable("membership").unwrap();
 
-    let rp_membership_person = conjunction
+    let links_membership_person = conjunction
         .constraints_mut()
-        .add_role_player(var_membership, var_person, var_membership_member_type)
+        .add_links(var_membership, var_person, var_membership_member_type)
         .unwrap()
         .clone();
 
@@ -487,8 +484,8 @@ fn traverse_rp_bounded_relation_player() {
         )),
         Step::Intersection(IntersectionStep::new(
             var_membership_member_type,
-            vec![ConstraintInstruction::RolePlayer(RolePlayerInstruction::new(
-                rp_membership_person.clone(),
+            vec![ConstraintInstruction::Links(LinksInstruction::new(
+                links_membership_person,
                 Inputs::Dual([var_membership, var_person]),
                 annotated_program.entry_annotations(),
             ))],
@@ -514,7 +511,7 @@ fn traverse_rp_bounded_relation_player() {
 }
 
 #[test]
-fn traverse_rp_reverse_unbounded_sorted_from() {
+fn traverse_links_reverse_unbounded_sorted_from() {
     let (_tmp_dir, storage) = setup_storage();
 
     setup_database(storage.clone());
@@ -537,9 +534,9 @@ fn traverse_rp_reverse_unbounded_sorted_from() {
     let var_group = conjunction.get_or_declare_variable("group").unwrap();
     let var_membership = conjunction.get_or_declare_variable("membership").unwrap();
 
-    let rp_membership_person = conjunction
+    let links_membership_person = conjunction
         .constraints_mut()
-        .add_role_player(var_membership, var_person, var_membership_member_type)
+        .add_links(var_membership, var_person, var_membership_member_type)
         .unwrap()
         .clone();
 
@@ -568,8 +565,8 @@ fn traverse_rp_reverse_unbounded_sorted_from() {
     // Plan
     let steps = vec![Step::Intersection(IntersectionStep::new(
         var_person,
-        vec![ConstraintInstruction::RolePlayerReverse(RolePlayerReverseInstruction::new(
-            rp_membership_person.clone(),
+        vec![ConstraintInstruction::LinksReverse(LinksReverseInstruction::new(
+            links_membership_person,
             Inputs::None([]),
             annotated_program.entry_annotations(),
         ))],
@@ -595,7 +592,7 @@ fn traverse_rp_reverse_unbounded_sorted_from() {
 }
 
 #[test]
-fn traverse_rp_reverse_unbounded_sorted_to() {
+fn traverse_links_reverse_unbounded_sorted_to() {
     let (_tmp_dir, storage) = setup_storage();
 
     setup_database(storage.clone());
@@ -618,9 +615,9 @@ fn traverse_rp_reverse_unbounded_sorted_to() {
     let var_group = conjunction.get_or_declare_variable("group").unwrap();
     let var_membership = conjunction.get_or_declare_variable("membership").unwrap();
 
-    let rp_membership_person = conjunction
+    let links_membership_person = conjunction
         .constraints_mut()
-        .add_role_player(var_membership, var_person, var_membership_member_type)
+        .add_links(var_membership, var_person, var_membership_member_type)
         .unwrap()
         .clone();
 
@@ -649,8 +646,8 @@ fn traverse_rp_reverse_unbounded_sorted_to() {
     // Plan
     let steps = vec![Step::Intersection(IntersectionStep::new(
         var_membership,
-        vec![ConstraintInstruction::RolePlayerReverse(RolePlayerReverseInstruction::new(
-            rp_membership_person,
+        vec![ConstraintInstruction::LinksReverse(LinksReverseInstruction::new(
+            links_membership_person,
             Inputs::None([]),
             annotated_program.entry_annotations(),
         ))],
@@ -676,7 +673,7 @@ fn traverse_rp_reverse_unbounded_sorted_to() {
 }
 
 #[test]
-fn traverse_rp_reverse_bounded_player() {
+fn traverse_links_reverse_bounded_player() {
     let (_tmp_dir, storage) = setup_storage();
 
     setup_database(storage.clone());
@@ -699,9 +696,9 @@ fn traverse_rp_reverse_bounded_player() {
     let var_group = conjunction.get_or_declare_variable("group").unwrap();
     let var_membership = conjunction.get_or_declare_variable("membership").unwrap();
 
-    let rp_membership_person = conjunction
+    let links_membership_person = conjunction
         .constraints_mut()
-        .add_role_player(var_membership, var_person, var_membership_member_type)
+        .add_links(var_membership, var_person, var_membership_member_type)
         .unwrap()
         .clone();
 
@@ -741,8 +738,8 @@ fn traverse_rp_reverse_bounded_player() {
         )),
         Step::Intersection(IntersectionStep::new(
             var_membership,
-            vec![ConstraintInstruction::RolePlayerReverse(RolePlayerReverseInstruction::new(
-                rp_membership_person,
+            vec![ConstraintInstruction::LinksReverse(LinksReverseInstruction::new(
+                links_membership_person,
                 Inputs::Single([var_person]),
                 annotated_program.entry_annotations(),
             ))],
@@ -769,7 +766,7 @@ fn traverse_rp_reverse_bounded_player() {
 }
 
 #[test]
-fn traverse_rp_reverse_bounded_player_relation() {
+fn traverse_links_reverse_bounded_player_relation() {
     let (_tmp_dir, storage) = setup_storage();
 
     setup_database(storage.clone());
@@ -792,9 +789,9 @@ fn traverse_rp_reverse_bounded_player_relation() {
     let var_group = conjunction.get_or_declare_variable("group").unwrap();
     let var_membership = conjunction.get_or_declare_variable("membership").unwrap();
 
-    let rp_membership_person = conjunction
+    let links_membership_person = conjunction
         .constraints_mut()
-        .add_role_player(var_membership, var_person, var_membership_member_type)
+        .add_links(var_membership, var_person, var_membership_member_type)
         .unwrap()
         .clone();
 
@@ -844,8 +841,8 @@ fn traverse_rp_reverse_bounded_player_relation() {
         )),
         Step::Intersection(IntersectionStep::new(
             var_membership_member_type,
-            vec![ConstraintInstruction::RolePlayerReverse(RolePlayerReverseInstruction::new(
-                rp_membership_person,
+            vec![ConstraintInstruction::LinksReverse(LinksReverseInstruction::new(
+                links_membership_person,
                 Inputs::Dual([var_membership, var_person]),
                 annotated_program.entry_annotations(),
             ))],

--- a/ir/pattern/constraint.rs
+++ b/ir/pattern/constraint.rs
@@ -149,7 +149,7 @@ impl<'cx> ConstraintsBuilder<'cx> {
         let links = Constraint::from(Links::new(relation, player, role_type));
         self.context.set_variable_category(relation, VariableCategory::Object, links.clone())?;
         self.context.set_variable_category(player, VariableCategory::Object, links.clone())?;
-        self.context.set_variable_category(role_type, VariableCategory::Type, links.clone())?;
+        self.context.set_variable_category(role_type, VariableCategory::RoleType, links.clone())?;
         let constraint = self.constraints.add_constraint(links);
         Ok(constraint.as_links().unwrap())
     }

--- a/ir/pattern/constraint.rs
+++ b/ir/pattern/constraint.rs
@@ -135,23 +135,23 @@ impl<'cx> ConstraintsBuilder<'cx> {
         Ok(constraint.as_has().unwrap())
     }
 
-    pub fn add_role_player(
+    pub fn add_links(
         &mut self,
         relation: Variable,
         player: Variable,
         role_type: Variable,
-    ) -> Result<&RolePlayer<Variable>, PatternDefinitionError> {
+    ) -> Result<&Links<Variable>, PatternDefinitionError> {
         debug_assert!(
             self.context.is_variable_available(self.constraints.scope, relation)
                 && self.context.is_variable_available(self.constraints.scope, player)
                 && self.context.is_variable_available(self.constraints.scope, role_type)
         );
-        let role_player = Constraint::from(RolePlayer::new(relation, player, role_type));
-        self.context.set_variable_category(relation, VariableCategory::Object, role_player.clone())?;
-        self.context.set_variable_category(player, VariableCategory::Object, role_player.clone())?;
-        self.context.set_variable_category(role_type, VariableCategory::Type, role_player.clone())?;
-        let constraint = self.constraints.add_constraint(role_player);
-        Ok(constraint.as_role_player().unwrap())
+        let links = Constraint::from(Links::new(relation, player, role_type));
+        self.context.set_variable_category(relation, VariableCategory::Object, links.clone())?;
+        self.context.set_variable_category(player, VariableCategory::Object, links.clone())?;
+        self.context.set_variable_category(role_type, VariableCategory::Type, links.clone())?;
+        let constraint = self.constraints.add_constraint(links);
+        Ok(constraint.as_links().unwrap())
     }
 
     pub fn add_comparison(
@@ -302,7 +302,7 @@ pub enum Constraint<ID: IrID> {
     Label(Label<ID>),
     Sub(Sub<ID>),
     Isa(Isa<ID>),
-    RolePlayer(RolePlayer<ID>),
+    Links(Links<ID>),
     Has(Has<ID>),
     ExpressionBinding(ExpressionBinding<ID>),
     FunctionCallBinding(FunctionCallBinding<ID>),
@@ -318,7 +318,7 @@ impl<ID: IrID> Constraint<ID> {
             Constraint::Label(label) => Box::new(label.ids()),
             Constraint::Sub(sub) => Box::new(sub.ids()),
             Constraint::Isa(isa) => Box::new(isa.ids()),
-            Constraint::RolePlayer(rp) => Box::new(rp.ids()),
+            Constraint::Links(rp) => Box::new(rp.ids()),
             Constraint::Has(has) => Box::new(has.ids()),
             Constraint::ExpressionBinding(binding) => Box::new(binding.ids_assigned()),
             Constraint::FunctionCallBinding(binding) => Box::new(binding.ids_assigned()),
@@ -337,7 +337,7 @@ impl<ID: IrID> Constraint<ID> {
             Constraint::Label(label) => label.ids_foreach(function),
             Constraint::Sub(sub) => sub.ids_foreach(function),
             Constraint::Isa(isa) => isa.ids_foreach(function),
-            Constraint::RolePlayer(rp) => rp.ids_foreach(function),
+            Constraint::Links(rp) => rp.ids_foreach(function),
             Constraint::Has(has) => has.ids_foreach(function),
             Constraint::ExpressionBinding(binding) => binding.ids_foreach(function),
             Constraint::FunctionCallBinding(binding) => binding.ids_foreach(function),
@@ -395,9 +395,9 @@ impl<ID: IrID> Constraint<ID> {
         }
     }
 
-    pub(crate) fn as_role_player(&self) -> Option<&RolePlayer<ID>> {
+    pub(crate) fn as_links(&self) -> Option<&Links<ID>> {
         match self {
-            Constraint::RolePlayer(rp) => Some(rp),
+            Constraint::Links(rp) => Some(rp),
             _ => None,
         }
     }
@@ -458,7 +458,7 @@ impl<ID: IrID> fmt::Display for Constraint<ID> {
             Constraint::Label(constraint) => fmt::Display::fmt(constraint, f),
             Constraint::Sub(constraint) => fmt::Display::fmt(constraint, f),
             Constraint::Isa(constraint) => fmt::Display::fmt(constraint, f),
-            Constraint::RolePlayer(constraint) => fmt::Display::fmt(constraint, f),
+            Constraint::Links(constraint) => fmt::Display::fmt(constraint, f),
             Constraint::Has(constraint) => fmt::Display::fmt(constraint, f),
             Constraint::ExpressionBinding(constraint) => fmt::Display::fmt(constraint, f),
             Constraint::FunctionCallBinding(constraint) => fmt::Display::fmt(constraint, f),
@@ -626,13 +626,13 @@ pub enum IsaKind {
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, Hash)]
-pub struct RolePlayer<ID> {
+pub struct Links<ID> {
     pub(crate) relation: ID,
     pub(crate) player: ID,
     pub(crate) role_type: ID,
 }
 
-impl<ID: IrID> RolePlayer<ID> {
+impl<ID: IrID> Links<ID> {
     pub fn new(relation: ID, player: ID, role_type: ID) -> Self {
         Self { relation, player, role_type }
     }
@@ -662,8 +662,8 @@ impl<ID: IrID> RolePlayer<ID> {
         function(self.role_type, ConstraintIDSide::Filter);
     }
 
-    pub fn map<T: IrID>(self, mapping: &HashMap<ID, T>) -> RolePlayer<T> {
-        RolePlayer::new(
+    pub fn map<T: IrID>(self, mapping: &HashMap<ID, T>) -> Links<T> {
+        Links::new(
             *mapping.get(&self.relation).unwrap(),
             *mapping.get(&self.player).unwrap(),
             *mapping.get(&self.role_type).unwrap(),
@@ -671,13 +671,13 @@ impl<ID: IrID> RolePlayer<ID> {
     }
 }
 
-impl<ID: IrID> From<RolePlayer<ID>> for Constraint<ID> {
-    fn from(role_player: RolePlayer<ID>) -> Self {
-        Constraint::RolePlayer(role_player)
+impl<ID: IrID> From<Links<ID>> for Constraint<ID> {
+    fn from(links: Links<ID>) -> Self {
+        Constraint::Links(links)
     }
 }
 
-impl<ID: IrID> fmt::Display for RolePlayer<ID> {
+impl<ID: IrID> fmt::Display for Links<ID> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{} rp {} (role: {})", self.relation, self.player, self.role_type)
     }

--- a/ir/translation/constraints.rs
+++ b/ir/translation/constraints.rs
@@ -193,12 +193,12 @@ fn add_typeql_relation(
             typeql::statement::thing::RolePlayer::Typed(type_, var) => {
                 let player = register_typeql_var(constraints, var)?;
                 let type_ = register_typeql_type_var_any(constraints, type_)?;
-                constraints.add_role_player(relation, player, type_)?;
+                constraints.add_links(relation, player, type_)?;
             }
             typeql::statement::thing::RolePlayer::Untyped(var) => {
                 let player = register_typeql_var(constraints, var)?;
                 let role_type = constraints.create_anonymous_variable()?;
-                constraints.add_role_player(relation, player, role_type)?;
+                constraints.add_links(relation, player, role_type)?;
             }
         }
     }


### PR DESCRIPTION
## Usage and product changes

We rename the role player edge to be referred to as a "links" edge, to avoid confusion with the `RolePlayer` struct which refers to a player in a relation bundled with the role type tag.