### PR TITLE
Introduce periodic fsync to guarantee commits are persisted to disk

### DIFF
--- a/concept/benches/bench_thing_write.rs
+++ b/concept/benches/bench_thing_write.rs
@@ -83,7 +83,7 @@ fn write_entity_attributes(
 }
 
 fn create_schema(storage: Arc<MVCCStorage<WALClient>>) {
-    let (type_manager, thing_manager) = load_managers(storage.clone());
+    let (type_manager, thing_manager) = load_managers(storage.clone(), None);
     let mut snapshot: WriteSnapshot<WALClient> = storage.clone().open_snapshot_write();
     let age_type = type_manager.create_attribute_type(&mut snapshot, AGE_LABEL.get().unwrap()).unwrap();
     age_type.set_value_type(&mut snapshot, &type_manager, &thing_manager, ValueType::Long).unwrap();

--- a/concept/tests/test_statistics.rs
+++ b/concept/tests/test_statistics.rs
@@ -214,7 +214,7 @@ fn read_statistics(storage: Arc<MVCCStorage<WALClient>>, thing_manager: &ThingMa
 fn create_entity() {
     let (_tmp_dir, mut storage) = create_core_storage();
     setup_concept_storage(&mut storage);
-    let (type_manager, thing_manager) = load_managers(storage.clone());
+    let (type_manager, thing_manager) = load_managers(storage.clone(), None);
 
     let person_label = Label::build("person");
 
@@ -239,7 +239,7 @@ fn create_entity() {
 fn delete_twice() {
     let (_tmp_dir, mut storage) = create_core_storage();
     setup_concept_storage(&mut storage);
-    let (type_manager, thing_manager) = load_managers(storage.clone());
+    let (type_manager, thing_manager) = load_managers(storage.clone(), None);
 
     let person_label = Label::build("person");
 
@@ -269,7 +269,7 @@ fn delete_twice() {
 fn put_has_twice() {
     let (_tmp_dir, mut storage) = create_core_storage();
     setup_concept_storage(&mut storage);
-    let (type_manager, thing_manager) = load_managers(storage.clone());
+    let (type_manager, thing_manager) = load_managers(storage.clone(), None);
 
     let person_label = Label::build("person");
     let name_label = Label::build("name");
@@ -304,7 +304,7 @@ fn put_has_twice() {
 fn put_plays() {
     let (_tmp_dir, mut storage) = create_core_storage();
     setup_concept_storage(&mut storage);
-    let (type_manager, thing_manager) = load_managers(storage.clone());
+    let (type_manager, thing_manager) = load_managers(storage.clone(), None);
 
     let person_label = Label::build("person");
     let friendship_label = Label::build("friendship");

--- a/concept/tests/test_thing.rs
+++ b/concept/tests/test_thing.rs
@@ -50,7 +50,7 @@ fn thing_create_iterate() {
 
     let mut snapshot: WriteSnapshot<WALClient> = storage.clone().open_snapshot_write();
     {
-        let (type_manager, thing_manager) = load_managers(storage.clone());
+        let (type_manager, thing_manager) = load_managers(storage.clone(), None);
 
         let person_label = Label::build("person");
         let person_type = type_manager.create_entity_type(&mut snapshot, &person_label).unwrap();
@@ -67,7 +67,7 @@ fn thing_create_iterate() {
 
     {
         let snapshot: ReadSnapshot<WALClient> = storage.clone().open_snapshot_read();
-        let (_, thing_manager) = load_managers(storage.clone());
+        let (_, thing_manager) = load_managers(storage.clone(), None);
         let entities_count = thing_manager.get_entities(&snapshot).count();
         assert_eq!(entities_count, 4);
     }
@@ -86,7 +86,7 @@ fn attribute_create() {
 
     let mut snapshot: WriteSnapshot<WALClient> = storage.clone().open_snapshot_write();
     {
-        let (type_manager, thing_manager) = load_managers(storage.clone());
+        let (type_manager, thing_manager) = load_managers(storage.clone(), None);
         let age_type = type_manager.create_attribute_type(&mut snapshot, &age_label).unwrap();
         age_type.set_value_type(&mut snapshot, &type_manager, &thing_manager, ValueType::Long).unwrap();
         age_type
@@ -124,7 +124,7 @@ fn attribute_create() {
 
     {
         let snapshot: ReadSnapshot<WALClient> = storage.clone().open_snapshot_read();
-        let (type_manager, thing_manager) = load_managers(storage.clone());
+        let (type_manager, thing_manager) = load_managers(storage.clone(), None);
         let attributes_count = thing_manager.get_attributes(&snapshot).unwrap().count();
         assert_eq!(attributes_count, 2);
 
@@ -153,7 +153,7 @@ fn has() {
 
     let mut snapshot: WriteSnapshot<WALClient> = storage.clone().open_snapshot_write();
     {
-        let (type_manager, thing_manager) = load_managers(storage.clone());
+        let (type_manager, thing_manager) = load_managers(storage.clone(), None);
 
         let age_type = type_manager.create_attribute_type(&mut snapshot, &age_label).unwrap();
         age_type.set_value_type(&mut snapshot, &type_manager, &thing_manager, ValueType::Long).unwrap();
@@ -201,7 +201,7 @@ fn has() {
 
     {
         let snapshot: ReadSnapshot<WALClient> = storage.clone().open_snapshot_read();
-        let (_, thing_manager) = load_managers(storage.clone());
+        let (_, thing_manager) = load_managers(storage.clone(), None);
         let attributes_count = thing_manager.get_attributes(&snapshot).unwrap().count();
         assert_eq!(attributes_count, 2);
 
@@ -228,7 +228,7 @@ fn attribute_cleanup_on_concurrent_detach() {
 
     let mut snapshot: WriteSnapshot<WALClient> = storage.clone().open_snapshot_write();
     {
-        let (type_manager, thing_manager) = load_managers(storage.clone());
+        let (type_manager, thing_manager) = load_managers(storage.clone(), None);
         let age_type = type_manager.create_attribute_type(&mut snapshot, &age_label).unwrap();
         age_type.set_value_type(&mut snapshot, &type_manager, &thing_manager, ValueType::Long).unwrap();
         let name_type = type_manager.create_attribute_type(&mut snapshot, &name_label).unwrap();
@@ -267,7 +267,7 @@ fn attribute_cleanup_on_concurrent_detach() {
     let mut snapshot_2: WriteSnapshot<WALClient> = storage.clone().open_snapshot_write();
 
     {
-        let (type_manager, thing_manager) = load_managers(storage.clone());
+        let (type_manager, thing_manager) = load_managers(storage.clone(), None);
 
         let name_type = type_manager.get_attribute_type(&snapshot_1, &name_label).unwrap().unwrap();
         let age_type = type_manager.get_attribute_type(&snapshot_1, &age_label).unwrap().unwrap();
@@ -295,7 +295,7 @@ fn attribute_cleanup_on_concurrent_detach() {
     }
 
     {
-        let (type_manager, thing_manager) = load_managers(storage.clone());
+        let (type_manager, thing_manager) = load_managers(storage.clone(), None);
 
         let name_type = type_manager.get_attribute_type(&snapshot_2, &name_label).unwrap().unwrap();
         let age_type = type_manager.get_attribute_type(&snapshot_2, &age_label).unwrap().unwrap();
@@ -342,7 +342,7 @@ fn attribute_cleanup_on_concurrent_detach() {
 
     {
         let snapshot: ReadSnapshot<WALClient> = storage.clone().open_snapshot_read();
-        let (type_manager, thing_manager) = load_managers(storage.clone());
+        let (type_manager, thing_manager) = load_managers(storage.clone(), None);
 
         let age_type = type_manager.get_attribute_type(&snapshot, &age_label).unwrap().unwrap();
 
@@ -364,7 +364,7 @@ fn role_player_distinct() {
 
     let mut snapshot: WriteSnapshot<WALClient> = storage.clone().open_snapshot_write();
     {
-        let (type_manager, thing_manager) = load_managers(storage.clone());
+        let (type_manager, thing_manager) = load_managers(storage.clone(), None);
 
         let employment_type = type_manager.create_relation_type(&mut snapshot, &employment_label).unwrap();
         employment_type
@@ -458,7 +458,7 @@ fn role_player_distinct() {
     snapshot.commit().unwrap();
     {
         let snapshot: ReadSnapshot<WALClient> = storage.clone().open_snapshot_read();
-        let (type_manager, thing_manager) = load_managers(storage.clone());
+        let (type_manager, thing_manager) = load_managers(storage.clone(), None);
 
         let entities: Vec<Entity<'static>> =
             thing_manager.get_entities(&snapshot).map_static(|result| result.unwrap().into_owned()).collect();
@@ -497,7 +497,7 @@ fn role_player_duplicates() {
 
     let mut snapshot: WriteSnapshot<WALClient> = storage.clone().open_snapshot_write();
     {
-        let (type_manager, thing_manager) = load_managers(storage.clone());
+        let (type_manager, thing_manager) = load_managers(storage.clone(), None);
         let list_type = type_manager.create_relation_type(&mut snapshot, &list_label).unwrap();
         list_type
             .create_relates(&mut snapshot, &type_manager, &thing_manager, entry_role_label, Ordering::Unordered, None)
@@ -596,7 +596,7 @@ fn role_player_duplicates() {
     snapshot.commit().unwrap();
     {
         let snapshot: ReadSnapshot<WALClient> = storage.clone().open_snapshot_read();
-        let (type_manager, thing_manager) = load_managers(storage.clone());
+        let (type_manager, thing_manager) = load_managers(storage.clone(), None);
         let entities: Vec<Entity<'static>> =
             thing_manager.get_entities(&snapshot).map_static(|result| result.unwrap().into_owned()).collect();
         assert_eq!(entities.len(), 2);
@@ -663,7 +663,7 @@ fn role_player_duplicates() {
 fn attribute_string_write_read() {
     let (_tmp_dir, mut storage) = create_core_storage();
     setup_concept_storage(&mut storage);
-    let (type_manager, thing_manager) = load_managers(storage.clone());
+    let (type_manager, thing_manager) = load_managers(storage.clone(), None);
 
     let attr_label = Label::build("test_string_attr");
     let short_string = "short".to_owned();
@@ -731,7 +731,7 @@ fn attribute_string_write_read() {
 fn attribute_struct_write_read() {
     let (_tmp_dir, mut storage) = create_core_storage();
     setup_concept_storage(&mut storage);
-    let (type_manager, thing_manager) = load_managers(storage.clone());
+    let (type_manager, thing_manager) = load_managers(storage.clone(), None);
 
     let attr_label = Label::build("struct_test_attr");
     let struct_name = "struct_test_test".to_owned();
@@ -809,7 +809,7 @@ fn attribute_struct_write_read() {
 fn read_attribute_struct_by_field() {
     let (_tmp_dir, mut storage) = create_core_storage();
     setup_concept_storage(&mut storage);
-    let (type_manager, thing_manager) = load_managers(storage.clone());
+    let (type_manager, thing_manager) = load_managers(storage.clone(), None);
 
     let attr_label = Label::build("index_test_attr");
     let nested_struct_spec =
@@ -891,7 +891,7 @@ fn read_attribute_struct_by_field() {
 fn attribute_struct_errors() {
     let (_tmp_dir, mut storage) = create_core_storage();
     setup_concept_storage(&mut storage);
-    let (type_manager, thing_manager) = load_managers(storage.clone());
+    let (type_manager, thing_manager) = load_managers(storage.clone(), None);
 
     let (struct_key, nested_struct_key) = {
         let mut snapshot = storage.clone().open_snapshot_write();

--- a/concept/tests/test_utils_concept.rs
+++ b/concept/tests/test_utils_concept.rs
@@ -17,16 +17,19 @@ use encoding::graph::{
 };
 use storage::{
     durability_client::{DurabilityClient, WALClient},
+    sequence_number::SequenceNumber,
     MVCCStorage,
 };
-use storage::sequence_number::SequenceNumber;
 
 pub fn setup_concept_storage(storage: &mut Arc<MVCCStorage<WALClient>>) {
     let mut storage = Arc::get_mut(storage).unwrap();
     storage.durability_mut().register_record_type::<Statistics>();
 }
 
-pub fn load_managers(storage: Arc<MVCCStorage<WALClient>>, type_cache_at: Option<SequenceNumber>) -> (Arc<TypeManager>, Arc<ThingManager>) {
+pub fn load_managers(
+    storage: Arc<MVCCStorage<WALClient>>,
+    type_cache_at: Option<SequenceNumber>,
+) -> (Arc<TypeManager>, Arc<ThingManager>) {
     let definition_key_generator = Arc::new(DefinitionKeyGenerator::new());
     let mut statistics = Statistics::new(DurabilitySequenceNumber::MIN);
     statistics.may_synchronise(storage.as_ref()).unwrap();

--- a/concept/tests/test_utils_concept.rs
+++ b/concept/tests/test_utils_concept.rs
@@ -8,7 +8,7 @@ use std::sync::Arc;
 
 use concept::{
     thing::{statistics::Statistics, thing_manager::ThingManager},
-    type_::type_manager::TypeManager,
+    type_::type_manager::{type_cache::TypeCache, TypeManager},
 };
 use durability::DurabilitySequenceNumber;
 use encoding::graph::{
@@ -19,19 +19,29 @@ use storage::{
     durability_client::{DurabilityClient, WALClient},
     MVCCStorage,
 };
+use storage::sequence_number::SequenceNumber;
 
 pub fn setup_concept_storage(storage: &mut Arc<MVCCStorage<WALClient>>) {
     let mut storage = Arc::get_mut(storage).unwrap();
     storage.durability_mut().register_record_type::<Statistics>();
 }
 
-pub fn load_managers(storage: Arc<MVCCStorage<WALClient>>) -> (Arc<TypeManager>, Arc<ThingManager>) {
+pub fn load_managers(storage: Arc<MVCCStorage<WALClient>>, type_cache_at: Option<SequenceNumber>) -> (Arc<TypeManager>, Arc<ThingManager>) {
     let definition_key_generator = Arc::new(DefinitionKeyGenerator::new());
     let mut statistics = Statistics::new(DurabilitySequenceNumber::MIN);
     statistics.may_synchronise(storage.as_ref()).unwrap();
     let type_vertex_generator = Arc::new(TypeVertexGenerator::new());
-    let thing_vertex_generator = Arc::new(ThingVertexGenerator::load(storage).unwrap());
-    let type_manager = Arc::new(TypeManager::new(definition_key_generator, type_vertex_generator, None));
-    let thing_manager = Arc::new(ThingManager::new(thing_vertex_generator, type_manager.clone(), Arc::new(statistics)));
+    let thing_vertex_generator = Arc::new(ThingVertexGenerator::load(storage.clone()).unwrap());
+    let cache = if let Some(sequence_number) = type_cache_at {
+        Some(Arc::new(TypeCache::new(storage, sequence_number).unwrap()))
+    } else {
+        None
+    };
+    let type_manager = Arc::new(TypeManager::new(definition_key_generator, type_vertex_generator, cache));
+    let thing_manager = Arc::new(ThingManager::new(
+        thing_vertex_generator,
+        type_manager.clone(),
+        Arc::new(Statistics::new(DurabilitySequenceNumber::MIN)),
+    ));
     (type_manager, thing_manager)
 }

--- a/durability/BUILD
+++ b/durability/BUILD
@@ -28,6 +28,7 @@ rust_library(
     deps = [
         "//common/logger",
         "//common/primitive",
+        "//resource",
 
         "@crates//:itertools",
         "@crates//:serde",

--- a/executor/benches/BUILD
+++ b/executor/benches/BUILD
@@ -37,6 +37,34 @@ rust_test(
     use_libtest_harness = False,
 )
 
+# To run this via Bazel, Criterion must be provided the --bench argument:
+#   bazel run --compilation_mode=opt //executor/benches:bench_insert_queries -- --bench
+rust_test(
+    name = "bench_insert_queries_multithreaded",
+    srcs = glob([
+        "bench_insert_queries_multithreaded.rs",
+        "common.rs",
+    ]),
+    deps = [
+        "//answer",
+        "//compiler",
+        "//concept",
+        "//durability",
+        "//encoding",
+        "//executor",
+        "//ir",
+        "//resource",
+        "//storage",
+        "//util/test:test_utils",
+        "@vaticle_typeql//rust:typeql",
+
+        "@crates//:criterion",
+        "@crates//:rand",
+        "@crates//:pprof",
+    ],
+    use_libtest_harness = False,
+)
+
 checkstyle_test(
     name = "checkstyle",
     include = glob(["*", "*/*", "*/*/*"]),

--- a/executor/benches/BUILD
+++ b/executor/benches/BUILD
@@ -56,6 +56,10 @@ rust_test(
         "//resource",
         "//storage",
         "//util/test:test_utils",
+        "//concept/tests:test_utils_concept",
+        "//encoding/tests:test_utils_encoding",
+
+
         "@vaticle_typeql//rust:typeql",
 
         "@crates//:criterion",

--- a/executor/benches/BUILD
+++ b/executor/benches/BUILD
@@ -15,6 +15,7 @@ rust_test(
     ]),
     deps = [
         "//answer",
+        "//common/lending_iterator",
         "//compiler",
         "//concept",
         "//durability",
@@ -47,6 +48,7 @@ rust_test(
     ]),
     deps = [
         "//answer",
+        "//common/lending_iterator",
         "//compiler",
         "//concept",
         "//durability",

--- a/executor/benches/bench_insert_queries.rs
+++ b/executor/benches/bench_insert_queries.rs
@@ -163,7 +163,6 @@ fn criterion_benchmark(c: &mut Criterion) {
     // group.measurement_time(Duration::from_secs(200));
     group.sampling_mode(SamplingMode::Linear);
 
-
     let (_tmp_dir, mut storage) = create_core_storage();
     setup_database(&mut storage);
     let (type_manager, thing_manager) = load_managers(storage.clone(), Some(storage.read_watermark()));

--- a/executor/benches/bench_insert_queries.rs
+++ b/executor/benches/bench_insert_queries.rs
@@ -51,9 +51,9 @@ static NAME_LABEL: OnceLock<Label> = OnceLock::new();
 fn setup_database(storage: &mut Arc<MVCCStorage<WALClient>>) {
     setup_concept_storage(storage);
 
-    let (type_manager, thing_manager) = load_managers(storage.clone());
+    let (type_manager, thing_manager) = load_managers(storage.clone(), None);
     let mut snapshot = storage.clone().open_snapshot_write();
-
+    let mut snapshot = storage.clone().open_snapshot_write();
     let person_type = type_manager.create_entity_type(&mut snapshot, PERSON_LABEL.get().unwrap()).unwrap();
     let group_type = type_manager.create_entity_type(&mut snapshot, GROUP_LABEL.get().unwrap()).unwrap();
 
@@ -163,9 +163,10 @@ fn criterion_benchmark(c: &mut Criterion) {
     // group.measurement_time(Duration::from_secs(200));
     group.sampling_mode(SamplingMode::Linear);
 
+
     let (_tmp_dir, mut storage) = create_core_storage();
     setup_database(&mut storage);
-    let (type_manager, thing_manager) = load_managers(storage.clone());
+    let (type_manager, thing_manager) = load_managers(storage.clone(), Some(storage.read_watermark()));
 
     group.bench_function("insert_queries", |b| {
         b.iter(|| {

--- a/executor/benches/bench_insert_queries_multithreaded.rs
+++ b/executor/benches/bench_insert_queries_multithreaded.rs
@@ -1,0 +1,227 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+#![deny(unused_must_use)]
+
+use std::{array, collections::HashMap, ffi::c_int, fs::File, path::Path, sync::{Arc, OnceLock}, thread};
+use std::thread::JoinHandle;
+use std::time::Duration;
+
+use answer::variable_value::VariableValue;
+use compiler::match_::inference::annotated_functions::IndexedAnnotatedFunctions;
+use concept::{
+    thing::{object::ObjectAPI, thing_manager::ThingManager},
+    type_::{type_manager::TypeManager, Ordering, OwnerAPI, PlayerAPI},
+};
+use criterion::{criterion_group, criterion_main, profiler::Profiler, Criterion, SamplingMode};
+use encoding::value::{label::Label, value_type::ValueType};
+use executor::{batch::Row, write::insert_executor::WriteError};
+use pprof::ProfilerGuard;
+use rand::distributions::DistString;
+use storage::{
+    durability_client::WALClient,
+    snapshot::{CommittableSnapshot, WritableSnapshot, WriteSnapshot},
+    MVCCStorage,
+};
+use test_utils::init_logging;
+
+use crate::common::{load_managers, setup_storage};
+
+mod common;
+
+static PERSON_LABEL: OnceLock<Label> = OnceLock::new();
+static GROUP_LABEL: OnceLock<Label> = OnceLock::new();
+static MEMBERSHIP_LABEL: OnceLock<Label> = OnceLock::new();
+static MEMBERSHIP_MEMBER_LABEL: OnceLock<Label> = OnceLock::new();
+static MEMBERSHIP_GROUP_LABEL: OnceLock<Label> = OnceLock::new();
+static AGE_LABEL: OnceLock<Label> = OnceLock::new();
+static NAME_LABEL: OnceLock<Label> = OnceLock::new();
+
+fn setup_schema(storage: Arc<MVCCStorage<WALClient>>) {
+    let (type_manager, thing_manager) = load_managers(storage.clone(), None);
+
+    let mut snapshot: WriteSnapshot<WALClient> = storage.clone().open_snapshot_write();
+    let person_type = type_manager.create_entity_type(&mut snapshot, PERSON_LABEL.get().unwrap()).unwrap();
+    let group_type = type_manager.create_entity_type(&mut snapshot, GROUP_LABEL.get().unwrap()).unwrap();
+
+    let membership_type = type_manager.create_relation_type(&mut snapshot, MEMBERSHIP_LABEL.get().unwrap()).unwrap();
+    let relates_member = membership_type
+        .create_relates(
+            &mut snapshot,
+            &type_manager,
+            &thing_manager,
+            MEMBERSHIP_MEMBER_LABEL.get().unwrap().name().as_str(),
+            Ordering::Unordered,
+            None,
+        )
+        .unwrap();
+    let membership_member_type = relates_member.role();
+    let relates_group = membership_type
+        .create_relates(
+            &mut snapshot,
+            &type_manager,
+            &thing_manager,
+            MEMBERSHIP_GROUP_LABEL.get().unwrap().name().as_str(),
+            Ordering::Unordered,
+            None,
+        )
+        .unwrap();
+    let membership_group_type = relates_group.role();
+
+    let age_type = type_manager.create_attribute_type(&mut snapshot, AGE_LABEL.get().unwrap()).unwrap();
+    age_type.set_value_type(&mut snapshot, &type_manager, &thing_manager, ValueType::Long).unwrap();
+    let name_type = type_manager.create_attribute_type(&mut snapshot, NAME_LABEL.get().unwrap()).unwrap();
+    name_type.set_value_type(&mut snapshot, &type_manager, &thing_manager, ValueType::String).unwrap();
+
+    person_type.set_owns(&mut snapshot, &type_manager, &thing_manager, age_type.clone(), Ordering::Unordered).unwrap();
+    person_type.set_owns(&mut snapshot, &type_manager, &thing_manager, name_type.clone(), Ordering::Unordered).unwrap();
+    person_type.set_plays(&mut snapshot, &type_manager, &thing_manager, membership_member_type.clone()).unwrap();
+    group_type.set_plays(&mut snapshot, &type_manager, &thing_manager, membership_group_type.clone()).unwrap();
+
+    snapshot.commit().unwrap();
+}
+
+fn execute_insert(
+    snapshot: &mut impl WritableSnapshot,
+    type_manager: &TypeManager,
+    thing_manager: &ThingManager,
+    query_str: &str,
+    input_row_var_names: &Vec<&str>,
+    input_rows: Vec<Vec<VariableValue<'static>>>,
+) -> Result<Vec<Vec<VariableValue<'static>>>, WriteError> {
+    let typeql_insert = typeql::parse_query(query_str).unwrap().into_pipeline().stages.pop().unwrap().into_insert();
+    let block = ir::translation::writes::translate_insert(&typeql_insert).unwrap().finish();
+    let input_row_format = input_row_var_names
+        .iter()
+        .enumerate()
+        .map(|(i, v)| (block.context().get_variable_named(v, block.scope_id()).unwrap().clone(), i))
+        .collect::<HashMap<_, _>>();
+    let (entry_annotations, _) = compiler::match_::inference::type_inference::infer_types(
+        &block,
+        vec![],
+        snapshot,
+        &type_manager,
+        &IndexedAnnotatedFunctions::empty(),
+    )
+    .unwrap();
+    let insert_plan = compiler::insert::insert::build_insert_plan(
+        block.conjunction().constraints(),
+        &input_row_format,
+        &entry_annotations,
+    )
+    .unwrap();
+
+    let mut output_rows = Vec::with_capacity(input_rows.len());
+    for mut input_row in input_rows {
+        let mut output_vec = (0..insert_plan.n_created_concepts + input_row_format.len())
+            .map(|_| VariableValue::Empty)
+            .collect::<Vec<_>>();
+        let mut output_multiplicity = 0;
+        let output_row = Row::new(&mut output_vec, &mut output_multiplicity);
+        executor::write::insert_executor::execute_insert(
+            snapshot,
+            &thing_manager,
+            &insert_plan,
+            &Row::new(input_row.as_mut_slice(), &mut 1),
+            output_row,
+            &mut Vec::new(),
+        )?;
+        output_rows.push(output_vec);
+    }
+    Ok(output_rows)
+}
+
+fn criterion_benchmark(c: &mut Criterion) {
+    PERSON_LABEL.set(Label::new_static("person")).unwrap();
+    GROUP_LABEL.set(Label::new_static("group")).unwrap();
+    MEMBERSHIP_LABEL.set(Label::new_static("membership")).unwrap();
+    MEMBERSHIP_MEMBER_LABEL.set(Label::new_static_scoped("member", "membership", "membership:member")).unwrap();
+    MEMBERSHIP_GROUP_LABEL.set(Label::new_static_scoped("group", "membership", "membership:group")).unwrap();
+    AGE_LABEL.set(Label::new_static("age")).unwrap();
+    NAME_LABEL.set(Label::new_static("name")).unwrap();
+    init_logging();
+
+    let mut group = c.benchmark_group("test insert queries");
+    group.sample_size(20);
+    group.sampling_mode(SamplingMode::Flat);
+    // group.measurement_time(Duration::from_secs(20));
+
+    let (_tmp_dir, storage) = setup_storage();
+    setup_schema(storage.clone());
+    let (type_manager, thing_manager) = load_managers(storage.clone(), Some(storage.read_watermark()));
+    let thing_manager_arced = Arc::new(thing_manager);
+    group.bench_function("insert_queries_multithreaded", |b| {
+        b.iter(|| {
+            const NUM_THREADS: usize = 32;
+            const INTERNAL_ITERS: u64 = 250;
+            let join_handles: [JoinHandle<()>; NUM_THREADS] = array::from_fn(|_| {
+                let storage_cloned = storage.clone();
+                let type_manager_cloned = type_manager.clone();
+                let thing_manager_cloned = thing_manager_arced.clone();
+                thread::spawn(move || {
+                    for _ in 0..INTERNAL_ITERS {
+                        let mut snapshot = storage_cloned.clone().open_snapshot_write();
+                        let age: u32 = rand::random();
+                        let row = execute_insert(
+                            &mut snapshot,
+                            &type_manager_cloned,
+                            &thing_manager_cloned,
+                            &format!("insert $p isa person, has age {age};"),
+                            &vec![],
+                            vec![vec![]],
+                        )
+                            .unwrap();
+                        snapshot.commit().unwrap();
+                    }
+                })
+            });
+            for join_handle in join_handles {
+                join_handle.join().unwrap()
+            }
+        });
+    });
+}
+
+pub struct FlamegraphProfiler<'a> {
+    frequency: c_int,
+    active_profiler: Option<ProfilerGuard<'a>>,
+}
+
+impl<'a> FlamegraphProfiler<'a> {
+    #[allow(dead_code)]
+    pub fn new(frequency: c_int) -> Self {
+        Self { frequency, active_profiler: None }
+    }
+}
+
+impl<'a> Profiler for FlamegraphProfiler<'a> {
+    fn start_profiling(&mut self, _benchmark_id: &str, _benchmark_dir: &Path) {
+        self.active_profiler = Some(ProfilerGuard::new(self.frequency).unwrap());
+    }
+
+    fn stop_profiling(&mut self, _benchmark_id: &str, benchmark_dir: &Path) {
+        std::fs::create_dir_all(benchmark_dir).unwrap();
+        let flamegraph_path = benchmark_dir.join("flamegraph.svg");
+        let flamegraph_file = File::create(flamegraph_path).expect("File system error while creating flamegraph.svg");
+        if let Some(profiler) = self.active_profiler.take() {
+            profiler.report().build().unwrap().flamegraph(flamegraph_file).expect("Error writing flamegraph");
+        }
+    }
+}
+
+fn profiled() -> Criterion {
+    Criterion::default().with_profiler(FlamegraphProfiler::new(10))
+}
+
+// criterion_group!(
+//     name = benches;
+//     config= profiled();
+//     targets = criterion_benchmark
+// );
+
+// TODO: disable profiling when running on mac, since pprof seems to crash sometimes?
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);

--- a/executor/benches/bench_insert_queries_multithreaded.rs
+++ b/executor/benches/bench_insert_queries_multithreaded.rs
@@ -6,7 +6,7 @@
 
 #![deny(unused_must_use)]
 
-use std::{array, collections::HashMap, ffi::c_int, fs::File, path::Path, sync::{Arc, OnceLock}, thread};
+use std::{array, collections::HashMap, sync::{Arc, OnceLock}, thread};
 use std::sync::RwLock;
 use std::thread::{JoinHandle, sleep};
 use std::time::{Duration, Instant};
@@ -18,19 +18,21 @@ use concept::{
     type_::{type_manager::TypeManager, Ordering, OwnerAPI, PlayerAPI},
 };
 use encoding::value::{label::Label, value_type::ValueType};
-use executor::{batch::Row, write::insert_executor::WriteError};
 
-use rand::distributions::DistString;
+use compiler::match_::inference::type_inference::infer_types;
+use compiler::VariablePosition;
+use executor::row::Row;
+use executor::write::insert::InsertExecutor;
+use executor::write::WriteError;
+use ir::translation::TranslationContext;
 use storage::{
     durability_client::WALClient,
-    snapshot::{CommittableSnapshot, WritableSnapshot, WriteSnapshot},
+    snapshot::{CommittableSnapshot, WritableSnapshot},
     MVCCStorage,
 };
 use test_utils::init_logging;
-
-use crate::common::{load_managers, setup_storage};
-
-mod common;
+use test_utils_concept::{load_managers, setup_concept_storage};
+use test_utils_encoding::create_core_storage;
 
 static PERSON_LABEL: OnceLock<Label> = OnceLock::new();
 static GROUP_LABEL: OnceLock<Label> = OnceLock::new();
@@ -39,11 +41,11 @@ static MEMBERSHIP_MEMBER_LABEL: OnceLock<Label> = OnceLock::new();
 static MEMBERSHIP_GROUP_LABEL: OnceLock<Label> = OnceLock::new();
 static AGE_LABEL: OnceLock<Label> = OnceLock::new();
 static NAME_LABEL: OnceLock<Label> = OnceLock::new();
+fn setup_database(storage: &mut Arc<MVCCStorage<WALClient>>) {
+    setup_concept_storage(storage);
 
-fn setup_schema(storage: Arc<MVCCStorage<WALClient>>) {
     let (type_manager, thing_manager) = load_managers(storage.clone(), None);
-
-    let mut snapshot: WriteSnapshot<WALClient> = storage.clone().open_snapshot_write();
+    let mut snapshot = storage.clone().open_snapshot_write();
     let person_type = type_manager.create_entity_type(&mut snapshot, PERSON_LABEL.get().unwrap()).unwrap();
     let group_type = type_manager.create_entity_type(&mut snapshot, GROUP_LABEL.get().unwrap()).unwrap();
 
@@ -76,8 +78,8 @@ fn setup_schema(storage: Arc<MVCCStorage<WALClient>>) {
     let name_type = type_manager.create_attribute_type(&mut snapshot, NAME_LABEL.get().unwrap()).unwrap();
     name_type.set_value_type(&mut snapshot, &type_manager, &thing_manager, ValueType::String).unwrap();
 
-    person_type.set_owns(&mut snapshot, &type_manager, &thing_manager, age_type.clone(), Ordering::Unordered).unwrap();
-    person_type.set_owns(&mut snapshot, &type_manager, &thing_manager, name_type.clone(), Ordering::Unordered).unwrap();
+    person_type.set_owns(&mut snapshot, &type_manager, &thing_manager, age_type.clone()).unwrap();
+    person_type.set_owns(&mut snapshot, &type_manager, &thing_manager, name_type.clone()).unwrap();
     person_type.set_plays(&mut snapshot, &type_manager, &thing_manager, membership_member_type.clone()).unwrap();
     group_type.set_plays(&mut snapshot, &type_manager, &thing_manager, membership_group_type.clone()).unwrap();
 
@@ -93,50 +95,44 @@ fn execute_insert(
     input_rows: Vec<Vec<VariableValue<'static>>>,
 ) -> Result<Vec<Vec<VariableValue<'static>>>, WriteError> {
     let typeql_insert = typeql::parse_query(query_str).unwrap().into_pipeline().stages.pop().unwrap().into_insert();
-    let block = ir::translation::writes::translate_insert(&typeql_insert).unwrap().finish();
+    let mut translation_context = TranslationContext::new();
+    let block = ir::translation::writes::translate_insert(&mut translation_context, &typeql_insert).unwrap();
     let input_row_format = input_row_var_names
         .iter()
         .enumerate()
-        .map(|(i, v)| (block.context().get_variable_named(v, block.scope_id()).unwrap().clone(), i))
+        .map(|(i, v)| (*translation_context.visible_variables.get(*v).unwrap(), VariablePosition::new(i as u32)))
         .collect::<HashMap<_, _>>();
-    let (entry_annotations, _) = compiler::match_::inference::type_inference::infer_types(
+    let (entry_annotations, _) = infer_types(
         &block,
         vec![],
         snapshot,
-        &type_manager,
+        type_manager,
         &IndexedAnnotatedFunctions::empty(),
+        &translation_context.variable_registry,
     )
-    .unwrap();
-    let insert_plan = compiler::insert::insert::build_insert_plan(
-        block.conjunction().constraints(),
-        &input_row_format,
-        &entry_annotations,
-    )
-    .unwrap();
+        .unwrap();
+
+    let insert_plan =
+        compiler::insert::program::compile(Arc::new(translation_context.variable_registry), block.conjunction().constraints(), &input_row_format, &entry_annotations)
+            .unwrap();
 
     let mut output_rows = Vec::with_capacity(input_rows.len());
-    for mut input_row in input_rows {
-        let mut output_vec = (0..insert_plan.n_created_concepts + input_row_format.len())
-            .map(|_| VariableValue::Empty)
-            .collect::<Vec<_>>();
-        let mut output_multiplicity = 0;
-        let output_row = Row::new(&mut output_vec, &mut output_multiplicity);
-        executor::write::insert_executor::execute_insert(
+    let output_width = insert_plan.output_row_schema.len();
+    let insert_executor = InsertExecutor::new(insert_plan);
+    for input_row in input_rows {
+        let mut output_multiplicity = 1;
+        output_rows.push(
+            (0..output_width)
+                .map(|i| input_row.get(i).map_or_else(|| VariableValue::Empty, |existing| existing.clone()))
+                .collect::<Vec<_>>(),
+        );
+        insert_executor.execute_insert(
             snapshot,
-            &thing_manager,
-            &insert_plan,
-            &Row::new(input_row.as_mut_slice(), &mut 1),
-            output_row,
-            &mut Vec::new(),
+            thing_manager,
+            &mut Row::new(output_rows.last_mut().unwrap(), &mut output_multiplicity),
         )?;
-        output_rows.push(output_vec);
     }
     Ok(output_rows)
-}
-
-#[test]
-fn as_test() {
-    main()
 }
 
 fn main() {
@@ -149,10 +145,9 @@ fn main() {
     NAME_LABEL.set(Label::new_static("name")).unwrap();
     init_logging();
 
-    let (_tmp_dir, storage) = setup_storage();
-    setup_schema(storage.clone());
+    let (_tmp_dir, mut storage) = create_core_storage();
+    setup_database(&mut storage);
     let (type_manager, thing_manager) = load_managers(storage.clone(), Some(storage.read_watermark()));
-    let thing_manager_arced = Arc::new(thing_manager);
     const NUM_THREADS: usize = 32;
     const INTERNAL_ITERS: u64 = 100;
     let start_signal_rw_lock = Arc::new(RwLock::new(()));
@@ -160,14 +155,14 @@ fn main() {
     let join_handles: [JoinHandle<()>; NUM_THREADS] = array::from_fn(|_| {
         let storage_cloned = storage.clone();
         let type_manager_cloned = type_manager.clone();
-        let thing_manager_cloned = thing_manager_arced.clone();
+        let thing_manager_cloned = thing_manager.clone();
         let rw_lock_cloned = start_signal_rw_lock.clone();
         thread::spawn(move || {
             drop(rw_lock_cloned.read().unwrap());
             for _ in 0..INTERNAL_ITERS {
                 let mut snapshot = storage_cloned.clone().open_snapshot_write();
                 let age: u32 = rand::random();
-                let row = execute_insert(
+                let _row = execute_insert(
                     &mut snapshot,
                     &type_manager_cloned,
                     &thing_manager_cloned,

--- a/executor/tests/compile_execute.rs
+++ b/executor/tests/compile_execute.rs
@@ -39,7 +39,7 @@ const MEMBERSHIP_MEMBER_LABEL: Label = Label::new_static_scoped("member", "membe
 fn test_has_planning_traversal() {
     let (_tmp_dir, mut storage) = create_core_storage();
     setup_concept_storage(&mut storage);
-    let (type_manager, thing_manager) = load_managers(storage.clone());
+    let (type_manager, thing_manager) = load_managers(storage.clone(), None);
 
     let mut snapshot = storage.clone().open_snapshot_write();
 
@@ -102,7 +102,7 @@ fn test_has_planning_traversal() {
 
     // Executor
     let snapshot = Arc::new(storage.clone().open_snapshot_read());
-    let (type_manager, thing_manager) = load_managers(storage.clone());
+    let (type_manager, thing_manager) = load_managers(storage.clone(), None);
 
     let (entry_annotations, _) = infer_types(
         &block,
@@ -145,7 +145,7 @@ fn test_has_planning_traversal() {
 fn test_links_planning_traversal() {
     let (_tmp_dir, mut storage) = create_core_storage();
     setup_concept_storage(&mut storage);
-    let (type_manager, thing_manager) = load_managers(storage.clone());
+    let (type_manager, thing_manager) = load_managers(storage.clone(), None);
 
     let mut snapshot = storage.clone().open_snapshot_write();
 
@@ -240,7 +240,7 @@ fn test_links_planning_traversal() {
 
     // Executor
     let snapshot = Arc::new(storage.clone().open_snapshot_read());
-    let (type_manager, thing_manager) = load_managers(storage.clone());
+    let (type_manager, thing_manager) = load_managers(storage.clone(), None);
     let (entry_annotations, _) = infer_types(
         &block,
         vec![],

--- a/executor/tests/execute_comparison_check.rs
+++ b/executor/tests/execute_comparison_check.rs
@@ -39,7 +39,7 @@ const ATTRIBUTE_INDEPENDENT: AttributeTypeAnnotation = AttributeTypeAnnotation::
 fn setup_database(storage: &mut Arc<MVCCStorage<WALClient>>) {
     setup_concept_storage(storage);
 
-    let (type_manager, thing_manager) = load_managers(storage.clone());
+    let (type_manager, thing_manager) = load_managers(storage.clone(), None);
     let mut snapshot = storage.clone().open_snapshot_write();
 
     let age_type = type_manager.create_attribute_type(&mut snapshot, &AGE_LABEL).unwrap();
@@ -84,7 +84,7 @@ fn attribute_equality() {
     let entry = builder.finish();
 
     let snapshot = storage.clone().open_snapshot_read();
-    let (type_manager, thing_manager) = load_managers(storage.clone());
+    let (type_manager, thing_manager) = load_managers(storage.clone(), None);
     let (entry_annotations, _) = infer_types(
         &entry,
         Vec::new(),

--- a/executor/tests/execute_has.rs
+++ b/executor/tests/execute_has.rs
@@ -43,7 +43,7 @@ const NAME_LABEL: Label = Label::new_static("name");
 fn setup_database(storage: &mut Arc<MVCCStorage<WALClient>>) {
     setup_concept_storage(storage);
 
-    let (type_manager, thing_manager) = load_managers(storage.clone());
+    let (type_manager, thing_manager) = load_managers(storage.clone(), None);
     let mut snapshot = storage.clone().open_snapshot_write();
 
     let person_type = type_manager.create_entity_type(&mut snapshot, &PERSON_LABEL).unwrap();
@@ -129,7 +129,7 @@ fn traverse_has_unbounded_sorted_from() {
     let entry = builder.finish();
 
     let snapshot = Arc::new(storage.clone().open_snapshot_read());
-    let (type_manager, thing_manager) = load_managers(storage.clone());
+    let (type_manager, thing_manager) = load_managers(storage.clone(), None);
 
     let (entry_annotations, _) = infer_types(
         &entry,
@@ -180,7 +180,7 @@ fn traverse_has_bounded_sorted_from_chain_intersect() {
     let (_tmp_dir, mut storage) = create_core_storage();
     setup_database(&mut storage);
 
-    let (type_manager, thing_manager) = load_managers(storage.clone());
+    let (type_manager, thing_manager) = load_managers(storage.clone(), None);
     // query:
     //   match
     //    $person-1 has name $name;
@@ -309,7 +309,7 @@ fn traverse_has_unbounded_sorted_from_intersect() {
     let entry = builder.finish();
 
     let snapshot: ReadSnapshot<WALClient> = storage.clone().open_snapshot_read();
-    let (type_manager, thing_manager) = load_managers(storage.clone());
+    let (type_manager, thing_manager) = load_managers(storage.clone(), None);
     let (entry_annotations, _) = infer_types(
         &entry,
         vec![],
@@ -383,7 +383,7 @@ fn traverse_has_unbounded_sorted_to_merged() {
     let entry = builder.finish();
 
     let snapshot: ReadSnapshot<WALClient> = storage.clone().open_snapshot_read();
-    let (type_manager, thing_manager) = load_managers(storage.clone());
+    let (type_manager, thing_manager) = load_managers(storage.clone(), None);
     let (entry_annotations, _) = infer_types(
         &entry,
         vec![],
@@ -474,7 +474,7 @@ fn traverse_has_reverse_unbounded_sorted_from() {
     let entry = builder.finish();
 
     let snapshot: ReadSnapshot<WALClient> = storage.clone().open_snapshot_read();
-    let (type_manager, thing_manager) = load_managers(storage.clone());
+    let (type_manager, thing_manager) = load_managers(storage.clone(), None);
     let (entry_annotations, _) = infer_types(
         &entry,
         vec![],

--- a/executor/tests/execute_isa.rs
+++ b/executor/tests/execute_isa.rs
@@ -35,7 +35,7 @@ const DOG_LABEL: Label = Label::new_static("dog");
 fn setup_database(storage: &mut Arc<MVCCStorage<WALClient>>) {
     setup_concept_storage(storage);
 
-    let (type_manager, thing_manager) = load_managers(storage.clone());
+    let (type_manager, thing_manager) = load_managers(storage.clone(), None);
     let mut snapshot = storage.clone().open_snapshot_write();
 
     let animal_type = type_manager.create_entity_type(&mut snapshot, &ANIMAL_LABEL).unwrap();
@@ -79,7 +79,7 @@ fn traverse_isa_unbounded_sorted_thing() {
     let entry = builder.finish();
 
     let snapshot = storage.clone().open_snapshot_read();
-    let (type_manager, thing_manager) = load_managers(storage.clone());
+    let (type_manager, thing_manager) = load_managers(storage.clone(), None);
     let (entry_annotations, _) = infer_types(
         &entry,
         vec![],
@@ -146,7 +146,7 @@ fn traverse_isa_unbounded_sorted_type() {
     let entry = builder.finish();
 
     let snapshot = storage.clone().open_snapshot_read();
-    let (type_manager, thing_manager) = load_managers(storage.clone());
+    let (type_manager, thing_manager) = load_managers(storage.clone(), None);
     let (entry_annotations, _) = infer_types(
         &entry,
         vec![],
@@ -215,7 +215,7 @@ fn traverse_isa_bounded_thing() {
     let entry = builder.finish();
 
     let snapshot = storage.clone().open_snapshot_read();
-    let (type_manager, thing_manager) = load_managers(storage.clone());
+    let (type_manager, thing_manager) = load_managers(storage.clone(), None);
     let (entry_annotations, _) = infer_types(
         &entry,
         vec![],
@@ -294,7 +294,7 @@ fn traverse_isa_reverse_unbounded_sorted_thing() {
     let entry = builder.finish();
 
     let snapshot = storage.clone().open_snapshot_read();
-    let (type_manager, thing_manager) = load_managers(storage.clone());
+    let (type_manager, thing_manager) = load_managers(storage.clone(), None);
     let (entry_annotations, _) = infer_types(
         &entry,
         vec![],
@@ -361,7 +361,7 @@ fn traverse_isa_reverse_unbounded_sorted_type() {
     let entry = builder.finish();
 
     let snapshot = storage.clone().open_snapshot_read();
-    let (type_manager, thing_manager) = load_managers(storage.clone());
+    let (type_manager, thing_manager) = load_managers(storage.clone(), None);
     let (entry_annotations, _) = infer_types(
         &entry,
         vec![],
@@ -430,7 +430,7 @@ fn traverse_isa_reverse_bounded_type() {
     let entry = builder.finish();
 
     let snapshot = storage.clone().open_snapshot_read();
-    let (type_manager, thing_manager) = load_managers(storage.clone());
+    let (type_manager, thing_manager) = load_managers(storage.clone(), None);
     let (entry_annotations, _) = infer_types(
         &entry,
         vec![],

--- a/executor/tests/execute_links.rs
+++ b/executor/tests/execute_links.rs
@@ -50,7 +50,7 @@ const RELATES_CARDINALITY_ANY: RelatesAnnotation = RelatesAnnotation::Cardinalit
 fn setup_database(storage: &mut Arc<MVCCStorage<WALClient>>) {
     setup_concept_storage(storage);
 
-    let (type_manager, thing_manager) = load_managers(storage.clone());
+    let (type_manager, thing_manager) = load_managers(storage.clone(), None);
     let mut snapshot = storage.clone().open_snapshot_write();
 
     let person_type = type_manager.create_entity_type(&mut snapshot, &PERSON_LABEL).unwrap();
@@ -207,7 +207,7 @@ fn traverse_links_unbounded_sorted_from() {
 
     let entry = builder.finish();
     let snapshot = storage.clone().open_snapshot_read();
-    let (type_manager, thing_manager) = load_managers(storage.clone());
+    let (type_manager, thing_manager) = load_managers(storage.clone(), None);
     let (entry_annotations, _) = infer_types(
         &entry,
         vec![],
@@ -306,7 +306,7 @@ fn traverse_links_unbounded_sorted_to() {
 
     let entry = builder.finish();
     let snapshot = storage.clone().open_snapshot_read();
-    let (type_manager, thing_manager) = load_managers(storage.clone());
+    let (type_manager, thing_manager) = load_managers(storage.clone(), None);
     let (entry_annotations, _) = infer_types(
         &entry,
         vec![],
@@ -392,7 +392,7 @@ fn traverse_links_bounded_relation() {
     let entry = builder.finish();
 
     let snapshot = storage.clone().open_snapshot_read();
-    let (type_manager, thing_manager) = load_managers(storage.clone());
+    let (type_manager, thing_manager) = load_managers(storage.clone(), None);
     let (entry_annotations, _) = infer_types(
         &entry,
         vec![],
@@ -490,7 +490,7 @@ fn traverse_links_bounded_relation_player() {
     let entry = builder.finish();
 
     let snapshot = storage.clone().open_snapshot_read();
-    let (type_manager, thing_manager) = load_managers(storage.clone());
+    let (type_manager, thing_manager) = load_managers(storage.clone(), None);
     let (entry_annotations, _) = infer_types(
         &entry,
         vec![],
@@ -597,7 +597,7 @@ fn traverse_links_reverse_unbounded_sorted_from() {
     let entry = builder.finish();
 
     let snapshot = Arc::new(storage.clone().open_snapshot_read());
-    let (type_manager, thing_manager) = load_managers(storage.clone());
+    let (type_manager, thing_manager) = load_managers(storage.clone(), None);
     let (entry_annotations, _) = infer_types(
         &entry,
         vec![],
@@ -681,7 +681,7 @@ fn traverse_links_reverse_unbounded_sorted_to() {
     let entry = builder.finish();
 
     let snapshot = Arc::new(storage.clone().open_snapshot_read());
-    let (type_manager, thing_manager) = load_managers(storage.clone());
+    let (type_manager, thing_manager) = load_managers(storage.clone(), None);
     let (entry_annotations, _) = infer_types(
         &entry,
         vec![],
@@ -766,7 +766,7 @@ fn traverse_links_reverse_bounded_player() {
     let entry = builder.finish();
 
     let snapshot = storage.clone().open_snapshot_read();
-    let (type_manager, thing_manager) = load_managers(storage.clone());
+    let (type_manager, thing_manager) = load_managers(storage.clone(), None);
     let (entry_annotations, _) = infer_types(
         &entry,
         vec![],
@@ -863,7 +863,7 @@ fn traverse_links_reverse_bounded_player_relation() {
     let entry = builder.finish();
 
     let snapshot = storage.clone().open_snapshot_read();
-    let (type_manager, thing_manager) = load_managers(storage.clone());
+    let (type_manager, thing_manager) = load_managers(storage.clone(), None);
     let (entry_annotations, _) = infer_types(
         &entry,
         vec![],

--- a/executor/tests/execute_select.rs
+++ b/executor/tests/execute_select.rs
@@ -41,7 +41,7 @@ const EMAIL_LABEL: Label = Label::new_static("email");
 fn setup_database(storage: &mut Arc<MVCCStorage<WALClient>>) {
     setup_concept_storage(storage);
 
-    let (type_manager, thing_manager) = load_managers(storage.clone());
+    let (type_manager, thing_manager) = load_managers(storage.clone(), None);
     let mut snapshot = storage.clone().open_snapshot_write();
 
     let person_type = type_manager.create_entity_type(&mut snapshot, &PERSON_LABEL).unwrap();
@@ -153,7 +153,7 @@ fn anonymous_vars_not_enumerated_or_counted() {
 
     let (entry_annotations, _) = {
         let snapshot: ReadSnapshot<WALClient> = storage.clone().open_snapshot_read();
-        let (type_manager, _) = load_managers(storage.clone());
+        let (type_manager, _) = load_managers(storage.clone(), None);
         infer_types(
             &entry,
             vec![],
@@ -184,7 +184,7 @@ fn anonymous_vars_not_enumerated_or_counted() {
 
     // Executor
     let snapshot = Arc::new(storage.clone().open_snapshot_read());
-    let (_, thing_manager) = load_managers(storage.clone());
+    let (_, thing_manager) = load_managers(storage.clone(), None);
     let executor = ProgramExecutor::new(&program_plan, &snapshot, &thing_manager).unwrap();
 
     let iterator = executor.into_iterator(snapshot, thing_manager, ExecutionInterrupt::new_uninterruptible());
@@ -232,7 +232,7 @@ fn unselected_named_vars_counted() {
 
     let (entry_annotations, _) = {
         let snapshot: ReadSnapshot<WALClient> = storage.clone().open_snapshot_read();
-        let (type_manager, _) = load_managers(storage.clone());
+        let (type_manager, _) = load_managers(storage.clone(), None);
         infer_types(
             &entry,
             vec![],
@@ -264,7 +264,7 @@ fn unselected_named_vars_counted() {
 
     // Executor
     let snapshot: Arc<ReadSnapshot<WALClient>> = Arc::new(storage.clone().open_snapshot_read());
-    let (_, thing_manager) = load_managers(storage.clone());
+    let (_, thing_manager) = load_managers(storage.clone(), None);
     let executor = ProgramExecutor::new(&program_plan, &snapshot, &thing_manager).unwrap();
 
     let iterator = executor.into_iterator(snapshot, thing_manager, ExecutionInterrupt::new_uninterruptible());
@@ -323,7 +323,7 @@ fn cartesian_named_counted_checked() {
 
     let (entry_annotations, _) = {
         let snapshot: ReadSnapshot<WALClient> = storage.clone().open_snapshot_read();
-        let (type_manager, _) = load_managers(storage.clone());
+        let (type_manager, _) = load_managers(storage.clone(), None);
         infer_types(
             &entry,
             vec![],
@@ -364,7 +364,7 @@ fn cartesian_named_counted_checked() {
 
     // Executor
     let snapshot: Arc<ReadSnapshot<WALClient>> = Arc::new(storage.clone().open_snapshot_read());
-    let (_, thing_manager) = load_managers(storage.clone());
+    let (_, thing_manager) = load_managers(storage.clone(), None);
     let executor = ProgramExecutor::new(&program_plan, &snapshot, &thing_manager).unwrap();
 
     let iterator = executor.into_iterator(snapshot, thing_manager, ExecutionInterrupt::new_uninterruptible());

--- a/executor/tests/pipelines.rs
+++ b/executor/tests/pipelines.rs
@@ -40,7 +40,7 @@ fn setup_common() -> Context {
     let (_tmp_dir, mut storage) = create_core_storage();
     setup_concept_storage(&mut storage);
 
-    let (type_manager, thing_manager) = load_managers(storage.clone());
+    let (type_manager, thing_manager) = load_managers(storage.clone(), None);
     let function_manager = FunctionManager::new(Arc::new(DefinitionKeyGenerator::new()), None);
     let query_manager = QueryManager::new();
     let schema = r#"
@@ -57,7 +57,7 @@ fn setup_common() -> Context {
     let seq = snapshot.commit().unwrap();
 
     // reload to obtain latest vertex generators and statistics entries
-    let (type_manager, thing_manager) = load_managers(storage.clone());
+    let (type_manager, thing_manager) = load_managers(storage.clone(), None);
     Context { storage, type_manager, function_manager, query_manager, thing_manager }
 }
 

--- a/executor/tests/writes.rs
+++ b/executor/tests/writes.rs
@@ -40,7 +40,7 @@ const NAME_LABEL: Label = Label::new_static("name");
 
 fn setup_schema(storage: Arc<MVCCStorage<WALClient>>) {
     let mut snapshot: WriteSnapshot<WALClient> = storage.clone().open_snapshot_write();
-    let (type_manager, thing_manager) = load_managers(storage.clone());
+    let (type_manager, thing_manager) = load_managers(storage.clone(), None);
 
     let person_type = type_manager.create_entity_type(&mut snapshot, &PERSON_LABEL).unwrap();
     let group_type = type_manager.create_entity_type(&mut snapshot, &GROUP_LABEL).unwrap();
@@ -214,7 +214,7 @@ fn has() {
     let (_tmp_dir, mut storage) = create_core_storage();
     setup_concept_storage(&mut storage);
 
-    let (type_manager, thing_manager) = load_managers(storage.clone());
+    let (type_manager, thing_manager) = load_managers(storage.clone(), None);
     setup_schema(storage.clone());
     let mut snapshot = storage.clone().open_snapshot_write();
     execute_insert(
@@ -243,7 +243,7 @@ fn test() {
     let (_tmp_dir, mut storage) = create_core_storage();
     setup_concept_storage(&mut storage);
 
-    let (type_manager, thing_manager) = load_managers(storage.clone());
+    let (type_manager, thing_manager) = load_managers(storage.clone(), None);
     setup_schema(storage.clone());
 
     let mut snapshot = storage.clone().open_snapshot_write();
@@ -261,7 +261,7 @@ fn relation() {
     let (_tmp_dir, mut storage) = create_core_storage();
     setup_concept_storage(&mut storage);
 
-    let (type_manager, thing_manager) = load_managers(storage.clone());
+    let (type_manager, thing_manager) = load_managers(storage.clone(), None);
     setup_schema(storage.clone());
 
     let mut snapshot = storage.clone().open_snapshot_write();
@@ -316,7 +316,7 @@ fn relation_with_inferred_roles() {
     let (_tmp_dir, mut storage) = create_core_storage();
     setup_concept_storage(&mut storage);
 
-    let (type_manager, thing_manager) = load_managers(storage.clone());
+    let (type_manager, thing_manager) = load_managers(storage.clone(), None);
     setup_schema(storage.clone());
 
     let mut snapshot = storage.clone().open_snapshot_write();
@@ -371,7 +371,7 @@ fn test_has_with_input_rows() {
     let (_tmp_dir, mut storage) = create_core_storage();
     setup_concept_storage(&mut storage);
 
-    let (type_manager, thing_manager) = load_managers(storage.clone());
+    let (type_manager, thing_manager) = load_managers(storage.clone(), None);
     setup_schema(storage.clone());
     let mut snapshot = storage.clone().open_snapshot_write();
     let inserted_rows =
@@ -417,7 +417,7 @@ fn delete_has() {
     let (_tmp_dir, mut storage) = create_core_storage();
     setup_concept_storage(&mut storage);
 
-    let (type_manager, thing_manager) = load_managers(storage.clone());
+    let (type_manager, thing_manager) = load_managers(storage.clone(), None);
     setup_schema(storage.clone());
     let mut snapshot = storage.clone().open_snapshot_write();
     let inserted_rows =

--- a/query/tests/define.rs
+++ b/query/tests/define.rs
@@ -13,7 +13,7 @@ use test_utils_encoding::create_core_storage;
 fn basic() {
     let (_tmp_dir, mut storage) = create_core_storage();
     setup_concept_storage(&mut storage);
-    let (type_manager, thing_manager) = load_managers(storage.clone());
+    let (type_manager, thing_manager) = load_managers(storage.clone(), None);
     let mut snapshot = storage.clone().open_snapshot_schema();
     let query_manager = QueryManager::new();
 

--- a/resource/constants.rs
+++ b/resource/constants.rs
@@ -26,6 +26,7 @@ pub mod snapshot {
 
 pub mod storage {
     pub const TIMELINE_WINDOW_SIZE: usize = 100;
+    pub const WAL_FLUSH_INTERVAL_MICROSECONDS: u64 = 1000;
 }
 
 pub mod encoding {

--- a/resource/constants.rs
+++ b/resource/constants.rs
@@ -26,7 +26,7 @@ pub mod snapshot {
 
 pub mod storage {
     pub const TIMELINE_WINDOW_SIZE: usize = 100;
-    pub const WAL_FLUSH_INTERVAL_MICROSECONDS: u64 = 1000;
+    pub const WAL_SYNC_INTERVAL_MICROSECONDS: u64 = 1000;
 }
 
 pub mod encoding {

--- a/storage/durability_client.rs
+++ b/storage/durability_client.rs
@@ -9,9 +9,8 @@ use std::{
     error::Error,
     fmt, io,
     io::{Read, Write},
-    sync::Arc,
+    sync::{Arc, mpsc},
 };
-use std::sync::mpsc;
 
 use durability::{wal::WAL, DurabilityRecordType, DurabilityService, DurabilityServiceError, RawRecord};
 use itertools::Itertools;
@@ -142,7 +141,6 @@ impl WALClient {
 }
 
 impl DurabilityClient for WALClient {
-
     fn request_sync(&self) -> mpsc::Receiver<()> {
         self.wal.request_sync()
     }

--- a/storage/durability_client.rs
+++ b/storage/durability_client.rs
@@ -46,6 +46,8 @@ pub trait DurabilityClient {
     where
         Record: UnsequencedDurabilityRecord;
 
+    fn sync_all(&self);
+
     fn iter_from(
         &self,
         sequence_number: SequenceNumber,
@@ -139,6 +141,11 @@ impl WALClient {
 }
 
 impl DurabilityClient for WALClient {
+
+    fn sync_all(&self) {
+        self.wal.sync_all()
+    }
+
     fn register_record_type<Record: DurabilityRecord>(&mut self) {
         self.wal.register_record_type(Record::RECORD_TYPE, Record::RECORD_NAME);
     }

--- a/storage/durability_client.rs
+++ b/storage/durability_client.rs
@@ -9,7 +9,7 @@ use std::{
     error::Error,
     fmt, io,
     io::{Read, Write},
-    sync::{Arc, mpsc},
+    sync::{mpsc, Arc},
 };
 
 use durability::{wal::WAL, DurabilityRecordType, DurabilityService, DurabilityServiceError, RawRecord};

--- a/storage/durability_client.rs
+++ b/storage/durability_client.rs
@@ -11,6 +11,7 @@ use std::{
     io::{Read, Write},
     sync::Arc,
 };
+use std::sync::mpsc;
 
 use durability::{wal::WAL, DurabilityRecordType, DurabilityService, DurabilityServiceError, RawRecord};
 use itertools::Itertools;
@@ -46,7 +47,7 @@ pub trait DurabilityClient {
     where
         Record: UnsequencedDurabilityRecord;
 
-    fn sync_all(&self);
+    fn request_sync(&self) -> mpsc::Receiver<()>;
 
     fn iter_from(
         &self,
@@ -142,8 +143,8 @@ impl WALClient {
 
 impl DurabilityClient for WALClient {
 
-    fn sync_all(&self) {
-        self.wal.sync_all()
+    fn request_sync(&self) -> mpsc::Receiver<()> {
+        self.wal.request_sync()
     }
 
     fn register_record_type<Record: DurabilityRecord>(&mut self) {

--- a/storage/isolation_manager.rs
+++ b/storage/isolation_manager.rs
@@ -119,11 +119,8 @@ impl IsolationManager {
                     CommitStatus::Validated(commit_record) | CommitStatus::Applied(commit_record) => commit_record,
                     _ => panic!("get_commit_record called on uncommitted record"), // TODO: Do we want to be able to apply on pending?
                 };
-                Ok(ValidatedCommit::Write(WriteBatches::from_operations(
-                    sequence_number,
-                    commit_record.operations(),
-                )))
-            },
+                Ok(ValidatedCommit::Write(WriteBatches::from_operations(sequence_number, commit_record.operations())))
+            }
         }
     }
 
@@ -458,19 +455,13 @@ impl Timeline {
         (concurrent_windows, start_index_of_first_concurrent_window)
     }
 
-    fn try_get_window(
-        &self,
-        sequence_number: SequenceNumber,
-    ) -> Option<Arc<TimelineWindow<TIMELINE_WINDOW_SIZE>>> {
+    fn try_get_window(&self, sequence_number: SequenceNumber) -> Option<Arc<TimelineWindow<TIMELINE_WINDOW_SIZE>>> {
         let windows = self.windows.read().unwrap_or_log();
         let window_index = Self::resolve_window(&windows, sequence_number)?;
         Some(windows.get(window_index).unwrap().clone())
     }
 
-    fn get_or_create_window(
-        &self,
-        sequence_number: SequenceNumber,
-    ) -> Arc<TimelineWindow<TIMELINE_WINDOW_SIZE>> {
+    fn get_or_create_window(&self, sequence_number: SequenceNumber) -> Arc<TimelineWindow<TIMELINE_WINDOW_SIZE>> {
         let end = self.windows.read().unwrap_or_log().back().unwrap().end();
         if sequence_number >= end {
             self.create_windows_to(sequence_number);

--- a/storage/isolation_manager.rs
+++ b/storage/isolation_manager.rs
@@ -134,7 +134,7 @@ impl IsolationManager {
         // Pre-collect all the ARCs so we can validate against them.
         let (windows, first_sequence_number_in_memory) =
             self.timeline.collect_concurrent_windows(commit_record.open_sequence_number, commit_sequence_number);
-        if commit_record.open_sequence_number().next() <= first_sequence_number_in_memory {
+        if commit_record.open_sequence_number().next() < first_sequence_number_in_memory {
             if let Some(conflict) =
                 self.validate_concurrent_from_disk(commit_record, first_sequence_number_in_memory, durability_client)?
             {

--- a/storage/isolation_manager.rs
+++ b/storage/isolation_manager.rs
@@ -197,7 +197,6 @@ impl IsolationManager {
             let validate_against = SequenceNumber::from(validate_against);
             let window = &windows[window_index];
             debug_assert!(window_index < windows.len());
-            debug_assert!(commit_sequence_number > validate_against);
             if let Some(conflict) = resolve_concurrent(commit_record, validate_against, window) {
                 return Some(conflict);
             }

--- a/storage/storage.rs
+++ b/storage/storage.rs
@@ -14,8 +14,8 @@ use std::{
     fmt, fs, io,
     path::{Path, PathBuf},
     sync::{atomic::Ordering, Arc},
+    time::Duration,
 };
-use std::time::Duration;
 
 use bytes::{byte_array::ByteArray, byte_reference::ByteReference, Bytes};
 use isolation_manager::IsolationConflict;

--- a/storage/storage.rs
+++ b/storage/storage.rs
@@ -224,7 +224,7 @@ impl<Durability> MVCCStorage<Durability> {
         let result = match validated_commit {
             ValidatedCommit::Write(write_batches) => {
                 sync_notifier.recv().unwrap(); // Ensure WAL is persisted before inserting to the KV store
-               // Write to the k-v store
+                                               // Write to the k-v store
                 self.keyspaces
                     .write(write_batches)
                     .map_err(|error| Keyspace { name: self.name.to_owned(), source: Arc::new(error) })?;

--- a/storage/storage.rs
+++ b/storage/storage.rs
@@ -223,8 +223,8 @@ impl<Durability> MVCCStorage<Durability> {
             .map_err(|error| Durability { name: self.name.to_owned(), source: error })?;
         let result = match validated_commit {
             ValidatedCommit::Write(write_batches) => {
-                sync_notifier.recv().unwrap(); // Ensure WAL is persisted inserting to RocksDB
-                                               // Write to the k-v storage
+                sync_notifier.recv().unwrap(); // Ensure WAL is persisted before inserting to the KV store
+               // Write to the k-v store
                 self.keyspaces
                     .write(write_batches)
                     .map_err(|error| Keyspace { name: self.name.to_owned(), source: Arc::new(error) })?;


### PR DESCRIPTION
## Usage and product changes
Commits guarantee that changes have been persisted to the disk (using `fsync`) before changes are visible and the commit is acknowledged. The sync is done periodically and committing threads must wait for a signal that the sync is complete. This avoids the performance penalty of each commit doing its own sync, while providing guarantees that committed data is not lost in the event of an OS crash.

## Implementation
* Introduce an `fsync` thread in the WAL.
* Introduce a `request_sync` API to the WAL, which returns a `mpsc::receiver` which will receive a single `()` when the next fsync is completed.