### PR TITLE
Partially implement GRPC services & standardise error infrastructure

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -23,7 +23,7 @@ rust_binary(
         "//resource",
         "//server",
 
-        "@crates//:tokio"
+        "@crates//:tokio",
     ],
 )
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -149,6 +149,8 @@ vaticle_typedb_common()
 
 vaticle_typeql()
 
+vaticle_typedb_protocol()
+
 #load("//dependencies/vaticle:artifacts.bzl", "vaticle_typedb_console_artifact")
 #vaticle_typedb_console_artifact()
 

--- a/common/error/BUILD
+++ b/common/error/BUILD
@@ -4,30 +4,16 @@
 
 load("@vaticle_dependencies//tool/checkstyle:rules.bzl", "checkstyle_test")
 load("@rules_rust//rust:defs.bzl", "rust_library")
-package(default_visibility = ["//visibility:public",])
+
+package(default_visibility = ["//visibility:public"])
 
 rust_library(
-    name = "server",
+    name = "error",
+    crate_root = "error.rs",
     srcs = glob([
         "*.rs",
-        "service/*.rs",
     ]),
-    deps = [
-        "//common/bytes",
-        "//common/error",
-        "//database",
-        "//storage",
-        "//resource",
-        "@vaticle_typedb_protocol//grpc/rust:typedb_protocol",
-
-        "@crates//:itertools",
-        "@crates//:prost",
-        "@crates//:tokio",
-        "@crates//:tokio-stream",
-        "@crates//:tonic",
-        "@crates//:tonic-types",
-        "@crates//:tracing",
-    ]
+    deps = []
 )
 
 checkstyle_test(

--- a/common/error/error.rs
+++ b/common/error/error.rs
@@ -5,15 +5,22 @@
  */
 
 use std::error::Error;
-use std::fmt::{Debug, Display};
+use std::fmt::{Debug, Display, Formatter};
 
-pub trait ErrorSource {
+pub trait TypeDBError {
+    fn variant_name(&self) -> &'static str;
+
+    fn domain(&self) -> &'static str;
+
+    fn code(&self) -> &'static str;
+
+    fn prefix(&self) -> &'static str;
+
+    fn code_number(&self) -> usize;
+
+    fn format_description(&self) -> String;
+
     fn source(&self) -> Option<&dyn Error>;
-}
-
-
-pub trait TypeDBError: ErrorSource + Debug + Display{
-    fn code(&self) -> &str;
 
     fn source_typedb_error(&self) -> Option<&dyn TypeDBError>;
 
@@ -24,4 +31,129 @@ pub trait TypeDBError: ErrorSource + Debug + Display{
         }
         error
     }
+}
+
+impl Debug for dyn TypeDBError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        Display::fmt(self, f)
+    }
+}
+
+impl Display for dyn TypeDBError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        if self.source().is_some() {
+            write!(f, "[{}] {}. Cause: \n\t {:?}", self.code(), self.format_description(), self.source().unwrap())
+        } else {
+            write!(f, "[{}] {}", self.code(), self.format_description())
+        }
+    }
+}
+
+// ***USAGE WARNING***: We should not set both Source and TypeDBSource, TypeDBSource has precedence! This is only checked in runtime assertion
+#[macro_export]
+macro_rules! typedb_error {
+    ( $vis: vis $name:ident(domain = $domain: literal, prefix = $prefix: literal) { $(
+        $variant: ident (
+            $number: literal,
+            $description: literal
+            $(, source = $source: ty )?
+            $(, typedb_source = $typedb_source: ty )?
+            $(, $payload_name: ident = $payload_type: ty )*
+        ),
+    )*}) => {
+        $vis enum $name {
+            $(
+                $variant { $(source: $source, )? $(typedb_source: $typedb_source, )? $($payload_name: $payload_type, )* },
+            )*
+        }
+
+        impl TypeDBError for $name {
+
+            fn variant_name(&self) -> &'static str {
+                match self {
+                    $(
+                        Self::$variant { .. } => &stringify!($variant),
+                    )*
+                }
+            }
+
+            fn prefix(&self) -> &'static str {
+                & $prefix
+            }
+
+            fn code_number(&self) -> usize {
+                match self {
+                    $(
+                        Self::$variant { .. } => $number,
+                    )*
+                }
+            }
+
+            fn code(&self) -> &'static str {
+                match self {
+                    $(
+                        Self::$variant { .. } => & concat!($prefix, stringify!($number)),
+                    )*
+                }
+            }
+
+            fn format_description(&self) -> String {
+                match self {
+                    $(
+                        Self::$variant { $( $payload_name, )* .. } => format!($description),
+                    )*
+                }
+            }
+
+            fn source(&self) -> Option<&dyn Error> {
+                let error = match self {
+                    $(
+                        $( Self::$variant { source, .. } => Some(source as &$source), )?
+                    )*,
+                    _ => None
+                };
+                if ::core::cfg!( debug_assertions ) {
+                    // if both are set, they must be equal
+                    if error.is_some() && self.source_typedb_error().is_some() {
+                        ::core::assert!(error == self.source_typedb_error())
+                    }
+                }
+                error
+            }
+
+            fn source_typedb_error(&self) -> Option<&dyn TypeDBError> {
+                let error = match self {
+                    $(
+                        $( Self::$variant { typedb_source, .. } => Some(typedb_source as &$typedb_source), )?
+                    )*,
+                    _ => None
+                };
+                if ::core::cfg!( debug_assertions ) {
+                    // if both are set, they must be equal
+                    if error.is_some() && self.source().is_some() {
+                        ::core::assert!(error == self.source())
+                    }
+                }
+                error
+            }
+        }
+
+        // impl Debug for dyn $name {
+        //    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        //        Display::fmt(self, f)
+        //    }
+        // }
+        //
+        // impl Display for dyn $name {
+        //    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        //        if self.source_typedb_error().is_some() {
+        //           write!(f, "[{}] {}. Cause: \n\t {}", self.code(), self.description(), self.source_typedb_error().unwrap())
+        //        } else if self.source().is_some() {
+        //           write!(f, "[{}] {}. Cause: \n\t {:?}", self.code(), self.description(), self.source().unwrap())
+        //        } else {
+        //           write!(f, "[{}] {}", self.code(), self.description())
+        //        }
+        //    }
+        // }
+    };
 }

--- a/common/error/error.rs
+++ b/common/error/error.rs
@@ -1,0 +1,27 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+use std::error::Error;
+use std::fmt::{Debug, Display};
+
+pub trait ErrorSource {
+    fn source(&self) -> Option<&dyn Error>;
+}
+
+
+pub trait TypeDBError: ErrorSource + Debug + Display{
+    fn code(&self) -> &str;
+
+    fn source_typedb_error(&self) -> Option<&dyn TypeDBError>;
+
+    fn root_source_typedb_error(&self) -> &dyn TypeDBError where Self: Sized {
+        let mut error: &dyn TypeDBError = self;
+        while let Some(source) = error.source_typedb_error() {
+            error = source;
+        }
+        error
+    }
+}

--- a/common/options/BUILD
+++ b/common/options/BUILD
@@ -13,7 +13,9 @@ rust_library(
     srcs = glob([
         "*.rs",
     ]),
-    deps = []
+    deps = [
+        "//resource",
+    ]
 )
 
 checkstyle_test(

--- a/common/options/BUILD
+++ b/common/options/BUILD
@@ -4,30 +4,16 @@
 
 load("@vaticle_dependencies//tool/checkstyle:rules.bzl", "checkstyle_test")
 load("@rules_rust//rust:defs.bzl", "rust_library")
-package(default_visibility = ["//visibility:public",])
+
+package(default_visibility = ["//visibility:public"])
 
 rust_library(
-    name = "server",
+    name = "options",
+    crate_root = "options.rs",
     srcs = glob([
         "*.rs",
-        "service/*.rs",
     ]),
-    deps = [
-        "//common/bytes",
-        "//common/error",
-        "//database",
-        "//storage",
-        "//resource",
-        "@vaticle_typedb_protocol//grpc/rust:typedb_protocol",
-
-        "@crates//:itertools",
-        "@crates//:prost",
-        "@crates//:tokio",
-        "@crates//:tokio-stream",
-        "@crates//:tonic",
-        "@crates//:tonic-types",
-        "@crates//:tracing",
-    ]
+    deps = []
 )
 
 checkstyle_test(

--- a/common/options/options.rs
+++ b/common/options/options.rs
@@ -4,3 +4,6 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
+pub struct TransactionOptions {
+    parallel: bool,
+}

--- a/common/options/options.rs
+++ b/common/options/options.rs
@@ -4,6 +4,19 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
+use resource::constants::server::{DEFAULT_SCHEMA_LOCK_ACQUIRE_TIMEOUT_MILLIS, DEFAULT_TRANSACTION_PARALLEL};
+
+#[derive(Debug)]
 pub struct TransactionOptions {
-    parallel: bool,
+    pub parallel: bool,
+    pub schema_lock_acquire_timeout_millis: u64,
+}
+
+impl Default for TransactionOptions {
+    fn default() -> Self {
+        Self {
+            parallel: DEFAULT_TRANSACTION_PARALLEL,
+            schema_lock_acquire_timeout_millis: DEFAULT_SCHEMA_LOCK_ACQUIRE_TIMEOUT_MILLIS
+        }
+    }
 }

--- a/concept/thing/thing_manager.rs
+++ b/concept/thing/thing_manager.rs
@@ -92,6 +92,7 @@ use crate::{
 
 pub mod validation;
 
+#[derive(Debug)]
 pub struct ThingManager {
     vertex_generator: Arc<ThingVertexGenerator>,
     type_manager: Arc<TypeManager>,

--- a/concept/thing/thing_manager.rs
+++ b/concept/thing/thing_manager.rs
@@ -1965,17 +1965,8 @@ impl ThingManager {
     /// set cardinality annotation, unset cardinality annotation)
     ///
 
-    ///
     /// Clean up all parts of a relation index to do with a specific role player
     /// after the player has been deleted.
-    ///
-    ///
-    ///
-    /// RP1 <--RT 1, Count 1-- Relation --RT 2, count 2--> RP2
-    ///
-    /// RP 1 <-- Relation, RT 1, RT 2, Count --> RP2
-    ///
-    ///
     pub(crate) fn relation_index_player_deleted<'a>(
         &self,
         snapshot: &mut impl WritableSnapshot,

--- a/concept/thing/thing_manager.rs
+++ b/concept/thing/thing_manager.rs
@@ -1969,6 +1969,13 @@ impl ThingManager {
     /// Clean up all parts of a relation index to do with a specific role player
     /// after the player has been deleted.
     ///
+    ///
+    ///
+    /// RP1 <--RT 1, Count 1-- Relation --RT 2, count 2--> RP2
+    ///
+    /// RP 1 <-- Relation, RT 1, RT 2, Count --> RP2
+    ///
+    ///
     pub(crate) fn relation_index_player_deleted<'a>(
         &self,
         snapshot: &mut impl WritableSnapshot,

--- a/concept/type_/type_manager.rs
+++ b/concept/type_/type_manager.rs
@@ -65,6 +65,7 @@ pub mod validation;
 // TODO: this should be parametrised into the database options? Would be great to have it be changable at runtime!
 pub(crate) const RELATION_INDEX_THRESHOLD: u64 = 8;
 
+#[derive(Debug)]
 pub struct TypeManager {
     vertex_generator: Arc<TypeVertexGenerator>,
     definition_key_generator: Arc<DefinitionKeyGenerator>,

--- a/database/BUILD
+++ b/database/BUILD
@@ -13,6 +13,7 @@ rust_library(
     deps = [
         "//common/concurrency",
         "//common/logger",
+        "//common/options",
         "//concept",
         "//encoding",
         "//function",

--- a/database/database.rs
+++ b/database/database.rs
@@ -283,6 +283,7 @@ fn make_update_statistics_fn(
 #[derive(Debug)]
 pub enum DatabaseOpenError {
     InvalidUnicodeName { name: OsString },
+    CouldNotReadDataDirectory { path: PathBuf, source: io::Error },
     DirectoryCreate { path: PathBuf, source: io::Error },
     StorageOpen { source: StorageOpenError },
     WALOpen { source: WALError },
@@ -307,6 +308,7 @@ impl Error for DatabaseOpenError {
     fn source(&self) -> Option<&(dyn Error + 'static)> {
         match self {
             Self::InvalidUnicodeName { .. } => None,
+            Self::CouldNotReadDataDirectory { source, .. } => Some(source),
             Self::DirectoryCreate { source, .. } => Some(source),
             Self::StorageOpen { source } => Some(source),
             Self::WALOpen { source } => Some(source),

--- a/database/database_manager.rs
+++ b/database/database_manager.rs
@@ -1,0 +1,98 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+use std::collections::HashMap;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use itertools::Itertools;
+
+use storage::durability_client::WALClient;
+
+use crate::{Database, DatabaseDeleteError, DatabaseOpenError, DatabaseResetError};
+
+#[derive(Debug)]
+pub struct DatabaseManager {
+    data_directory: PathBuf,
+    databases: HashMap<String, Arc<Database<WALClient>>>,
+}
+
+impl DatabaseManager {
+    pub fn new(data_directory: &Path) -> Result<Self, DatabaseOpenError> {
+        let databases = fs::read_dir(data_directory)
+            .map_err(|error| DatabaseOpenError::CouldNotReadDataDirectory { path: data_directory.to_owned(), source: error })?
+            .map(|entry| {
+                let entry = entry
+                    .map_err(|error| DatabaseOpenError::CouldNotReadDataDirectory { path: data_directory.to_owned(), source: error })?;
+                let database = Database::<WALClient>::open(&entry.path())?;
+                Ok((database.name().to_owned(), Arc::new(database)))
+            })
+            .try_collect()?;
+
+        Ok(Self { data_directory: data_directory.to_owned(), databases })
+    }
+
+    pub fn create_database(&mut self, name: impl AsRef<str>) {
+        let name = name.as_ref();
+        self.databases
+            .entry(name.to_owned())
+            .or_insert_with(|| Arc::new(Database::<WALClient>::open(&self.data_directory.join(name)).unwrap()));
+    }
+
+    pub fn delete_database(&mut self, name: impl AsRef<str>) -> Result<(), DatabaseDeleteError> {
+        // TODO: this is a partial implementation, only single threaded and without cooperative transaction shutdown
+        // remove from map to make DB unavailable
+        let db = self.databases.remove(name.as_ref());
+        if let Some(db) = db {
+            match Arc::try_unwrap(db) {
+                Ok(unwrapped) => unwrapped.delete()?,
+                Err(arc) => {
+                    // failed to delete since it's in use - let's re-insert for now instead of losing the reference
+                    self.databases.insert(name.as_ref().to_owned(), arc);
+                    return Err(DatabaseDeleteError::InUse {});
+                }
+            }
+        }
+        Ok(())
+    }
+
+    pub fn reset_else_recreate_database(&mut self, name: impl AsRef<str>) -> Result<(), DatabaseDeleteError> {
+        // TODO: this is a partial implementation, only single threaded and without cooperative transaction shutdown
+        // remove from map to make DB unavailable
+        let db = self.databases.remove(name.as_ref());
+        let result = if let Some(db) = db {
+            match Arc::try_unwrap(db) {
+                Ok(mut unwrapped) => {
+                    let reset_result = unwrapped.reset();
+                    self.databases.insert(name.as_ref().to_owned(), Arc::new(unwrapped));
+                    reset_result
+                }
+                Err(arc) => {
+                    // failed to reset since it's in use - let's re-insert for now instead of losing the reference
+                    self.databases.insert(name.as_ref().to_owned(), arc);
+                    Err(DatabaseResetError::InUse {})
+                }
+            }
+        } else {
+            self.create_database(name);
+            return Ok(());
+        };
+
+        Ok(match result {
+            Ok(_) => (),
+            Err(_) => {
+                self.delete_database(name.as_ref())?;
+                self.create_database(name)
+            }
+        })
+    }
+
+    pub fn database(&self, name: &str) -> Option<&Database<WALClient>> {
+        self.databases.get(name).map(|arc| &**arc)
+    }
+
+}

--- a/database/database_manager.rs
+++ b/database/database_manager.rs
@@ -91,8 +91,7 @@ impl DatabaseManager {
         })
     }
 
-    pub fn database(&self, name: &str) -> Option<&Database<WALClient>> {
-        self.databases.get(name).map(|arc| &**arc)
+    pub fn database(&self, name: &str) -> Option<Arc<Database<WALClient>>> {
+        self.databases.get(name).map(|arc| arc.clone())
     }
-
 }

--- a/database/lib.rs
+++ b/database/lib.rs
@@ -7,7 +7,8 @@
 #![deny(unused_must_use)]
 #![deny(elided_lifetimes_in_paths)]
 
-mod database;
+pub mod database;
 pub mod transaction;
+pub mod database_manager;
 
 pub use self::database::{Database, DatabaseDeleteError, DatabaseOpenError, DatabaseResetError};

--- a/database/transaction.rs
+++ b/database/transaction.rs
@@ -27,6 +27,7 @@ use storage::{
 
 use crate::Database;
 
+#[derive(Debug)]
 pub struct TransactionRead<D> {
     pub snapshot: ReadSnapshot<D>,
     pub type_manager: Arc<TypeManager>,
@@ -67,6 +68,7 @@ impl<D: DurabilityClient> TransactionRead<D> {
     }
 }
 
+#[derive(Debug)]
 pub struct TransactionWrite<D> {
     pub snapshot: WriteSnapshot<D>,
     pub type_manager: Arc<TypeManager>,
@@ -129,6 +131,7 @@ impl<D: DurabilityClient> TransactionWrite<D> {
     }
 }
 
+#[derive(Debug)]
 pub struct TransactionSchema<D> {
     pub snapshot: SchemaSnapshot<D>,
     pub type_manager: Arc<TypeManager>,

--- a/database/transaction.rs
+++ b/database/transaction.rs
@@ -132,6 +132,7 @@ impl<D: DurabilityClient> TransactionWrite<D> {
             .map_err(|errs| DataCommitError::ConceptWriteErrors { source: errs })?;
         drop(self.type_manager);
         snapshot.commit().map_err(|err| DataCommitError::SnapshotError { source: err })?;
+        self.database.release_write_transaction();
         Ok(())
     }
 
@@ -258,6 +259,7 @@ impl<D: DurabilityClient> TransactionSchema<D> {
 
         *schema_commit_guard = schema;
 
+        self.database.release_schema_transaction();
         Ok(())
     }
 

--- a/database/transaction.rs
+++ b/database/transaction.rs
@@ -126,6 +126,10 @@ impl<D: DurabilityClient> TransactionWrite<D> {
         Ok(())
     }
 
+    pub fn rollback(&mut self) {
+        self.snapshot.clear()
+    }
+
     pub fn close(self) {
         drop(self.thing_manager);
         drop(self.type_manager);
@@ -138,6 +142,9 @@ pub enum DataCommitError {
     ConceptWriteErrors { source: Vec<ConceptWriteError> },
     SnapshotError { source: SnapshotError },
 }
+
+// TODO: when we use typedb_error!, how do we pring stack trace? If we use the stack trace of each of these, we'll end up with a tree!
+//       If there's 1, we can use the stack trace, otherwise, we should list out all the errors?
 
 #[derive(Debug)]
 pub struct TransactionSchema<D> {
@@ -225,6 +232,10 @@ impl<D: DurabilityClient> TransactionSchema<D> {
         *schema_commit_guard = schema;
 
         Ok(())
+    }
+
+    pub fn rollback(&mut self) {
+        self.snapshot.clear()
     }
 
     pub fn close(self) {

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -12,14 +12,10 @@ def vaticle_bazel_distribution():
     )
 
 def vaticle_dependencies():
-#    git_repository(
-#        name = "vaticle_dependencies",
-#        remote = "https://github.com/typedb/dependencies",
-#        commit = "3243bc0358016881da4418fb4e7877dba9866674",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
-#    )
-    native.local_repository(
+    git_repository(
         name = "vaticle_dependencies",
-        path = "../dependencies",
+        remote = "https://github.com/typedb/dependencies",
+        commit = "2831e94d01dd670ae00483d625afe8883ec0a556",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
     )
 
 def vaticle_typeql():
@@ -37,14 +33,10 @@ def vaticle_typedb_common():
     )
 
 def vaticle_typedb_protocol():
-#    git_repository(
-#        name = "vaticle_typedb_protocol",
-#        remote = "https://github.com/typedb/typedb-protocol",
-#        commit = "f341f1de18ee34058b8b0f1245ac966926d7973f",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_protocol
-#    )
-    native.local_repository(
+    git_repository(
         name = "vaticle_typedb_protocol",
-        path = "../typedb-protocol",
+        remote = "https://github.com/typedb/typedb-protocol",
+        commit = "cd505da11b97a48e016618a0dce754fa53b87379",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_protocol
     )
 
 def vaticle_typedb_behaviour():

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -37,10 +37,14 @@ def vaticle_typedb_common():
     )
 
 def vaticle_typedb_protocol():
-    git_repository(
+#    git_repository(
+#        name = "vaticle_typedb_protocol",
+#        remote = "https://github.com/typedb/typedb-protocol",
+#        commit = "f341f1de18ee34058b8b0f1245ac966926d7973f",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_protocol
+#    )
+    native.local_repository(
         name = "vaticle_typedb_protocol",
-        remote = "https://github.com/typedb/typedb-protocol",
-        commit = "f341f1de18ee34058b8b0f1245ac966926d7973f",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_protocol
+        path = "../typedb-protocol",
     )
 
 def vaticle_typedb_behaviour():

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -12,10 +12,14 @@ def vaticle_bazel_distribution():
     )
 
 def vaticle_dependencies():
-    git_repository(
+#    git_repository(
+#        name = "vaticle_dependencies",
+#        remote = "https://github.com/typedb/dependencies",
+#        commit = "3243bc0358016881da4418fb4e7877dba9866674",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
+#    )
+    native.local_repository(
         name = "vaticle_dependencies",
-        remote = "https://github.com/typedb/dependencies",
-        commit = "1f3339f5990d3ed66b42fc018e6aeb4213bc58bb",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
+        path = "../dependencies",
     )
 
 def vaticle_typeql():
@@ -36,7 +40,7 @@ def vaticle_typedb_protocol():
     git_repository(
         name = "vaticle_typedb_protocol",
         remote = "https://github.com/typedb/typedb-protocol",
-        tag = "2.25.2",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_protocol
+        commit = "f341f1de18ee34058b8b0f1245ac966926d7973f",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_protocol
     )
 
 def vaticle_typedb_behaviour():

--- a/encoding/graph/common/schema_id_allocator.rs
+++ b/encoding/graph/common/schema_id_allocator.rs
@@ -40,6 +40,7 @@ pub trait SchemaID: Sized {
     fn ids_exhausted_error(prefix: Prefix) -> EncodingError;
 }
 
+#[derive(Debug)]
 pub struct SchemaIDAllocator<T: SchemaID> {
     last_allocated_type_id: AtomicU64,
     prefix: Prefix,

--- a/encoding/graph/definition/definition_key_generator.rs
+++ b/encoding/graph/definition/definition_key_generator.rs
@@ -12,6 +12,7 @@ use crate::{
     Keyable,
 };
 
+#[derive(Debug)]
 pub struct DefinitionKeyGenerator {
     next_struct: DefinitionKeyAllocator,
     next_function: DefinitionKeyAllocator,

--- a/encoding/graph/thing/vertex_generator.rs
+++ b/encoding/graph/thing/vertex_generator.rs
@@ -42,6 +42,7 @@ use crate::{
     AsBytes, Keyable, Prefixed,
 };
 
+#[derive(Debug)]
 pub struct ThingVertexGenerator {
     entity_ids: Box<[AtomicU64]>,
     relation_ids: Box<[AtomicU64]>,

--- a/encoding/graph/type_/vertex_generator.rs
+++ b/encoding/graph/type_/vertex_generator.rs
@@ -13,6 +13,7 @@ use crate::{
     Keyable,
 };
 
+#[derive(Debug)]
 pub struct TypeVertexGenerator {
     next_entity: TypeVertexAllocator,
     next_relation: TypeVertexAllocator,

--- a/function/function_manager.rs
+++ b/function/function_manager.rs
@@ -39,6 +39,7 @@ use storage::{
 use crate::{function::SchemaFunction, function_cache::FunctionCache, FunctionError};
 
 /// Analogy to TypeManager, but specialised just for Functions
+#[derive(Debug)]
 pub struct FunctionManager {
     definition_key_generator: Arc<DefinitionKeyGenerator>,
     function_cache: Option<Arc<FunctionCache>>,

--- a/main.rs
+++ b/main.rs
@@ -9,7 +9,6 @@
 
 use logger::initialise_logging;
 use resource::constants::server::ASCII_LOGO;
-use server::typedb;
 
 #[tokio::main]
 async fn main() {
@@ -17,10 +16,10 @@ async fn main() {
 
     let _guard = initialise_logging();
 
-    typedb::Server::open("runtimedata/server/data").unwrap()
+    server::typedb::Server::open("runtimedata/server/data").unwrap()
         .serve()
+        .await
         .unwrap()
-        .await;
 }
 
 fn print_ascii_logo() {

--- a/main.rs
+++ b/main.rs
@@ -11,12 +11,16 @@ use logger::initialise_logging;
 use resource::constants::server::ASCII_LOGO;
 use server::typedb;
 
-fn main() {
+#[tokio::main]
+async fn main() {
     print_ascii_logo(); // very important
 
     let _guard = initialise_logging();
 
-    typedb::Server::open("runtimedata/server/data").unwrap().serve();
+    typedb::Server::open("runtimedata/server/data").unwrap()
+        .serve()
+        .unwrap()
+        .await;
 }
 
 fn print_ascii_logo() {

--- a/query/lib.rs
+++ b/query/lib.rs
@@ -8,7 +8,7 @@ use encoding::{graph::type_::Kind, value::label::Label};
 use typeql::schema::definable::type_::Capability;
 
 mod define;
-mod error;
+pub mod error;
 pub mod query_manager;
 mod util;
 

--- a/resource/constants.rs
+++ b/resource/constants.rs
@@ -5,7 +5,12 @@
  */
 
 pub mod server {
+    use std::time::Duration;
+
     pub const ASCII_LOGO: &str = include_str!("typedb-ascii.txt");
+
+    pub const DEFAULT_TRANSACTION_TIMEOUT_MILLIS: u64 = Duration::from_secs(5 * 60).as_millis() as u64;
+    pub const DEFAULT_PREFETCH_SIZE: u64 = 10;
 }
 
 pub mod traversal {

--- a/resource/constants.rs
+++ b/resource/constants.rs
@@ -11,6 +11,8 @@ pub mod server {
 
     pub const DEFAULT_TRANSACTION_TIMEOUT_MILLIS: u64 = Duration::from_secs(5 * 60).as_millis() as u64;
     pub const DEFAULT_PREFETCH_SIZE: u64 = 10;
+    pub const DEFAULT_SCHEMA_LOCK_ACQUIRE_TIMEOUT_MILLIS: u64 = Duration::from_secs(10).as_millis() as u64;
+    pub const DEFAULT_TRANSACTION_PARALLEL: bool = true;
 }
 
 pub mod traversal {

--- a/server/BUILD
+++ b/server/BUILD
@@ -14,8 +14,13 @@ rust_library(
     deps = [
         "//database",
         "//storage",
+        "@vaticle_typedb_protocol//grpc/rust:typedb_protocol",
 
         "@crates//:itertools",
+        "@crates//:prost",
+        "@crates//:tokio",
+        "@crates//:tokio-stream",
+        "@crates//:tonic",
     ]
 )
 

--- a/server/BUILD
+++ b/server/BUILD
@@ -10,6 +10,7 @@ rust_library(
     name = "server",
     srcs = glob([
         "*.rs",
+        "service/*.rs",
     ]),
     deps = [
         "//database",

--- a/server/BUILD
+++ b/server/BUILD
@@ -16,8 +16,11 @@ rust_library(
         "//common/bytes",
         "//common/error",
         "//database",
+        "//query",
         "//storage",
         "//resource",
+
+        "@vaticle_typeql//rust:typeql",
         "@vaticle_typedb_protocol//grpc/rust:typedb_protocol",
 
         "@crates//:itertools",

--- a/server/BUILD
+++ b/server/BUILD
@@ -30,6 +30,7 @@ rust_library(
         "@crates//:tonic",
         "@crates//:tonic-types",
         "@crates//:tracing",
+        "@crates//:uuid",
     ]
 )
 

--- a/server/BUILD
+++ b/server/BUILD
@@ -15,6 +15,7 @@ rust_library(
     deps = [
         "//common/bytes",
         "//common/error",
+        "//common/options",
         "//database",
         "//query",
         "//storage",

--- a/server/service/connection_service.rs
+++ b/server/service/connection_service.rs
@@ -4,6 +4,3 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-pub(crate) mod typedb_service;
-pub(crate) mod transaction_service;
-mod connection_service;

--- a/server/service/error.rs
+++ b/server/service/error.rs
@@ -1,0 +1,82 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+use std::error::Error;
+use std::fmt;
+use tonic::{Code, Status};
+use tonic_types::{ErrorDetails, StatusExt};
+use error::TypeDBError;
+
+
+pub(crate) enum ProtocolError {
+    MissingField { name: &'static str, description: &'static str },
+    TransactionAlreadyOpen {},
+    TransactionClosed {},
+}
+
+impl Into<Status> for ProtocolError {
+    fn into(self) -> Status {
+        match self {
+            Self::MissingField { name, description } => {
+                Status::with_error_details(
+                    Code::InvalidArgument,
+                    "Bad request",
+                    ErrorDetails::with_bad_request_violation(
+                        name,
+                        format!("{}. Check client-server compatibility?", description),
+                    ),
+                )
+            }
+            Self::TransactionAlreadyOpen {} => {
+                Status::already_exists("Transaction already open.")
+            }
+            Self::TransactionClosed {} => {
+                Status::new(Code::InvalidArgument, "Transaction already closed, no further operations possible.")
+            }
+        }
+    }
+}
+
+#[derive(Debug)]
+pub(crate) enum TransactionServiceError {
+    UnrecognisedTransactionType { enum_variant: i32 },
+    DatabaseNotFound { name: String },
+    CannotCommitReadTransaction {},
+}
+
+impl fmt::Display for TransactionServiceError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Debug::fmt(self, f)
+    }
+}
+
+impl Error for TransactionServiceError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match self {
+            Self::UnrecognisedTransactionType { .. }
+            | Self::CannotCommitReadTransaction { .. }
+            | Self::DatabaseNotFound { .. } => None,
+        }
+    }
+}
+
+trait StatusConvertible {
+    fn into_status(self) -> Status;
+}
+
+impl<T: TypeDBError> StatusConvertible for T {
+    fn into_status(self) -> Status {
+        let details = ErrorDetails::new();
+
+        let root_source = self.root_source_typedb_error();
+        root_source.();
+
+    }
+}
+
+impl<T: StatusConvertible> Into<Status> for T {
+
+}

--- a/server/service/mod.rs
+++ b/server/service/mod.rs
@@ -7,3 +7,5 @@
 pub(crate) mod typedb_service;
 pub(crate) mod transaction_service;
 mod error;
+
+pub(crate) type RequestID = [u8; 16];

--- a/server/service/mod.rs
+++ b/server/service/mod.rs
@@ -6,4 +6,4 @@
 
 pub(crate) mod typedb_service;
 pub(crate) mod transaction_service;
-mod connection_service;
+mod error;

--- a/server/service/mod.rs
+++ b/server/service/mod.rs
@@ -4,8 +4,4 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-#![deny(unused_must_use)]
-#![deny(elided_lifetimes_in_paths)]
-
-pub mod typedb;
-mod service;
+pub(crate) mod typedb_service;

--- a/server/service/transaction_service.rs
+++ b/server/service/transaction_service.rs
@@ -4,21 +4,72 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
+use std::future::Future;
+use std::sync::Arc;
+
+use tokio::sync::mpsc::error::SendError;
 use tokio::sync::mpsc::Sender;
 use tokio_stream::StreamExt;
-use tonic::{Streaming};
-use typedb_protocol::transaction::{Client};
+use tonic::{Code, Status, Streaming};
+use tonic_types::{ErrorDetails, FieldViolation, StatusExt};
+use tracing::{event, Level};
+use typedb_protocol::Server;
+use typedb_protocol::transaction::{Client, Req, Type};
+use bytes::util::HexBytesFormatter;
 
+use database::database_manager::DatabaseManager;
+use database::transaction::{TransactionRead, TransactionSchema, TransactionWrite};
+use resource::constants::server::{DEFAULT_PREFETCH_SIZE, DEFAULT_TRANSACTION_TIMEOUT_MILLIS};
+use storage::durability_client::WALClient;
+
+use crate::service::error::{ProtocolError, TransactionServiceError};
+
+// TODO: where does this belong?
+#[derive(Debug)]
+pub enum Transaction {
+    Read(TransactionRead<WALClient>),
+    Write(TransactionWrite<WALClient>),
+    Schema(TransactionSchema<WALClient>),
+}
+
+#[derive(Debug)]
 pub(crate) struct TransactionService {
+    database_manager: Arc<DatabaseManager>,
+
     request_stream: Streaming<Client>,
-    response_sender: Sender<()>,
+    response_sender: Sender<Result<typedb_protocol::transaction::Server, Status>>,
 
     is_open: bool,
+    transaction_timeout_millis: Option<u64>,
+    prefetch_size: Option<u64>,
+    network_latency_millis: Option<u64>,
+
+    transaction: Option<Transaction>,
+}
+
+macro_rules! close_service {
+    () => {return;};
 }
 
 impl TransactionService {
-    pub(crate) fn new(request_stream: Streaming<Client>, response_sender: Sender<_>) -> _ {
-        Self { request_stream, response_sender, is_open: false }
+    pub(crate) fn new(
+        request_stream: Streaming<Client>,
+        response_sender: Sender<Result<typedb_protocol::transaction::Server, Status>>,
+        database_manager: Arc<DatabaseManager>,
+    ) -> Self {
+        Self {
+            database_manager,
+
+            request_stream,
+            response_sender,
+
+            is_open: false,
+            transaction_timeout_millis: None,
+            prefetch_size: None,
+            network_latency_millis: None,
+
+            transaction: None,
+        }
     }
 
     pub(crate) async fn listen(&mut self) {
@@ -26,12 +77,11 @@ impl TransactionService {
             let next = self.request_stream.next().await;
             match next {
                 None => {
-                    // TODO: network stream/transaction has ended
-                    return
-                },
+                    close_service!();
+                }
                 Some(Err(error)) => {
-                    // TODO: grpc error
-                    todo!()
+                    event!(Level::DEBUG, "GRPC error", ?error);
+                    close_service!();
                 }
                 Some(Ok(message)) => {
                     for request in message.reqs {
@@ -39,39 +89,105 @@ impl TransactionService {
                         let metadata = request.metadata;
                         match request.req {
                             None => {
-                                // TODO: unexpected state: oneof in Protobuf should always be populated.
+                                self.send_err(ProtocolError::MissingField {
+                                    name: "req",
+                                    description: "Transaction message must contain a request.",
+                                }.into()).await;
+                                close_service!()
                             }
                             Some(req) => {
-                                match (self.is_open, req) {
-                                    (false, typedb_protocol::transaction::req::Req::OpenReq(open_req)) => {
-                                        // TODO open txn
-                                    },
-                                    (true, typedb_protocol::transaction::req::Req::OpenReq(_)) => {
-                                        // TODO: unexpected state: already open
-                                    },
-                                    (true, typedb_protocol::transaction::req::Req::QueryReq(query_req)) => {
-                                        // TODO: compile query, create executor, respond with initial message and then await initial answers to send
-                                    }
-                                    (true, typedb_protocol::transaction::req::Req::StreamReq(stream_req)) => {
-                                        //
-                                    }
-                                    (true, typedb_protocol::transaction::req::Req::CommitReq(commit_req)) => {}
-                                    (true, typedb_protocol::transaction::req::Req::RollbackReq(rollback_req)) => {}
-                                    (true, typedb_protocol::transaction::req::Req::CloseReq(close_req)) => {
-                                    }
-                                    (false, _) => {
-                                        // TODO: unexpected state: already closed
-                                    }
+                                let result = self.handle_request(&request_id, req);
+                                if let Some(err) = result {
+                                    self.send_err(err).await;
+                                    close_service!();
                                 }
                             }
                         }
                     }
                 }
             }
+        }
+    }
 
+    fn handle_request(&mut self, request_id: &[u8], req: typedb_protocol::transaction::req::Req) -> Result<(), Status> {
+        match (self.is_open, req) {
+            (false, typedb_protocol::transaction::req::Req::OpenReq(open_req)) => {
+                match self.handle_open(open_req) {
+                    Ok(_) => event!(Level::TRACE, "Transaction opened, request ID: {:?}", HexBytesFormatter(request_id)),
+                    Err(status) => return Err(status),
+                }
+            }
+            (true, typedb_protocol::transaction::req::Req::OpenReq(_)) => {
+                return Err(ProtocolError::TransactionAlreadyOpen {}.into())
+            }
+            (true, typedb_protocol::transaction::req::Req::QueryReq(query_req)) => {
+                // TODO: compile query, create executor, respond with initial message and then await initial answers to send
+            }
+            (true, typedb_protocol::transaction::req::Req::StreamReq(stream_req)) => {
+                //
+            }
+            (true, typedb_protocol::transaction::req::Req::CommitReq(commit_req)) => {
+                self.handle_commit(commit_req)
+            }
+            (true, typedb_protocol::transaction::req::Req::RollbackReq(rollback_req)) => {}
+            (true, typedb_protocol::transaction::req::Req::CloseReq(close_req)) => {}
+            (false, _) => {
+                Err(ProtocolError::TransactionClosed {})
+            }
+        }
+        Ok(())
+    }
 
+    fn handle_open(&mut self, open_req: typedb_protocol::transaction::open::Req) -> Result<(), Status> {
+        self.network_latency_millis = Some(open_req.network_latency_millis);
+        if let Some(options) = open_req.options {
+            self.prefetch_size = options.prefetch_size.or(Some(DEFAULT_PREFETCH_SIZE));
+            self.transaction_timeout_millis = options.transaction_timeout_millis.or(Some(DEFAULT_TRANSACTION_TIMEOUT_MILLIS));
+        }
 
-            let result = self.response_sender.send(()).await;
+        let transaction_type = typedb_protocol::transaction::Type::try_from(open_req.r#type)
+            .map_err(|err| TransactionServiceError::UnrecognisedTransactionType { enum_variant: open_req.r#type })?;
+
+        let database_name = open_req.database;
+        let database = self.database_manager.database(database_name.as_ref())
+            .ok_or_else(|| TransactionServiceError::DatabaseNotFound { name: database_name })?;
+
+        let transaction = match transaction_type {
+            Type::Read => {
+                Transaction::Read(TransactionRead::open(database))
+            }
+            Type::Write => {
+                Transaction::Write(TransactionWrite::open(database))
+            }
+            Type::Schema => {
+                Transaction::Schema(TransactionSchema::open(database))
+            }
+        };
+        self.transaction = Some(transaction);
+        self.is_open = true;
+        Ok(())
+    }
+
+    fn handle_commit(&mut self, commit_req:  typedb_protocol::transaction::commit::Req) -> Result<(), Status> {
+        match self.transaction.take().unwrap() {
+            Transaction::Read(_) => {
+
+            }
+            Transaction::Write(transaction) => {
+                let result = transaction.commit();
+            }
+            Transaction::Schema(transaction) => {
+                let result = transaction.commit();
+            }
+        }
+    }
+
+    async fn send_err(&mut self, err: Status) {
+        let result = self.response_sender.send(
+            Err(err)
+        ).await;
+        if let Err(send_error) = result {
+            event!(Level::DEBUG, "Failed to send error to client", ?send_error);
         }
     }
 }

--- a/server/service/transaction_service.rs
+++ b/server/service/transaction_service.rs
@@ -1,0 +1,77 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+use tokio::sync::mpsc::Sender;
+use tokio_stream::StreamExt;
+use tonic::{Streaming};
+use typedb_protocol::transaction::{Client};
+
+pub(crate) struct TransactionService {
+    request_stream: Streaming<Client>,
+    response_sender: Sender<()>,
+
+    is_open: bool,
+}
+
+impl TransactionService {
+    pub(crate) fn new(request_stream: Streaming<Client>, response_sender: Sender<_>) -> _ {
+        Self { request_stream, response_sender, is_open: false }
+    }
+
+    pub(crate) async fn listen(&mut self) {
+        loop {
+            let next = self.request_stream.next().await;
+            match next {
+                None => {
+                    // TODO: network stream/transaction has ended
+                    return
+                },
+                Some(Err(error)) => {
+                    // TODO: grpc error
+                    todo!()
+                }
+                Some(Ok(message)) => {
+                    for request in message.reqs {
+                        let request_id = request.req_id;
+                        let metadata = request.metadata;
+                        match request.req {
+                            None => {
+                                // TODO: unexpected state: oneof in Protobuf should always be populated.
+                            }
+                            Some(req) => {
+                                match (self.is_open, req) {
+                                    (false, typedb_protocol::transaction::req::Req::OpenReq(open_req)) => {
+                                        // TODO open txn
+                                    },
+                                    (true, typedb_protocol::transaction::req::Req::OpenReq(_)) => {
+                                        // TODO: unexpected state: already open
+                                    },
+                                    (true, typedb_protocol::transaction::req::Req::QueryReq(query_req)) => {
+                                        // TODO: compile query, create executor, respond with initial message and then await initial answers to send
+                                    }
+                                    (true, typedb_protocol::transaction::req::Req::StreamReq(stream_req)) => {
+                                        //
+                                    }
+                                    (true, typedb_protocol::transaction::req::Req::CommitReq(commit_req)) => {}
+                                    (true, typedb_protocol::transaction::req::Req::RollbackReq(rollback_req)) => {}
+                                    (true, typedb_protocol::transaction::req::Req::CloseReq(close_req)) => {
+                                    }
+                                    (false, _) => {
+                                        // TODO: unexpected state: already closed
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
+
+
+            let result = self.response_sender.send(()).await;
+        }
+    }
+}

--- a/server/service/transaction_service.rs
+++ b/server/service/transaction_service.rs
@@ -342,13 +342,14 @@ impl TransactionService {
                 database
             } = schema_transaction;
             let mut snapshot = Arc::into_inner(snapshot).unwrap();
-            let (snapshot, type_manager, result) = spawn_blocking(move || {
+            let (snapshot, type_manager, thing_manager, result) = spawn_blocking(move || {
                 let result = QueryManager::new().execute_schema(
                     &mut snapshot,
                     &type_manager,
+                    &thing_manager,
                     query,
                 ).map_err(|err| TransactionServiceError::QueryExecutionFailed { source: err }.into_status());
-                (snapshot, type_manager, result)
+                (snapshot, type_manager, thing_manager, result)
             }).await.unwrap();
             result?;
             let transaction = TransactionSchema::from(

--- a/server/service/typedb_service.rs
+++ b/server/service/typedb_service.rs
@@ -1,0 +1,63 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+use tokio_stream::StreamExt;
+use tonic::{Request, Response, Status, Streaming};
+use typedb_protocol;
+use typedb_protocol::connection::pulse::{Req, Res};
+use typedb_protocol::transaction::Client;
+
+#[derive(Debug, Default)]
+pub(crate) struct TypeDBService {
+
+}
+
+#[tonic::async_trait]
+impl typedb_protocol::type_db_server::TypeDb for TypeDBService {
+    async fn connection_open(&self, request: Request<typedb_protocol::connection::open::Req>) -> Result<Response<typedb_protocol::connection::open::Res>, Status> {
+        todo!()
+    }
+
+    async fn connection_pulse(&self, request: Request<Req>) -> Result<Response<Res>, Status> {
+        todo!()
+    }
+
+    async fn databases_get(&self, request: Request<typedb_protocol::database_manager::get::Req>) -> Result<Response<typedb_protocol::database_manager::get::Res>, Status> {
+        todo!()
+    }
+
+    async fn databases_all(&self, request: Request<typedb_protocol::database_manager::all::Req>) -> Result<Response<typedb_protocol::database_manager::all::Res>, Status> {
+        todo!()
+    }
+
+    async fn databases_contains(&self, request: Request<typedb_protocol::database_manager::contains::Req>) -> Result<Response<typedb_protocol::database_manager::contains::Res>, Status> {
+        todo!()
+    }
+
+    async fn databases_create(&self, request: Request<typedb_protocol::database_manager::create::Req>) -> Result<Response<typedb_protocol::database_manager::create::Res>, Status> {
+        todo!()
+    }
+
+    async fn database_schema(&self, request: Request<typedb_protocol::database::schema::Req>) -> Result<Response<typedb_protocol::database::schema::Res>, Status> {
+        todo!()
+    }
+
+    async fn database_type_schema(&self, request: Request<typedb_protocol::database::type_schema::Req>) -> Result<Response<typedb_protocol::database::type_schema::Res>, Status> {
+        todo!()
+    }
+
+    async fn database_delete(&self, request: Request<typedb_protocol::database::delete::Req>) -> Result<Response<typedb_protocol::database::delete::Res>, Status> {
+        todo!()
+    }
+
+    type transactionStream = ();
+
+    async fn transaction(&self, request: Request<Streaming<Client>>) -> Result<Response<Self::transactionStream>, Status> {
+        let mut stream = request.into_inner();
+
+        stream.next().await;
+    }
+}

--- a/server/service/typedb_service.rs
+++ b/server/service/typedb_service.rs
@@ -81,11 +81,10 @@ impl typedb_protocol::type_db_server::TypeDb for TypeDBService {
         let mut request_stream = request.into_inner();
         let (response_sender, response_receiver) = channel(10);
         let mut service = TransactionService::new(request_stream, response_sender, self.database_manager.clone());
-        // tokio::spawn(async move {
-        //     service.listen().await
-        // });
-        // let stream: ReceiverStream<Result<Server, Status>> = ReceiverStream::new(response_receiver);
-        // Ok(Response::new(Box::pin(stream)))
-        todo!()
+        tokio::spawn(async move {
+            service.listen().await
+        });
+        let stream: ReceiverStream<Result<Server, Status>> = ReceiverStream::new(response_receiver);
+        Ok(Response::new(Box::pin(stream)))
     }
 }

--- a/server/service/typedb_service.rs
+++ b/server/service/typedb_service.rs
@@ -78,14 +78,14 @@ impl typedb_protocol::type_db_server::TypeDb for TypeDBService {
     type transactionStream = Pin<Box<ReceiverStream<Result<typedb_protocol::transaction::Server, tonic::Status>>>>;
 
     async fn transaction(&self, request: Request<Streaming<Client>>) -> Result<Response<Self::transactionStream>, Status> {
-        //       therefore we need to hold onto the DatabaseManager as a reference or by Arc in the Txn Service??
         let mut request_stream = request.into_inner();
         let (response_sender, response_receiver) = channel(10);
         let mut service = TransactionService::new(request_stream, response_sender, self.database_manager.clone());
-        tokio::spawn(async move {
-            service.listen().await
-        });
-        let stream: ReceiverStream<Result<Server, Status>> = ReceiverStream::new(response_receiver);
-        Ok(Response::new(Box::pin(stream)))
+        // tokio::spawn(async move {
+        //     service.listen().await
+        // });
+        // let stream: ReceiverStream<Result<Server, Status>> = ReceiverStream::new(response_receiver);
+        // Ok(Response::new(Box::pin(stream)))
+        todo!()
     }
 }

--- a/server/typedb.rs
+++ b/server/typedb.rs
@@ -5,27 +5,26 @@
  */
 
 use std::{
-    collections::HashMap,
     error::Error,
     fmt, fs, io,
-    path::{Path, PathBuf},
-    sync::Arc,
+    path::{Path, PathBuf}
+    ,
 };
 
-use database::{Database, DatabaseDeleteError, DatabaseOpenError, DatabaseResetError};
-use itertools::Itertools;
-use storage::durability_client::WALClient;
+use database::database_manager::DatabaseManager;
+use database::DatabaseOpenError;
+
 use crate::service::typedb_service::TypeDBService;
 
 #[derive(Debug)]
 pub struct Server {
     data_directory: PathBuf,
-    databases: HashMap<String, Arc<Database<WALClient>>>,
+    typedb_service: Option<TypeDBService>,
 }
 
 impl Server {
     pub fn open(data_directory: impl AsRef<Path>) -> Result<Self, ServerOpenError> {
-        use ServerOpenError::{CouldNotCreateDataDirectory, CouldNotReadDataDirectory, DatabaseOpen, NotADirectory};
+        use ServerOpenError::{CouldNotCreateDataDirectory, NotADirectory};
         let data_directory = data_directory.as_ref();
 
         if !data_directory.exists() {
@@ -35,90 +34,25 @@ impl Server {
             return Err(NotADirectory { path: data_directory.to_owned() });
         }
 
-        let databases = fs::read_dir(data_directory)
-            .map_err(|error| CouldNotReadDataDirectory { path: data_directory.to_owned(), source: error })?
-            .map(|entry| {
-                let entry = entry
-                    .map_err(|error| CouldNotReadDataDirectory { path: data_directory.to_owned(), source: error })?;
-                let database =
-                    Database::<WALClient>::open(&entry.path()).map_err(|error| DatabaseOpen { source: error })?;
-                Ok((database.name().to_owned(), Arc::new(database)))
-            })
-            .try_collect()?;
+        let database_manager = DatabaseManager::new(data_directory)
+            .map_err(|err| ServerOpenError::DatabaseOpenError { source: err })?;
         let data_directory = data_directory.to_owned();
 
-        Ok(Self { data_directory, databases })
+        let typedb_service = TypeDBService::new(database_manager);
+
+        Ok(Self { data_directory, typedb_service: Some(typedb_service) })
     }
 
-    pub fn create_database(&mut self, name: impl AsRef<str>) {
-        let name = name.as_ref();
-        self.databases
-            .entry(name.to_owned())
-            .or_insert_with(|| Arc::new(Database::<WALClient>::open(&self.data_directory.join(name)).unwrap()));
-    }
-
-    pub fn delete_database(&mut self, name: impl AsRef<str>) -> Result<(), DatabaseDeleteError> {
-        // TODO: this is a partial implementation, only single threaded and without cooperative transaction shutdown
-        // remove from map to make DB unavailable
-        let db = self.databases.remove(name.as_ref());
-        if let Some(db) = db {
-            match Arc::try_unwrap(db) {
-                Ok(unwrapped) => unwrapped.delete()?,
-                Err(arc) => {
-                    // failed to delete since it's in use - let's re-insert for now instead of losing the reference
-                    self.databases.insert(name.as_ref().to_owned(), arc);
-                    return Err(DatabaseDeleteError::InUse {});
-                }
-            }
-        }
-        Ok(())
-    }
-
-    pub fn reset_else_recreate_database(&mut self, name: impl AsRef<str>) -> Result<(), DatabaseDeleteError> {
-        // TODO: this is a partial implementation, only single threaded and without cooperative transaction shutdown
-        // remove from map to make DB unavailable
-        let db = self.databases.remove(name.as_ref());
-        let result = if let Some(db) = db {
-            match Arc::try_unwrap(db) {
-                Ok(mut unwrapped) => {
-                    let reset_result = unwrapped.reset();
-                    self.databases.insert(name.as_ref().to_owned(), Arc::new(unwrapped));
-                    reset_result
-                }
-                Err(arc) => {
-                    // failed to reset since it's in use - let's re-insert for now instead of losing the reference
-                    self.databases.insert(name.as_ref().to_owned(), arc);
-                    Err(DatabaseResetError::InUse {})
-                }
-            }
-        } else {
-            self.create_database(name);
-            return Ok(());
-        };
-
-        Ok(match result {
-            Ok(_) => (),
-            Err(_) => {
-                self.delete_database(name.as_ref())?;
-                self.create_database(name)
-            }
-        })
-    }
-
-    pub fn database(&self, name: &str) -> Option<&Database<WALClient>> {
-        self.databases.get(name).map(|arc| &**arc)
-    }
-
-    pub fn databases(&self) -> &HashMap<String, Arc<Database<WALClient>>> {
-        &self.databases
+    pub fn database_manager(&self) -> &DatabaseManager {
+        self.typedb_service.as_ref().unwrap().database_manager()
     }
 
     pub async fn serve(self) -> Result<(), Box<dyn Error>> {
         let address = "localhost:1729".parse().unwrap();
-        let typedb_service = TypeDBService::default();
 
+        // TODO: could also construct in Server and await here only
         Server::builder()
-            .add_service(typedb_service)
+            .add_service(self.typedb_service.take().unwrap())
             .serve(address)
             .await?;
         Ok(())
@@ -129,8 +63,7 @@ impl Server {
 pub enum ServerOpenError {
     NotADirectory { path: PathBuf },
     CouldNotCreateDataDirectory { path: PathBuf, source: io::Error },
-    CouldNotReadDataDirectory { path: PathBuf, source: io::Error },
-    DatabaseOpen { source: DatabaseOpenError },
+    DatabaseOpenError { source: DatabaseOpenError }
 }
 
 impl Error for ServerOpenError {}

--- a/server/typedb.rs
+++ b/server/typedb.rs
@@ -10,7 +10,6 @@ use std::{
     path::{Path, PathBuf}
     ,
 };
-use tonic::transport::Server;
 
 use database::database_manager::DatabaseManager;
 use database::DatabaseOpenError;
@@ -18,12 +17,12 @@ use database::DatabaseOpenError;
 use crate::service::typedb_service::TypeDBService;
 
 #[derive(Debug)]
-pub struct Server2 {
+pub struct Server {
     data_directory: PathBuf,
     typedb_service: Option<TypeDBService>,
 }
 
-impl Server2 {
+impl Server {
     pub fn open(data_directory: impl AsRef<Path>) -> Result<Self, ServerOpenError> {
         use ServerOpenError::{CouldNotCreateDataDirectory, NotADirectory};
         let data_directory = data_directory.as_ref();

--- a/server/typedb.rs
+++ b/server/typedb.rs
@@ -10,6 +10,7 @@ use std::{
     path::{Path, PathBuf}
     ,
 };
+use tonic::transport::Server;
 
 use database::database_manager::DatabaseManager;
 use database::DatabaseOpenError;
@@ -17,12 +18,12 @@ use database::DatabaseOpenError;
 use crate::service::typedb_service::TypeDBService;
 
 #[derive(Debug)]
-pub struct Server {
+pub struct Server2 {
     data_directory: PathBuf,
     typedb_service: Option<TypeDBService>,
 }
 
-impl Server {
+impl Server2 {
     pub fn open(data_directory: impl AsRef<Path>) -> Result<Self, ServerOpenError> {
         use ServerOpenError::{CouldNotCreateDataDirectory, NotADirectory};
         let data_directory = data_directory.as_ref();
@@ -52,6 +53,7 @@ impl Server {
 
         // TODO: could also construct in Server and await here only
         Server::builder()
+            .http2_keepalive_interval()
             .add_service(self.typedb_service.take().unwrap())
             .serve(address)
             .await?;

--- a/server/typedb.rs
+++ b/server/typedb.rs
@@ -49,14 +49,14 @@ impl Server2 {
     }
 
     pub async fn serve(self) -> Result<(), Box<dyn Error>> {
-        let address = "localhost:1729".parse().unwrap();
+        // let address = "localhost:1729".parse().unwrap();
 
         // TODO: could also construct in Server and await here only
-        Server::builder()
-            .http2_keepalive_interval()
-            .add_service(self.typedb_service.take().unwrap())
-            .serve(address)
-            .await?;
+        // Server::builder()
+            // .http2_keepalive_interval()
+            // .add_service(self.typedb_service.take().unwrap())
+            // .serve(address)
+            // .await?;
         Ok(())
     }
 }

--- a/server/typedb.rs
+++ b/server/typedb.rs
@@ -15,6 +15,7 @@ use std::{
 use database::{Database, DatabaseDeleteError, DatabaseOpenError, DatabaseResetError};
 use itertools::Itertools;
 use storage::durability_client::WALClient;
+use crate::service::typedb_service::TypeDBService;
 
 #[derive(Debug)]
 pub struct Server {
@@ -45,6 +46,7 @@ impl Server {
             })
             .try_collect()?;
         let data_directory = data_directory.to_owned();
+
         Ok(Self { data_directory, databases })
     }
 
@@ -111,8 +113,15 @@ impl Server {
         &self.databases
     }
 
-    pub fn serve(self) {
-        todo!()
+    pub async fn serve(self) -> Result<(), Box<dyn Error>> {
+        let address = "localhost:1729".parse().unwrap();
+        let typedb_service = TypeDBService::default();
+
+        Server::builder()
+            .add_service(typedb_service)
+            .serve(address)
+            .await?;
+        Ok(())
     }
 }
 

--- a/storage/keyspace/keyspace.rs
+++ b/storage/keyspace/keyspace.rs
@@ -280,6 +280,7 @@ impl Keyspace {
     }
 
     pub(crate) fn delete(self) -> Result<(), KeyspaceDeleteError> {
+        drop(self.kv_storage);
         fs::remove_dir_all(self.path.clone())
             .map_err(|error| KeyspaceDeleteError::DirectoryRemove { name: self.name, source: error })?;
         Ok(())

--- a/storage/snapshot/buffer.rs
+++ b/storage/snapshot/buffer.rs
@@ -83,6 +83,13 @@ impl OperationsBuffer {
             buffer.iterate_range(KeyRange::new_unbounded(Bytes::Array(ByteArray::<BUFFER_KEY_INLINE>::empty())))
         })
     }
+
+    pub fn clear(&mut self) {
+        self.locks.clear();
+        for buffer in self.write_buffers.iter_mut() {
+            buffer.clear();
+        }
+    }
 }
 
 impl<'a> IntoIterator for &'a OperationsBuffer {
@@ -231,6 +238,10 @@ impl WriteBuffer {
 
     pub fn get_write(&self, key: ByteReference<'_>) -> Option<&Write> {
         self.writes.get(key.bytes())
+    }
+
+    pub fn clear(&mut self) {
+        self.writes.clear()
     }
 }
 

--- a/storage/snapshot/snapshot.rs
+++ b/storage/snapshot/snapshot.rs
@@ -164,6 +164,10 @@ pub trait WritableSnapshot: ReadableSnapshot {
         self.operations_mut().lock_add(key, LockType::Exclusive)
     }
 
+    fn clear(&mut self) {
+        self.operations_mut().clear()
+    }
+
     fn close_resources(&self);
 }
 
@@ -368,6 +372,8 @@ impl<D: DurabilityClient> CommittableSnapshot<D> for WriteSnapshot<D> {
             }
         }
     }
+
+
 
     fn into_commit_record(self) -> CommitRecord {
         CommitRecord::new(self.operations, self.open_sequence_number, CommitType::Data)

--- a/tests/behaviour/concept/type/BUILD
+++ b/tests/behaviour/concept/type/BUILD
@@ -59,6 +59,7 @@ rust_test(
         "@crates//:tokio",
     ],
     data = ["@vaticle_typedb_behaviour//concept/type:owns.feature"],
+    crate_features = ["bazel"],
 )
 
 rust_test(

--- a/tests/behaviour/concept/type/BUILD
+++ b/tests/behaviour/concept/type/BUILD
@@ -14,6 +14,7 @@ rust_test(
         "@crates//:tokio",
     ],
     data = ["@vaticle_typedb_behaviour//concept/type:attributetype.feature"],
+    crate_features = ["bazel"],
 )
 
 rust_test(
@@ -24,6 +25,7 @@ rust_test(
         "@crates//:tokio",
     ],
     data = ["@vaticle_typedb_behaviour//concept/type:entitytype.feature"],
+    crate_features = ["bazel"],
 )
 
 rust_test(
@@ -34,6 +36,7 @@ rust_test(
         "@crates//:tokio",
     ],
     data = ["@vaticle_typedb_behaviour//concept/type:relationtype.feature"],
+    crate_features = ["bazel"],
 )
 
 rust_test(
@@ -44,6 +47,7 @@ rust_test(
         "@crates//:tokio",
     ],
     data = ["@vaticle_typedb_behaviour//concept/type:plays.feature"],
+    crate_features = ["bazel"],
 )
 
 rust_test(
@@ -66,6 +70,7 @@ rust_test(
         "@crates//:tokio",
     ],
     data = ["@vaticle_typedb_behaviour//concept/type:owns-annotations.feature"],
+    crate_features = ["bazel"],
 )
 
 checkstyle_test(

--- a/tests/behaviour/concept/type/attribute_type.rs
+++ b/tests/behaviour/concept/type/attribute_type.rs
@@ -11,5 +11,11 @@ async fn test() {
     // Bazel specific path: when running the test in bazel, the external data from
     // @vaticle_typedb_behaviour is stored in a directory that is a sibling to
     // the working directory.
-    assert!(Context::test("../vaticle_typedb_behaviour/concept/type/attributetype.feature", false).await);
+    #[cfg(feature = "bazel")]
+    let path = "../vaticle_typedb_behaviour/concept/type/attributetype.feature";
+
+    #[cfg(not(feature = "bazel"))]
+    let path = "bazel-typedb/external/vaticle_typedb_behaviour/concept/type/attributetype.feature";
+
+    assert!(Context::test(path, true).await);
 }

--- a/tests/behaviour/concept/type/entity_type.rs
+++ b/tests/behaviour/concept/type/entity_type.rs
@@ -11,5 +11,11 @@ async fn test() {
     // Bazel specific path: when running the test in bazel, the external data from
     // @vaticle_typedb_behaviour is stored in a directory that is a sibling to
     // the working directory.
-    assert!(Context::test("../vaticle_typedb_behaviour/concept/type/entitytype.feature", false).await);
+    #[cfg(feature = "bazel")]
+    let path = "../vaticle_typedb_behaviour/concept/type/entitytype.feature";
+
+    #[cfg(not(feature = "bazel"))]
+    let path = "bazel-typedb/external/vaticle_typedb_behaviour/concept/type/entitytype.feature";
+
+    assert!(Context::test(path, true).await);
 }

--- a/tests/behaviour/concept/type/owns.rs
+++ b/tests/behaviour/concept/type/owns.rs
@@ -11,5 +11,11 @@ async fn test() {
     // Bazel specific path: when running the test in bazel, the external data from
     // @vaticle_typedb_behaviour is stored in a directory that is a sibling to
     // the working directory.
-    assert!(Context::test("../vaticle_typedb_behaviour/concept/type/owns.feature", false).await);
+    #[cfg(feature = "bazel")]
+        let path = "../vaticle_typedb_behaviour/concept/type/owns.feature";
+
+    #[cfg(not(feature = "bazel"))]
+        let path = "bazel-typedb/external/vaticle_typedb_behaviour/concept/type/owns.feature";
+
+    assert!(Context::test(path, true).await);
 }

--- a/tests/behaviour/concept/type/owns_annotations.rs
+++ b/tests/behaviour/concept/type/owns_annotations.rs
@@ -12,10 +12,10 @@ async fn test() {
     // @vaticle_typedb_behaviour is stored in a directory that is a sibling to
     // the working directory.
     #[cfg(feature = "bazel")]
-        let path = "../vaticle_typedb_behaviour/concept/type/owns-annotation.feature";
+        let path = "../vaticle_typedb_behaviour/concept/type/owns-annotations.feature";
 
     #[cfg(not(feature = "bazel"))]
-        let path = "bazel-typedb/external/vaticle_typedb_behaviour/concept/type/owns-annotation.feature";
+        let path = "bazel-typedb/external/vaticle_typedb_behaviour/concept/type/owns-annotations.feature";
 
     assert!(Context::test(path, true).await);
 }

--- a/tests/behaviour/concept/type/owns_annotations.rs
+++ b/tests/behaviour/concept/type/owns_annotations.rs
@@ -11,5 +11,11 @@ async fn test() {
     // Bazel specific path: when running the test in bazel, the external data from
     // @vaticle_typedb_behaviour is stored in a directory that is a sibling to
     // the working directory.
-    assert!(Context::test("../vaticle_typedb_behaviour/concept/type/owns-annotations.feature", false).await);
+    #[cfg(feature = "bazel")]
+        let path = "../vaticle_typedb_behaviour/concept/type/owns-annotation.feature";
+
+    #[cfg(not(feature = "bazel"))]
+        let path = "bazel-typedb/external/vaticle_typedb_behaviour/concept/type/owns-annotation.feature";
+
+    assert!(Context::test(path, true).await);
 }

--- a/tests/behaviour/concept/type/plays.rs
+++ b/tests/behaviour/concept/type/plays.rs
@@ -11,5 +11,11 @@ async fn test() {
     // Bazel specific path: when running the test in bazel, the external data from
     // @vaticle_typedb_behaviour is stored in a directory that is a sibling to
     // the working directory.
-    assert!(Context::test("../vaticle_typedb_behaviour/concept/type/plays.feature", false).await);
+    #[cfg(feature = "bazel")]
+        let path = "../vaticle_typedb_behaviour/concept/type/plays.feature";
+
+    #[cfg(not(feature = "bazel"))]
+        let path = "bazel-typedb/external/vaticle_typedb_behaviour/concept/type/plays.feature";
+
+    assert!(Context::test(path, true).await);
 }

--- a/tests/behaviour/concept/type/relation_type.rs
+++ b/tests/behaviour/concept/type/relation_type.rs
@@ -11,5 +11,12 @@ async fn test() {
     // Bazel specific path: when running the test in bazel, the external data from
     // @vaticle_typedb_behaviour is stored in a directory that is a sibling to
     // the working directory.
-    assert!(Context::test("../vaticle_typedb_behaviour/concept/type/relationtype.feature", false).await);
+    #[cfg(feature = "bazel")]
+        let path = "../vaticle_typedb_behaviour/concept/type/relationtype.feature";
+
+    #[cfg(not(feature = "bazel"))]
+        let path = "bazel-typedb/external/vaticle_typedb_behaviour/concept/type/relationtype.feature";
+
+    assert!(Context::test(path, true).await);
+
 }

--- a/tests/behaviour/connection/database/BUILD
+++ b/tests/behaviour/connection/database/BUILD
@@ -15,6 +15,7 @@ rust_test(
         "@crates//:tokio",
     ],
     data = ["@vaticle_typedb_behaviour//connection:database.feature"],
+    crate_features = ["bazel"],
 )
 
 checkstyle_test(

--- a/tests/behaviour/connection/database/database.rs
+++ b/tests/behaviour/connection/database/database.rs
@@ -11,5 +11,11 @@ async fn test() {
     // Bazel specific path: when running the test in bazel, the external data from
     // @vaticle_typedb_behaviour is stored in a directory that is a sibling to
     // the working directory.
-    assert!(Context::test("../vaticle_typedb_behaviour/connection/database.feature", true).await);
+    #[cfg(feature = "bazel")]
+    let path = "../vaticle_typedb_behaviour/connection/database.feature";
+
+    #[cfg(not(feature = "bazel"))]
+    let path = "bazel-typedb/external/vaticle_typedb_behaviour/connection/database.feature";
+
+    assert!(Context::test(path, true).await);
 }

--- a/tests/behaviour/connection/transaction/BUILD
+++ b/tests/behaviour/connection/transaction/BUILD
@@ -15,6 +15,7 @@ rust_test(
         "@crates//:tokio",
     ],
     data = ["@vaticle_typedb_behaviour//connection:transaction.feature"],
+    crate_features = ["bazel"],
 )
 
 checkstyle_test(

--- a/tests/behaviour/connection/transaction/transaction.rs
+++ b/tests/behaviour/connection/transaction/transaction.rs
@@ -11,5 +11,11 @@ async fn test() {
     // Bazel specific path: when running the test in bazel, the external data from
     // @vaticle_typedb_behaviour is stored in a directory that is a sibling to
     // the working directory.
-    assert!(Context::test("../vaticle_typedb_behaviour/connection/transaction.feature", true).await);
+    #[cfg(feature = "bazel")]
+    let path = "../vaticle_typedb_behaviour/connection/transaction.feature";
+
+    #[cfg(not(feature = "bazel"))]
+    let path = "bazel-typedb/external/vaticle_typedb_behaviour/connection/transaction.feature";
+
+    assert!(Context::test(path, true).await);
 }

--- a/tests/behaviour/debug/debug.feature
+++ b/tests/behaviour/debug/debug.feature
@@ -6,32 +6,3 @@ Feature: Debugging Space
 
   # Paste any scenarios below for debugging.
   # Do not commit any changes to this file.
-
-  Background:
-    Given typedb starts
-    Given connection opens with default authentication
-    Given connection has been opened
-    Given connection does not have any database
-    Given connection create database: typedb
-    Given connection open schema transaction for database: typedb
-    # Write schema for the test scenarios
-    Given create attribute type: username
-    Given attribute(username) set value type: string
-    Given create attribute type: email
-    Given attribute(email) set value type: string
-    Given create entity type: person
-    Given entity(person) set owns: username
-    Given entity(person) get owns(username) set annotation: @key
-    Given entity(person) set owns: email
-    Given transaction commits
-    Given connection open write transaction for database: typedb
-
-  Scenario: Entity can be created
-    When $a = entity(person) create new instance with key(username): alice
-    Then entity $a exists
-    Then entity $a has type: person
-    Then entity(person) get instances contain: $a
-    Then transaction commits
-    When connection open read transaction for database: typedb
-    When $a = entity(person) get instance with key(username): alice
-    Then entity(person) get instances contain: $a

--- a/tests/behaviour/debug/debug.feature
+++ b/tests/behaviour/debug/debug.feature
@@ -6,3 +6,32 @@ Feature: Debugging Space
 
   # Paste any scenarios below for debugging.
   # Do not commit any changes to this file.
+
+  Background:
+    Given typedb starts
+    Given connection opens with default authentication
+    Given connection has been opened
+    Given connection does not have any database
+    Given connection create database: typedb
+    Given connection open schema transaction for database: typedb
+    # Write schema for the test scenarios
+    Given create attribute type: username
+    Given attribute(username) set value type: string
+    Given create attribute type: email
+    Given attribute(email) set value type: string
+    Given create entity type: person
+    Given entity(person) set owns: username
+    Given entity(person) get owns(username) set annotation: @key
+    Given entity(person) set owns: email
+    Given transaction commits
+    Given connection open write transaction for database: typedb
+
+  Scenario: Entity can be created
+    When $a = entity(person) create new instance with key(username): alice
+    Then entity $a exists
+    Then entity $a has type: person
+    Then entity(person) get instances contain: $a
+    Then transaction commits
+    When connection open read transaction for database: typedb
+    When $a = entity(person) get instance with key(username): alice
+    Then entity(person) get instances contain: $a

--- a/tests/behaviour/steps/BUILD
+++ b/tests/behaviour/steps/BUILD
@@ -15,6 +15,7 @@ rust_library(
         "//answer:answer",
         "//common/primitive",
         "//common/lending_iterator",
+        "//common/options",
         "//compiler:compiler",
         "//concept:concept",
         "//database:database",

--- a/tests/behaviour/steps/concept/thing/attribute.rs
+++ b/tests/behaviour/steps/concept/thing/attribute.rs
@@ -164,10 +164,10 @@ async fn attribute_is_none(context: &mut Context, var: params::Var, is_none: par
 async fn delete_attributes_of_type(context: &mut Context, type_label: params::Label) {
     with_write_tx!(context, |tx| {
         let attribute_type =
-            tx.type_manager.get_attribute_type(&tx.snapshot, &type_label.into_typedb()).unwrap().unwrap();
-        let mut attribute_iterator = tx.thing_manager.get_attributes_in(&mut tx.snapshot, attribute_type).unwrap();
+            tx.type_manager.get_attribute_type(tx.snapshot.as_ref(), &type_label.into_typedb()).unwrap().unwrap();
+        let mut attribute_iterator = tx.thing_manager.get_attributes_in(tx.snapshot.as_ref(), attribute_type).unwrap();
         while let Some(attribute) = attribute_iterator.next() {
-            attribute.unwrap().delete(&mut tx.snapshot, &tx.thing_manager).unwrap();
+            attribute.unwrap().delete(Arc::get_mut(&mut tx.snapshot).unwrap(), &tx.thing_manager).unwrap();
         }
     })
 }
@@ -198,8 +198,8 @@ async fn attribute_instances_contain(
 async fn object_instances_is_empty(context: &mut Context, type_label: params::Label, is_empty_or_not: IsEmptyOrNot) {
     with_read_tx!(context, |tx| {
         let attribute_type =
-            tx.type_manager.get_attribute_type(&tx.snapshot, &type_label.into_typedb()).unwrap().unwrap();
+            tx.type_manager.get_attribute_type(tx.snapshot.as_ref(), &type_label.into_typedb()).unwrap().unwrap();
         is_empty_or_not
-            .check(tx.thing_manager.get_attributes_in(&tx.snapshot, attribute_type).unwrap().next().is_none());
+            .check(tx.thing_manager.get_attributes_in(tx.snapshot.as_ref(), attribute_type).unwrap().next().is_none());
     });
 }

--- a/tests/behaviour/steps/concept/thing/has.rs
+++ b/tests/behaviour/steps/concept/thing/has.rs
@@ -65,8 +65,8 @@ fn object_unset_has_ordered_impl(
 ) -> Result<(), ConceptWriteError> {
     with_write_tx!(context, |tx| {
         let attribute_type =
-            tx.type_manager.get_attribute_type(&tx.snapshot, &attribute_type_label.into_typedb()).unwrap().unwrap();
-        object.unset_has_ordered(&mut tx.snapshot, &tx.thing_manager, attribute_type)
+            tx.type_manager.get_attribute_type(tx.snapshot.as_ref(), &attribute_type_label.into_typedb()).unwrap().unwrap();
+        object.unset_has_ordered(Arc::get_mut(&mut tx.snapshot).unwrap(), &tx.thing_manager, attribute_type)
     })
 }
 
@@ -181,9 +181,9 @@ async fn object_get_has_list_is(
     object_root.assert(&object.type_());
     let actuals = with_read_tx!(context, |tx| {
         let attribute_type =
-            tx.type_manager.get_attribute_type(&tx.snapshot, &attribute_type_label.into_typedb()).unwrap().unwrap();
+            tx.type_manager.get_attribute_type(tx.snapshot.as_ref(), &attribute_type_label.into_typedb()).unwrap().unwrap();
         object
-            .get_has_type_ordered(&tx.snapshot, &tx.thing_manager, attribute_type)
+            .get_has_type_ordered(tx.snapshot.as_ref(), &tx.thing_manager, attribute_type)
             .unwrap()
             .into_iter()
             .map(|attr| attr.into_owned())
@@ -209,7 +209,7 @@ async fn object_get_has_is_empty(
     object_root.assert(&object.type_());
     let actuals = with_read_tx!(context, |tx| {
         object
-            .get_has_unordered(&tx.snapshot, &tx.thing_manager)
+            .get_has_unordered(tx.snapshot.as_ref(), &tx.thing_manager)
             .map_static(|res| {
                 let (attribute, _count) = res.unwrap();
                 attribute.into_owned()

--- a/tests/behaviour/steps/concept/thing/object.rs
+++ b/tests/behaviour/steps/concept/thing/object.rs
@@ -111,19 +111,19 @@ async fn delete_objects_of_type(
     type_label: params::Label,
 ) {
     with_write_tx!(context, |tx| {
-        let object_type = tx.type_manager.get_object_type(&tx.snapshot, &type_label.into_typedb()).unwrap().unwrap();
+        let object_type = tx.type_manager.get_object_type(tx.snapshot.as_ref(), &type_label.into_typedb()).unwrap().unwrap();
         object_root_label.assert(&object_type);
         match object_type {
             ObjectType::Entity(entity_type) => {
-                let mut entity_iterator = tx.thing_manager.get_entities_in(&mut tx.snapshot, entity_type);
+                let mut entity_iterator = tx.thing_manager.get_entities_in(tx.snapshot.as_ref(), entity_type);
                 while let Some(entity) = entity_iterator.next() {
-                    entity.unwrap().delete(&mut tx.snapshot, &tx.thing_manager).unwrap();
+                    entity.unwrap().delete(Arc::get_mut(&mut tx.snapshot).unwrap(), &tx.thing_manager).unwrap();
                 }
             }
             ObjectType::Relation(relation_type) => {
-                let mut relation_iterator = tx.thing_manager.get_relations_in(&mut tx.snapshot, relation_type);
+                let mut relation_iterator = tx.thing_manager.get_relations_in(tx.snapshot.as_ref(), relation_type);
                 while let Some(relation) = relation_iterator.next() {
-                    relation.unwrap().delete(&mut tx.snapshot, &tx.thing_manager).unwrap();
+                    relation.unwrap().delete(Arc::get_mut(&mut tx.snapshot).unwrap(), &tx.thing_manager).unwrap();
                 }
             }
         }

--- a/tests/behaviour/steps/concept/thing/relation.rs
+++ b/tests/behaviour/steps/concept/thing/relation.rs
@@ -111,11 +111,11 @@ async fn relation_remove_count_players_for_role(
     with_write_tx!(context, |tx| {
         let role_type = relation
             .type_()
-            .get_relates_role_name(&tx.snapshot, &tx.type_manager, role_label.into_typedb().name().as_str())
+            .get_relates_role_name(tx.snapshot.as_ref(), &tx.type_manager, role_label.into_typedb().name().as_str())
             .unwrap()
             .unwrap()
             .role();
-        relation.remove_player_many(&mut tx.snapshot, &tx.thing_manager, role_type, player, count).unwrap();
+        relation.remove_player_many(Arc::get_mut(&mut tx.snapshot).unwrap(), &tx.thing_manager, role_type, player, count).unwrap();
     });
 }
 
@@ -153,12 +153,12 @@ async fn relation_get_players_ordered_is(
     let relation = context.objects.get(&relation_var.name).unwrap().as_ref().unwrap().object.clone().unwrap_relation();
     let actuals = with_read_tx!(context, |tx| {
         let relates = relation.type_().get_relates_role_name(
-            &tx.snapshot,
+            tx.snapshot.as_ref(),
             &tx.type_manager,
             role_label.into_typedb().name().as_str(),
         );
         let role_type = relates.unwrap().unwrap().role();
-        let players = relation.get_players_ordered(&tx.snapshot, &tx.thing_manager, role_type).unwrap();
+        let players = relation.get_players_ordered(tx.snapshot.as_ref(), &tx.thing_manager, role_type).unwrap();
         players.into_iter().map(Object::into_owned).collect_vec()
     });
     let players =
@@ -247,12 +247,12 @@ async fn relation_get_players_for_role_empty(
     let actuals = with_read_tx!(context, |tx| {
         let role_type = relation
             .type_()
-            .get_relates_role_name(&tx.snapshot, &tx.type_manager, role_label.into_typedb().name().as_str())
+            .get_relates_role_name(tx.snapshot.as_ref(), &tx.type_manager, role_label.into_typedb().name().as_str())
             .unwrap()
             .unwrap()
             .role();
         relation
-            .get_players_role_type(&tx.snapshot, &tx.thing_manager, role_type)
+            .get_players_role_type(tx.snapshot.as_ref(), &tx.thing_manager, role_type)
             .map_static(|res| res.unwrap().into_owned())
             .collect::<Vec<_>>()
     });

--- a/tests/behaviour/steps/concept/type_/attribute_type.rs
+++ b/tests/behaviour/steps/concept/type_/attribute_type.rs
@@ -85,10 +85,10 @@ pub async fn attribute_type_get_value_type_declared(
 ) {
     with_read_tx!(context, |tx| {
         let attribute_type =
-            tx.type_manager.get_attribute_type(&tx.snapshot, &type_label.into_typedb()).unwrap().unwrap();
+            tx.type_manager.get_attribute_type(tx.snapshot.as_ref(), &type_label.into_typedb()).unwrap().unwrap();
         assert_eq!(
-            value_type.into_typedb(&tx.type_manager, &tx.snapshot),
-            attribute_type.get_value_type_declared(&tx.snapshot, &tx.type_manager).unwrap().unwrap()
+            value_type.into_typedb(&tx.type_manager, tx.snapshot.as_ref()),
+            attribute_type.get_value_type_declared(tx.snapshot.as_ref(), &tx.type_manager).unwrap().unwrap()
         );
     });
 }
@@ -98,8 +98,8 @@ pub async fn attribute_type_get_value_type_declared(
 pub async fn attribute_type_get_value_type_declared_is_null(context: &mut Context, type_label: params::Label) {
     with_read_tx!(context, |tx| {
         let attribute_type =
-            tx.type_manager.get_attribute_type(&tx.snapshot, &type_label.into_typedb()).unwrap().unwrap();
-        assert_eq!(None, attribute_type.get_value_type_declared(&tx.snapshot, &tx.type_manager).unwrap());
+            tx.type_manager.get_attribute_type(tx.snapshot.as_ref(), &type_label.into_typedb()).unwrap().unwrap();
+        assert_eq!(None, attribute_type.get_value_type_declared(tx.snapshot.as_ref(), &tx.type_manager).unwrap());
     });
 }
 

--- a/tests/behaviour/steps/concept/type_/attribute_type.rs
+++ b/tests/behaviour/steps/concept/type_/attribute_type.rs
@@ -4,6 +4,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
+use std::sync::Arc;
 use concept::type_::{object_type::ObjectType, TypeAPI};
 use cucumber::gherkin::Step;
 use itertools::Itertools;
@@ -25,10 +26,10 @@ pub async fn attribute_type_set_value_type(
 ) {
     with_schema_tx!(context, |tx| {
         let attribute_type =
-            tx.type_manager.get_attribute_type(&tx.snapshot, &type_label.into_typedb()).unwrap().unwrap();
-        let parsed_value_type = value_type.into_typedb(&tx.type_manager, &tx.snapshot);
+            tx.type_manager.get_attribute_type(tx.snapshot.as_ref(), &type_label.into_typedb()).unwrap().unwrap();
+        let parsed_value_type = value_type.into_typedb(&tx.type_manager, tx.snapshot.as_ref());
         let res =
-            attribute_type.set_value_type(&mut tx.snapshot, &tx.type_manager, &tx.thing_manager, parsed_value_type);
+            attribute_type.set_value_type(Arc::get_mut(&mut tx.snapshot).unwrap(), &tx.type_manager, &tx.thing_manager, parsed_value_type);
         may_error.check_concept_write_without_read_errors(&res);
     });
 }
@@ -42,8 +43,8 @@ pub async fn attribute_type_unset_value_type(
 ) {
     with_schema_tx!(context, |tx| {
         let attribute_type =
-            tx.type_manager.get_attribute_type(&tx.snapshot, &type_label.into_typedb()).unwrap().unwrap();
-        let res = attribute_type.unset_value_type(&mut tx.snapshot, &tx.type_manager, &tx.thing_manager);
+            tx.type_manager.get_attribute_type(tx.snapshot.as_ref(), &type_label.into_typedb()).unwrap().unwrap();
+        let res = attribute_type.unset_value_type(Arc::get_mut(&mut tx.snapshot).unwrap(), &tx.type_manager, &tx.thing_manager);
         may_error.check_concept_write_without_read_errors(&res);
     });
 }
@@ -57,10 +58,10 @@ pub async fn attribute_type_get_value_type(
 ) {
     with_read_tx!(context, |tx| {
         let attribute_type =
-            tx.type_manager.get_attribute_type(&tx.snapshot, &type_label.into_typedb()).unwrap().unwrap();
+            tx.type_manager.get_attribute_type(tx.snapshot.as_ref(), &type_label.into_typedb()).unwrap().unwrap();
         assert_eq!(
-            value_type.into_typedb(&tx.type_manager, &tx.snapshot),
-            attribute_type.get_value_type(&tx.snapshot, &tx.type_manager).unwrap().unwrap()
+            value_type.into_typedb(&tx.type_manager, tx.snapshot.as_ref()),
+            attribute_type.get_value_type(tx.snapshot.as_ref(), &tx.type_manager).unwrap().unwrap()
         );
     });
 }
@@ -70,8 +71,8 @@ pub async fn attribute_type_get_value_type(
 pub async fn attribute_type_get_value_type_is_null(context: &mut Context, type_label: params::Label) {
     with_read_tx!(context, |tx| {
         let attribute_type =
-            tx.type_manager.get_attribute_type(&tx.snapshot, &type_label.into_typedb()).unwrap().unwrap();
-        assert_eq!(None, attribute_type.get_value_type(&tx.snapshot, &tx.type_manager).unwrap());
+            tx.type_manager.get_attribute_type(tx.snapshot.as_ref(), &type_label.into_typedb()).unwrap().unwrap();
+        assert_eq!(None, attribute_type.get_value_type(tx.snapshot.as_ref(), &tx.type_manager).unwrap());
     });
 }
 
@@ -113,16 +114,16 @@ pub async fn get_owners_contain(
     let expected_labels = util::iter_table(step).map(|str| str.to_owned()).collect_vec();
     with_read_tx!(context, |tx| {
         let attribute_type =
-            tx.type_manager.get_attribute_type(&tx.snapshot, &type_label.into_typedb()).unwrap().unwrap();
+            tx.type_manager.get_attribute_type(tx.snapshot.as_ref(), &type_label.into_typedb()).unwrap().unwrap();
 
         let mut actual_labels = Vec::new();
-        attribute_type.get_owns(&tx.snapshot, &tx.type_manager).unwrap().iter().for_each(|(owner, _owns)| {
+        attribute_type.get_owns(tx.snapshot.as_ref(), &tx.type_manager).unwrap().iter().for_each(|(owner, _owns)| {
             let owner_label = match owner {
                 ObjectType::Entity(owner) => {
-                    owner.get_label(&tx.snapshot, &tx.type_manager).unwrap().scoped_name().as_str().to_owned()
+                    owner.get_label(tx.snapshot.as_ref(), &tx.type_manager).unwrap().scoped_name().as_str().to_owned()
                 }
                 ObjectType::Relation(owner) => {
-                    owner.get_label(&tx.snapshot, &tx.type_manager).unwrap().scoped_name().as_str().to_owned()
+                    owner.get_label(tx.snapshot.as_ref(), &tx.type_manager).unwrap().scoped_name().as_str().to_owned()
                 }
             };
             actual_labels.push(owner_label);
@@ -142,16 +143,16 @@ pub async fn get_declaring_owners_contain(
     let expected_labels = util::iter_table(step).map(|str| str.to_owned()).collect_vec();
     with_read_tx!(context, |tx| {
         let attribute_type =
-            tx.type_manager.get_attribute_type(&tx.snapshot, &type_label.into_typedb()).unwrap().unwrap();
+            tx.type_manager.get_attribute_type(tx.snapshot.as_ref(), &type_label.into_typedb()).unwrap().unwrap();
 
         let mut actual_labels = Vec::new();
-        attribute_type.get_owns_declared(&tx.snapshot, &tx.type_manager).unwrap().iter().for_each(|owns| {
+        attribute_type.get_owns_declared(tx.snapshot.as_ref(), &tx.type_manager).unwrap().iter().for_each(|owns| {
             let owner_label = match owns.owner() {
                 ObjectType::Entity(owner) => {
-                    owner.get_label(&tx.snapshot, &tx.type_manager).unwrap().scoped_name().as_str().to_owned()
+                    owner.get_label(tx.snapshot.as_ref(), &tx.type_manager).unwrap().scoped_name().as_str().to_owned()
                 }
                 ObjectType::Relation(owner) => {
-                    owner.get_label(&tx.snapshot, &tx.type_manager).unwrap().scoped_name().as_str().to_owned()
+                    owner.get_label(tx.snapshot.as_ref(), &tx.type_manager).unwrap().scoped_name().as_str().to_owned()
                 }
             };
             actual_labels.push(owner_label);

--- a/tests/behaviour/steps/concept/type_/owns.rs
+++ b/tests/behaviour/steps/concept/type_/owns.rs
@@ -97,7 +97,7 @@ pub async fn get_owns_set_override(
                 .unwrap()
                 .unwrap();
             let overridden_owns_opt =
-                owner_supertype.get_owns_attribute(&tx.snapshot, &tx.type_manager, overridden_attr_type).unwrap();
+                owner_supertype.get_owns_attribute(tx.snapshot.as_ref(), &tx.type_manager, overridden_attr_type).unwrap();
 
             if let Some(overridden_owns) = overridden_owns_opt {
                 let res = owns.set_override(Arc::get_mut(&mut tx.snapshot).unwrap(), &tx.type_manager, &tx.thing_manager, overridden_owns);

--- a/tests/behaviour/steps/concept/type_/relation_type.rs
+++ b/tests/behaviour/steps/concept/type_/relation_type.rs
@@ -343,8 +343,8 @@ pub async fn relation_role_get_supertype(
             .unwrap();
         let role = relates.role();
         let superrole = role.get_supertype(tx.snapshot.as_ref(), &tx.type_manager).unwrap().unwrap();
-        let relates_override = relates.get_override(&tx.snapshot, &tx.type_manager).unwrap();
-        assert_eq!(relates_override.clone().unwrap(), *superrole.get_relates(&tx.snapshot, &tx.type_manager).unwrap());
+        let relates_override = relates.get_override(tx.snapshot.as_ref(), &tx.type_manager).unwrap();
+        assert_eq!(relates_override.clone().unwrap(), *superrole.get_relates(tx.snapshot.as_ref(), &tx.type_manager).unwrap());
         assert_eq!(
             expected_superrole_label.into_typedb().scoped_name(),
             superrole.get_label(tx.snapshot.as_ref(), &tx.type_manager).unwrap().scoped_name()
@@ -361,14 +361,14 @@ pub async fn relation_role_get_supertype_exists(
     exists: ExistsOrDoesnt,
 ) {
     with_read_tx!(context, |tx| {
-        let relation = tx.type_manager.get_relation_type(&tx.snapshot, &relation_label.into_typedb()).unwrap().unwrap();
+        let relation = tx.type_manager.get_relation_type(tx.snapshot.as_ref(), &relation_label.into_typedb()).unwrap().unwrap();
         let role = tx
             .type_manager
-            .resolve_relates(&tx.snapshot, relation, role_label.into_typedb().name().as_str())
+            .resolve_relates(tx.snapshot.as_ref(), relation, role_label.into_typedb().name().as_str())
             .unwrap()
             .unwrap()
             .role();
-        let superrole = role.get_supertype(&tx.snapshot, &tx.type_manager).unwrap();
+        let superrole = role.get_supertype(tx.snapshot.as_ref(), &tx.type_manager).unwrap();
         exists.check(&superrole, &format!("superrole for role type {}", role_label.into_typedb()));
     });
 }
@@ -383,14 +383,14 @@ pub async fn relation_role_supertypes_is_empty(
     step: &Step,
 ) {
     with_read_tx!(context, |tx| {
-        let relation = tx.type_manager.get_relation_type(&tx.snapshot, &relation_label.into_typedb()).unwrap().unwrap();
+        let relation = tx.type_manager.get_relation_type(tx.snapshot.as_ref(), &relation_label.into_typedb()).unwrap().unwrap();
         let role = tx
             .type_manager
-            .resolve_relates(&tx.snapshot, relation, role_label.into_typedb().name().as_str())
+            .resolve_relates(tx.snapshot.as_ref(), relation, role_label.into_typedb().name().as_str())
             .unwrap()
             .unwrap()
             .role();
-        let is_empty = role.get_supertypes_transitive(&tx.snapshot, &tx.type_manager).unwrap().is_empty();
+        let is_empty = role.get_supertypes_transitive(tx.snapshot.as_ref(), &tx.type_manager).unwrap().is_empty();
         is_empty_or_not.check(is_empty);
     });
 }
@@ -580,7 +580,7 @@ pub async fn relation_role_set_annotation(
             }
             TypeDBAnnotation::Distinct(_) | TypeDBAnnotation::Cardinality(_) => {
                 res = relates.set_annotation(
-                    &mut tx.snapshot,
+                    Arc::get_mut(&mut tx.snapshot).unwrap(),
                     &tx.type_manager,
                     &tx.thing_manager,
                     parsed_annotation.try_into().unwrap(),

--- a/tests/behaviour/steps/concept/type_/struct_definition.rs
+++ b/tests/behaviour/steps/concept/type_/struct_definition.rs
@@ -4,6 +4,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
+use std::sync::Arc;
 use cucumber::gherkin::Step;
 use macro_rules_attribute::apply;
 
@@ -21,7 +22,7 @@ pub async fn struct_create(context: &mut Context, type_label: Label, may_error: 
     with_schema_tx!(context, |tx| {
         may_error.check_concept_write_without_read_errors(
             &tx.type_manager
-                .create_struct(&mut tx.snapshot, type_label.into_typedb().scoped_name().as_str().to_owned()),
+                .create_struct(Arc::get_mut(&mut tx.snapshot).unwrap(), type_label.into_typedb().scoped_name().as_str().to_owned()),
         );
     });
 }
@@ -32,11 +33,11 @@ pub async fn struct_delete(context: &mut Context, type_label: Label, may_error: 
     with_schema_tx!(context, |tx| {
         if let Some(definition_key) = &tx
             .type_manager
-            .get_struct_definition_key(&tx.snapshot, type_label.into_typedb().scoped_name().as_str())
+            .get_struct_definition_key(tx.snapshot.as_ref(), type_label.into_typedb().scoped_name().as_str())
             .unwrap()
         {
             may_error.check_concept_write_without_read_errors(&tx.type_manager.delete_struct(
-                &mut tx.snapshot,
+                Arc::get_mut(&mut tx.snapshot).unwrap(),
                 &tx.thing_manager,
                 definition_key,
             ));
@@ -54,11 +55,11 @@ pub async fn struct_exists(context: &mut Context, type_label: Label, exists: Exi
     with_read_tx!(context, |tx| {
         let definition_key_opt = &tx
             .type_manager
-            .get_struct_definition_key(&tx.snapshot, type_label.into_typedb().scoped_name().as_str())
+            .get_struct_definition_key(tx.snapshot.as_ref(), type_label.into_typedb().scoped_name().as_str())
             .unwrap();
         exists.check(&definition_key_opt, &format!("struct definition key for {}", type_label.into_typedb()));
         if let Some(definition_key) = definition_key_opt {
-            let struct_definition = &tx.type_manager.get_struct_definition(&tx.snapshot, definition_key.clone());
+            let struct_definition = &tx.type_manager.get_struct_definition(tx.snapshot.as_ref(), definition_key.clone());
             exists.check_result(&struct_definition, &format!("struct definition for {}", type_label.into_typedb()));
         }
     });
@@ -80,12 +81,12 @@ pub async fn struct_create_field_with_value_type(
     with_schema_tx!(context, |tx| {
         let definition_key = &tx
             .type_manager
-            .get_struct_definition_key(&tx.snapshot, type_label.into_typedb().scoped_name().as_str())
+            .get_struct_definition_key(tx.snapshot.as_ref(), type_label.into_typedb().scoped_name().as_str())
             .unwrap()
             .unwrap();
-        let parsed_value_type = value_type.into_typedb(&tx.type_manager, &tx.snapshot);
+        let parsed_value_type = value_type.into_typedb(&tx.type_manager, tx.snapshot.as_ref());
         may_error.check_concept_write_without_read_errors(&tx.type_manager.create_struct_field(
-            &mut tx.snapshot,
+            Arc::get_mut(&mut tx.snapshot).unwrap(),
             definition_key.clone(),
             field_label.into_typedb().scoped_name().as_str(),
             parsed_value_type,
@@ -100,11 +101,11 @@ pub async fn struct_delete_field(context: &mut Context, type_label: Label, field
     with_schema_tx!(context, |tx| {
         let definition_key = &tx
             .type_manager
-            .get_struct_definition_key(&tx.snapshot, type_label.into_typedb().scoped_name().as_str())
+            .get_struct_definition_key(tx.snapshot.as_ref(), type_label.into_typedb().scoped_name().as_str())
             .unwrap()
             .unwrap();
         may_error.check_concept_write_without_read_errors(&tx.type_manager.delete_struct_field(
-            &mut tx.snapshot,
+            Arc::get_mut(&mut tx.snapshot).unwrap(),
             &tx.thing_manager,
             definition_key.clone(),
             field_label.into_typedb().scoped_name().as_str().to_owned(),
@@ -124,10 +125,10 @@ pub async fn struct_get_fields_contains_or_doesnt(
     with_read_tx!(context, |tx| {
         let definition_key = &tx
             .type_manager
-            .get_struct_definition_key(&tx.snapshot, type_label.into_typedb().scoped_name().as_str())
+            .get_struct_definition_key(tx.snapshot.as_ref(), type_label.into_typedb().scoped_name().as_str())
             .unwrap()
             .unwrap();
-        let struct_definition = &tx.type_manager.get_struct_definition(&tx.snapshot, definition_key.clone()).unwrap();
+        let struct_definition = &tx.type_manager.get_struct_definition(tx.snapshot.as_ref(), definition_key.clone()).unwrap();
         let actual_fields: Vec<String> =
             struct_definition.field_names.keys().cloned().map(|key| key.to_owned()).collect();
         contains_or_doesnt.check(&expected_fields, &actual_fields);
@@ -145,17 +146,17 @@ pub async fn struct_get_field_get_value_type(
     with_read_tx!(context, |tx| {
         let definition_key = &tx
             .type_manager
-            .get_struct_definition_key(&tx.snapshot, type_label.into_typedb().scoped_name().as_str())
+            .get_struct_definition_key(tx.snapshot.as_ref(), type_label.into_typedb().scoped_name().as_str())
             .unwrap()
             .unwrap();
-        let struct_definition = &tx.type_manager.get_struct_definition(&tx.snapshot, definition_key.clone()).unwrap();
+        let struct_definition = &tx.type_manager.get_struct_definition(tx.snapshot.as_ref(), definition_key.clone()).unwrap();
         let actual_value_type = struct_definition
             .fields
             .get(struct_definition.field_names.get(field_label.into_typedb().scoped_name().as_str()).unwrap())
             .unwrap()
             .value_type
             .clone();
-        assert_eq!(value_type.into_typedb(&tx.type_manager, &tx.snapshot), actual_value_type);
+        assert_eq!(value_type.into_typedb(&tx.type_manager, tx.snapshot.as_ref()), actual_value_type);
     });
 }
 
@@ -170,10 +171,10 @@ pub async fn struct_get_field_is_optional(
     with_read_tx!(context, |tx| {
         let definition_key = &tx
             .type_manager
-            .get_struct_definition_key(&tx.snapshot, type_label.into_typedb().scoped_name().as_str())
+            .get_struct_definition_key(tx.snapshot.as_ref(), type_label.into_typedb().scoped_name().as_str())
             .unwrap()
             .unwrap();
-        let struct_definition = &tx.type_manager.get_struct_definition(&tx.snapshot, definition_key.clone()).unwrap();
+        let struct_definition = &tx.type_manager.get_struct_definition(tx.snapshot.as_ref(), definition_key.clone()).unwrap();
         let actual_is_optional = struct_definition
             .fields
             .get(struct_definition.field_names.get(field_label.into_typedb().scoped_name().as_str()).unwrap())

--- a/tests/behaviour/steps/concept/type_/thing_type.rs
+++ b/tests/behaviour/steps/concept/type_/thing_type.rs
@@ -410,20 +410,20 @@ pub async fn type_unset_supertype(
         match root_label.into_typedb() {
             Kind::Attribute => {
                 let thistype =
-                    tx.type_manager.get_attribute_type(&tx.snapshot, &type_label.into_typedb()).unwrap().unwrap();
-                let res = thistype.unset_supertype(&mut tx.snapshot, &tx.type_manager, &tx.thing_manager);
+                    tx.type_manager.get_attribute_type(tx.snapshot.as_ref(), &type_label.into_typedb()).unwrap().unwrap();
+                let res = thistype.unset_supertype(Arc::get_mut(&mut tx.snapshot).unwrap(), &tx.type_manager, &tx.thing_manager);
                 may_error.check_concept_write_without_read_errors(&res);
             }
             Kind::Entity => {
                 let thistype =
-                    tx.type_manager.get_entity_type(&tx.snapshot, &type_label.into_typedb()).unwrap().unwrap();
-                let res = thistype.unset_supertype(&mut tx.snapshot, &tx.type_manager, &tx.thing_manager);
+                    tx.type_manager.get_entity_type(tx.snapshot.as_ref(), &type_label.into_typedb()).unwrap().unwrap();
+                let res = thistype.unset_supertype(Arc::get_mut(&mut tx.snapshot).unwrap(), &tx.type_manager, &tx.thing_manager);
                 may_error.check_concept_write_without_read_errors(&res);
             }
             Kind::Relation => {
                 let thistype =
-                    tx.type_manager.get_relation_type(&tx.snapshot, &type_label.into_typedb()).unwrap().unwrap();
-                let res = thistype.unset_supertype(&mut tx.snapshot, &tx.type_manager, &tx.thing_manager);
+                    tx.type_manager.get_relation_type(tx.snapshot.as_ref(), &type_label.into_typedb()).unwrap().unwrap();
+                let res = thistype.unset_supertype(Arc::get_mut(&mut tx.snapshot).unwrap(), &tx.type_manager, &tx.thing_manager);
                 may_error.check_concept_write_without_read_errors(&res);
             }
             Kind::Role => unreachable!("Can only address roles through relation(relation_label) get role(role_name)"),
@@ -460,7 +460,7 @@ pub async fn type_get_supertype_exists(
 ) {
     with_read_tx!(context, |tx| {
         with_type!(tx, root_label, type_label, type_, {
-            let supertype = type_.get_supertype(&tx.snapshot, &tx.type_manager).unwrap();
+            let supertype = type_.get_supertype(tx.snapshot.as_ref(), &tx.type_manager).unwrap();
             exists.check(&supertype, &format!("supertype for type {}", type_label.into_typedb()));
         });
     });
@@ -559,38 +559,38 @@ pub async fn get_types_contain(
         match root_label {
             RootLabelExtended::Entity => &tx
                 .type_manager
-                .get_entity_types(&tx.snapshot)
+                .get_entity_types(tx.snapshot.as_ref())
                 .unwrap()
                 .into_iter()
-                .map(|type_| type_.get_label(&tx.snapshot, &tx.type_manager).unwrap().scoped_name().as_str().to_owned())
+                .map(|type_| type_.get_label(tx.snapshot.as_ref(), &tx.type_manager).unwrap().scoped_name().as_str().to_owned())
                 .collect_vec(),
             RootLabelExtended::Relation => &tx
                 .type_manager
-                .get_relation_types(&tx.snapshot)
+                .get_relation_types(tx.snapshot.as_ref())
                 .unwrap()
                 .into_iter()
-                .map(|type_| type_.get_label(&tx.snapshot, &tx.type_manager).unwrap().scoped_name().as_str().to_owned())
+                .map(|type_| type_.get_label(tx.snapshot.as_ref(), &tx.type_manager).unwrap().scoped_name().as_str().to_owned())
                 .collect_vec(),
             RootLabelExtended::Attribute => &tx
                 .type_manager
-                .get_attribute_types(&tx.snapshot)
+                .get_attribute_types(tx.snapshot.as_ref())
                 .unwrap()
                 .into_iter()
-                .map(|type_| type_.get_label(&tx.snapshot, &tx.type_manager).unwrap().scoped_name().as_str().to_owned())
+                .map(|type_| type_.get_label(tx.snapshot.as_ref(), &tx.type_manager).unwrap().scoped_name().as_str().to_owned())
                 .collect_vec(),
             RootLabelExtended::Role => &tx
                 .type_manager
-                .get_role_types(&tx.snapshot)
+                .get_role_types(tx.snapshot.as_ref())
                 .unwrap()
                 .into_iter()
-                .map(|type_| type_.get_label(&tx.snapshot, &tx.type_manager).unwrap().scoped_name().as_str().to_owned())
+                .map(|type_| type_.get_label(tx.snapshot.as_ref(), &tx.type_manager).unwrap().scoped_name().as_str().to_owned())
                 .collect_vec(),
             RootLabelExtended::Object => &tx
                 .type_manager
-                .get_object_types(&tx.snapshot)
+                .get_object_types(tx.snapshot.as_ref())
                 .unwrap()
                 .into_iter()
-                .map(|type_| type_.get_label(&tx.snapshot, &tx.type_manager).unwrap().scoped_name().as_str().to_owned())
+                .map(|type_| type_.get_label(tx.snapshot.as_ref(), &tx.type_manager).unwrap().scoped_name().as_str().to_owned())
                 .collect_vec(),
         }
     });
@@ -602,11 +602,11 @@ pub async fn get_types_contain(
 pub async fn get_types_empty(context: &mut Context, root_label: RootLabelExtended, is_empty_or_not: IsEmptyOrNot) {
     let is_empty = with_read_tx!(context, |tx| {
         match root_label {
-            RootLabelExtended::Entity => &tx.type_manager.get_entity_types(&tx.snapshot).unwrap().is_empty(),
-            RootLabelExtended::Relation => &tx.type_manager.get_relation_types(&tx.snapshot).unwrap().is_empty(),
-            RootLabelExtended::Attribute => &tx.type_manager.get_attribute_types(&tx.snapshot).unwrap().is_empty(),
-            RootLabelExtended::Role => &tx.type_manager.get_role_types(&tx.snapshot).unwrap().is_empty(),
-            RootLabelExtended::Object => &tx.type_manager.get_object_types(&tx.snapshot).unwrap().is_empty(),
+            RootLabelExtended::Entity => &tx.type_manager.get_entity_types(tx.snapshot.as_ref()).unwrap().is_empty(),
+            RootLabelExtended::Relation => &tx.type_manager.get_relation_types(tx.snapshot.as_ref()).unwrap().is_empty(),
+            RootLabelExtended::Attribute => &tx.type_manager.get_attribute_types(tx.snapshot.as_ref()).unwrap().is_empty(),
+            RootLabelExtended::Role => &tx.type_manager.get_role_types(tx.snapshot.as_ref()).unwrap().is_empty(),
+            RootLabelExtended::Object => &tx.type_manager.get_object_types(tx.snapshot.as_ref()).unwrap().is_empty(),
         }
     });
     is_empty_or_not.check(*is_empty)

--- a/tests/behaviour/steps/connection/mod.rs
+++ b/tests/behaviour/steps/connection/mod.rs
@@ -37,5 +37,5 @@ pub async fn connection_ignore(_: &mut Context) {}
 #[apply(generic_step)]
 #[step("connection does not have any database")]
 pub async fn connection_does_not_have_any_database(context: &mut Context) {
-    assert!(context.server.as_ref().unwrap().lock().unwrap().databases().is_empty())
+    assert!(context.server().unwrap().lock().unwrap().database_manager().database_names().is_empty())
 }

--- a/tests/behaviour/steps/connection/transaction.rs
+++ b/tests/behaviour/steps/connection/transaction.rs
@@ -7,6 +7,7 @@
 use concept::error::ConceptWriteError;
 use database::transaction::{DataCommitError, SchemaCommitError, TransactionRead, TransactionSchema, TransactionWrite};
 use macro_rules_attribute::apply;
+use options::TransactionOptions;
 
 use crate::{
     assert::assert_matches,
@@ -22,9 +23,9 @@ pub async fn connection_open_transaction(context: &mut Context, tx_type: String,
     let server = context.server().unwrap().lock().unwrap();
     let database = server.database_manager().database(&db_name).unwrap();
     let tx = match tx_type.as_str() {
-        "read" => ActiveTransaction::Read(TransactionRead::open(database.clone())),
-        "write" => ActiveTransaction::Write(TransactionWrite::open(database.clone())),
-        "schema" => ActiveTransaction::Schema(TransactionSchema::open(database.clone())),
+        "read" => ActiveTransaction::Read(TransactionRead::open(database.clone(), TransactionOptions::default())),
+        "write" => ActiveTransaction::Write(TransactionWrite::open(database.clone(), TransactionOptions::default())),
+        "schema" => ActiveTransaction::Schema(TransactionSchema::open(database.clone(), TransactionOptions::default())),
         _ => unreachable!("Unrecognised transaction type"),
     };
     drop(server);


### PR DESCRIPTION
## Usage and product changes
We flesh out the architecture of the new 3.0 Protocol, the Transaction service, database transaction exclusivity between write and schema transactions, and introduce the TypeDBError enum which exposes the APIs required to generate stack traces and error messages.

We also implement full database cleanup on deletion, which has dramatically sped up the runtime of BDD tests!

## Implementation

Note: partially complete GRPC transaction service only.