### PR TITLE
Refactor vertices conversion to reduce clones and clean up test code. Remove RootLabel name usages

### DIFF
--- a/answer/lib.rs
+++ b/answer/lib.rs
@@ -15,11 +15,13 @@ use concept::{
     },
 };
 use encoding::{
-    graph::type_::{vertex::TypeVertex, Kind},
+    graph::type_::{
+        vertex::{TypeVertex, TypeVertexEncoding},
+        Kind,
+    },
     value::value::Value,
     AsBytes,
 };
-use encoding::graph::type_::vertex::TypeVertexEncoding;
 use lending_iterator::higher_order::Hkt;
 
 pub mod answer_map;

--- a/answer/lib.rs
+++ b/answer/lib.rs
@@ -19,6 +19,7 @@ use encoding::{
     value::value::Value,
     AsBytes,
 };
+use encoding::graph::type_::vertex::TypeVertexEncoding;
 use lending_iterator::higher_order::Hkt;
 
 pub mod answer_map;

--- a/common/error/error.rs
+++ b/common/error/error.rs
@@ -4,11 +4,12 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-use std::error::Error;
-use std::fmt::{Debug, Display, Formatter};
+use std::{
+    error::Error,
+    fmt::{Debug, Display, Formatter},
+};
 
 pub trait TypeDBError {
-
     fn variant_name(&self) -> &'static str;
 
     fn domain(&self) -> &'static str;
@@ -25,7 +26,10 @@ pub trait TypeDBError {
 
     fn source_typedb_error(&self) -> Option<&dyn TypeDBError>;
 
-    fn root_source_typedb_error(&self) -> &dyn TypeDBError where Self: Sized {
+    fn root_source_typedb_error(&self) -> &dyn TypeDBError
+    where
+        Self: Sized,
+    {
         let mut error: &dyn TypeDBError = self;
         while let Some(source) = error.source_typedb_error() {
             error = source;
@@ -57,7 +61,6 @@ impl Display for dyn TypeDBError {
         }
     }
 }
-
 
 // ***USAGE WARNING***: We should not set both Source and TypeDBSource, TypeDBSource has precedence!
 #[macro_export]

--- a/common/options/options.rs
+++ b/common/options/options.rs
@@ -16,7 +16,7 @@ impl Default for TransactionOptions {
     fn default() -> Self {
         Self {
             parallel: DEFAULT_TRANSACTION_PARALLEL,
-            schema_lock_acquire_timeout_millis: DEFAULT_SCHEMA_LOCK_ACQUIRE_TIMEOUT_MILLIS
+            schema_lock_acquire_timeout_millis: DEFAULT_SCHEMA_LOCK_ACQUIRE_TIMEOUT_MILLIS,
         }
     }
 }

--- a/concept/error.rs
+++ b/concept/error.rs
@@ -47,7 +47,6 @@ impl Error for ConceptError {
 
 #[derive(Debug, Clone)]
 pub enum ConceptWriteError {
-    RootModification,
     SnapshotGet { source: SnapshotGetError },
     SnapshotIterate { source: Arc<SnapshotIteratorError> },
     ConceptRead { source: ConceptReadError },
@@ -78,7 +77,6 @@ impl Error for ConceptWriteError {
             Self::Encoding { source, .. } => Some(source),
             Self::SchemaValidation { source, .. } => Some(source),
             Self::DataValidation { source, .. } => Some(source),
-            Self::RootModification { .. } => None,
             Self::Annotation { .. } => None,
             Self::SetHasOrderedOwnsUnordered { .. } => None,
             Self::SetPlayersOrderedRoleUnordered { .. } => None,

--- a/concept/thing/attribute.rs
+++ b/concept/thing/attribute.rs
@@ -16,14 +16,13 @@ use bytes::{byte_array::ByteArray, Bytes};
 use encoding::{
     graph::{
         thing::{edge::ThingEdgeHasReverse, vertex_attribute::AttributeVertex, ThingVertex},
-        type_::vertex::PrefixedTypeVertexEncoding,
+        type_::vertex::{PrefixedTypeVertexEncoding, TypeVertexEncoding},
         Typed,
     },
     layout::prefix::Prefix,
     value::{decode_value_u64, value::Value, value_type::ValueType},
     AsBytes, Keyable,
 };
-use encoding::graph::type_::vertex::TypeVertexEncoding;
 use iterator::State;
 use lending_iterator::{higher_order::Hkt, LendingIterator, Peekable};
 use resource::constants::snapshot::{BUFFER_KEY_INLINE, BUFFER_VALUE_INLINE};

--- a/concept/thing/attribute.rs
+++ b/concept/thing/attribute.rs
@@ -23,6 +23,7 @@ use encoding::{
     value::{decode_value_u64, value::Value, value_type::ValueType},
     AsBytes, Keyable,
 };
+use encoding::graph::type_::vertex::TypeVertexEncoding;
 use iterator::State;
 use lending_iterator::{higher_order::Hkt, LendingIterator, Peekable};
 use resource::constants::snapshot::{BUFFER_KEY_INLINE, BUFFER_VALUE_INLINE};

--- a/concept/thing/entity.rs
+++ b/concept/thing/entity.rs
@@ -4,21 +4,18 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-use std::{
-    fmt::{Display, Formatter},
-};
+use std::fmt::{Display, Formatter};
 
 use bytes::{byte_array::ByteArray, Bytes};
 use encoding::{
     graph::{
         thing::{vertex_object::ObjectVertex, ThingVertex},
-        type_::vertex::PrefixedTypeVertexEncoding,
+        type_::vertex::{PrefixedTypeVertexEncoding, TypeVertexEncoding},
         Typed,
     },
     layout::prefix::Prefix,
     AsBytes, Keyable, Prefixed,
 };
-use encoding::graph::type_::vertex::TypeVertexEncoding;
 use lending_iterator::{higher_order::Hkt, LendingIterator};
 use storage::snapshot::{ReadableSnapshot, WritableSnapshot};
 

--- a/concept/thing/entity.rs
+++ b/concept/thing/entity.rs
@@ -5,7 +5,6 @@
  */
 
 use std::{
-    collections::HashSet,
     fmt::{Display, Formatter},
 };
 
@@ -19,7 +18,7 @@ use encoding::{
     layout::prefix::Prefix,
     AsBytes, Keyable, Prefixed,
 };
-use iterator::Collector;
+use encoding::graph::type_::vertex::TypeVertexEncoding;
 use lending_iterator::{higher_order::Hkt, LendingIterator};
 use storage::snapshot::{ReadableSnapshot, WritableSnapshot};
 
@@ -27,7 +26,7 @@ use crate::{
     error::{ConceptReadError, ConceptWriteError},
     thing::{
         object::{Object, ObjectAPI},
-        relation::{IndexedPlayersIterator, RelationRoleIterator},
+        relation::IndexedPlayersIterator,
         thing_manager::ThingManager,
         HKInstance, ThingAPI,
     },

--- a/concept/thing/object.rs
+++ b/concept/thing/object.rs
@@ -38,8 +38,8 @@ use crate::{
         HKInstance, ThingAPI,
     },
     type_::{
-        attribute_type::AttributeType, object_type::ObjectType, role_type::RoleType,
-        type_manager::TypeManager, Capability, ObjectTypeAPI, Ordering, OwnerAPI, TypeAPI,
+        attribute_type::AttributeType, object_type::ObjectType, role_type::RoleType, type_manager::TypeManager,
+        Capability, ObjectTypeAPI, Ordering, OwnerAPI, TypeAPI,
     },
     ConceptStatus,
 };

--- a/concept/thing/object.rs
+++ b/concept/thing/object.rs
@@ -38,8 +38,8 @@ use crate::{
         HKInstance, ThingAPI,
     },
     type_::{
-        attribute_type::AttributeType, object_type::ObjectType, owns::Owns, role_type::RoleType,
-        type_manager::TypeManager, Capability, ObjectTypeAPI, Ordering, OwnerAPI, PlayerAPI, TypeAPI,
+        attribute_type::AttributeType, object_type::ObjectType, role_type::RoleType,
+        type_manager::TypeManager, Capability, ObjectTypeAPI, Ordering, OwnerAPI, TypeAPI,
     },
     ConceptStatus,
 };

--- a/concept/thing/relation.rs
+++ b/concept/thing/relation.rs
@@ -24,6 +24,7 @@ use encoding::{
     value::decode_value_u64,
     AsBytes, Keyable, Prefixed,
 };
+use encoding::graph::type_::vertex::TypeVertexEncoding;
 use lending_iterator::{higher_order::Hkt, LendingIterator};
 use resource::constants::snapshot::{BUFFER_KEY_INLINE, BUFFER_VALUE_INLINE};
 use storage::{
@@ -40,11 +41,9 @@ use crate::{
         HKInstance, ThingAPI,
     },
     type_::{
-        annotation::AnnotationDistinct,
-        relates::RelatesAnnotation,
         relation_type::RelationType,
         role_type::RoleType,
-        type_manager::{type_reader::TypeReader, TypeManager},
+        type_manager::TypeManager,
         Capability, ObjectTypeAPI, Ordering, OwnerAPI, TypeAPI,
     },
     ByteReference, ConceptAPI, ConceptStatus,

--- a/concept/thing/relation.rs
+++ b/concept/thing/relation.rs
@@ -17,14 +17,13 @@ use encoding::{
             vertex_object::ObjectVertex,
             ThingVertex,
         },
-        type_::vertex::PrefixedTypeVertexEncoding,
+        type_::vertex::{PrefixedTypeVertexEncoding, TypeVertexEncoding},
         Typed,
     },
     layout::prefix::Prefix,
     value::decode_value_u64,
     AsBytes, Keyable, Prefixed,
 };
-use encoding::graph::type_::vertex::TypeVertexEncoding;
 use lending_iterator::{higher_order::Hkt, LendingIterator};
 use resource::constants::snapshot::{BUFFER_KEY_INLINE, BUFFER_VALUE_INLINE};
 use storage::{
@@ -41,10 +40,8 @@ use crate::{
         HKInstance, ThingAPI,
     },
     type_::{
-        relation_type::RelationType,
-        role_type::RoleType,
-        type_manager::TypeManager,
-        Capability, ObjectTypeAPI, Ordering, OwnerAPI, TypeAPI,
+        relation_type::RelationType, role_type::RoleType, type_manager::TypeManager, Capability, ObjectTypeAPI,
+        Ordering, OwnerAPI, TypeAPI,
     },
     ByteReference, ConceptAPI, ConceptStatus,
 };

--- a/concept/thing/statistics.rs
+++ b/concept/thing/statistics.rs
@@ -24,6 +24,7 @@ use encoding::graph::{
     Typed,
 };
 use serde::{Deserialize, Serialize};
+use encoding::graph::type_::vertex::TypeVertexEncoding;
 use storage::{
     durability_client::{DurabilityClient, DurabilityClientError, DurabilityRecord, UnsequencedDurabilityRecord},
     isolation_manager::CommitType,

--- a/concept/thing/statistics.rs
+++ b/concept/thing/statistics.rs
@@ -20,11 +20,10 @@ use encoding::graph::{
         vertex_object::ObjectVertex,
         ThingVertex,
     },
-    type_::vertex::{PrefixedTypeVertexEncoding, TypeID, TypeIDUInt},
+    type_::vertex::{PrefixedTypeVertexEncoding, TypeID, TypeIDUInt, TypeVertexEncoding},
     Typed,
 };
 use serde::{Deserialize, Serialize};
-use encoding::graph::type_::vertex::TypeVertexEncoding;
 use storage::{
     durability_client::{DurabilityClient, DurabilityClientError, DurabilityRecord, UnsequencedDurabilityRecord},
     isolation_manager::CommitType,

--- a/concept/thing/thing_manager.rs
+++ b/concept/thing/thing_manager.rs
@@ -877,7 +877,7 @@ impl ThingManager {
 
     fn create_commit_locks(&self, snapshot: &mut impl WritableSnapshot) -> Result<(), ConceptReadError> {
         // TODO: Should not collect here (iterate_writes() already copies)
-        for (key, write) in snapshot.iterate_writes().collect_vec() {
+        for (key, _) in snapshot.iterate_writes().collect_vec() {
             let key_reference = StorageKeyReference::from(&key);
             if ThingEdgeHas::is_has(key_reference) {
                 let has = ThingEdgeHas::new(Bytes::Reference(key_reference.byte_ref()));

--- a/concept/thing/thing_manager/validation/operation_time_validation.rs
+++ b/concept/thing/thing_manager/validation/operation_time_validation.rs
@@ -317,8 +317,8 @@ impl OperationTimeValidation {
         let uniqueness_source = owns
             .get_uniqueness_source(snapshot, thing_manager.type_manager())
             .map_err(DataValidationError::ConceptRead)?;
-        if let Some(unique_root) = uniqueness_source {
-            let mut queue = VecDeque::from([(unique_root.owner(), unique_root.clone())]);
+        if let Some(unique_source) = uniqueness_source {
+            let mut queue = VecDeque::from([(unique_source.owner(), unique_source.clone())]);
 
             while let Some((current_owner_type, current_owns)) = queue.pop_back() {
                 let mut objects = thing_manager.get_objects_in(snapshot, current_owner_type.clone());

--- a/concept/type_/annotation.rs
+++ b/concept/type_/annotation.rs
@@ -583,7 +583,7 @@ macro_rules! empty_type_vertex_property_encoding {
                 $property
             }
 
-            fn to_value_bytes(self) -> Option<Bytes<'a, BUFFER_VALUE_INLINE>> {
+            fn to_value_bytes(&self) -> Option<Bytes<'a, BUFFER_VALUE_INLINE>> {
                 None
             }
         }
@@ -597,11 +597,11 @@ macro_rules! unreachable_type_vertex_property_encoding {
         impl<'a> TypeVertexPropertyEncoding<'a> for $property {
             const INFIX: Infix = $infix;
 
-            fn from_value_bytes<'b>(value: ByteReference<'b>) -> $property {
+            fn from_value_bytes<'b>(_: ByteReference<'b>) -> $property {
                 unreachable!("TypeVertexPropertyEncoding is not be implemented for {}", stringify!($property))
             }
 
-            fn to_value_bytes(self) -> Option<Bytes<'a, BUFFER_VALUE_INLINE>> {
+            fn to_value_bytes(&self) -> Option<Bytes<'a, BUFFER_VALUE_INLINE>> {
                 unreachable!("TypeVertexPropertyEncoding is not be implemented for {}", stringify!($property))
             }
         }
@@ -626,7 +626,7 @@ impl<'a> TypeVertexPropertyEncoding<'a> for AnnotationRegex {
         AnnotationRegex::new(std::str::from_utf8(value.bytes()).unwrap().to_owned())
     }
 
-    fn to_value_bytes(self) -> Option<Bytes<'a, BUFFER_VALUE_INLINE>> {
+    fn to_value_bytes(&self) -> Option<Bytes<'a, BUFFER_VALUE_INLINE>> {
         Some(Bytes::Array(ByteArray::copy(self.regex().as_bytes())))
     }
 }
@@ -639,7 +639,7 @@ impl<'a> TypeVertexPropertyEncoding<'a> for AnnotationRange {
         bincode::deserialize(value.bytes()).unwrap()
     }
 
-    fn to_value_bytes(self) -> Option<Bytes<'a, BUFFER_VALUE_INLINE>> {
+    fn to_value_bytes(&self) -> Option<Bytes<'a, BUFFER_VALUE_INLINE>> {
         Some(Bytes::copy(bincode::serialize(&self).unwrap().as_slice()))
     }
 }
@@ -652,7 +652,7 @@ impl<'a> TypeVertexPropertyEncoding<'a> for AnnotationValues {
         bincode::deserialize(value.bytes()).unwrap()
     }
 
-    fn to_value_bytes(self) -> Option<Bytes<'a, BUFFER_VALUE_INLINE>> {
+    fn to_value_bytes(&self) -> Option<Bytes<'a, BUFFER_VALUE_INLINE>> {
         Some(Bytes::copy(bincode::serialize(&self).unwrap().as_slice()))
     }
 }
@@ -667,7 +667,7 @@ macro_rules! empty_type_edge_property_encoder {
                 $property
             }
 
-            fn to_value_bytes(self) -> Option<Bytes<'a, BUFFER_VALUE_INLINE>> {
+            fn to_value_bytes(&self) -> Option<Bytes<'a, BUFFER_VALUE_INLINE>> {
                 None
             }
         }
@@ -681,11 +681,11 @@ macro_rules! unreachable_type_edge_property_encoder {
         impl<'a> TypeEdgePropertyEncoding<'a> for $property {
             const INFIX: Infix = $infix;
 
-            fn from_value_bytes<'b>(value: ByteReference<'b>) -> $property {
+            fn from_value_bytes<'b>(_: ByteReference<'b>) -> $property {
                 unreachable!("TypeEdgePropertyEncoding is not be implemented for {}", stringify!($property))
             }
 
-            fn to_value_bytes(self) -> Option<Bytes<'a, BUFFER_VALUE_INLINE>> {
+            fn to_value_bytes(&self) -> Option<Bytes<'a, BUFFER_VALUE_INLINE>> {
                 unreachable!("TypeEdgePropertyEncoding is not be implemented for {}", stringify!($property))
             }
         }
@@ -708,8 +708,8 @@ impl<'a> TypeEdgePropertyEncoding<'a> for AnnotationCardinality {
         bincode::deserialize(value.bytes()).unwrap()
     }
 
-    fn to_value_bytes(self) -> Option<Bytes<'a, BUFFER_VALUE_INLINE>> {
-        Some(Bytes::copy(bincode::serialize(&self).unwrap().as_slice()))
+    fn to_value_bytes(&self) -> Option<Bytes<'a, BUFFER_VALUE_INLINE>> {
+        Some(Bytes::copy(bincode::serialize(self).unwrap().as_slice()))
     }
 }
 
@@ -721,7 +721,7 @@ impl<'a> TypeEdgePropertyEncoding<'a> for AnnotationRegex {
         AnnotationRegex::new(std::str::from_utf8(value.bytes()).unwrap().to_owned())
     }
 
-    fn to_value_bytes(self) -> Option<Bytes<'a, BUFFER_VALUE_INLINE>> {
+    fn to_value_bytes(&self) -> Option<Bytes<'a, BUFFER_VALUE_INLINE>> {
         Some(Bytes::Array(ByteArray::copy(self.regex().as_bytes())))
     }
 }
@@ -734,7 +734,7 @@ impl<'a> TypeEdgePropertyEncoding<'a> for AnnotationRange {
         bincode::deserialize(value.bytes()).unwrap()
     }
 
-    fn to_value_bytes(self) -> Option<Bytes<'a, BUFFER_VALUE_INLINE>> {
+    fn to_value_bytes(&self) -> Option<Bytes<'a, BUFFER_VALUE_INLINE>> {
         Some(Bytes::copy(bincode::serialize(&self).unwrap().as_slice()))
     }
 }
@@ -747,7 +747,7 @@ impl<'a> TypeEdgePropertyEncoding<'a> for AnnotationValues {
         bincode::deserialize(value.bytes()).unwrap()
     }
 
-    fn to_value_bytes(self) -> Option<Bytes<'a, BUFFER_VALUE_INLINE>> {
+    fn to_value_bytes(&self) -> Option<Bytes<'a, BUFFER_VALUE_INLINE>> {
         Some(Bytes::copy(bincode::serialize(&self).unwrap().as_slice()))
     }
 }

--- a/concept/type_/attribute_type.rs
+++ b/concept/type_/attribute_type.rs
@@ -67,6 +67,10 @@ impl<'a> TypeVertexEncoding<'a> for AttributeType<'a> {
         }
     }
 
+    fn vertex(&self) -> TypeVertex<'_> {
+        self.vertex.as_reference()
+    }
+
     fn into_vertex(self) -> TypeVertex<'a> {
         self.vertex
     }
@@ -87,10 +91,6 @@ impl<'a> TypeAPI<'a> for AttributeType<'a> {
 
     fn new(vertex: TypeVertex<'a>) -> AttributeType<'a> {
         Self::from_vertex(vertex).unwrap()
-    }
-
-    fn vertex(&self) -> TypeVertex<'_> {
-        self.vertex.as_reference()
     }
 
     fn is_abstract(
@@ -153,7 +153,7 @@ impl<'a> TypeAPI<'a> for AttributeType<'a> {
 
 impl<'a> KindAPI<'a> for AttributeType<'a> {
     type AnnotationType = AttributeTypeAnnotation;
-    const ROOT_KIND: Kind = Kind::Attribute;
+    const KIND: Kind = Kind::Attribute;
 
     fn get_annotations_declared<'m>(
         &self,

--- a/concept/type_/constraint.rs
+++ b/concept/type_/constraint.rs
@@ -6,19 +6,13 @@
 
 use std::collections::{HashMap, HashSet};
 
-use storage::snapshot::{ReadableSnapshot, WritableSnapshot};
-
 use crate::{
-    error::ConceptReadError,
-    thing::thing_manager::ThingManager,
     type_::{
         annotation::{
             Annotation, AnnotationAbstract, AnnotationCardinality, AnnotationCascade, AnnotationCategory,
             AnnotationDistinct, AnnotationError, AnnotationIndependent, AnnotationKey, AnnotationRange,
-            AnnotationRegex, AnnotationUnique, AnnotationValues, DefaultFrom,
+            AnnotationRegex, AnnotationUnique, AnnotationValues,
         },
-        owns::Owns,
-        type_manager::{type_reader::TypeReader, TypeManager},
         Capability,
     },
 };

--- a/concept/type_/constraint.rs
+++ b/concept/type_/constraint.rs
@@ -6,15 +6,13 @@
 
 use std::collections::{HashMap, HashSet};
 
-use crate::{
-    type_::{
-        annotation::{
-            Annotation, AnnotationAbstract, AnnotationCardinality, AnnotationCascade, AnnotationCategory,
-            AnnotationDistinct, AnnotationError, AnnotationIndependent, AnnotationKey, AnnotationRange,
-            AnnotationRegex, AnnotationUnique, AnnotationValues,
-        },
-        Capability,
+use crate::type_::{
+    annotation::{
+        Annotation, AnnotationAbstract, AnnotationCardinality, AnnotationCascade, AnnotationCategory,
+        AnnotationDistinct, AnnotationError, AnnotationIndependent, AnnotationKey, AnnotationRange, AnnotationRegex,
+        AnnotationUnique, AnnotationValues,
     },
+    Capability,
 };
 
 pub struct Constraint {}

--- a/concept/type_/entity_type.rs
+++ b/concept/type_/entity_type.rs
@@ -74,6 +74,10 @@ impl<'a> TypeVertexEncoding<'a> for EntityType<'a> {
         }
     }
 
+    fn vertex(&self) -> TypeVertex<'_> {
+        self.vertex.as_reference()
+    }
+
     fn into_vertex(self) -> TypeVertex<'a> {
         self.vertex
     }
@@ -83,10 +87,6 @@ impl<'a> TypeAPI<'a> for EntityType<'a> {
     type SelfStatic = EntityType<'static>;
     fn new(vertex: TypeVertex<'a>) -> EntityType<'a> {
         Self::from_vertex(vertex).unwrap()
-    }
-
-    fn vertex(&self) -> TypeVertex<'_> {
-        self.vertex.as_reference()
     }
 
     fn is_abstract(
@@ -155,7 +155,7 @@ impl<'a> ObjectTypeAPI<'a> for EntityType<'a> {
 
 impl<'a> KindAPI<'a> for EntityType<'a> {
     type AnnotationType = EntityTypeAnnotation;
-    const ROOT_KIND: Kind = Kind::Entity;
+    const KIND: Kind = Kind::Entity;
 
     fn get_annotations_declared<'m>(
         &self,

--- a/concept/type_/mod.rs
+++ b/concept/type_/mod.rs
@@ -64,8 +64,6 @@ pub trait TypeAPI<'a>: ConceptAPI<'a> + TypeVertexEncoding<'a> + Sized + Clone +
         Self::from_bytes(b).unwrap()
     }
 
-    fn vertex(&self) -> TypeVertex<'_>;
-
     fn is_abstract(
         &self,
         snapshot: &impl ReadableSnapshot,
@@ -120,7 +118,7 @@ pub trait TypeAPI<'a>: ConceptAPI<'a> + TypeVertexEncoding<'a> + Sized + Clone +
 
 pub trait KindAPI<'a>: TypeAPI<'a> {
     type AnnotationType: Hash + Eq + Clone + TryFrom<Annotation, Error = AnnotationError> + Into<Annotation>;
-    const ROOT_KIND: Kind;
+    const KIND: Kind;
 
     fn get_annotations_declared<'this>(
         &'this self,
@@ -340,7 +338,7 @@ impl<'a> TypeVertexPropertyEncoding<'a> for Ordering {
         bincode::deserialize(value.bytes()).unwrap()
     }
 
-    fn to_value_bytes(self) -> Option<Bytes<'a, BUFFER_VALUE_INLINE>> {
+    fn to_value_bytes(&self) -> Option<Bytes<'a, BUFFER_VALUE_INLINE>> {
         Some(Bytes::copy(bincode::serialize(&self).unwrap().as_slice()))
     }
 }
@@ -352,7 +350,7 @@ impl<'a> TypeEdgePropertyEncoding<'a> for Ordering {
         bincode::deserialize(value.bytes()).unwrap()
     }
 
-    fn to_value_bytes(self) -> Option<Bytes<'a, BUFFER_VALUE_INLINE>> {
+    fn to_value_bytes(&self) -> Option<Bytes<'a, BUFFER_VALUE_INLINE>> {
         Some(Bytes::copy(bincode::serialize(&self).unwrap().as_slice()))
     }
 }
@@ -435,7 +433,7 @@ impl<'a, EDGE: TypeEdgeEncoding<'static>> TypeEdgePropertyEncoding<'a> for EdgeO
         Self { overrides: EDGE::decode_canonical_edge(Bytes::Reference(value).into_owned()) }
     }
 
-    fn to_value_bytes(self) -> Option<Bytes<'a, BUFFER_VALUE_INLINE>> {
+    fn to_value_bytes(&self) -> Option<Bytes<'a, BUFFER_VALUE_INLINE>> {
         Some(Bytes::Reference(self.overrides.to_canonical_type_edge().bytes()).into_owned())
     }
 }

--- a/concept/type_/object_type.rs
+++ b/concept/type_/object_type.rs
@@ -66,6 +66,13 @@ impl<'a> TypeVertexEncoding<'a> for ObjectType<'a> {
         }
     }
 
+    fn vertex(&self) -> TypeVertex<'_> {
+        match self {
+            ObjectType::Entity(entity) => entity.vertex(),
+            ObjectType::Relation(relation) => relation.vertex(),
+        }
+    }
+
     fn into_vertex(self) -> TypeVertex<'a> {
         with_object_type!(self, |object| { object.into_vertex() })
     }
@@ -137,13 +144,6 @@ impl<'a> TypeAPI<'a> for ObjectType<'a> {
 
     fn new(vertex: TypeVertex<'a>) -> Self {
         Self::from_vertex(vertex).unwrap()
-    }
-
-    fn vertex(&self) -> TypeVertex<'_> {
-        match self {
-            ObjectType::Entity(entity) => entity.vertex(),
-            ObjectType::Relation(relation) => relation.vertex(),
-        }
     }
 
     fn is_abstract(

--- a/concept/type_/owns.rs
+++ b/concept/type_/owns.rs
@@ -7,10 +7,9 @@
 use std::collections::{HashMap, HashSet};
 
 use encoding::{
-    graph::type_::{edge::TypeEdgeEncoding, CapabilityKind},
+    graph::type_::{edge::TypeEdgeEncoding, vertex::TypeVertexEncoding, CapabilityKind},
     layout::prefix::Prefix,
 };
-use encoding::graph::type_::vertex::TypeVertexEncoding;
 use primitive::maybe_owns::MaybeOwns;
 use storage::snapshot::{ReadableSnapshot, WritableSnapshot};
 

--- a/concept/type_/owns.rs
+++ b/concept/type_/owns.rs
@@ -10,6 +10,7 @@ use encoding::{
     graph::type_::{edge::TypeEdgeEncoding, CapabilityKind},
     layout::prefix::Prefix,
 };
+use encoding::graph::type_::vertex::TypeVertexEncoding;
 use primitive::maybe_owns::MaybeOwns;
 use storage::snapshot::{ReadableSnapshot, WritableSnapshot};
 

--- a/concept/type_/plays.rs
+++ b/concept/type_/plays.rs
@@ -7,10 +7,9 @@
 use std::collections::{HashMap, HashSet};
 
 use encoding::{
-    graph::type_::{edge::TypeEdgeEncoding, CapabilityKind},
+    graph::type_::{edge::TypeEdgeEncoding, vertex::TypeVertexEncoding, CapabilityKind},
     layout::prefix::Prefix,
 };
-use encoding::graph::type_::vertex::TypeVertexEncoding;
 use primitive::maybe_owns::MaybeOwns;
 use storage::snapshot::{ReadableSnapshot, WritableSnapshot};
 

--- a/concept/type_/plays.rs
+++ b/concept/type_/plays.rs
@@ -10,6 +10,7 @@ use encoding::{
     graph::type_::{edge::TypeEdgeEncoding, CapabilityKind},
     layout::prefix::Prefix,
 };
+use encoding::graph::type_::vertex::TypeVertexEncoding;
 use primitive::maybe_owns::MaybeOwns;
 use storage::snapshot::{ReadableSnapshot, WritableSnapshot};
 

--- a/concept/type_/relates.rs
+++ b/concept/type_/relates.rs
@@ -20,11 +20,10 @@ use crate::{
         annotation::{
             Annotation, AnnotationCardinality, AnnotationCategory, AnnotationDistinct, AnnotationError, DefaultFrom,
         },
-        plays::Plays,
         relation_type::RelationType,
         role_type::RoleType,
         type_manager::TypeManager,
-        Capability, Ordering, TypeAPI,
+        Capability, TypeAPI,
     },
 };
 

--- a/concept/type_/relation_type.rs
+++ b/concept/type_/relation_type.rs
@@ -74,6 +74,10 @@ impl<'a> TypeVertexEncoding<'a> for RelationType<'a> {
         }
     }
 
+    fn vertex(&self) -> TypeVertex<'_> {
+        self.vertex.as_reference()
+    }
+
     fn into_vertex(self) -> TypeVertex<'a> {
         self.vertex
     }
@@ -88,10 +92,6 @@ impl<'a> TypeAPI<'a> for RelationType<'a> {
 
     fn new(vertex: TypeVertex<'a>) -> RelationType<'_> {
         Self::from_vertex(vertex).unwrap()
-    }
-
-    fn vertex(&self) -> TypeVertex<'_> {
-        self.vertex.as_reference()
     }
 
     fn is_abstract(
@@ -154,7 +154,7 @@ impl<'a> TypeAPI<'a> for RelationType<'a> {
 
 impl<'a> KindAPI<'a> for RelationType<'a> {
     type AnnotationType = RelationTypeAnnotation;
-    const ROOT_KIND: Kind = Kind::Relation;
+    const KIND: Kind = Kind::Relation;
 
     fn get_annotations_declared<'m>(
         &self,

--- a/concept/type_/role_type.rs
+++ b/concept/type_/role_type.rs
@@ -116,6 +116,10 @@ impl<'a> TypeVertexEncoding<'a> for RoleType<'a> {
         }
     }
 
+    fn vertex(&self) -> TypeVertex<'_> {
+        self.vertex.as_reference()
+    }
+
     fn into_vertex(self) -> TypeVertex<'a> {
         self.vertex
     }
@@ -126,10 +130,6 @@ impl<'a> TypeAPI<'a> for RoleType<'a> {
 
     fn new(vertex: TypeVertex<'a>) -> RoleType<'_> {
         Self::from_vertex(vertex).unwrap()
-    }
-
-    fn vertex(&self) -> TypeVertex<'_> {
-        self.vertex.as_reference()
     }
 
     fn is_abstract(
@@ -192,7 +192,7 @@ impl<'a> TypeAPI<'a> for RoleType<'a> {
 
 impl<'a> KindAPI<'a> for RoleType<'a> {
     type AnnotationType = RoleTypeAnnotation;
-    const ROOT_KIND: Kind = Kind::Role;
+    const KIND: Kind = Kind::Role;
 
     fn get_annotations_declared<'m>(
         &self,

--- a/concept/type_/type_manager.rs
+++ b/concept/type_/type_manager.rs
@@ -44,7 +44,7 @@ use crate::{
         attribute_type::{AttributeType, AttributeTypeAnnotation},
         constraint::Constraint,
         entity_type::{EntityType, EntityTypeAnnotation},
-        object_type::{with_object_type, ObjectType},
+        object_type::ObjectType,
         owns::{Owns, OwnsAnnotation},
         plays::{Plays, PlaysAnnotation},
         relates::{Relates, RelatesAnnotation},
@@ -1226,10 +1226,11 @@ impl TypeManager {
         Ok(())
     }
 
+    // TODO: Check data instances?
     pub fn delete_struct_field(
         &self,
         snapshot: &mut impl WritableSnapshot,
-        thing_manager: &ThingManager,
+        _thing_manager: &ThingManager,
         definition_key: DefinitionKey<'static>,
         field_name: String,
     ) -> Result<(), ConceptWriteError> {
@@ -1240,10 +1241,11 @@ impl TypeManager {
         Ok(())
     }
 
+    // TODO: Check data instances?
     pub fn delete_struct(
         &self,
         snapshot: &mut impl WritableSnapshot,
-        thing_manager: &ThingManager,
+        _thing_manager: &ThingManager,
         definition_key: &DefinitionKey<'static>,
     ) -> Result<(), ConceptWriteError> {
         OperationTimeValidation::validate_deleted_struct_is_not_used_in_schema(snapshot, definition_key)
@@ -1552,7 +1554,7 @@ impl TypeManager {
     ) -> Result<(), ConceptWriteError> {
         debug_assert!(OperationTimeValidation::validate_type_exists(snapshot, type_.clone()).is_ok());
 
-        match T::ROOT_KIND {
+        match T::KIND {
             Kind::Entity | Kind::Attribute => {
                 OperationTimeValidation::validate_label_uniqueness(snapshot, &label.clone().into_owned())
                     .map_err(|source| ConceptWriteError::SchemaValidation { source })?;

--- a/concept/type_/type_manager/type_cache/kind_cache.rs
+++ b/concept/type_/type_manager/type_cache/kind_cache.rs
@@ -11,14 +11,13 @@ use encoding::{
     graph::{
         type_::{
             edge::TypeEdge,
-            vertex::{PrefixedTypeVertexEncoding, TypeVertex},
+            vertex::{PrefixedTypeVertexEncoding, TypeVertex, TypeVertexEncoding},
         },
         Typed,
     },
     layout::prefix::Prefix,
     value::{label::Label, value_type::ValueType},
 };
-use encoding::graph::type_::vertex::TypeVertexEncoding;
 use lending_iterator::LendingIterator;
 use storage::{key_range::KeyRange, snapshot::ReadableSnapshot};
 

--- a/concept/type_/type_manager/type_cache/kind_cache.rs
+++ b/concept/type_/type_manager/type_cache/kind_cache.rs
@@ -18,6 +18,7 @@ use encoding::{
     layout::prefix::Prefix,
     value::{label::Label, value_type::ValueType},
 };
+use encoding::graph::type_::vertex::TypeVertexEncoding;
 use lending_iterator::LendingIterator;
 use storage::{key_range::KeyRange, snapshot::ReadableSnapshot};
 

--- a/concept/type_/type_manager/type_cache/selection.rs
+++ b/concept/type_/type_manager/type_cache/selection.rs
@@ -31,7 +31,7 @@ macro_rules! impl_cache_getter {
             type CacheType = $cache_type;
             fn get_cache<'cache>(type_cache: &'cache TypeCache, type_: $inner_type<'a>) -> &'cache Self::CacheType {
                 use ::encoding::graph::Typed;
-                use $crate::type_::TypeAPI;
+                use encoding::graph::type_::vertex::TypeVertexEncoding;
                 let as_u16 = type_.vertex().type_id_().as_u16();
                 type_cache.$member_name[as_u16 as usize].as_ref().unwrap()
             }

--- a/concept/type_/type_manager/type_reader.rs
+++ b/concept/type_/type_manager/type_reader.rs
@@ -80,7 +80,7 @@ impl TypeReader {
         let key = LabelToTypeVertexIndex::build(&Label::build(name_with_colon.as_str())).into_storage_key();
         let vec = snapshot
             .iterate_range(KeyRange::new_within(key, IdentifierIndex::<TypeVertex<'static>>::FIXED_WIDTH_ENCODING))
-            .collect_cloned_vec(|key, value| match RoleType::from_bytes(Bytes::copy(value.bytes())) {
+            .collect_cloned_vec(|_, value| match RoleType::from_bytes(Bytes::copy(value.bytes())) {
                 Err(_) => None,
                 Ok(role_type) => Some(role_type),
             })

--- a/concept/type_/type_manager/type_writer.rs
+++ b/concept/type_/type_manager/type_writer.rs
@@ -11,22 +11,21 @@ use encoding::{
     graph::{
         definition::{definition_key::DefinitionKey, r#struct::StructDefinition, DefinitionValueEncoding},
         type_::{
-            edge::{TypeEdge, TypeEdgeEncoding},
+            edge::TypeEdgeEncoding,
             index::{LabelToTypeVertexIndex, NameToStructDefinitionIndex},
             property::{TypeEdgePropertyEncoding, TypeVertexPropertyEncoding},
             vertex::TypeVertexEncoding,
         },
     },
-    value::{label::Label, string_bytes::StringBytes, value_type::ValueType},
+    value::{label::Label, value_type::ValueType},
     AsBytes, Keyable,
 };
-use resource::constants::snapshot::BUFFER_KEY_INLINE;
-use storage::{key_range::KeyRange, snapshot::WritableSnapshot};
+use storage::snapshot::WritableSnapshot;
 
 use crate::{
     error::ConceptWriteError,
     type_::{
-        attribute_type::AttributeType, owns::Owns, relates::Relates, relation_type::RelationType, role_type::RoleType,
+        attribute_type::AttributeType, owns::Owns,
         sub::Sub, type_manager::type_reader::TypeReader, EdgeOverride, Ordering, TypeAPI,
     },
 };
@@ -52,10 +51,10 @@ impl<Snapshot: WritableSnapshot> TypeWriter<Snapshot> {
     }
 
     pub(crate) fn storage_delete_struct(snapshot: &mut Snapshot, definition_key: &DefinitionKey<'static>) {
-        let existing_struct = TypeReader::get_struct_definition(snapshot, definition_key.clone());
+        let existing_struct = TypeReader::get_struct_definition(snapshot, definition_key.as_reference());
         if let Ok(struct_definition) = existing_struct {
             let index_key = NameToStructDefinitionIndex::build(struct_definition.name.as_str());
-            snapshot.delete(definition_key.clone().into_storage_key().into_owned_array());
+            snapshot.delete(definition_key.as_storage_key().into_owned_array());
             snapshot.delete(index_key.into_storage_key().into_owned_array());
         }
     }
@@ -83,7 +82,7 @@ impl<Snapshot: WritableSnapshot> TypeWriter<Snapshot> {
     where
         EDGE: TypeEdgeEncoding<'static> + Clone,
     {
-        let canonical_key = capability.clone().to_canonical_type_edge().into_storage_key();
+        let canonical_key = capability.to_canonical_type_edge().into_storage_key();
         let reverse_key = capability.to_reverse_type_edge().into_storage_key();
         debug_assert!(snapshot.contains(canonical_key.as_reference()).unwrap_or(false));
         debug_assert!(snapshot.contains(reverse_key.as_reference()).unwrap_or(false));
@@ -111,9 +110,9 @@ impl<Snapshot: WritableSnapshot> TypeWriter<Snapshot> {
     where
         T: TypeAPI<'static>,
     {
-        let sub_edge = Sub::from_vertices(subtype.clone(), supertype.clone());
-        snapshot.put(sub_edge.clone().to_canonical_type_edge().into_storage_key().into_owned_array());
-        snapshot.put(sub_edge.clone().to_reverse_type_edge().into_storage_key().into_owned_array());
+        let sub_edge = Sub::from_vertices(subtype, supertype);
+        snapshot.put(sub_edge.to_canonical_type_edge().into_storage_key().into_owned_array());
+        snapshot.put(sub_edge.to_reverse_type_edge().into_storage_key().into_owned_array());
     }
 
     pub(crate) fn storage_may_delete_supertype<T>(snapshot: &mut Snapshot, subtype: T) -> Result<(), ConceptWriteError>
@@ -122,9 +121,9 @@ impl<Snapshot: WritableSnapshot> TypeWriter<Snapshot> {
     {
         let supertype = TypeReader::get_supertype(snapshot, subtype.clone())?;
         if let Some(supertype) = supertype {
-            let sub_edge = Sub::from_vertices(subtype.clone(), supertype.clone());
-            snapshot.delete(sub_edge.clone().to_canonical_type_edge().into_storage_key().into_owned_array());
-            snapshot.delete(sub_edge.clone().to_reverse_type_edge().into_storage_key().into_owned_array());
+            let sub_edge = Sub::from_vertices(subtype, supertype);
+            snapshot.delete(sub_edge.to_canonical_type_edge().into_storage_key().into_owned_array());
+            snapshot.delete(sub_edge.to_reverse_type_edge().into_storage_key().into_owned_array());
         }
         Ok(())
     }
@@ -146,16 +145,16 @@ impl<Snapshot: WritableSnapshot> TypeWriter<Snapshot> {
     where
         EDGE: TypeEdgeEncoding<'static> + Clone,
     {
-        snapshot.put(capability.clone().to_canonical_type_edge().into_storage_key().into_owned_array());
-        snapshot.put(capability.clone().to_reverse_type_edge().into_storage_key().into_owned_array());
+        snapshot.put(capability.to_canonical_type_edge().into_storage_key().into_owned_array());
+        snapshot.put(capability.to_reverse_type_edge().into_storage_key().into_owned_array());
     }
 
     pub(crate) fn storage_delete_edge<EDGE>(snapshot: &mut Snapshot, capability: EDGE)
     where
         EDGE: TypeEdgeEncoding<'static> + Clone,
     {
-        snapshot.delete(capability.clone().to_canonical_type_edge().into_storage_key().into_owned_array());
-        snapshot.delete(capability.clone().to_reverse_type_edge().into_storage_key().into_owned_array());
+        snapshot.delete(capability.to_canonical_type_edge().into_storage_key().into_owned_array());
+        snapshot.delete(capability.to_reverse_type_edge().into_storage_key().into_owned_array());
     }
 
     pub(crate) fn storage_insert_type_vertex_property<'a, P>(

--- a/concept/type_/type_manager/type_writer.rs
+++ b/concept/type_/type_manager/type_writer.rs
@@ -25,8 +25,8 @@ use storage::snapshot::WritableSnapshot;
 use crate::{
     error::ConceptWriteError,
     type_::{
-        attribute_type::AttributeType, owns::Owns,
-        sub::Sub, type_manager::type_reader::TypeReader, EdgeOverride, Ordering, TypeAPI,
+        attribute_type::AttributeType, owns::Owns, sub::Sub, type_manager::type_reader::TypeReader, EdgeOverride,
+        Ordering, TypeAPI,
     },
 };
 

--- a/concept/type_/type_manager/validation/commit_time_validation.rs
+++ b/concept/type_/type_manager/validation/commit_time_validation.rs
@@ -627,7 +627,7 @@ impl CommitTimeValidation {
             if supertype_annotations.keys().contains(&annotation) {
                 validation_errors.push(
                     SchemaValidationError::CannotRedeclareInheritedAnnotationWithoutSpecializationForType(
-                        T::ROOT_KIND,
+                        T::KIND,
                         get_label_or_concept_read_err(snapshot, type_.clone())?,
                         get_label_or_concept_read_err(snapshot, supertype.clone())?,
                         annotation.clone().into(),

--- a/concept/type_/type_manager/validation/operation_time_validation.rs
+++ b/concept/type_/type_manager/validation/operation_time_validation.rs
@@ -3574,7 +3574,7 @@ impl OperationTimeValidation {
         type_: T,
     ) -> Result<(), SchemaValidationError> {
         let annotation = Annotation::Abstract(AnnotationAbstract);
-        match T::ROOT_KIND {
+        match T::KIND {
             Kind::Entity => {
                 let entity_type = EntityType::new(type_.vertex().into_owned());
                 Self::validate_new_annotation_compatible_with_entity_type_and_subtypes_instances(
@@ -3628,7 +3628,7 @@ impl OperationTimeValidation {
         type_: T,
         new_supertype: T,
     ) -> Result<(), SchemaValidationError> {
-        match T::ROOT_KIND {
+        match T::KIND {
             Kind::Entity => {
                 let entity_type = EntityType::new(type_.vertex().into_owned());
                 let entity_supertype = EntityType::new(new_supertype.vertex().into_owned());
@@ -3698,7 +3698,7 @@ impl OperationTimeValidation {
         thing_manager: &ThingManager,
         type_: T,
     ) -> Result<bool, ConceptReadError> {
-        match T::ROOT_KIND {
+        match T::KIND {
             Kind::Entity => {
                 let entity_type = EntityType::new(type_.vertex().into_owned());
                 let mut iterator = thing_manager.get_entities_in(snapshot, entity_type.clone().into_owned());

--- a/concept/type_/type_manager/validation/validation.rs
+++ b/concept/type_/type_manager/validation/validation.rs
@@ -12,7 +12,6 @@ use storage::snapshot::ReadableSnapshot;
 
 use crate::{
     error::ConceptReadError,
-    thing::thing_manager::ThingManager,
     type_::{
         annotation::{
             Annotation, AnnotationCardinality, AnnotationCategory, AnnotationKey, AnnotationRange, AnnotationRegex,

--- a/encoding/graph/type_/edge.rs
+++ b/encoding/graph/type_/edge.rs
@@ -141,11 +141,11 @@ pub trait TypeEdgeEncoding<'a>: Sized {
         )
     }
 
-    fn to_canonical_type_edge(self) -> TypeEdge<'a> {
+    fn to_canonical_type_edge(&self) -> TypeEdge<'a> {
         TypeEdge::build(Self::CANONICAL_PREFIX, self.canonical_from().into_vertex(), self.canonical_to().into_vertex())
     }
 
-    fn to_reverse_type_edge(self) -> TypeEdge<'a> {
+    fn to_reverse_type_edge(&self) -> TypeEdge<'a> {
         TypeEdge::build(Self::REVERSE_PREFIX, self.canonical_to().into_vertex(), self.canonical_from().into_vertex())
     }
 

--- a/encoding/graph/type_/property.rs
+++ b/encoding/graph/type_/property.rs
@@ -132,7 +132,7 @@ pub trait TypeVertexPropertyEncoding<'a> {
         TypeVertexProperty::build(vertex.into_vertex(), Self::INFIX)
     }
 
-    fn to_value_bytes(self) -> Option<Bytes<'a, BUFFER_VALUE_INLINE>>; // TODO: Can this be just Bytes?
+    fn to_value_bytes(&self) -> Option<Bytes<'a, BUFFER_VALUE_INLINE>>; // TODO: Can this be just Bytes?
     fn is_decodable_from(key_bytes: Bytes<'_, BUFFER_KEY_INLINE>) -> bool {
         key_bytes.length() == TypeVertexProperty::LENGTH_NO_SUFFIX
             && TypeVertexProperty::new(key_bytes).infix() == Self::INFIX
@@ -249,7 +249,7 @@ pub trait TypeEdgePropertyEncoding<'a>: Sized {
         TypeEdgeProperty::build(edge.to_canonical_type_edge(), Self::INFIX)
     }
 
-    fn to_value_bytes(self) -> Option<Bytes<'a, BUFFER_VALUE_INLINE>>;
+    fn to_value_bytes(&self) -> Option<Bytes<'a, BUFFER_VALUE_INLINE>>;
 
     fn is_decodable_from(key_bytes: Bytes<'_, BUFFER_KEY_INLINE>) -> bool {
         key_bytes.length() == TypeEdgeProperty::LENGTH_NO_SUFFIX

--- a/encoding/graph/type_/vertex.rs
+++ b/encoding/graph/type_/vertex.rs
@@ -140,6 +140,8 @@ pub trait TypeVertexEncoding<'a>: Sized {
         Self::from_vertex(TypeVertex::new(bytes))
     }
 
+    fn vertex(&self) -> TypeVertex<'_>;
+
     fn into_vertex(self) -> TypeVertex<'a>;
 }
 

--- a/encoding/tests/test_type_vertex.rs
+++ b/encoding/tests/test_type_vertex.rs
@@ -37,6 +37,10 @@ impl<'a> TypeVertexEncoding<'a> for MockEntityType<'a> {
         Ok(MockEntityType { vertex })
     }
 
+    fn vertex(&self) -> TypeVertex<'_> {
+        self.vertex.as_reference()
+    }
+
     fn into_vertex(self) -> TypeVertex<'a> {
         self.vertex
     }

--- a/encoding/value/label.rs
+++ b/encoding/value/label.rs
@@ -100,7 +100,7 @@ impl<'a> TypeVertexPropertyEncoding<'a> for Label<'a> {
         Label::parse_from_bytes(string_bytes)
     }
 
-    fn to_value_bytes(self) -> Option<Bytes<'a, BUFFER_VALUE_INLINE>> {
+    fn to_value_bytes(&self) -> Option<Bytes<'a, BUFFER_VALUE_INLINE>> {
         Some(Bytes::Array(ByteArray::from(self.scoped_name().bytes())))
     }
 }

--- a/encoding/value/value_type.rs
+++ b/encoding/value/value_type.rs
@@ -237,7 +237,7 @@ impl TypeVertexPropertyEncoding<'static> for ValueType {
         ValueTypeBytes::new(bytes).to_value_type()
     }
 
-    fn to_value_bytes(self) -> Option<Bytes<'static, BUFFER_VALUE_INLINE>> {
+    fn to_value_bytes(&self) -> Option<Bytes<'static, BUFFER_VALUE_INLINE>> {
         Some(Bytes::Array(ByteArray::copy(&ValueTypeBytes::build(&self).into_bytes())))
     }
 }

--- a/tests/behaviour/steps/concept/thing/attribute.rs
+++ b/tests/behaviour/steps/concept/thing/attribute.rs
@@ -203,7 +203,11 @@ async fn attribute_instances_contain(
 
 #[apply(generic_step)]
 #[step(expr = r"attribute\({type_label}\) get instances {is_empty_or_not}")]
-async fn object_instances_is_empty(context: &mut Context, type_label: params::Label, is_empty_or_not: params::IsEmptyOrNot) {
+async fn object_instances_is_empty(
+    context: &mut Context,
+    type_label: params::Label,
+    is_empty_or_not: params::IsEmptyOrNot,
+) {
     with_read_tx!(context, |tx| {
         let attribute_type =
             tx.type_manager.get_attribute_type(tx.snapshot.as_ref(), &type_label.into_typedb()).unwrap().unwrap();

--- a/tests/behaviour/steps/concept/thing/attribute.rs
+++ b/tests/behaviour/steps/concept/thing/attribute.rs
@@ -16,7 +16,7 @@ use macro_rules_attribute::apply;
 
 use crate::{
     generic_step,
-    params::{self, check_boolean, IsEmptyOrNot},
+    params::{self, check_boolean},
     transaction_context::{with_read_tx, with_write_tx},
     Context,
 };
@@ -203,7 +203,7 @@ async fn attribute_instances_contain(
 
 #[apply(generic_step)]
 #[step(expr = r"attribute\({type_label}\) get instances {is_empty_or_not}")]
-async fn object_instances_is_empty(context: &mut Context, type_label: params::Label, is_empty_or_not: IsEmptyOrNot) {
+async fn object_instances_is_empty(context: &mut Context, type_label: params::Label, is_empty_or_not: params::IsEmptyOrNot) {
     with_read_tx!(context, |tx| {
         let attribute_type =
             tx.type_manager.get_attribute_type(tx.snapshot.as_ref(), &type_label.into_typedb()).unwrap().unwrap();

--- a/tests/behaviour/steps/concept/thing/common.rs
+++ b/tests/behaviour/steps/concept/thing/common.rs
@@ -10,14 +10,14 @@ use macro_rules_attribute::apply;
 use crate::{generic_step, params, Context};
 
 #[apply(generic_step)]
-#[step(expr = r"{root_label} {var} {exists_or_doesnt}")]
+#[step(expr = r"{kind} {var} {exists_or_doesnt}")]
 async fn object_exists(
     context: &mut Context,
-    root_label: params::RootLabel,
+    kind: params::Kind,
     var: params::Var,
     exists_or_doesnt: params::ExistsOrDoesnt,
 ) {
-    match root_label.into_typedb() {
+    match kind.into_typedb() {
         Kind::Attribute => {
             let attribute = context.attributes.get(&var.name).expect("no variable {} in context.");
             exists_or_doesnt.check(attribute, &format!("variable {}", var.name));

--- a/tests/behaviour/steps/concept/thing/has.rs
+++ b/tests/behaviour/steps/concept/thing/has.rs
@@ -18,7 +18,12 @@ use itertools::Itertools;
 use lending_iterator::LendingIterator;
 use macro_rules_attribute::apply;
 
-use crate::{generic_step, params::check_boolean, transaction_context::{with_read_tx, with_write_tx}, Context, params};
+use crate::{
+    generic_step, params,
+    params::check_boolean,
+    transaction_context::{with_read_tx, with_write_tx},
+    Context,
+};
 
 pub(super) fn object_set_has_impl(
     context: &mut Context,

--- a/tests/behaviour/steps/concept/thing/object.rs
+++ b/tests/behaviour/steps/concept/thing/object.rs
@@ -103,8 +103,6 @@ async fn delete_object(context: &mut Context, object_kind: params::ObjectKind, v
     let object = context.objects[&var.name].as_ref().unwrap().object.clone();
     object_kind.assert(&object.type_());
     with_write_tx!(context, |tx| { object.delete(Arc::get_mut(&mut tx.snapshot).unwrap(), &tx.thing_manager).unwrap() })
-    object_kind.assert(&object.type_());
-    with_write_tx!(context, |tx| { object.delete(&mut tx.snapshot, &tx.thing_manager).unwrap() })
 }
 
 #[apply(generic_step)]

--- a/tests/behaviour/steps/concept/thing/relation.rs
+++ b/tests/behaviour/steps/concept/thing/relation.rs
@@ -15,13 +15,7 @@ use itertools::Itertools;
 use lending_iterator::LendingIterator;
 use macro_rules_attribute::apply;
 
-use crate::{
-    concept::type_::BehaviourConceptTestExecutionError,
-    generic_step, params,
-    params::{check_boolean, IsEmptyOrNot},
-    transaction_context::{with_read_tx, with_write_tx},
-    Context,
-};
+use crate::{concept::type_::BehaviourConceptTestExecutionError, generic_step, params::check_boolean, transaction_context::{with_read_tx, with_write_tx}, Context, params};
 
 #[apply(generic_step)]
 #[step(expr = r"relation {var} add player for role\({type_label}\): {var}{may_error}")]
@@ -245,7 +239,7 @@ async fn relation_get_players_for_role_empty(
     context: &mut Context,
     relation_var: params::Var,
     role_label: params::Label,
-    is_empty_or_not: IsEmptyOrNot,
+    is_empty_or_not: params::IsEmptyOrNot,
 ) {
     let relation = context.objects.get(&relation_var.name).unwrap().as_ref().unwrap().object.clone().unwrap_relation();
     let actuals = with_read_tx!(context, |tx| {
@@ -291,16 +285,16 @@ async fn relation_get_players_for_role_contains(
 }
 
 #[apply(generic_step)]
-#[step(expr = r"{object_root_label} {var} get relations {contains_or_doesnt}: {var}")]
+#[step(expr = r"{object_kind} {var} get relations {contains_or_doesnt}: {var}")]
 async fn object_get_relations_contain(
     context: &mut Context,
-    object_root: params::ObjectRootLabel,
+    object_kind: params::ObjectKind,
     player_var: params::Var,
     contains_or_doesnt: params::ContainsOrDoesnt,
     relation_var: params::Var,
 ) {
     let player = &context.objects.get(&player_var.name).unwrap().as_ref().unwrap().object;
-    object_root.assert(&player.type_());
+    object_kind.assert(&player.type_());
     let relations = with_read_tx!(context, |tx| {
         player
             .get_relations(tx.snapshot.as_ref(), &tx.thing_manager)
@@ -315,11 +309,11 @@ async fn object_get_relations_contain(
 
 #[apply(generic_step)]
 #[step(
-    expr = r"{object_root_label} {var} get relations\({type_label}\) with role\({type_label}\) {contains_or_doesnt}: {var}"
+    expr = r"{object_kind} {var} get relations\({type_label}\) with role\({type_label}\) {contains_or_doesnt}: {var}"
 )]
 async fn object_get_relations_of_type_with_role_contain(
     context: &mut Context,
-    object_root: params::ObjectRootLabel,
+    object_kind: params::ObjectKind,
     player_var: params::Var,
     relation_type_label: params::Label,
     role_label: params::Label,
@@ -327,7 +321,7 @@ async fn object_get_relations_of_type_with_role_contain(
     relation_var: params::Var,
 ) {
     let player = &context.objects.get(&player_var.name).unwrap().as_ref().unwrap().object;
-    object_root.assert(&player.type_());
+    object_kind.assert(&player.type_());
     let relations = with_read_tx!(context, |tx| {
         let relation_type = tx
             .type_manager

--- a/tests/behaviour/steps/concept/thing/relation.rs
+++ b/tests/behaviour/steps/concept/thing/relation.rs
@@ -15,7 +15,13 @@ use itertools::Itertools;
 use lending_iterator::LendingIterator;
 use macro_rules_attribute::apply;
 
-use crate::{concept::type_::BehaviourConceptTestExecutionError, generic_step, params::check_boolean, transaction_context::{with_read_tx, with_write_tx}, Context, params};
+use crate::{
+    concept::type_::BehaviourConceptTestExecutionError,
+    generic_step, params,
+    params::check_boolean,
+    transaction_context::{with_read_tx, with_write_tx},
+    Context,
+};
 
 #[apply(generic_step)]
 #[step(expr = r"relation {var} add player for role\({type_label}\): {var}{may_error}")]

--- a/tests/behaviour/steps/concept/type_/owns.rs
+++ b/tests/behaviour/steps/concept/type_/owns.rs
@@ -20,15 +20,15 @@ use crate::{
 };
 
 #[apply(generic_step)]
-#[step(expr = "{root_label}\\({type_label}\\) set owns: {type_label}{may_error}")]
+#[step(expr = "{kind}\\({type_label}\\) set owns: {type_label}{may_error}")]
 pub async fn set_owns(
     context: &mut Context,
-    root_label: params::RootLabel,
+    kind: params::Kind,
     type_label: params::Label,
     attribute_type_label: params::Label,
     may_error: params::MayError,
 ) {
-    let object_type = get_as_object_type(context, root_label.into_typedb(), &type_label);
+    let object_type = get_as_object_type(context, kind.into_typedb(), &type_label);
     with_schema_tx!(context, |tx| {
         let attr_type = tx
             .type_manager
@@ -47,15 +47,15 @@ pub async fn set_owns(
 }
 
 #[apply(generic_step)]
-#[step(expr = "{root_label}\\({type_label}\\) set owns: {type_label}[]{may_error}")]
+#[step(expr = "{kind}\\({type_label}\\) set owns: {type_label}[]{may_error}")]
 pub async fn set_owns_ordered(
     context: &mut Context,
-    root_label: params::RootLabel,
+    kind: params::Kind,
     type_label: params::Label,
     attribute_type_label: params::Label,
     may_error: params::MayError,
 ) {
-    let object_type = get_as_object_type(context, root_label.into_typedb(), &type_label);
+    let object_type = get_as_object_type(context, kind.into_typedb(), &type_label);
     with_schema_tx!(context, |tx| {
         let attr_type = tx
             .type_manager
@@ -74,15 +74,15 @@ pub async fn set_owns_ordered(
 }
 
 #[apply(generic_step)]
-#[step(expr = "{root_label}\\({type_label}\\) unset owns: {type_label}{may_error}")]
+#[step(expr = "{kind}\\({type_label}\\) unset owns: {type_label}{may_error}")]
 pub async fn unset_owns(
     context: &mut Context,
-    root_label: params::RootLabel,
+    kind: params::Kind,
     type_label: params::Label,
     attribute_type_label: params::Label,
     may_error: params::MayError,
 ) {
-    let object_type = get_as_object_type(context, root_label.into_typedb(), &type_label);
+    let object_type = get_as_object_type(context, kind.into_typedb(), &type_label);
     with_schema_tx!(context, |tx| {
         let attr_type = tx
             .type_manager
@@ -100,16 +100,16 @@ pub async fn unset_owns(
 }
 
 #[apply(generic_step)]
-#[step(expr = "{root_label}\\({type_label}\\) get owns\\({type_label}\\) set override: {type_label}{may_error}")]
+#[step(expr = "{kind}\\({type_label}\\) get owns\\({type_label}\\) set override: {type_label}{may_error}")]
 pub async fn get_owns_set_override(
     context: &mut Context,
-    root_label: params::RootLabel,
+    kind: params::Kind,
     type_label: params::Label,
     attr_type_label: params::Label,
     overridden_type_label: params::Label,
     may_error: params::MayError,
 ) {
-    let owner = get_as_object_type(context, root_label.into_typedb(), &type_label);
+    let owner = get_as_object_type(context, kind.into_typedb(), &type_label);
     with_schema_tx!(context, |tx| {
         let attr_type =
             tx.type_manager.get_attribute_type(tx.snapshot.as_ref(), &attr_type_label.into_typedb()).unwrap().unwrap();
@@ -144,15 +144,15 @@ pub async fn get_owns_set_override(
 }
 
 #[apply(generic_step)]
-#[step(expr = "{root_label}\\({type_label}\\) get owns\\({type_label}\\) unset override{may_error}")]
+#[step(expr = "{kind}\\({type_label}\\) get owns\\({type_label}\\) unset override{may_error}")]
 pub async fn get_owns_unset_override(
     context: &mut Context,
-    root_label: params::RootLabel,
+    kind: params::Kind,
     type_label: params::Label,
     attr_type_label: params::Label,
     may_error: params::MayError,
 ) {
-    let owner = get_as_object_type(context, root_label.into_typedb(), &type_label);
+    let owner = get_as_object_type(context, kind.into_typedb(), &type_label);
     with_schema_tx!(context, |tx| {
         let attr_type =
             tx.type_manager.get_attribute_type(tx.snapshot.as_ref(), &attr_type_label.into_typedb()).unwrap().unwrap();
@@ -163,16 +163,16 @@ pub async fn get_owns_unset_override(
 }
 
 #[apply(generic_step)]
-#[step(expr = "{root_label}\\({type_label}\\) get owns\\({type_label}\\) set annotation: {annotation}{may_error}")]
+#[step(expr = "{kind}\\({type_label}\\) get owns\\({type_label}\\) set annotation: {annotation}{may_error}")]
 pub async fn get_owns_set_annotation(
     context: &mut Context,
-    root_label: params::RootLabel,
+    kind: params::Kind,
     type_label: params::Label,
     attr_type_label: params::Label,
     annotation: params::Annotation,
     may_error: params::MayError,
 ) {
-    let object_type = get_as_object_type(context, root_label.into_typedb(), &type_label);
+    let object_type = get_as_object_type(context, kind.into_typedb(), &type_label);
     with_schema_tx!(context, |tx| {
         let attr_type =
             tx.type_manager.get_attribute_type(tx.snapshot.as_ref(), &attr_type_label.into_typedb()).unwrap().unwrap();
@@ -190,18 +190,16 @@ pub async fn get_owns_set_annotation(
 }
 
 #[apply(generic_step)]
-#[step(
-    expr = "{root_label}\\({type_label}\\) get owns\\({type_label}\\) unset annotation: {annotation_category}{may_error}"
-)]
+#[step(expr = "{kind}\\({type_label}\\) get owns\\({type_label}\\) unset annotation: {annotation_category}{may_error}")]
 pub async fn get_owns_unset_annotation(
     context: &mut Context,
-    root_label: params::RootLabel,
+    kind: params::Kind,
     type_label: params::Label,
     attr_type_label: params::Label,
     annotation_category: params::AnnotationCategory,
     may_error: params::MayError,
 ) {
-    let object_type = get_as_object_type(context, root_label.into_typedb(), &type_label);
+    let object_type = get_as_object_type(context, kind.into_typedb(), &type_label);
     with_schema_tx!(context, |tx| {
         let attr_type =
             tx.type_manager.get_attribute_type(tx.snapshot.as_ref(), &attr_type_label.into_typedb()).unwrap().unwrap();
@@ -217,18 +215,16 @@ pub async fn get_owns_unset_annotation(
 }
 
 #[apply(generic_step)]
-#[step(
-    expr = "{root_label}\\({type_label}\\) get owns\\({type_label}\\) get annotations {contains_or_doesnt}: {annotation}"
-)]
+#[step(expr = "{kind}\\({type_label}\\) get owns\\({type_label}\\) get annotations {contains_or_doesnt}: {annotation}")]
 pub async fn get_owns_annotations_contains(
     context: &mut Context,
-    root_label: params::RootLabel,
+    kind: params::Kind,
     type_label: params::Label,
     attr_type_label: params::Label,
     contains_or_doesnt: params::ContainsOrDoesnt,
     annotation: params::Annotation,
 ) {
-    let object_type = get_as_object_type(context, root_label.into_typedb(), &type_label);
+    let object_type = get_as_object_type(context, kind.into_typedb(), &type_label);
     with_read_tx!(context, |tx| {
         let attr_type =
             tx.type_manager.get_attribute_type(tx.snapshot.as_ref(), &attr_type_label.into_typedb()).unwrap().unwrap();
@@ -244,17 +240,17 @@ pub async fn get_owns_annotations_contains(
 
 #[apply(generic_step)]
 #[step(
-    expr = "{root_label}\\({type_label}\\) get owns\\({type_label}\\) get annotation categories {contains_or_doesnt}: {annotation_category}"
+    expr = "{kind}\\({type_label}\\) get owns\\({type_label}\\) get annotation categories {contains_or_doesnt}: {annotation_category}"
 )]
 pub async fn get_owns_annotations_categories_contains(
     context: &mut Context,
-    root_label: params::RootLabel,
+    kind: params::Kind,
     type_label: params::Label,
     attr_type_label: params::Label,
     contains_or_doesnt: params::ContainsOrDoesnt,
     annotation_category: params::AnnotationCategory,
 ) {
-    let object_type = get_as_object_type(context, root_label.into_typedb(), &type_label);
+    let object_type = get_as_object_type(context, kind.into_typedb(), &type_label);
     with_read_tx!(context, |tx| {
         let attr_type =
             tx.type_manager.get_attribute_type(tx.snapshot.as_ref(), &attr_type_label.into_typedb()).unwrap().unwrap();
@@ -273,17 +269,17 @@ pub async fn get_owns_annotations_categories_contains(
 
 #[apply(generic_step)]
 #[step(
-    expr = "{root_label}\\({type_label}\\) get owns\\({type_label}\\) get declared annotations {contains_or_doesnt}: {annotation}"
+    expr = "{kind}\\({type_label}\\) get owns\\({type_label}\\) get declared annotations {contains_or_doesnt}: {annotation}"
 )]
 pub async fn get_owns_declared_annotations_contains(
     context: &mut Context,
-    root_label: params::RootLabel,
+    kind: params::Kind,
     type_label: params::Label,
     attr_type_label: params::Label,
     contains_or_doesnt: params::ContainsOrDoesnt,
     annotation: params::Annotation,
 ) {
-    let object_type = get_as_object_type(context, root_label.into_typedb(), &type_label);
+    let object_type = get_as_object_type(context, kind.into_typedb(), &type_label);
     with_read_tx!(context, |tx| {
         let attr_type =
             tx.type_manager.get_attribute_type(tx.snapshot.as_ref(), &attr_type_label.into_typedb()).unwrap().unwrap();
@@ -298,15 +294,15 @@ pub async fn get_owns_declared_annotations_contains(
 }
 
 #[apply(generic_step)]
-#[step(expr = "{root_label}\\({type_label}\\) get owns\\({type_label}\\) get annotations {is_empty_or_not}")]
+#[step(expr = "{kind}\\({type_label}\\) get owns\\({type_label}\\) get annotations {is_empty_or_not}")]
 pub async fn get_owns_annotations_is_empty(
     context: &mut Context,
-    root_label: params::RootLabel,
+    kind: params::Kind,
     type_label: params::Label,
     attr_type_label: params::Label,
     is_empty_or_not: params::IsEmptyOrNot,
 ) {
-    let object_type = get_as_object_type(context, root_label.into_typedb(), &type_label);
+    let object_type = get_as_object_type(context, kind.into_typedb(), &type_label);
     with_read_tx!(context, |tx| {
         let attr_type =
             tx.type_manager.get_attribute_type(tx.snapshot.as_ref(), &attr_type_label.into_typedb()).unwrap().unwrap();
@@ -318,15 +314,15 @@ pub async fn get_owns_annotations_is_empty(
 }
 
 #[apply(generic_step)]
-#[step(expr = "{root_label}\\({type_label}\\) get owns\\({type_label}\\) get declared annotations {is_empty_or_not}")]
+#[step(expr = "{kind}\\({type_label}\\) get owns\\({type_label}\\) get declared annotations {is_empty_or_not}")]
 pub async fn get_owns_declared_annotations_is_empty(
     context: &mut Context,
-    root_label: params::RootLabel,
+    kind: params::Kind,
     type_label: params::Label,
     attr_type_label: params::Label,
     is_empty_or_not: params::IsEmptyOrNot,
 ) {
-    let object_type = get_as_object_type(context, root_label.into_typedb(), &type_label);
+    let object_type = get_as_object_type(context, kind.into_typedb(), &type_label);
     with_read_tx!(context, |tx| {
         let attr_type =
             tx.type_manager.get_attribute_type(tx.snapshot.as_ref(), &attr_type_label.into_typedb()).unwrap().unwrap();
@@ -338,15 +334,15 @@ pub async fn get_owns_declared_annotations_is_empty(
 }
 
 #[apply(generic_step)]
-#[step(expr = "{root_label}\\({type_label}\\) get owns\\({type_label}\\) get cardinality: {annotation}")]
+#[step(expr = "{kind}\\({type_label}\\) get owns\\({type_label}\\) get cardinality: {annotation}")]
 pub async fn get_owns_cardinality(
     context: &mut Context,
-    root_label: params::RootLabel,
+    kind: params::Kind,
     type_label: params::Label,
     attr_type_label: params::Label,
     cardinality_annotation: params::Annotation,
 ) {
-    let object_type = get_as_object_type(context, root_label.into_typedb(), &type_label);
+    let object_type = get_as_object_type(context, kind.into_typedb(), &type_label);
     with_read_tx!(context, |tx| {
         let attr_type =
             tx.type_manager.get_attribute_type(tx.snapshot.as_ref(), &attr_type_label.into_typedb()).unwrap().unwrap();
@@ -361,16 +357,16 @@ pub async fn get_owns_cardinality(
 }
 
 #[apply(generic_step)]
-#[step(expr = "{root_label}\\({type_label}\\) get owns {contains_or_doesnt}:")]
+#[step(expr = "{kind}\\({type_label}\\) get owns {contains_or_doesnt}:")]
 pub async fn get_owns_contain(
     context: &mut Context,
-    root_label: params::RootLabel,
+    kind: params::Kind,
     type_label: params::Label,
     contains: params::ContainsOrDoesnt,
     step: &Step,
 ) {
     let expected_labels = util::iter_table(step).map(|str| str.to_owned()).collect_vec();
-    let object_type = get_as_object_type(context, root_label.into_typedb(), &type_label);
+    let object_type = get_as_object_type(context, kind.into_typedb(), &type_label);
     with_read_tx!(context, |tx| {
         let actual_labels = object_type
             .get_owns(tx.snapshot.as_ref(), &tx.type_manager)
@@ -390,14 +386,14 @@ pub async fn get_owns_contain(
 }
 
 #[apply(generic_step)]
-#[step(expr = "{root_label}\\({type_label}\\) get owns {is_empty_or_not}")]
+#[step(expr = "{kind}\\({type_label}\\) get owns {is_empty_or_not}")]
 pub async fn get_owns_is_empty(
     context: &mut Context,
-    root_label: params::RootLabel,
+    kind: params::Kind,
     type_label: params::Label,
     is_empty_or_not: params::IsEmptyOrNot,
 ) {
-    let object_type = get_as_object_type(context, root_label.into_typedb(), &type_label);
+    let object_type = get_as_object_type(context, kind.into_typedb(), &type_label);
     with_read_tx!(context, |tx| {
         let actual_is_empty = object_type.get_owns(tx.snapshot.as_ref(), &tx.type_manager).unwrap().is_empty();
         is_empty_or_not.check(actual_is_empty);
@@ -405,16 +401,16 @@ pub async fn get_owns_is_empty(
 }
 
 #[apply(generic_step)]
-#[step(expr = "{root_label}\\({type_label}\\) get declared owns {contains_or_doesnt}:")]
+#[step(expr = "{kind}\\({type_label}\\) get declared owns {contains_or_doesnt}:")]
 pub async fn get_declared_owns_contain(
     context: &mut Context,
-    root_label: params::RootLabel,
+    kind: params::Kind,
     type_label: params::Label,
     contains: params::ContainsOrDoesnt,
     step: &Step,
 ) {
     let expected_labels = util::iter_table(step).map(|str| str.to_owned()).collect_vec();
-    let object_type = get_as_object_type(context, root_label.into_typedb(), &type_label);
+    let object_type = get_as_object_type(context, kind.into_typedb(), &type_label);
     with_read_tx!(context, |tx| {
         let actual_labels = object_type
             .get_owns_declared(tx.snapshot.as_ref(), &tx.type_manager)
@@ -434,15 +430,15 @@ pub async fn get_declared_owns_contain(
 }
 
 #[apply(generic_step)]
-#[step(expr = "{root_label}\\({type_label}\\) get owns overridden\\({type_label}\\) {exists_or_doesnt}")]
+#[step(expr = "{kind}\\({type_label}\\) get owns overridden\\({type_label}\\) {exists_or_doesnt}")]
 pub async fn get_owns_overridden_exists(
     context: &mut Context,
-    root_label: params::RootLabel,
+    kind: params::Kind,
     type_label: params::Label,
     attr_type_label: params::Label,
     exists: params::ExistsOrDoesnt,
 ) {
-    let object_type = get_as_object_type(context, root_label.into_typedb(), &type_label);
+    let object_type = get_as_object_type(context, kind.into_typedb(), &type_label);
     with_read_tx!(context, |tx| {
         let attr_type =
             tx.type_manager.get_attribute_type(tx.snapshot.as_ref(), &attr_type_label.into_typedb()).unwrap().unwrap();
@@ -456,15 +452,15 @@ pub async fn get_owns_overridden_exists(
 }
 
 #[apply(generic_step)]
-#[step(expr = "{root_label}\\({type_label}\\) get owns\\({type_label}\\) get label: {type_label}")]
+#[step(expr = "{kind}\\({type_label}\\) get owns\\({type_label}\\) get label: {type_label}")]
 pub async fn get_owns_get_label(
     context: &mut Context,
-    root_label: params::RootLabel,
+    kind: params::Kind,
     type_label: params::Label,
     attr_type_label: params::Label,
     expected_label: params::Label,
 ) {
-    let owner = get_as_object_type(context, root_label.into_typedb(), &type_label);
+    let owner = get_as_object_type(context, kind.into_typedb(), &type_label);
     with_read_tx!(context, |tx| {
         let attr_type =
             tx.type_manager.get_attribute_type(tx.snapshot.as_ref(), &attr_type_label.into_typedb()).unwrap().unwrap();
@@ -481,15 +477,15 @@ pub async fn get_owns_get_label(
 }
 
 #[apply(generic_step)]
-#[step(expr = "{root_label}\\({type_label}\\) get owns overridden\\({type_label}\\) get label: {type_label}")]
+#[step(expr = "{kind}\\({type_label}\\) get owns overridden\\({type_label}\\) get label: {type_label}")]
 pub async fn get_owns_overridden_get_label(
     context: &mut Context,
-    root_label: params::RootLabel,
+    kind: params::Kind,
     type_label: params::Label,
     attr_type_label: params::Label,
     expected_overridden: params::Label,
 ) {
-    let owner = get_as_object_type(context, root_label.into_typedb(), &type_label);
+    let owner = get_as_object_type(context, kind.into_typedb(), &type_label);
     with_read_tx!(context, |tx| {
         let attr_type =
             tx.type_manager.get_attribute_type(tx.snapshot.as_ref(), &attr_type_label.into_typedb()).unwrap().unwrap();
@@ -508,16 +504,16 @@ pub async fn get_owns_overridden_get_label(
 }
 
 #[apply(generic_step)]
-#[step(expr = "{root_label}\\({type_label}\\) get owns\\({type_label}\\) set ordering: {ordering}{may_error}")]
+#[step(expr = "{kind}\\({type_label}\\) get owns\\({type_label}\\) set ordering: {ordering}{may_error}")]
 pub async fn get_owns_set_ordering(
     context: &mut Context,
-    root_label: params::RootLabel,
+    kind: params::Kind,
     type_label: params::Label,
     attr_type_label: params::Label,
     ordering: params::Ordering,
     may_error: params::MayError,
 ) {
-    let object_type = get_as_object_type(context, root_label.into_typedb(), &type_label);
+    let object_type = get_as_object_type(context, kind.into_typedb(), &type_label);
     with_schema_tx!(context, |tx| {
         let attr_type =
             tx.type_manager.get_attribute_type(tx.snapshot.as_ref(), &attr_type_label.into_typedb()).unwrap().unwrap();
@@ -533,15 +529,15 @@ pub async fn get_owns_set_ordering(
 }
 
 #[apply(generic_step)]
-#[step(expr = "{root_label}\\({type_label}\\) get owns\\({type_label}\\) get ordering: {ordering}")]
+#[step(expr = "{kind}\\({type_label}\\) get owns\\({type_label}\\) get ordering: {ordering}")]
 pub async fn get_owns_get_ordering(
     context: &mut Context,
-    root_label: params::RootLabel,
+    kind: params::Kind,
     type_label: params::Label,
     attr_type_label: params::Label,
     ordering: params::Ordering,
 ) {
-    let object_type = get_as_object_type(context, root_label.into_typedb(), &type_label);
+    let object_type = get_as_object_type(context, kind.into_typedb(), &type_label);
     with_read_tx!(context, |tx| {
         let attr_type =
             tx.type_manager.get_attribute_type(tx.snapshot.as_ref(), &attr_type_label.into_typedb()).unwrap().unwrap();

--- a/tests/behaviour/steps/concept/type_/plays.rs
+++ b/tests/behaviour/steps/concept/type_/plays.rs
@@ -12,11 +12,22 @@ use itertools::Itertools;
 use macro_rules_attribute::apply;
 
 use super::thing_type::get_as_object_type;
-use crate::{concept::type_::BehaviourConceptTestExecutionError, generic_step, transaction_context::{with_read_tx, with_schema_tx}, util, Context, params};
+use crate::{
+    concept::type_::BehaviourConceptTestExecutionError,
+    generic_step, params,
+    transaction_context::{with_read_tx, with_schema_tx},
+    util, Context,
+};
 
 #[apply(generic_step)]
 #[step(expr = "{kind}\\({type_label}\\) set plays: {type_label}{may_error}")]
-pub async fn set_plays(context: &mut Context, kind: params::Kind, type_label: params::Label, role_label: params::Label, may_error: params::MayError) {
+pub async fn set_plays(
+    context: &mut Context,
+    kind: params::Kind,
+    type_label: params::Label,
+    role_label: params::Label,
+    may_error: params::MayError,
+) {
     let object_type = get_as_object_type(context, kind.into_typedb(), &type_label);
     with_schema_tx!(context, |tx| {
         let role_type =
@@ -33,7 +44,13 @@ pub async fn set_plays(context: &mut Context, kind: params::Kind, type_label: pa
 
 #[apply(generic_step)]
 #[step(expr = "{kind}\\({type_label}\\) unset plays: {type_label}{may_error}")]
-pub async fn unset_plays(context: &mut Context, kind: params::Kind, type_label: params::Label, role_label: params::Label, may_error: params::MayError) {
+pub async fn unset_plays(
+    context: &mut Context,
+    kind: params::Kind,
+    type_label: params::Label,
+    role_label: params::Label,
+    may_error: params::MayError,
+) {
     let object_type = get_as_object_type(context, kind.into_typedb(), &type_label);
     with_schema_tx!(context, |tx| {
         let role_type =
@@ -110,7 +127,12 @@ pub async fn get_declared_plays_contain(
 
 #[apply(generic_step)]
 #[step(expr = "{kind}\\({type_label}\\) get plays {is_empty_or_not}")]
-pub async fn get_plays_is_empty(context: &mut Context, kind: params::Kind, type_label: params::Label, is_empty_or_not: params::IsEmptyOrNot) {
+pub async fn get_plays_is_empty(
+    context: &mut Context,
+    kind: params::Kind,
+    type_label: params::Label,
+    is_empty_or_not: params::IsEmptyOrNot,
+) {
     let object_type = get_as_object_type(context, kind.into_typedb(), &type_label);
     with_read_tx!(context, |tx| {
         let actual_is_empty = object_type.get_plays(tx.snapshot.as_ref(), &tx.type_manager).unwrap().is_empty();

--- a/tests/behaviour/steps/concept/type_/plays.rs
+++ b/tests/behaviour/steps/concept/type_/plays.rs
@@ -12,24 +12,12 @@ use itertools::Itertools;
 use macro_rules_attribute::apply;
 
 use super::thing_type::get_as_object_type;
-use crate::{
-    concept::type_::BehaviourConceptTestExecutionError,
-    generic_step, params,
-    params::{Annotation, AnnotationCategory, ContainsOrDoesnt, IsEmptyOrNot, Label, MayError, RootLabel},
-    transaction_context::{with_read_tx, with_schema_tx},
-    util, Context,
-};
+use crate::{concept::type_::BehaviourConceptTestExecutionError, generic_step, transaction_context::{with_read_tx, with_schema_tx}, util, Context, params};
 
 #[apply(generic_step)]
-#[step(expr = "{root_label}\\({type_label}\\) set plays: {type_label}{may_error}")]
-pub async fn set_plays(
-    context: &mut Context,
-    root_label: RootLabel,
-    type_label: Label,
-    role_label: Label,
-    may_error: MayError,
-) {
-    let object_type = get_as_object_type(context, root_label.into_typedb(), &type_label);
+#[step(expr = "{kind}\\({type_label}\\) set plays: {type_label}{may_error}")]
+pub async fn set_plays(context: &mut Context, kind: params::Kind, type_label: params::Label, role_label: params::Label, may_error: params::MayError) {
+    let object_type = get_as_object_type(context, kind.into_typedb(), &type_label);
     with_schema_tx!(context, |tx| {
         let role_type =
             tx.type_manager.get_role_type(tx.snapshot.as_ref(), &role_label.into_typedb()).unwrap().unwrap();
@@ -44,15 +32,9 @@ pub async fn set_plays(
 }
 
 #[apply(generic_step)]
-#[step(expr = "{root_label}\\({type_label}\\) unset plays: {type_label}{may_error}")]
-pub async fn unset_plays(
-    context: &mut Context,
-    root_label: RootLabel,
-    type_label: Label,
-    role_label: Label,
-    may_error: MayError,
-) {
-    let object_type = get_as_object_type(context, root_label.into_typedb(), &type_label);
+#[step(expr = "{kind}\\({type_label}\\) unset plays: {type_label}{may_error}")]
+pub async fn unset_plays(context: &mut Context, kind: params::Kind, type_label: params::Label, role_label: params::Label, may_error: params::MayError) {
+    let object_type = get_as_object_type(context, kind.into_typedb(), &type_label);
     with_schema_tx!(context, |tx| {
         let role_type =
             tx.type_manager.get_role_type(tx.snapshot.as_ref(), &role_label.into_typedb()).unwrap().unwrap();
@@ -67,16 +49,16 @@ pub async fn unset_plays(
 }
 
 #[apply(generic_step)]
-#[step(expr = "{root_label}\\({type_label}\\) get plays {contains_or_doesnt}:")]
+#[step(expr = "{kind}\\({type_label}\\) get plays {contains_or_doesnt}:")]
 pub async fn get_plays_contain(
     context: &mut Context,
     step: &Step,
-    root_label: RootLabel,
-    type_label: Label,
-    contains: ContainsOrDoesnt,
+    kind: params::Kind,
+    type_label: params::Label,
+    contains: params::ContainsOrDoesnt,
 ) {
     let expected_labels = util::iter_table(step).map(|str| str.to_owned()).collect_vec();
-    let object_type = get_as_object_type(context, root_label.into_typedb(), &type_label);
+    let object_type = get_as_object_type(context, kind.into_typedb(), &type_label);
     with_read_tx!(context, |tx| {
         let actual_labels = object_type
             .get_plays(tx.snapshot.as_ref(), &tx.type_manager)
@@ -97,16 +79,16 @@ pub async fn get_plays_contain(
 }
 
 #[apply(generic_step)]
-#[step(expr = "{root_label}\\({type_label}\\) get declared plays {contains_or_doesnt}:")]
+#[step(expr = "{kind}\\({type_label}\\) get declared plays {contains_or_doesnt}:")]
 pub async fn get_declared_plays_contain(
     context: &mut Context,
     step: &Step,
-    root_label: RootLabel,
-    type_label: Label,
-    contains: ContainsOrDoesnt,
+    kind: params::Kind,
+    type_label: params::Label,
+    contains: params::ContainsOrDoesnt,
 ) {
     let expected_labels = util::iter_table(step).map(|str| str.to_owned()).collect_vec();
-    let object_type = get_as_object_type(context, root_label.into_typedb(), &type_label);
+    let object_type = get_as_object_type(context, kind.into_typedb(), &type_label);
     with_read_tx!(context, |tx| {
         let actual_labels = object_type
             .get_plays_declared(tx.snapshot.as_ref(), &tx.type_manager)
@@ -127,14 +109,9 @@ pub async fn get_declared_plays_contain(
 }
 
 #[apply(generic_step)]
-#[step(expr = "{root_label}\\({type_label}\\) get plays {is_empty_or_not}")]
-pub async fn get_plays_is_empty(
-    context: &mut Context,
-    root_label: RootLabel,
-    type_label: Label,
-    is_empty_or_not: IsEmptyOrNot,
-) {
-    let object_type = get_as_object_type(context, root_label.into_typedb(), &type_label);
+#[step(expr = "{kind}\\({type_label}\\) get plays {is_empty_or_not}")]
+pub async fn get_plays_is_empty(context: &mut Context, kind: params::Kind, type_label: params::Label, is_empty_or_not: params::IsEmptyOrNot) {
+    let object_type = get_as_object_type(context, kind.into_typedb(), &type_label);
     with_read_tx!(context, |tx| {
         let actual_is_empty = object_type.get_plays(tx.snapshot.as_ref(), &tx.type_manager).unwrap().is_empty();
         is_empty_or_not.check(actual_is_empty);
@@ -142,16 +119,16 @@ pub async fn get_plays_is_empty(
 }
 
 #[apply(generic_step)]
-#[step(expr = "{root_label}\\({type_label}\\) get plays\\({type_label}\\) set override: {type_label}{may_error}")]
+#[step(expr = "{kind}\\({type_label}\\) get plays\\({type_label}\\) set override: {type_label}{may_error}")]
 pub async fn get_plays_set_override(
     context: &mut Context,
-    root_label: RootLabel,
-    type_label: Label,
-    role_label: Label,
-    overridden_role_label: Label,
-    may_error: MayError,
+    kind: params::Kind,
+    type_label: params::Label,
+    role_label: params::Label,
+    overridden_role_label: params::Label,
+    may_error: params::MayError,
 ) {
-    let player_type = get_as_object_type(context, root_label.into_typedb(), &type_label);
+    let player_type = get_as_object_type(context, kind.into_typedb(), &type_label);
     with_schema_tx!(context, |tx| {
         let role_type =
             tx.type_manager.get_role_type(tx.snapshot.as_ref(), &role_label.into_typedb()).unwrap().unwrap();
@@ -185,15 +162,15 @@ pub async fn get_plays_set_override(
 }
 
 #[apply(generic_step)]
-#[step(expr = "{root_label}\\({type_label}\\) get plays\\({type_label}\\) unset override{may_error}")]
+#[step(expr = "{kind}\\({type_label}\\) get plays\\({type_label}\\) unset override{may_error}")]
 pub async fn get_plays_unset_override(
     context: &mut Context,
-    root_label: RootLabel,
-    type_label: Label,
-    role_label: Label,
-    may_error: MayError,
+    kind: params::Kind,
+    type_label: params::Label,
+    role_label: params::Label,
+    may_error: params::MayError,
 ) {
-    let player_type = get_as_object_type(context, root_label.into_typedb(), &type_label);
+    let player_type = get_as_object_type(context, kind.into_typedb(), &type_label);
     with_schema_tx!(context, |tx| {
         let role_type =
             tx.type_manager.get_role_type(tx.snapshot.as_ref(), &role_label.into_typedb()).unwrap().unwrap();
@@ -204,15 +181,15 @@ pub async fn get_plays_unset_override(
 }
 
 #[apply(generic_step)]
-#[step(expr = "{root_label}\\({type_label}\\) get plays overridden\\({type_label}\\) {exists_or_doesnt}")]
+#[step(expr = "{kind}\\({type_label}\\) get plays overridden\\({type_label}\\) {exists_or_doesnt}")]
 pub async fn get_plays_overridden_exists(
     context: &mut Context,
-    root_label: RootLabel,
-    type_label: Label,
-    role_label: Label,
+    kind: params::Kind,
+    type_label: params::Label,
+    role_label: params::Label,
     exists: params::ExistsOrDoesnt,
 ) {
-    let player_type = get_as_object_type(context, root_label.into_typedb(), &type_label);
+    let player_type = get_as_object_type(context, kind.into_typedb(), &type_label);
     with_read_tx!(context, |tx| {
         let role_type =
             tx.type_manager.get_role_type(tx.snapshot.as_ref(), &role_label.into_typedb()).unwrap().unwrap();
@@ -226,15 +203,15 @@ pub async fn get_plays_overridden_exists(
 }
 
 #[apply(generic_step)]
-#[step(expr = "{root_label}\\({type_label}\\) get plays overridden\\({type_label}\\) get label: {type_label}")]
+#[step(expr = "{kind}\\({type_label}\\) get plays overridden\\({type_label}\\) get label: {type_label}")]
 pub async fn get_plays_overridden_get_label(
     context: &mut Context,
-    root_label: RootLabel,
-    type_label: Label,
-    role_label: Label,
-    expected_overridden: Label,
+    kind: params::Kind,
+    type_label: params::Label,
+    role_label: params::Label,
+    expected_overridden: params::Label,
 ) {
-    let player_type = get_as_object_type(context, root_label.into_typedb(), &type_label);
+    let player_type = get_as_object_type(context, kind.into_typedb(), &type_label);
     with_read_tx!(context, |tx| {
         let role_type =
             tx.type_manager.get_role_type(tx.snapshot.as_ref(), &role_label.into_typedb()).unwrap().unwrap();
@@ -254,16 +231,16 @@ pub async fn get_plays_overridden_get_label(
 }
 
 #[apply(generic_step)]
-#[step(expr = "{root_label}\\({type_label}\\) get plays\\({type_label}\\) set annotation: {annotation}{may_error}")]
+#[step(expr = "{kind}\\({type_label}\\) get plays\\({type_label}\\) set annotation: {annotation}{may_error}")]
 pub async fn get_plays_set_annotation(
     context: &mut Context,
-    root_label: RootLabel,
-    type_label: Label,
-    role_label: Label,
-    annotation: Annotation,
-    may_error: MayError,
+    kind: params::Kind,
+    type_label: params::Label,
+    role_label: params::Label,
+    annotation: params::Annotation,
+    may_error: params::MayError,
 ) {
-    let player_type = get_as_object_type(context, root_label.into_typedb(), &type_label);
+    let player_type = get_as_object_type(context, kind.into_typedb(), &type_label);
     with_schema_tx!(context, |tx| {
         let role_type =
             tx.type_manager.get_role_type(tx.snapshot.as_ref(), &role_label.into_typedb()).unwrap().unwrap();
@@ -280,17 +257,17 @@ pub async fn get_plays_set_annotation(
 
 #[apply(generic_step)]
 #[step(
-    expr = "{root_label}\\({type_label}\\) get plays\\({type_label}\\) unset annotation: {annotation_category}{may_error}"
+    expr = "{kind}\\({type_label}\\) get plays\\({type_label}\\) unset annotation: {annotation_category}{may_error}"
 )]
 pub async fn get_plays_unset_annotation(
     context: &mut Context,
-    root_label: RootLabel,
-    type_label: Label,
-    role_label: Label,
-    annotation_category: AnnotationCategory,
-    may_error: MayError,
+    kind: params::Kind,
+    type_label: params::Label,
+    role_label: params::Label,
+    annotation_category: params::AnnotationCategory,
+    may_error: params::MayError,
 ) {
-    let player_type = get_as_object_type(context, root_label.into_typedb(), &type_label);
+    let player_type = get_as_object_type(context, kind.into_typedb(), &type_label);
     with_schema_tx!(context, |tx| {
         let role_type =
             tx.type_manager.get_role_type(tx.snapshot.as_ref(), &role_label.into_typedb()).unwrap().unwrap();
@@ -307,17 +284,17 @@ pub async fn get_plays_unset_annotation(
 
 #[apply(generic_step)]
 #[step(
-    expr = "{root_label}\\({type_label}\\) get plays\\({type_label}\\) get annotations {contains_or_doesnt}: {annotation}"
+    expr = "{kind}\\({type_label}\\) get plays\\({type_label}\\) get annotations {contains_or_doesnt}: {annotation}"
 )]
 pub async fn get_plays_annotations_contains(
     context: &mut Context,
-    root_label: RootLabel,
-    type_label: Label,
-    role_label: Label,
-    contains_or_doesnt: ContainsOrDoesnt,
-    annotation: Annotation,
+    kind: params::Kind,
+    type_label: params::Label,
+    role_label: params::Label,
+    contains_or_doesnt: params::ContainsOrDoesnt,
+    annotation: params::Annotation,
 ) {
-    let player_type = get_as_object_type(context, root_label.into_typedb(), &type_label);
+    let player_type = get_as_object_type(context, kind.into_typedb(), &type_label);
     with_read_tx!(context, |tx| {
         let role_type =
             tx.type_manager.get_role_type(tx.snapshot.as_ref(), &role_label.into_typedb()).unwrap().unwrap();
@@ -332,17 +309,17 @@ pub async fn get_plays_annotations_contains(
 
 #[apply(generic_step)]
 #[step(
-    expr = "{root_label}\\({type_label}\\) get plays\\({type_label}\\) get annotation categories {contains_or_doesnt}: {annotation_category}"
+    expr = "{kind}\\({type_label}\\) get plays\\({type_label}\\) get annotation categories {contains_or_doesnt}: {annotation_category}"
 )]
 pub async fn get_plays_annotation_categories_contains(
     context: &mut Context,
-    root_label: RootLabel,
-    type_label: Label,
-    role_label: Label,
-    contains_or_doesnt: ContainsOrDoesnt,
-    annotation_category: AnnotationCategory,
+    kind: params::Kind,
+    type_label: params::Label,
+    role_label: params::Label,
+    contains_or_doesnt: params::ContainsOrDoesnt,
+    annotation_category: params::AnnotationCategory,
 ) {
-    let player_type = get_as_object_type(context, root_label.into_typedb(), &type_label);
+    let player_type = get_as_object_type(context, kind.into_typedb(), &type_label);
     with_read_tx!(context, |tx| {
         let role_type =
             tx.type_manager.get_role_type(tx.snapshot.as_ref(), &role_label.into_typedb()).unwrap().unwrap();
@@ -361,17 +338,17 @@ pub async fn get_plays_annotation_categories_contains(
 
 #[apply(generic_step)]
 #[step(
-    expr = "{root_label}\\({type_label}\\) get plays\\({type_label}\\) get declared annotations {contains_or_doesnt}: {annotation}"
+    expr = "{kind}\\({type_label}\\) get plays\\({type_label}\\) get declared annotations {contains_or_doesnt}: {annotation}"
 )]
 pub async fn get_plays_declared_annotations_contains(
     context: &mut Context,
-    root_label: RootLabel,
-    type_label: Label,
-    role_label: Label,
-    contains_or_doesnt: ContainsOrDoesnt,
-    annotation: Annotation,
+    kind: params::Kind,
+    type_label: params::Label,
+    role_label: params::Label,
+    contains_or_doesnt: params::ContainsOrDoesnt,
+    annotation: params::Annotation,
 ) {
-    let player_type = get_as_object_type(context, root_label.into_typedb(), &type_label);
+    let player_type = get_as_object_type(context, kind.into_typedb(), &type_label);
     with_read_tx!(context, |tx| {
         let role_type =
             tx.type_manager.get_role_type(tx.snapshot.as_ref(), &role_label.into_typedb()).unwrap().unwrap();
@@ -385,15 +362,15 @@ pub async fn get_plays_declared_annotations_contains(
 }
 
 #[apply(generic_step)]
-#[step(expr = "{root_label}\\({type_label}\\) get plays\\({type_label}\\) get annotations {is_empty_or_not}")]
+#[step(expr = "{kind}\\({type_label}\\) get plays\\({type_label}\\) get annotations {is_empty_or_not}")]
 pub async fn get_owns_annotations_is_empty(
     context: &mut Context,
-    root_label: RootLabel,
-    type_label: Label,
-    role_label: Label,
-    is_empty_or_not: IsEmptyOrNot,
+    kind: params::Kind,
+    type_label: params::Label,
+    role_label: params::Label,
+    is_empty_or_not: params::IsEmptyOrNot,
 ) {
-    let player_type = get_as_object_type(context, root_label.into_typedb(), &type_label);
+    let player_type = get_as_object_type(context, kind.into_typedb(), &type_label);
     with_read_tx!(context, |tx| {
         let role_type =
             tx.type_manager.get_role_type(tx.snapshot.as_ref(), &role_label.into_typedb()).unwrap().unwrap();
@@ -404,15 +381,15 @@ pub async fn get_owns_annotations_is_empty(
 }
 
 #[apply(generic_step)]
-#[step(expr = "{root_label}\\({type_label}\\) get plays\\({type_label}\\) get declared annotations {is_empty_or_not}")]
+#[step(expr = "{kind}\\({type_label}\\) get plays\\({type_label}\\) get declared annotations {is_empty_or_not}")]
 pub async fn get_owns_declared_annotations_is_empty(
     context: &mut Context,
-    root_label: RootLabel,
-    type_label: Label,
-    role_label: Label,
-    is_empty_or_not: IsEmptyOrNot,
+    kind: params::Kind,
+    type_label: params::Label,
+    role_label: params::Label,
+    is_empty_or_not: params::IsEmptyOrNot,
 ) {
-    let player_type = get_as_object_type(context, root_label.into_typedb(), &type_label);
+    let player_type = get_as_object_type(context, kind.into_typedb(), &type_label);
     with_read_tx!(context, |tx| {
         let role_type =
             tx.type_manager.get_role_type(tx.snapshot.as_ref(), &role_label.into_typedb()).unwrap().unwrap();
@@ -424,15 +401,15 @@ pub async fn get_owns_declared_annotations_is_empty(
 }
 
 #[apply(generic_step)]
-#[step(expr = "{root_label}\\({type_label}\\) get plays\\({type_label}\\) get cardinality: {annotation}")]
+#[step(expr = "{kind}\\({type_label}\\) get plays\\({type_label}\\) get cardinality: {annotation}")]
 pub async fn get_plays_cardinality(
     context: &mut Context,
-    root_label: RootLabel,
-    type_label: Label,
-    role_label: Label,
-    cardinality_annotation: Annotation,
+    kind: params::Kind,
+    type_label: params::Label,
+    role_label: params::Label,
+    cardinality_annotation: params::Annotation,
 ) {
-    let player_type = get_as_object_type(context, root_label.into_typedb(), &type_label);
+    let player_type = get_as_object_type(context, kind.into_typedb(), &type_label);
     with_read_tx!(context, |tx| {
         let role_type =
             tx.type_manager.get_role_type(tx.snapshot.as_ref(), &role_label.into_typedb()).unwrap().unwrap();

--- a/tests/behaviour/steps/concept/type_/relation_type.rs
+++ b/tests/behaviour/steps/concept/type_/relation_type.rs
@@ -20,7 +20,12 @@ use cucumber::gherkin::Step;
 use itertools::Itertools;
 use macro_rules_attribute::apply;
 
-use crate::{concept::type_::BehaviourConceptTestExecutionError, generic_step, transaction_context::{with_read_tx, with_schema_tx}, util, Context, params};
+use crate::{
+    concept::type_::BehaviourConceptTestExecutionError,
+    generic_step, params,
+    transaction_context::{with_read_tx, with_schema_tx},
+    util, Context,
+};
 
 #[apply(generic_step)]
 #[step(expr = r"relation\({type_label}\) create role: {type_label}{may_error}")]
@@ -182,7 +187,12 @@ pub async fn relation_role_unset_override(
 
 #[apply(generic_step)]
 #[step(expr = r"relation\({type_label}\) get roles {contains_or_doesnt}:")]
-pub async fn relation_roles_contain(context: &mut Context, type_label: params::Label, contains: params::ContainsOrDoesnt, step: &Step) {
+pub async fn relation_roles_contain(
+    context: &mut Context,
+    type_label: params::Label,
+    contains: params::ContainsOrDoesnt,
+    step: &Step,
+) {
     let expected_labels: Vec<String> = util::iter_table(step).map(|str| str.to_owned()).collect::<Vec<String>>();
     with_read_tx!(context, |tx| {
         let relation_type =
@@ -207,7 +217,11 @@ pub async fn relation_roles_contain(context: &mut Context, type_label: params::L
 
 #[apply(generic_step)]
 #[step(expr = r"relation\({type_label}\) get roles {is_empty_or_not}")]
-pub async fn relation_roles_is_empty(context: &mut Context, type_label: params::Label, is_empty_or_not: params::IsEmptyOrNot,) {
+pub async fn relation_roles_is_empty(
+    context: &mut Context,
+    type_label: params::Label,
+    is_empty_or_not: params::IsEmptyOrNot,
+) {
     with_read_tx!(context, |tx| {
         let relation_type =
             tx.type_manager.get_relation_type(tx.snapshot.as_ref(), &type_label.into_typedb()).unwrap().unwrap();
@@ -261,7 +275,11 @@ pub async fn relation_declared_roles_contain(
 
 #[apply(generic_step)]
 #[step(expr = r"relation\({type_label}\) get declared roles {is_empty_or_not}")]
-pub async fn relation_declared_roles_is_empty(context: &mut Context, type_label: params::Label, is_empty_or_not: params::IsEmptyOrNot,) {
+pub async fn relation_declared_roles_is_empty(
+    context: &mut Context,
+    type_label: params::Label,
+    is_empty_or_not: params::IsEmptyOrNot,
+) {
     with_read_tx!(context, |tx| {
         let type_ =
             tx.type_manager.get_relation_type(tx.snapshot.as_ref(), &type_label.into_typedb()).unwrap().unwrap();
@@ -285,7 +303,12 @@ pub async fn relation_declared_roles_is_empty(context: &mut Context, type_label:
 
 #[apply(generic_step)]
 #[step(expr = r"relation\({type_label}\) get role\({type_label}\) {exists_or_doesnt}")]
-pub async fn relation_role_exists(context: &mut Context, type_label: params::Label, role_label: params::Label, exists: params::ExistsOrDoesnt) {
+pub async fn relation_role_exists(
+    context: &mut Context,
+    type_label: params::Label,
+    role_label: params::Label,
+    exists: params::ExistsOrDoesnt,
+) {
     with_read_tx!(context, |tx| {
         let relation =
             tx.type_manager.get_relation_type(tx.snapshot.as_ref(), &type_label.into_typedb()).unwrap().unwrap();

--- a/tests/behaviour/steps/concept/type_/relation_type.rs
+++ b/tests/behaviour/steps/concept/type_/relation_type.rs
@@ -20,21 +20,15 @@ use cucumber::gherkin::Step;
 use itertools::Itertools;
 use macro_rules_attribute::apply;
 
-use crate::{
-    concept::type_::BehaviourConceptTestExecutionError,
-    generic_step, params,
-    params::{Annotation, AnnotationCategory, ContainsOrDoesnt, ExistsOrDoesnt, IsEmptyOrNot, Label, MayError},
-    transaction_context::{with_read_tx, with_schema_tx},
-    util, Context,
-};
+use crate::{concept::type_::BehaviourConceptTestExecutionError, generic_step, transaction_context::{with_read_tx, with_schema_tx}, util, Context, params};
 
 #[apply(generic_step)]
 #[step(expr = r"relation\({type_label}\) create role: {type_label}{may_error}")]
 pub async fn relation_type_create_role(
     context: &mut Context,
-    type_label: Label,
-    role_label: Label,
-    may_error: MayError,
+    type_label: params::Label,
+    role_label: params::Label,
+    may_error: params::MayError,
 ) {
     let res = relation_type_create_role_impl(
         context,
@@ -50,10 +44,10 @@ pub async fn relation_type_create_role(
 #[step(expr = r"relation\({type_label}\) create role: {type_label}, with {annotation}{may_error}")]
 pub async fn relation_type_create_role_with_cardinality(
     context: &mut Context,
-    type_label: Label,
-    role_label: Label,
-    annotation: Annotation,
-    may_error: MayError,
+    type_label: params::Label,
+    role_label: params::Label,
+    annotation: params::Annotation,
+    may_error: params::MayError,
 ) {
     let res = relation_type_create_role_impl(context, type_label, role_label, Ordering::Unordered, Some(annotation));
     may_error.check_concept_write_without_read_errors(&res);
@@ -63,9 +57,9 @@ pub async fn relation_type_create_role_with_cardinality(
 #[step(expr = r"relation\({type_label}\) create role: {type_label}[]{may_error}")]
 pub async fn relation_type_create_ordered_role(
     context: &mut Context,
-    type_label: Label,
-    role_label: Label,
-    may_error: MayError,
+    type_label: params::Label,
+    role_label: params::Label,
+    may_error: params::MayError,
 ) {
     let res = relation_type_create_role_impl(
         context,
@@ -81,10 +75,10 @@ pub async fn relation_type_create_ordered_role(
 #[step(expr = r"relation\({type_label}\) create role: {type_label}[], with {annotation}{may_error}")]
 pub async fn relation_type_create_ordered_role_with_cardinality(
     context: &mut Context,
-    type_label: Label,
-    role_label: Label,
-    annotation: Annotation,
-    may_error: MayError,
+    type_label: params::Label,
+    role_label: params::Label,
+    annotation: params::Annotation,
+    may_error: params::MayError,
 ) {
     let res = relation_type_create_role_impl(context, type_label, role_label, Ordering::Ordered, Some(annotation));
     may_error.check_concept_write_without_read_errors(&res);
@@ -92,10 +86,10 @@ pub async fn relation_type_create_ordered_role_with_cardinality(
 
 pub fn relation_type_create_role_impl(
     context: &mut Context,
-    type_label: Label,
-    role_label: Label,
+    type_label: params::Label,
+    role_label: params::Label,
     ordering: Ordering,
-    annotation: Option<Annotation>,
+    annotation: Option<params::Annotation>,
 ) -> Result<Relates<'static>, ConceptWriteError> {
     let cardinality = match annotation {
         None => None,
@@ -123,10 +117,10 @@ pub fn relation_type_create_role_impl(
 #[step(expr = r"relation\({type_label}\) get role\({type_label}\) set override: {type_label}{may_error}")]
 pub async fn relation_role_set_override(
     context: &mut Context,
-    type_label: Label,
-    role_label: Label,
-    superrole_label: Label,
-    may_error: MayError,
+    type_label: params::Label,
+    role_label: params::Label,
+    superrole_label: params::Label,
+    may_error: params::MayError,
 ) {
     with_schema_tx!(context, |tx| {
         let relation_type =
@@ -166,9 +160,9 @@ pub async fn relation_role_set_override(
 #[step(expr = r"relation\({type_label}\) get role\({type_label}\) unset override{may_error}")]
 pub async fn relation_role_unset_override(
     context: &mut Context,
-    type_label: Label,
-    role_label: Label,
-    may_error: MayError,
+    type_label: params::Label,
+    role_label: params::Label,
+    may_error: params::MayError,
 ) {
     with_schema_tx!(context, |tx| {
         let relation_type =
@@ -188,7 +182,7 @@ pub async fn relation_role_unset_override(
 
 #[apply(generic_step)]
 #[step(expr = r"relation\({type_label}\) get roles {contains_or_doesnt}:")]
-pub async fn relation_roles_contain(context: &mut Context, type_label: Label, contains: ContainsOrDoesnt, step: &Step) {
+pub async fn relation_roles_contain(context: &mut Context, type_label: params::Label, contains: params::ContainsOrDoesnt, step: &Step) {
     let expected_labels: Vec<String> = util::iter_table(step).map(|str| str.to_owned()).collect::<Vec<String>>();
     with_read_tx!(context, |tx| {
         let relation_type =
@@ -213,7 +207,7 @@ pub async fn relation_roles_contain(context: &mut Context, type_label: Label, co
 
 #[apply(generic_step)]
 #[step(expr = r"relation\({type_label}\) get roles {is_empty_or_not}")]
-pub async fn relation_roles_is_empty(context: &mut Context, type_label: Label, is_empty_or_not: IsEmptyOrNot) {
+pub async fn relation_roles_is_empty(context: &mut Context, type_label: params::Label, is_empty_or_not: params::IsEmptyOrNot,) {
     with_read_tx!(context, |tx| {
         let relation_type =
             tx.type_manager.get_relation_type(tx.snapshot.as_ref(), &type_label.into_typedb()).unwrap().unwrap();
@@ -239,8 +233,8 @@ pub async fn relation_roles_is_empty(context: &mut Context, type_label: Label, i
 #[step(expr = r"relation\({type_label}\) get declared roles {contains_or_doesnt}:")]
 pub async fn relation_declared_roles_contain(
     context: &mut Context,
-    type_label: Label,
-    contains: ContainsOrDoesnt,
+    type_label: params::Label,
+    contains: params::ContainsOrDoesnt,
     step: &Step,
 ) {
     let expected_labels: Vec<String> = util::iter_table(step).map(|str| str.to_owned()).collect::<Vec<String>>();
@@ -267,7 +261,7 @@ pub async fn relation_declared_roles_contain(
 
 #[apply(generic_step)]
 #[step(expr = r"relation\({type_label}\) get declared roles {is_empty_or_not}")]
-pub async fn relation_declared_roles_is_empty(context: &mut Context, type_label: Label, is_empty_or_not: IsEmptyOrNot) {
+pub async fn relation_declared_roles_is_empty(context: &mut Context, type_label: params::Label, is_empty_or_not: params::IsEmptyOrNot,) {
     with_read_tx!(context, |tx| {
         let type_ =
             tx.type_manager.get_relation_type(tx.snapshot.as_ref(), &type_label.into_typedb()).unwrap().unwrap();
@@ -291,7 +285,7 @@ pub async fn relation_declared_roles_is_empty(context: &mut Context, type_label:
 
 #[apply(generic_step)]
 #[step(expr = r"relation\({type_label}\) get role\({type_label}\) {exists_or_doesnt}")]
-pub async fn relation_role_exists(context: &mut Context, type_label: Label, role_label: Label, exists: ExistsOrDoesnt) {
+pub async fn relation_role_exists(context: &mut Context, type_label: params::Label, role_label: params::Label, exists: params::ExistsOrDoesnt) {
     with_read_tx!(context, |tx| {
         let relation =
             tx.type_manager.get_relation_type(tx.snapshot.as_ref(), &type_label.into_typedb()).unwrap().unwrap();
@@ -310,9 +304,9 @@ pub async fn relation_role_exists(context: &mut Context, type_label: Label, role
 #[step(expr = r"relation\({type_label}\) get role\({type_label}\) get label: {type_label}")]
 pub async fn relation_role_get_label(
     context: &mut Context,
-    type_label: Label,
-    role_label: Label,
-    expected_label: Label,
+    type_label: params::Label,
+    role_label: params::Label,
+    expected_label: params::Label,
 ) {
     with_read_tx!(context, |tx| {
         let relation =
@@ -337,9 +331,9 @@ pub async fn relation_role_get_label(
 #[step(expr = r"relation\({type_label}\) get role\({type_label}\) get name: {type_label}")]
 pub async fn relation_role_get_name(
     context: &mut Context,
-    type_label: Label,
-    role_label: Label,
-    expected_label: Label,
+    type_label: params::Label,
+    role_label: params::Label,
+    expected_label: params::Label,
 ) {
     with_read_tx!(context, |tx| {
         let relation =
@@ -364,9 +358,9 @@ pub async fn relation_role_get_name(
 #[step(expr = r"relation\({type_label}\) delete role: {type_label}{may_error}")]
 pub async fn relation_type_delete_role(
     context: &mut Context,
-    type_label: Label,
-    role_label: Label,
-    may_error: MayError,
+    type_label: params::Label,
+    role_label: params::Label,
+    may_error: params::MayError,
 ) {
     with_schema_tx!(context, |tx| {
         let relation =
@@ -389,9 +383,9 @@ pub async fn relation_type_delete_role(
 #[step(expr = r"relation\({type_label}\) get role\({type_label}\) get supertype: {type_label}")]
 pub async fn relation_role_get_supertype(
     context: &mut Context,
-    relation_label: Label,
-    role_label: Label,
-    expected_superrole_label: Label,
+    relation_label: params::Label,
+    role_label: params::Label,
+    expected_superrole_label: params::Label,
 ) {
     with_read_tx!(context, |tx| {
         let relation =
@@ -419,9 +413,9 @@ pub async fn relation_role_get_supertype(
 #[step(expr = r"relation\({type_label}\) get role\({type_label}\) get supertype {exists_or_doesnt}")]
 pub async fn relation_role_get_supertype_exists(
     context: &mut Context,
-    relation_label: Label,
-    role_label: Label,
-    exists: ExistsOrDoesnt,
+    relation_label: params::Label,
+    role_label: params::Label,
+    exists: params::ExistsOrDoesnt,
 ) {
     with_read_tx!(context, |tx| {
         let relation =
@@ -441,9 +435,9 @@ pub async fn relation_role_get_supertype_exists(
 #[step(expr = r"relation\({type_label}\) get role\({type_label}\) get supertypes {is_empty_or_not}")]
 pub async fn relation_role_supertypes_is_empty(
     context: &mut Context,
-    relation_label: Label,
-    role_label: Label,
-    is_empty_or_not: IsEmptyOrNot,
+    relation_label: params::Label,
+    role_label: params::Label,
+    is_empty_or_not: params::IsEmptyOrNot,
     step: &Step,
 ) {
     with_read_tx!(context, |tx| {
@@ -464,9 +458,9 @@ pub async fn relation_role_supertypes_is_empty(
 #[step(expr = r"relation\({type_label}\) get role\({type_label}\) get supertypes {contains_or_doesnt}:")]
 pub async fn relation_role_supertypes_contain(
     context: &mut Context,
-    relation_label: Label,
-    role_label: Label,
-    contains: ContainsOrDoesnt,
+    relation_label: params::Label,
+    role_label: params::Label,
+    contains: params::ContainsOrDoesnt,
     step: &Step,
 ) {
     let expected_labels = util::iter_table(step).map(|str| str.to_owned()).collect_vec();
@@ -496,9 +490,9 @@ pub async fn relation_role_supertypes_contain(
 #[step(expr = r"relation\({type_label}\) get role\({type_label}\) get subtypes {contains_or_doesnt}:")]
 pub async fn relation_role_subtypes_contain(
     context: &mut Context,
-    relation_label: Label,
-    role_label: Label,
-    contains: ContainsOrDoesnt,
+    relation_label: params::Label,
+    role_label: params::Label,
+    contains: params::ContainsOrDoesnt,
     step: &Step,
 ) {
     let expected_labels = util::iter_table(step).map(|str| str.to_owned()).collect_vec();
@@ -527,9 +521,9 @@ pub async fn relation_role_subtypes_contain(
 #[step(expr = r"relation\({type_label}\) get role\({type_label}\) get subtypes {is_empty_or_not}")]
 pub async fn relation_role_subtypes_is_empty(
     context: &mut Context,
-    relation_label: Label,
-    role_label: Label,
-    is_empty_or_not: IsEmptyOrNot,
+    relation_label: params::Label,
+    role_label: params::Label,
+    is_empty_or_not: params::IsEmptyOrNot,
 ) {
     with_read_tx!(context, |tx| {
         let relation =
@@ -556,10 +550,10 @@ pub async fn relation_role_subtypes_is_empty(
 #[step(expr = r"relation\({type_label}\) get role\({type_label}\) set name: {type_label}{may_error}")]
 pub async fn relation_role_set_name(
     context: &mut Context,
-    relation_label: Label,
-    role_label: Label,
-    to_label: Label,
-    may_error: MayError,
+    relation_label: params::Label,
+    role_label: params::Label,
+    to_label: params::Label,
+    may_error: params::MayError,
 ) {
     with_schema_tx!(context, |tx| {
         let relation =
@@ -583,9 +577,9 @@ pub async fn relation_role_set_name(
 #[step(expr = r"relation\({type_label}\) get overridden role\({type_label}\) {exists_or_doesnt}")]
 pub async fn relation_get_overridden_role(
     context: &mut Context,
-    relation_label: Label,
-    role_label: Label,
-    exists: ExistsOrDoesnt,
+    relation_label: params::Label,
+    role_label: params::Label,
+    exists: params::ExistsOrDoesnt,
 ) {
     with_read_tx!(context, |tx| {
         let relation =
@@ -608,9 +602,9 @@ pub async fn relation_get_overridden_role(
 #[step(expr = r"relation\({type_label}\) get overridden role\({type_label}\) get label: {type_label}")]
 pub async fn relation_overridden_role_get_label(
     context: &mut Context,
-    relation_label: Label,
-    role_label: Label,
-    expected_label: Label,
+    relation_label: params::Label,
+    role_label: params::Label,
+    expected_label: params::Label,
 ) {
     with_read_tx!(context, |tx| {
         let relation =
@@ -633,10 +627,10 @@ pub async fn relation_overridden_role_get_label(
 #[step(expr = r"relation\({type_label}\) get role\({type_label}\) set annotation: {annotation}{may_error}")]
 pub async fn relation_role_set_annotation(
     context: &mut Context,
-    relation_label: Label,
-    role_label: Label,
-    annotation: Annotation,
-    may_error: MayError,
+    relation_label: params::Label,
+    role_label: params::Label,
+    annotation: params::Annotation,
+    may_error: params::MayError,
 ) {
     with_schema_tx!(context, |tx| {
         let relation =
@@ -678,10 +672,10 @@ pub async fn relation_role_set_annotation(
 #[step(expr = r"relation\({type_label}\) get role\({type_label}\) unset annotation: {annotation_category}{may_error}")]
 pub async fn relation_role_unset_annotation(
     context: &mut Context,
-    relation_label: Label,
-    role_label: Label,
-    annotation_category: AnnotationCategory,
-    may_error: MayError,
+    relation_label: params::Label,
+    role_label: params::Label,
+    annotation_category: params::AnnotationCategory,
+    may_error: params::MayError,
 ) {
     with_schema_tx!(context, |tx| {
         let relation =
@@ -718,10 +712,10 @@ pub async fn relation_role_unset_annotation(
 #[step(expr = r"relation\({type_label}\) get role\({type_label}\) get annotations {contains_or_doesnt}: {annotation}")]
 pub async fn relation_role_annotations_contain(
     context: &mut Context,
-    relation_label: Label,
-    role_label: Label,
-    contains_or_doesnt: ContainsOrDoesnt,
-    annotation: Annotation,
+    relation_label: params::Label,
+    role_label: params::Label,
+    contains_or_doesnt: params::ContainsOrDoesnt,
+    annotation: params::Annotation,
 ) {
     with_read_tx!(context, |tx| {
         let relation =
@@ -759,10 +753,10 @@ pub async fn relation_role_annotations_contain(
 )]
 pub async fn relation_role_annotation_categories_contain(
     context: &mut Context,
-    relation_label: Label,
-    role_label: Label,
-    contains_or_doesnt: ContainsOrDoesnt,
-    annotation_category: AnnotationCategory,
+    relation_label: params::Label,
+    role_label: params::Label,
+    contains_or_doesnt: params::ContainsOrDoesnt,
+    annotation_category: params::AnnotationCategory,
 ) {
     with_read_tx!(context, |tx| {
         let relation =
@@ -807,10 +801,10 @@ pub async fn relation_role_annotation_categories_contain(
 )]
 pub async fn relation_role_declared_annotations_contain(
     context: &mut Context,
-    relation_label: Label,
-    role_label: Label,
-    contains_or_doesnt: ContainsOrDoesnt,
-    annotation: Annotation,
+    relation_label: params::Label,
+    role_label: params::Label,
+    contains_or_doesnt: params::ContainsOrDoesnt,
+    annotation: params::Annotation,
 ) {
     with_read_tx!(context, |tx| {
         let relation =
@@ -846,9 +840,9 @@ pub async fn relation_role_declared_annotations_contain(
 #[step(expr = r"relation\({type_label}\) get role\({type_label}\) get annotations {is_empty_or_not}")]
 pub async fn relation_role_annotations_is_empty(
     context: &mut Context,
-    relation_label: Label,
-    role_label: Label,
-    is_empty_or_not: IsEmptyOrNot,
+    relation_label: params::Label,
+    role_label: params::Label,
+    is_empty_or_not: params::IsEmptyOrNot,
 ) {
     with_read_tx!(context, |tx| {
         let relation =
@@ -870,9 +864,9 @@ pub async fn relation_role_annotations_is_empty(
 #[step(expr = r"relation\({type_label}\) get role\({type_label}\) get declared annotations {is_empty_or_not}")]
 pub async fn relation_role_declared_annotations_is_empty(
     context: &mut Context,
-    relation_label: Label,
-    role_label: Label,
-    is_empty_or_not: IsEmptyOrNot,
+    relation_label: params::Label,
+    role_label: params::Label,
+    is_empty_or_not: params::IsEmptyOrNot,
 ) {
     with_read_tx!(context, |tx| {
         let relation =
@@ -896,9 +890,9 @@ pub async fn relation_role_declared_annotations_is_empty(
 #[step(expr = r"relation\({type_label}\) get role\({type_label}\) get cardinality: {annotation}")]
 pub async fn relation_role_cardinality(
     context: &mut Context,
-    relation_label: Label,
-    role_label: Label,
-    cardinality_annotation: Annotation,
+    relation_label: params::Label,
+    role_label: params::Label,
+    cardinality_annotation: params::Annotation,
 ) {
     with_read_tx!(context, |tx| {
         let relation =
@@ -920,10 +914,10 @@ pub async fn relation_role_cardinality(
 #[step(expr = r"relation\({type_label}\) get role\({type_label}\) set ordering: {ordering}{may_error}")]
 pub async fn relation_role_set_ordering(
     context: &mut Context,
-    relation_label: Label,
-    role_label: Label,
+    relation_label: params::Label,
+    role_label: params::Label,
     ordering: params::Ordering,
-    may_error: MayError,
+    may_error: params::MayError,
 ) {
     with_schema_tx!(context, |tx| {
         let relation =
@@ -948,8 +942,8 @@ pub async fn relation_role_set_ordering(
 #[step(expr = r"relation\({type_label}\) get role\({type_label}\) get ordering: {ordering}")]
 pub async fn relation_role_get_ordering(
     context: &mut Context,
-    relation_label: Label,
-    role_label: Label,
+    relation_label: params::Label,
+    role_label: params::Label,
     ordering: params::Ordering,
 ) {
     with_read_tx!(context, |tx| {
@@ -969,9 +963,9 @@ pub async fn relation_role_get_ordering(
 #[step(expr = r"relation\({type_label}\) get role\({type_label}\) get players {contains_or_doesnt}:")]
 pub async fn role_type_players_contain(
     context: &mut Context,
-    relation_label: Label,
-    role_label: Label,
-    contains_or_doesnt: ContainsOrDoesnt,
+    relation_label: params::Label,
+    role_label: params::Label,
+    contains_or_doesnt: params::ContainsOrDoesnt,
     step: &Step,
 ) {
     let expected_labels: Vec<String> = util::iter_table(step).map(|str| str.to_owned()).collect::<Vec<String>>();
@@ -1014,9 +1008,9 @@ pub async fn role_type_players_contain(
 #[step(expr = r"relation\({type_label}\) get role\({type_label}\) get declared players {contains_or_doesnt}:")]
 pub async fn role_type_declared_players_contain(
     context: &mut Context,
-    relation_label: Label,
-    role_label: Label,
-    contains_or_doesnt: ContainsOrDoesnt,
+    relation_label: params::Label,
+    role_label: params::Label,
+    contains_or_doesnt: params::ContainsOrDoesnt,
     step: &Step,
 ) {
     let expected_labels: Vec<String> = util::iter_table(step).map(|str| str.to_owned()).collect::<Vec<String>>();

--- a/tests/behaviour/steps/concept/type_/struct_definition.rs
+++ b/tests/behaviour/steps/concept/type_/struct_definition.rs
@@ -99,7 +99,12 @@ pub async fn struct_create_field_with_value_type(
 
 #[apply(generic_step)]
 #[step(expr = "struct\\({type_label}\\) delete field: {type_label}{may_error}")]
-pub async fn struct_delete_field(context: &mut Context, type_label: params::Label, field_label: params::Label, may_error: params::MayError) {
+pub async fn struct_delete_field(
+    context: &mut Context,
+    type_label: params::Label,
+    field_label: params::Label,
+    may_error: params::MayError,
+) {
     with_schema_tx!(context, |tx| {
         let definition_key = &tx
             .type_manager

--- a/tests/behaviour/steps/concept/type_/struct_definition.rs
+++ b/tests/behaviour/steps/concept/type_/struct_definition.rs
@@ -12,14 +12,14 @@ use macro_rules_attribute::apply;
 use crate::{
     concept::type_::BehaviourConceptTestExecutionError,
     generic_step, params,
-    params::{check_boolean, ContainsOrDoesnt, ExistsOrDoesnt, Label, MayError, Optional, ValueType},
+    params::check_boolean,
     transaction_context::{with_read_tx, with_schema_tx},
     util, Context,
 };
 
 #[apply(generic_step)]
 #[step(expr = "create struct: {type_label}{may_error}")]
-pub async fn struct_create(context: &mut Context, type_label: Label, may_error: MayError) {
+pub async fn struct_create(context: &mut Context, type_label: params::Label, may_error: params::MayError) {
     with_schema_tx!(context, |tx| {
         may_error.check_concept_write_without_read_errors(&tx.type_manager.create_struct(
             Arc::get_mut(&mut tx.snapshot).unwrap(),
@@ -30,7 +30,7 @@ pub async fn struct_create(context: &mut Context, type_label: Label, may_error: 
 
 #[apply(generic_step)]
 #[step(expr = "delete struct: {type_label}{may_error}")]
-pub async fn struct_delete(context: &mut Context, type_label: Label, may_error: MayError) {
+pub async fn struct_delete(context: &mut Context, type_label: params::Label, may_error: params::MayError) {
     with_schema_tx!(context, |tx| {
         if let Some(definition_key) = &tx
             .type_manager
@@ -52,7 +52,7 @@ pub async fn struct_delete(context: &mut Context, type_label: Label, may_error: 
 
 #[apply(generic_step)]
 #[step(expr = "struct\\({type_label}\\) {exists_or_doesnt}")]
-pub async fn struct_exists(context: &mut Context, type_label: Label, exists: ExistsOrDoesnt) {
+pub async fn struct_exists(context: &mut Context, type_label: params::Label, exists: params::ExistsOrDoesnt) {
     with_read_tx!(context, |tx| {
         let definition_key_opt = &tx
             .type_manager
@@ -74,11 +74,11 @@ pub async fn struct_exists(context: &mut Context, type_label: Label, exists: Exi
 )]
 pub async fn struct_create_field_with_value_type(
     context: &mut Context,
-    type_label: Label,
-    field_label: Label,
-    value_type: ValueType,
-    optional: Optional,
-    may_error: MayError,
+    type_label: params::Label,
+    field_label: params::Label,
+    value_type: params::ValueType,
+    optional: params::Optional,
+    may_error: params::MayError,
 ) {
     with_schema_tx!(context, |tx| {
         let definition_key = &tx
@@ -99,7 +99,7 @@ pub async fn struct_create_field_with_value_type(
 
 #[apply(generic_step)]
 #[step(expr = "struct\\({type_label}\\) delete field: {type_label}{may_error}")]
-pub async fn struct_delete_field(context: &mut Context, type_label: Label, field_label: Label, may_error: MayError) {
+pub async fn struct_delete_field(context: &mut Context, type_label: params::Label, field_label: params::Label, may_error: params::MayError) {
     with_schema_tx!(context, |tx| {
         let definition_key = &tx
             .type_manager
@@ -119,8 +119,8 @@ pub async fn struct_delete_field(context: &mut Context, type_label: Label, field
 #[step(expr = "struct\\({type_label}\\) get fields {contains_or_doesnt}:")]
 pub async fn struct_get_fields_contains_or_doesnt(
     context: &mut Context,
-    type_label: Label,
-    contains_or_doesnt: ContainsOrDoesnt,
+    type_label: params::Label,
+    contains_or_doesnt: params::ContainsOrDoesnt,
     step: &Step,
 ) {
     let expected_fields: Vec<String> = util::iter_table(step).map(|str| str.to_owned()).collect();
@@ -142,9 +142,9 @@ pub async fn struct_get_fields_contains_or_doesnt(
 #[step(expr = "struct\\({type_label}\\) get field\\({type_label}\\) get value type: {value_type}")]
 pub async fn struct_get_field_get_value_type(
     context: &mut Context,
-    type_label: Label,
-    field_label: Label,
-    value_type: ValueType,
+    type_label: params::Label,
+    field_label: params::Label,
+    value_type: params::ValueType,
 ) {
     with_read_tx!(context, |tx| {
         let definition_key = &tx
@@ -168,8 +168,8 @@ pub async fn struct_get_field_get_value_type(
 #[step(expr = "struct\\({type_label}\\) get field\\({type_label}\\) is optional: {boolean}")]
 pub async fn struct_get_field_is_optional(
     context: &mut Context,
-    type_label: Label,
-    field_label: Label,
+    type_label: params::Label,
+    field_label: params::Label,
     is_optional: params::Boolean,
 ) {
     with_read_tx!(context, |tx| {

--- a/tests/behaviour/steps/concept/type_/thing_type.rs
+++ b/tests/behaviour/steps/concept/type_/thing_type.rs
@@ -11,16 +11,14 @@ use concept::type_::{
     relation_type::RelationTypeAnnotation, KindAPI, TypeAPI,
 };
 use cucumber::gherkin::Step;
-use encoding::{graph::type_::Kind, value::value_type::ValueType};
+use encoding::value::value_type::ValueType;
 use itertools::Itertools;
 use macro_rules_attribute::apply;
+use encoding::graph::type_::Kind;
 
 use crate::{
     generic_step,
-    params::{
-        Annotation, AnnotationCategory, ContainsOrDoesnt, ExistsOrDoesnt, IsEmptyOrNot, Label, MayError, RootLabel,
-        RootLabelExtended,
-    },
+    params,
     transaction_context::{with_read_tx, with_schema_tx, with_write_tx},
     util, with_type, Context,
 };
@@ -28,7 +26,6 @@ use crate::{
 #[macro_export]
 macro_rules! with_type {
     ($tx:ident, $kind:expr, $label:ident, $assign_to:ident, $block:block) => {
-        use encoding::graph::type_::Kind;
         match $kind.into_typedb() {
             Kind::Attribute => {
                 let $assign_to =
@@ -53,7 +50,6 @@ macro_rules! with_type {
 #[macro_export]
 macro_rules! with_type_and_value_type {
     ($tx:ident, $kind:expr, $label:ident, $assign_type_to:ident, $assign_value_type_to:ident, $block:block) => {
-        use encoding::graph::type_::Kind;
         let mut $assign_value_type_to: Option<ValueType> = None;
         match $kind.into_typedb() {
             Kind::Attribute => {
@@ -78,7 +74,7 @@ macro_rules! with_type_and_value_type {
     };
 }
 
-pub(super) fn get_as_object_type(context: &mut Context, kind: Kind, label: &Label) -> ObjectType<'static> {
+pub(super) fn get_as_object_type(context: &mut Context, kind: Kind, label: &params::Label) -> ObjectType<'static> {
     with_read_tx!(context, |tx| {
         match kind {
             Kind::Entity => {
@@ -97,10 +93,10 @@ pub(super) fn get_as_object_type(context: &mut Context, kind: Kind, label: &Labe
 }
 
 #[apply(generic_step)]
-#[step(expr = "create {root_label} type: {type_label}{may_error}")]
-pub async fn type_create(context: &mut Context, root_label: RootLabel, type_label: Label, may_error: MayError) {
+#[step(expr = "create {kind} type: {type_label}{may_error}")]
+pub async fn type_create(context: &mut Context, kind: params::Kind, type_label: params::Label, may_error: params::MayError) {
     with_schema_tx!(context, |tx| {
-        match root_label.into_typedb() {
+        match kind.into_typedb() {
             Kind::Entity => {
                 may_error.check_concept_write_without_read_errors(
                     &tx.type_manager
@@ -125,10 +121,10 @@ pub async fn type_create(context: &mut Context, root_label: RootLabel, type_labe
 }
 
 #[apply(generic_step)]
-#[step(expr = "delete {root_label} type: {type_label}{may_error}")]
-pub async fn type_delete(context: &mut Context, root_label: RootLabel, type_label: Label, may_error: MayError) {
+#[step(expr = "delete {kind} type: {type_label}{may_error}")]
+pub async fn type_delete(context: &mut Context, kind: params::Kind, type_label: params::Label, may_error: params::MayError) {
     with_schema_tx!(context, |tx| {
-        with_type!(tx, root_label, type_label, type_, {
+        with_type!(tx, kind, type_label, type_, {
             let res = type_.delete(Arc::get_mut(&mut tx.snapshot).unwrap(), &tx.type_manager, &tx.thing_manager);
             may_error.check_concept_write_without_read_errors(&res);
         });
@@ -137,10 +133,10 @@ pub async fn type_delete(context: &mut Context, root_label: RootLabel, type_labe
 
 //
 #[apply(generic_step)]
-#[step(expr = "{root_label}\\({type_label}\\) {exists_or_doesnt}")]
-pub async fn type_exists(context: &mut Context, root_label: RootLabel, type_label: Label, exists: ExistsOrDoesnt) {
+#[step(expr = "{kind}\\({type_label}\\) {exists_or_doesnt}")]
+pub async fn type_exists(context: &mut Context, kind: params::Kind, type_label: params::Label, exists: params::ExistsOrDoesnt) {
     with_read_tx!(context, |tx| {
-        match root_label.into_typedb() {
+        match kind.into_typedb() {
             Kind::Attribute => {
                 let type_ =
                     tx.type_manager.get_attribute_type(tx.snapshot.as_ref(), &type_label.into_typedb()).unwrap();
@@ -160,16 +156,16 @@ pub async fn type_exists(context: &mut Context, root_label: RootLabel, type_labe
 }
 
 #[apply(generic_step)]
-#[step(expr = "{root_label}\\({type_label}\\) set label: {type_label}{may_error}")]
+#[step(expr = "{kind}\\({type_label}\\) set label: {type_label}{may_error}")]
 pub async fn type_set_label(
     context: &mut Context,
-    root_label: RootLabel,
-    type_label: Label,
-    to_label: Label,
-    may_error: MayError,
+    kind: params::Kind,
+    type_label: params::Label,
+    to_label: params::Label,
+    may_error: params::MayError,
 ) {
     with_schema_tx!(context, |tx| {
-        with_type!(tx, root_label, type_label, type_, {
+        with_type!(tx, kind, type_label, type_, {
             may_error.check_concept_write_without_read_errors(&type_.set_label(
                 Arc::get_mut(&mut tx.snapshot).unwrap(),
                 &tx.type_manager,
@@ -180,10 +176,10 @@ pub async fn type_set_label(
 }
 
 #[apply(generic_step)]
-#[step(expr = "{root_label}\\({type_label}\\) get name: {type_label}")]
-pub async fn type_get_name(context: &mut Context, root_label: RootLabel, type_label: Label, expected: Label) {
+#[step(expr = "{kind}\\({type_label}\\) get name: {type_label}")]
+pub async fn type_get_name(context: &mut Context, kind: params::Kind, type_label: params::Label, expected: params::Label) {
     with_read_tx!(context, |tx| {
-        with_type!(tx, root_label, type_label, type_, {
+        with_type!(tx, kind, type_label, type_, {
             let actual_label = type_.get_label(tx.snapshot.as_ref(), &tx.type_manager);
             assert_eq!(expected.into_typedb().name(), actual_label.unwrap().name());
         });
@@ -191,10 +187,10 @@ pub async fn type_get_name(context: &mut Context, root_label: RootLabel, type_la
 }
 
 #[apply(generic_step)]
-#[step(expr = "{root_label}\\({type_label}\\) get label: {type_label}")]
-pub async fn type_get_label(context: &mut Context, root_label: RootLabel, type_label: Label, expected: Label) {
+#[step(expr = "{kind}\\({type_label}\\) get label: {type_label}")]
+pub async fn type_get_label(context: &mut Context, kind: params::Kind, type_label: params::Label, expected: params::Label) {
     with_read_tx!(context, |tx| {
-        with_type!(tx, root_label, type_label, type_, {
+        with_type!(tx, kind, type_label, type_, {
             let actual_label = type_.get_label(tx.snapshot.as_ref(), &tx.type_manager);
             assert_eq!(expected.into_typedb().scoped_name(), actual_label.unwrap().scoped_name());
         });
@@ -202,16 +198,16 @@ pub async fn type_get_label(context: &mut Context, root_label: RootLabel, type_l
 }
 
 #[apply(generic_step)]
-#[step(expr = "{root_label}\\({type_label}\\) set annotation: {annotation}{may_error}")]
+#[step(expr = "{kind}\\({type_label}\\) set annotation: {annotation}{may_error}")]
 pub async fn type_set_annotation(
     context: &mut Context,
-    root_label: RootLabel,
-    type_label: Label,
-    annotation: Annotation,
-    may_error: MayError,
+    kind: params::Kind,
+    type_label: params::Label,
+    annotation: params::Annotation,
+    may_error: params::MayError,
 ) {
     with_write_tx!(context, |tx| {
-        with_type_and_value_type!(tx, root_label, type_label, type_, value_type, {
+        with_type_and_value_type!(tx, kind, type_label, type_, value_type, {
             let res = type_.set_annotation(
                 Arc::get_mut(&mut tx.snapshot).unwrap(),
                 &tx.type_manager,
@@ -224,16 +220,16 @@ pub async fn type_set_annotation(
 }
 
 #[apply(generic_step)]
-#[step(expr = "{root_label}\\({type_label}\\) unset annotation: {annotation_category}{may_error}")]
+#[step(expr = "{kind}\\({type_label}\\) unset annotation: {annotation_category}{may_error}")]
 pub async fn type_unset_annotation(
     context: &mut Context,
-    root_label: RootLabel,
-    type_label: Label,
-    annotation_category: AnnotationCategory,
-    may_error: MayError,
+    kind: params::Kind,
+    type_label: params::Label,
+    annotation_category: params::AnnotationCategory,
+    may_error: params::MayError,
 ) {
     with_write_tx!(context, |tx| {
-        with_type!(tx, root_label, type_label, type_, {
+        with_type!(tx, kind, type_label, type_, {
             let res = type_.unset_annotation(
                 Arc::get_mut(&mut tx.snapshot).unwrap(),
                 &tx.type_manager,
@@ -245,16 +241,16 @@ pub async fn type_unset_annotation(
 }
 
 #[apply(generic_step)]
-#[step(expr = "{root_label}\\({type_label}\\) get annotations {contains_or_doesnt}: {annotation}")]
+#[step(expr = "{kind}\\({type_label}\\) get annotations {contains_or_doesnt}: {annotation}")]
 pub async fn type_annotations_contain(
     context: &mut Context,
-    root_label: RootLabel,
-    type_label: Label,
-    contains_or_doesnt: ContainsOrDoesnt,
-    annotation: Annotation,
+    kind: params::Kind,
+    type_label: params::Label,
+    contains_or_doesnt: params::ContainsOrDoesnt,
+    annotation: params::Annotation,
 ) {
     with_read_tx!(context, |tx| {
-        with_type_and_value_type!(tx, root_label, type_label, type_, value_type, {
+        with_type_and_value_type!(tx, kind, type_label, type_, value_type, {
             let actual_contains = type_
                 .get_annotations(tx.snapshot.as_ref(), &tx.type_manager)
                 .unwrap()
@@ -265,16 +261,16 @@ pub async fn type_annotations_contain(
 }
 
 #[apply(generic_step)]
-#[step(expr = "{root_label}\\({type_label}\\) get annotation categories {contains_or_doesnt}: {annotation_category}")]
+#[step(expr = "{kind}\\({type_label}\\) get annotation categories {contains_or_doesnt}: {annotation_category}")]
 pub async fn type_annotation_categories_contain(
     context: &mut Context,
-    root_label: RootLabel,
-    type_label: Label,
-    contains_or_doesnt: ContainsOrDoesnt,
-    annotation_category: AnnotationCategory,
+    kind: params::Kind,
+    type_label: params::Label,
+    contains_or_doesnt: params::ContainsOrDoesnt,
+    annotation_category: params::AnnotationCategory,
 ) {
     with_read_tx!(context, |tx| {
-        match root_label.into_typedb() {
+        match kind.into_typedb() {
             Kind::Attribute => {
                 let type_ = tx
                     .type_manager
@@ -326,16 +322,16 @@ pub async fn type_annotation_categories_contain(
 }
 
 #[apply(generic_step)]
-#[step(expr = "{root_label}\\({type_label}\\) get declared annotations {contains_or_doesnt}: {annotation}")]
+#[step(expr = "{kind}\\({type_label}\\) get declared annotations {contains_or_doesnt}: {annotation}")]
 pub async fn type_declared_annotations_contain(
     context: &mut Context,
-    root_label: RootLabel,
-    type_label: Label,
-    contains_or_doesnt: ContainsOrDoesnt,
-    annotation: Annotation,
+    kind: params::Kind,
+    type_label: params::Label,
+    contains_or_doesnt: params::ContainsOrDoesnt,
+    annotation: params::Annotation,
 ) {
     with_read_tx!(context, |tx| {
-        with_type_and_value_type!(tx, root_label, type_label, type_, value_type, {
+        with_type_and_value_type!(tx, kind, type_label, type_, value_type, {
             let actual_contains = type_
                 .get_annotations_declared(tx.snapshot.as_ref(), &tx.type_manager)
                 .unwrap()
@@ -346,15 +342,15 @@ pub async fn type_declared_annotations_contain(
 }
 
 #[apply(generic_step)]
-#[step(expr = "{root_label}\\({type_label}\\) get annotations {is_empty_or_not}")]
+#[step(expr = "{kind}\\({type_label}\\) get annotations {is_empty_or_not}")]
 pub async fn type_annotations_is_empty(
     context: &mut Context,
-    root_label: RootLabel,
-    type_label: Label,
-    is_empty_or_not: IsEmptyOrNot,
+    kind: params::Kind,
+    type_label: params::Label,
+    is_empty_or_not: params::IsEmptyOrNot,
 ) {
     with_read_tx!(context, |tx| {
-        with_type!(tx, root_label, type_label, type_, {
+        with_type!(tx, kind, type_label, type_, {
             let actual_is_empty = type_.get_annotations(tx.snapshot.as_ref(), &tx.type_manager).unwrap().is_empty();
             is_empty_or_not.check(actual_is_empty);
         });
@@ -362,15 +358,15 @@ pub async fn type_annotations_is_empty(
 }
 
 #[apply(generic_step)]
-#[step(expr = "{root_label}\\({type_label}\\) get declared annotations {is_empty_or_not}")]
+#[step(expr = "{kind}\\({type_label}\\) get declared annotations {is_empty_or_not}")]
 pub async fn type_declared_annotations_is_empty(
     context: &mut Context,
-    root_label: RootLabel,
-    type_label: Label,
-    is_empty_or_not: IsEmptyOrNot,
+    kind: params::Kind,
+    type_label: params::Label,
+    is_empty_or_not: params::IsEmptyOrNot,
 ) {
     with_read_tx!(context, |tx| {
-        with_type!(tx, root_label, type_label, type_, {
+        with_type!(tx, kind, type_label, type_, {
             let actual_is_empty =
                 type_.get_annotations_declared(tx.snapshot.as_ref(), &tx.type_manager).unwrap().is_empty();
             is_empty_or_not.check(actual_is_empty);
@@ -379,16 +375,16 @@ pub async fn type_declared_annotations_is_empty(
 }
 
 #[apply(generic_step)]
-#[step(expr = "{root_label}\\({type_label}\\) set supertype: {type_label}{may_error}")]
+#[step(expr = "{kind}\\({type_label}\\) set supertype: {type_label}{may_error}")]
 pub async fn type_set_supertype(
     context: &mut Context,
-    root_label: RootLabel,
-    type_label: Label,
-    supertype_label: Label,
-    may_error: MayError,
+    kind: params::Kind,
+    type_label: params::Label,
+    supertype_label: params::Label,
+    may_error: params::MayError,
 ) {
     with_schema_tx!(context, |tx| {
-        match root_label.into_typedb() {
+        match kind.into_typedb() {
             Kind::Attribute => {
                 let thistype = tx
                     .type_manager
@@ -449,15 +445,10 @@ pub async fn type_set_supertype(
 }
 
 #[apply(generic_step)]
-#[step(expr = "{root_label}\\({type_label}\\) unset supertype{may_error}")]
-pub async fn type_unset_supertype(
-    context: &mut Context,
-    root_label: RootLabel,
-    type_label: Label,
-    may_error: MayError,
-) {
+#[step(expr = "{kind}\\({type_label}\\) unset supertype{may_error}")]
+pub async fn type_unset_supertype(context: &mut Context, kind: params::Kind, type_label: params::Label, may_error: params::MayError) {
     with_schema_tx!(context, |tx| {
-        match root_label.into_typedb() {
+        match kind.into_typedb() {
             Kind::Attribute => {
                 let thistype = tx
                     .type_manager
@@ -500,15 +491,10 @@ pub async fn type_unset_supertype(
 }
 
 #[apply(generic_step)]
-#[step(expr = "{root_label}\\({type_label}\\) get supertype: {type_label}")]
-pub async fn type_get_supertype(
-    context: &mut Context,
-    root_label: RootLabel,
-    type_label: Label,
-    supertype_label: Label,
-) {
+#[step(expr = "{kind}\\({type_label}\\) get supertype: {type_label}")]
+pub async fn type_get_supertype(context: &mut Context, kind: params::Kind, type_label: params::Label, supertype_label: params::Label) {
     with_read_tx!(context, |tx| {
-        with_type!(tx, root_label, type_label, type_, {
+        with_type!(tx, kind, type_label, type_, {
             let supertype = type_.get_supertype(tx.snapshot.as_ref(), &tx.type_manager).unwrap().unwrap();
             assert_eq!(
                 supertype_label.into_typedb().scoped_name(),
@@ -519,15 +505,10 @@ pub async fn type_get_supertype(
 }
 
 #[apply(generic_step)]
-#[step(expr = "{root_label}\\({type_label}\\) get supertype {exists_or_doesnt}")]
-pub async fn type_get_supertype_exists(
-    context: &mut Context,
-    root_label: RootLabel,
-    type_label: Label,
-    exists: ExistsOrDoesnt,
-) {
+#[step(expr = "{kind}\\({type_label}\\) get supertype {exists_or_doesnt}")]
+pub async fn type_get_supertype_exists(context: &mut Context, kind: params::Kind, type_label: params::Label, exists: params::ExistsOrDoesnt) {
     with_read_tx!(context, |tx| {
-        with_type!(tx, root_label, type_label, type_, {
+        with_type!(tx, kind, type_label, type_, {
             let supertype = type_.get_supertype(tx.snapshot.as_ref(), &tx.type_manager).unwrap();
             exists.check(&supertype, &format!("supertype for type {}", type_label.into_typedb()));
         });
@@ -535,17 +516,17 @@ pub async fn type_get_supertype_exists(
 }
 
 #[apply(generic_step)]
-#[step(expr = "{root_label}\\({type_label}\\) get supertypes {contains_or_doesnt}:")]
+#[step(expr = "{kind}\\({type_label}\\) get supertypes {contains_or_doesnt}:")]
 pub async fn get_supertypes_transitive_contain(
     context: &mut Context,
-    root_label: RootLabel,
-    type_label: Label,
-    contains: ContainsOrDoesnt,
+    kind: params::Kind,
+    type_label: params::Label,
+    contains: params::ContainsOrDoesnt,
     step: &Step,
 ) {
     let expected_labels = util::iter_table(step).map(|str| str.to_owned()).collect_vec();
     with_read_tx!(context, |tx| {
-        with_type!(tx, root_label, type_label, type_, {
+        with_type!(tx, kind, type_label, type_, {
             let supertype_labels = type_
                 .get_supertypes_transitive(tx.snapshot.as_ref(), &tx.type_manager)
                 .unwrap()
@@ -565,15 +546,15 @@ pub async fn get_supertypes_transitive_contain(
 }
 
 #[apply(generic_step)]
-#[step(expr = "{root_label}\\({type_label}\\) get supertypes {is_empty_or_not}")]
+#[step(expr = "{kind}\\({type_label}\\) get supertypes {is_empty_or_not}")]
 pub async fn get_supertypes_transitive_is_empty(
     context: &mut Context,
-    root_label: RootLabel,
-    type_label: Label,
-    is_empty_or_not: IsEmptyOrNot,
+    kind: params::Kind,
+    type_label: params::Label,
+    is_empty_or_not: params::IsEmptyOrNot,
 ) {
     with_read_tx!(context, |tx| {
-        with_type!(tx, root_label, type_label, type_, {
+        with_type!(tx, kind, type_label, type_, {
             is_empty_or_not
                 .check(type_.get_supertypes_transitive(tx.snapshot.as_ref(), &tx.type_manager).unwrap().is_empty());
         });
@@ -581,17 +562,17 @@ pub async fn get_supertypes_transitive_is_empty(
 }
 
 #[apply(generic_step)]
-#[step(expr = "{root_label}\\({type_label}\\) get subtypes {contains_or_doesnt}:")]
+#[step(expr = "{kind}\\({type_label}\\) get subtypes {contains_or_doesnt}:")]
 pub async fn get_subtypes_contain(
     context: &mut Context,
-    root_label: RootLabel,
-    type_label: Label,
-    contains: ContainsOrDoesnt,
+    kind: params::Kind,
+    type_label: params::Label,
+    contains: params::ContainsOrDoesnt,
     step: &Step,
 ) {
     let expected_labels = util::iter_table(step).map(|str| str.to_owned()).collect_vec();
     with_read_tx!(context, |tx| {
-        with_type!(tx, root_label, type_label, type_, {
+        with_type!(tx, kind, type_label, type_, {
             let subtype_labels = type_
                 .get_subtypes_transitive(tx.snapshot.as_ref(), &tx.type_manager)
                 .unwrap()
@@ -606,15 +587,15 @@ pub async fn get_subtypes_contain(
 }
 
 #[apply(generic_step)]
-#[step(expr = "{root_label}\\({type_label}\\) get subtypes {is_empty_or_not}")]
+#[step(expr = "{kind}\\({type_label}\\) get subtypes {is_empty_or_not}")]
 pub async fn get_subtypes_is_empty(
     context: &mut Context,
-    root_label: RootLabel,
-    type_label: Label,
-    is_empty_or_not: IsEmptyOrNot,
+    kind: params::Kind,
+    type_label: params::Label,
+    is_empty_or_not: params::IsEmptyOrNot,
 ) {
     with_read_tx!(context, |tx| {
-        with_type!(tx, root_label, type_label, type_, {
+        with_type!(tx, kind, type_label, type_, {
             is_empty_or_not
                 .check(type_.get_subtypes_transitive(tx.snapshot.as_ref(), &tx.type_manager).unwrap().is_empty());
         });
@@ -622,17 +603,13 @@ pub async fn get_subtypes_is_empty(
 }
 
 #[apply(generic_step)]
-#[step(expr = "get {root_label_extended} types {contains_or_doesnt}:")]
-pub async fn get_types_contain(
-    context: &mut Context,
-    root_label: RootLabelExtended,
-    contains: ContainsOrDoesnt,
-    step: &Step,
-) {
+#[step(expr = "get {kind_extended} types {contains_or_doesnt}:")]
+pub async fn get_types_contain(context: &mut Context, kind: params::KindExtended, contains: params::ContainsOrDoesnt, step: &Step) {
     let expected_labels = util::iter_table(step).map(|str| str.to_owned()).collect_vec();
     let type_labels = with_read_tx!(context, |tx| {
-        match root_label {
-            RootLabelExtended::Entity => &tx
+        use params::KindExtended;
+        match kind {
+            KindExtended::Entity => &tx
                 .type_manager
                 .get_entity_types(tx.snapshot.as_ref())
                 .unwrap()
@@ -641,7 +618,7 @@ pub async fn get_types_contain(
                     type_.get_label(tx.snapshot.as_ref(), &tx.type_manager).unwrap().scoped_name().as_str().to_owned()
                 })
                 .collect_vec(),
-            RootLabelExtended::Relation => &tx
+            KindExtended::Relation => &tx
                 .type_manager
                 .get_relation_types(tx.snapshot.as_ref())
                 .unwrap()
@@ -650,7 +627,7 @@ pub async fn get_types_contain(
                     type_.get_label(tx.snapshot.as_ref(), &tx.type_manager).unwrap().scoped_name().as_str().to_owned()
                 })
                 .collect_vec(),
-            RootLabelExtended::Attribute => &tx
+            KindExtended::Attribute => &tx
                 .type_manager
                 .get_attribute_types(tx.snapshot.as_ref())
                 .unwrap()
@@ -659,7 +636,7 @@ pub async fn get_types_contain(
                     type_.get_label(tx.snapshot.as_ref(), &tx.type_manager).unwrap().scoped_name().as_str().to_owned()
                 })
                 .collect_vec(),
-            RootLabelExtended::Role => &tx
+            KindExtended::Role => &tx
                 .type_manager
                 .get_role_types(tx.snapshot.as_ref())
                 .unwrap()
@@ -668,7 +645,7 @@ pub async fn get_types_contain(
                     type_.get_label(tx.snapshot.as_ref(), &tx.type_manager).unwrap().scoped_name().as_str().to_owned()
                 })
                 .collect_vec(),
-            RootLabelExtended::Object => &tx
+            KindExtended::Object => &tx
                 .type_manager
                 .get_object_types(tx.snapshot.as_ref())
                 .unwrap()
@@ -683,19 +660,20 @@ pub async fn get_types_contain(
 }
 
 #[apply(generic_step)]
-#[step(expr = "get {root_label_extended} types {is_empty_or_not}")]
-pub async fn get_types_empty(context: &mut Context, root_label: RootLabelExtended, is_empty_or_not: IsEmptyOrNot) {
+#[step(expr = "get {kind_extended} types {is_empty_or_not}")]
+pub async fn get_types_empty(context: &mut Context, kind: params::KindExtended, is_empty_or_not: params::IsEmptyOrNot) {
     let is_empty = with_read_tx!(context, |tx| {
-        match root_label {
-            RootLabelExtended::Entity => &tx.type_manager.get_entity_types(tx.snapshot.as_ref()).unwrap().is_empty(),
-            RootLabelExtended::Relation => {
+        use params::KindExtended;
+        match kind {
+            KindExtended::Entity => &tx.type_manager.get_entity_types(tx.snapshot.as_ref()).unwrap().is_empty(),
+            KindExtended::Relation => {
                 &tx.type_manager.get_relation_types(tx.snapshot.as_ref()).unwrap().is_empty()
             }
-            RootLabelExtended::Attribute => {
+            KindExtended::Attribute => {
                 &tx.type_manager.get_attribute_types(tx.snapshot.as_ref()).unwrap().is_empty()
             }
-            RootLabelExtended::Role => &tx.type_manager.get_role_types(tx.snapshot.as_ref()).unwrap().is_empty(),
-            RootLabelExtended::Object => &tx.type_manager.get_object_types(tx.snapshot.as_ref()).unwrap().is_empty(),
+            KindExtended::Role => &tx.type_manager.get_role_types(tx.snapshot.as_ref()).unwrap().is_empty(),
+            KindExtended::Object => &tx.type_manager.get_object_types(tx.snapshot.as_ref()).unwrap().is_empty(),
         }
     });
     is_empty_or_not.check(*is_empty)

--- a/tests/behaviour/steps/concept/type_/thing_type.rs
+++ b/tests/behaviour/steps/concept/type_/thing_type.rs
@@ -11,14 +11,12 @@ use concept::type_::{
     relation_type::RelationTypeAnnotation, KindAPI, TypeAPI,
 };
 use cucumber::gherkin::Step;
-use encoding::value::value_type::ValueType;
+use encoding::{graph::type_::Kind, value::value_type::ValueType};
 use itertools::Itertools;
 use macro_rules_attribute::apply;
-use encoding::graph::type_::Kind;
 
 use crate::{
-    generic_step,
-    params,
+    generic_step, params,
     transaction_context::{with_read_tx, with_schema_tx, with_write_tx},
     util, with_type, Context,
 };
@@ -94,7 +92,12 @@ pub(super) fn get_as_object_type(context: &mut Context, kind: Kind, label: &para
 
 #[apply(generic_step)]
 #[step(expr = "create {kind} type: {type_label}{may_error}")]
-pub async fn type_create(context: &mut Context, kind: params::Kind, type_label: params::Label, may_error: params::MayError) {
+pub async fn type_create(
+    context: &mut Context,
+    kind: params::Kind,
+    type_label: params::Label,
+    may_error: params::MayError,
+) {
     with_schema_tx!(context, |tx| {
         match kind.into_typedb() {
             Kind::Entity => {
@@ -122,7 +125,12 @@ pub async fn type_create(context: &mut Context, kind: params::Kind, type_label: 
 
 #[apply(generic_step)]
 #[step(expr = "delete {kind} type: {type_label}{may_error}")]
-pub async fn type_delete(context: &mut Context, kind: params::Kind, type_label: params::Label, may_error: params::MayError) {
+pub async fn type_delete(
+    context: &mut Context,
+    kind: params::Kind,
+    type_label: params::Label,
+    may_error: params::MayError,
+) {
     with_schema_tx!(context, |tx| {
         with_type!(tx, kind, type_label, type_, {
             let res = type_.delete(Arc::get_mut(&mut tx.snapshot).unwrap(), &tx.type_manager, &tx.thing_manager);
@@ -134,7 +142,12 @@ pub async fn type_delete(context: &mut Context, kind: params::Kind, type_label: 
 //
 #[apply(generic_step)]
 #[step(expr = "{kind}\\({type_label}\\) {exists_or_doesnt}")]
-pub async fn type_exists(context: &mut Context, kind: params::Kind, type_label: params::Label, exists: params::ExistsOrDoesnt) {
+pub async fn type_exists(
+    context: &mut Context,
+    kind: params::Kind,
+    type_label: params::Label,
+    exists: params::ExistsOrDoesnt,
+) {
     with_read_tx!(context, |tx| {
         match kind.into_typedb() {
             Kind::Attribute => {
@@ -177,7 +190,12 @@ pub async fn type_set_label(
 
 #[apply(generic_step)]
 #[step(expr = "{kind}\\({type_label}\\) get name: {type_label}")]
-pub async fn type_get_name(context: &mut Context, kind: params::Kind, type_label: params::Label, expected: params::Label) {
+pub async fn type_get_name(
+    context: &mut Context,
+    kind: params::Kind,
+    type_label: params::Label,
+    expected: params::Label,
+) {
     with_read_tx!(context, |tx| {
         with_type!(tx, kind, type_label, type_, {
             let actual_label = type_.get_label(tx.snapshot.as_ref(), &tx.type_manager);
@@ -188,7 +206,12 @@ pub async fn type_get_name(context: &mut Context, kind: params::Kind, type_label
 
 #[apply(generic_step)]
 #[step(expr = "{kind}\\({type_label}\\) get label: {type_label}")]
-pub async fn type_get_label(context: &mut Context, kind: params::Kind, type_label: params::Label, expected: params::Label) {
+pub async fn type_get_label(
+    context: &mut Context,
+    kind: params::Kind,
+    type_label: params::Label,
+    expected: params::Label,
+) {
     with_read_tx!(context, |tx| {
         with_type!(tx, kind, type_label, type_, {
             let actual_label = type_.get_label(tx.snapshot.as_ref(), &tx.type_manager);
@@ -446,7 +469,12 @@ pub async fn type_set_supertype(
 
 #[apply(generic_step)]
 #[step(expr = "{kind}\\({type_label}\\) unset supertype{may_error}")]
-pub async fn type_unset_supertype(context: &mut Context, kind: params::Kind, type_label: params::Label, may_error: params::MayError) {
+pub async fn type_unset_supertype(
+    context: &mut Context,
+    kind: params::Kind,
+    type_label: params::Label,
+    may_error: params::MayError,
+) {
     with_schema_tx!(context, |tx| {
         match kind.into_typedb() {
             Kind::Attribute => {
@@ -492,7 +520,12 @@ pub async fn type_unset_supertype(context: &mut Context, kind: params::Kind, typ
 
 #[apply(generic_step)]
 #[step(expr = "{kind}\\({type_label}\\) get supertype: {type_label}")]
-pub async fn type_get_supertype(context: &mut Context, kind: params::Kind, type_label: params::Label, supertype_label: params::Label) {
+pub async fn type_get_supertype(
+    context: &mut Context,
+    kind: params::Kind,
+    type_label: params::Label,
+    supertype_label: params::Label,
+) {
     with_read_tx!(context, |tx| {
         with_type!(tx, kind, type_label, type_, {
             let supertype = type_.get_supertype(tx.snapshot.as_ref(), &tx.type_manager).unwrap().unwrap();
@@ -506,7 +539,12 @@ pub async fn type_get_supertype(context: &mut Context, kind: params::Kind, type_
 
 #[apply(generic_step)]
 #[step(expr = "{kind}\\({type_label}\\) get supertype {exists_or_doesnt}")]
-pub async fn type_get_supertype_exists(context: &mut Context, kind: params::Kind, type_label: params::Label, exists: params::ExistsOrDoesnt) {
+pub async fn type_get_supertype_exists(
+    context: &mut Context,
+    kind: params::Kind,
+    type_label: params::Label,
+    exists: params::ExistsOrDoesnt,
+) {
     with_read_tx!(context, |tx| {
         with_type!(tx, kind, type_label, type_, {
             let supertype = type_.get_supertype(tx.snapshot.as_ref(), &tx.type_manager).unwrap();
@@ -604,7 +642,12 @@ pub async fn get_subtypes_is_empty(
 
 #[apply(generic_step)]
 #[step(expr = "get {kind_extended} types {contains_or_doesnt}:")]
-pub async fn get_types_contain(context: &mut Context, kind: params::KindExtended, contains: params::ContainsOrDoesnt, step: &Step) {
+pub async fn get_types_contain(
+    context: &mut Context,
+    kind: params::KindExtended,
+    contains: params::ContainsOrDoesnt,
+    step: &Step,
+) {
     let expected_labels = util::iter_table(step).map(|str| str.to_owned()).collect_vec();
     let type_labels = with_read_tx!(context, |tx| {
         use params::KindExtended;

--- a/tests/behaviour/steps/concept/type_/thing_type.rs
+++ b/tests/behaviour/steps/concept/type_/thing_type.rs
@@ -709,12 +709,8 @@ pub async fn get_types_empty(context: &mut Context, kind: params::KindExtended, 
         use params::KindExtended;
         match kind {
             KindExtended::Entity => &tx.type_manager.get_entity_types(tx.snapshot.as_ref()).unwrap().is_empty(),
-            KindExtended::Relation => {
-                &tx.type_manager.get_relation_types(tx.snapshot.as_ref()).unwrap().is_empty()
-            }
-            KindExtended::Attribute => {
-                &tx.type_manager.get_attribute_types(tx.snapshot.as_ref()).unwrap().is_empty()
-            }
+            KindExtended::Relation => &tx.type_manager.get_relation_types(tx.snapshot.as_ref()).unwrap().is_empty(),
+            KindExtended::Attribute => &tx.type_manager.get_attribute_types(tx.snapshot.as_ref()).unwrap().is_empty(),
             KindExtended::Role => &tx.type_manager.get_role_types(tx.snapshot.as_ref()).unwrap().is_empty(),
             KindExtended::Object => &tx.type_manager.get_object_types(tx.snapshot.as_ref()).unwrap().is_empty(),
         }

--- a/tests/behaviour/steps/connection/transaction.rs
+++ b/tests/behaviour/steps/connection/transaction.rs
@@ -12,7 +12,7 @@ use options::TransactionOptions;
 use crate::{
     assert::assert_matches,
     generic_step,
-    params::{check_boolean, Boolean, MayError},
+    params::{self, check_boolean},
     ActiveTransaction, Context,
 };
 
@@ -34,7 +34,7 @@ pub async fn connection_open_transaction(context: &mut Context, tx_type: String,
 
 #[apply(generic_step)]
 #[step(expr = "transaction is open: {boolean}")]
-pub async fn transaction_is_open(context: &mut Context, is_open: Boolean) {
+pub async fn transaction_is_open(context: &mut Context, is_open: params::Boolean) {
     check_boolean!(is_open, context.transaction().is_some());
 }
 
@@ -51,7 +51,7 @@ pub async fn transaction_has_type(context: &mut Context, tx_type: String) {
 
 #[apply(generic_step)]
 #[step(expr = "transaction commits{may_error}")]
-pub async fn transaction_commits(context: &mut Context, may_error: MayError) {
+pub async fn transaction_commits(context: &mut Context, may_error: params::MayError) {
     match context.take_transaction().unwrap() {
         ActiveTransaction::Read(_) => {}
         ActiveTransaction::Write(tx) => {
@@ -92,13 +92,13 @@ pub async fn open_transactions_in_parallel(context: &mut Context) {
 
 #[apply(generic_step)]
 #[step(expr = "transactions in parallel are null: {boolean}")]
-pub async fn transations_in_parallel_are_null(context: &mut Context, are_null: Boolean) {
+pub async fn transations_in_parallel_are_null(context: &mut Context, are_null: params::Boolean) {
     todo!()
 }
 
 #[apply(generic_step)]
 #[step(expr = "transactions in parallel are open: {boolean}")]
-pub async fn transactions_in_parallel_are_open(context: &mut Context, are_open: Boolean) {
+pub async fn transactions_in_parallel_are_open(context: &mut Context, are_open: params::Boolean) {
     todo!()
 }
 

--- a/tests/behaviour/steps/params.rs
+++ b/tests/behaviour/steps/params.rs
@@ -307,18 +307,18 @@ impl FromStr for Label {
 }
 
 #[derive(Debug, Parameter)]
-#[param(name = "root_label", regex = r"(attribute|entity|relation)")]
-pub(crate) struct RootLabel {
+#[param(name = "kind", regex = r"(attribute|entity|relation)")]
+pub(crate) struct Kind {
     kind: TypeDBTypeKind,
 }
 
-impl RootLabel {
+impl Kind {
     pub fn into_typedb(&self) -> TypeDBTypeKind {
         self.kind
     }
 }
 
-impl FromStr for RootLabel {
+impl FromStr for Kind {
     type Err = String;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let kind = match s {
@@ -327,17 +327,17 @@ impl FromStr for RootLabel {
             "relation" => TypeDBTypeKind::Relation,
             _ => unreachable!(),
         };
-        Ok(RootLabel { kind })
+        Ok(Kind { kind })
     }
 }
 
 #[derive(Debug, Parameter)]
-#[param(name = "object_root_label", regex = r"(entity|relation|entities|relations)")]
-pub(crate) struct ObjectRootLabel {
+#[param(name = "object_kind", regex = r"(entity|relation|entities|relations)")]
+pub(crate) struct ObjectKind {
     kind: TypeDBTypeKind,
 }
 
-impl ObjectRootLabel {
+impl ObjectKind {
     pub fn into_typedb(&self) -> TypeDBTypeKind {
         self.kind
     }
@@ -346,12 +346,12 @@ impl ObjectRootLabel {
         match self.kind {
             TypeDBTypeKind::Entity => assert_matches!(object, ObjectType::Entity(_)),
             TypeDBTypeKind::Relation => assert_matches!(object, ObjectType::Relation(_)),
-            _ => unreachable!("an ObjectRootLabel contains a non-object kind: {:?}", self.kind),
+            _ => unreachable!("an ObjectKind contains a non-object kind: {:?}", self.kind),
         }
     }
 }
 
-impl FromStr for ObjectRootLabel {
+impl FromStr for ObjectKind {
     type Err = String;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let kind = match s {
@@ -364,8 +364,8 @@ impl FromStr for ObjectRootLabel {
 }
 
 #[derive(Debug, Parameter)]
-#[param(name = "root_label_extended", regex = r"(attribute|entity|relation|role|object)")]
-pub(crate) enum RootLabelExtended {
+#[param(name = "kind_extended", regex = r"(attribute|entity|relation|role|object)")]
+pub(crate) enum KindExtended {
     Attribute,
     Entity,
     Relation,
@@ -373,7 +373,7 @@ pub(crate) enum RootLabelExtended {
     Object,
 }
 
-impl FromStr for RootLabelExtended {
+impl FromStr for KindExtended {
     type Err = String;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         Ok(match s {
@@ -382,7 +382,7 @@ impl FromStr for RootLabelExtended {
             "relation" => Self::Relation,
             "role" => Self::Role,
             "object" => Self::Object,
-            invalid => return Err(format!("Invalid `RootLabelExtended`: {invalid}")),
+            invalid => return Err(format!("Invalid `KindExtended`: {invalid}")),
         })
     }
 }


### PR DESCRIPTION
## Usage and product changes
We reduce the amount of methods that consume `self` and force us to use `clone` for their usages:
* Move `fn vertex` from `TypeAPI` to `TypeVertexEncoding`
* Make some non-`into_``TypeEdgeEncoding` methods accept `&self` instead of `self`.

Moreover, we clean the test code that used `RootLabel`, switching to `Kind` instead.