### PR TITLE
Add TypeQLMayError for query BDDs

### DIFF
--- a/tests/behaviour/steps/params.rs
+++ b/tests/behaviour/steps/params.rs
@@ -158,7 +158,6 @@ macro_rules! check_boolean {
     };
 }
 pub(crate) use check_boolean;
-use primitive::either::Either;
 
 impl FromStr for Boolean {
     type Err = String;


### PR DESCRIPTION
## Usage and product changes
We add `TypeQLMayError`, a specification of `MayError` for `query` BDDs. It separates expected failures to `Logic` and `Parsing`.

Firstly, it's needed for better 3.0 tests rewrite, so we don't miss any incorrectly translated queries.
Secondly, the absence of at least this kind of failure reason specification already caused troubles in 3.x: for example, there is a 2.x test in `define.feature`, which fails because its `typeql` statement is not correct, but we expect it to fail for a logical reason (not sub):
```
  Scenario: defining a less strict annotation on an inherited ownership throws
    Then typeql define; throws exception
      """
      define child, owns email @unique;
      """
```

This can be easily changed to specific error code checks in the future. 

Usage example:
```
#[apply(generic_step)]
#[step(expr = r"typeql define{typeql_may_error}")]
async fn typeql_define(context: &mut Context, may_error: params::TypeQLMayError, step: &Step) {
    let query_parsed = typeql::parse_query(step.docstring.as_ref().unwrap().as_str());
    if may_error.check_parsing(&query_parsed).is_some() { // If we expect the error, it is unwrapped
        return;
    }

    let typeql_define = query_parsed.unwrap().into_schema();
    with_schema_tx!(context, |tx| {
        let result = QueryManager::new().execute_schema(
            Arc::get_mut(&mut tx.snapshot).unwrap(),
            &tx.type_manager,
            &tx.thing_manager,
            typeql_define,
        );
        may_error.check_logic(&result);
    });
}
```