### PR TITLE
Finish GRPC transaction service and migrate more error types

### DIFF
--- a/common/error/typeql.rs
+++ b/common/error/typeql.rs
@@ -34,11 +34,11 @@ impl TypeDBError for typeql::Error {
         format!("Causes:\n{}", self)
     }
 
-    fn source(&self) -> Option<&dyn Error> {
+    fn source(&self) -> Option<&(dyn Error + Send)> {
         None
     }
 
-    fn source_typedb_error(&self) -> Option<&dyn TypeDBError> {
+    fn source_typedb_error(&self) -> Option<&(dyn TypeDBError + Send)> {
         None
     }
 }

--- a/compiler/expression/instructions/binary.rs
+++ b/compiler/expression/instructions/binary.rs
@@ -12,20 +12,20 @@
 
 use std::{marker::PhantomData, ops::Rem};
 
-use encoding::value::{value::DBValue, value_type::ValueTypeCategory};
+use encoding::value::{value::NativeValueConvertible, value_type::ValueTypeCategory};
 
 use crate::expression::{expression_compiler::ExpressionCompilationContext, ExpressionCompileError};
 
-pub trait BinaryExpression<T1: DBValue, T2: DBValue, R: DBValue> {
+pub trait BinaryExpression<T1: NativeValueConvertible, T2: NativeValueConvertible, R: NativeValueConvertible> {
     const OP_CODE: ExpressionOpCode;
     fn evaluate(a1: T1, a2: T2) -> Result<R, ExpressionEvaluationError>;
 }
 
 pub struct Binary<T1, T2, R, F>
 where
-    T1: DBValue,
-    T2: DBValue,
-    R: DBValue,
+    T1: NativeValueConvertible,
+    T2: NativeValueConvertible,
+    R: NativeValueConvertible,
     F: BinaryExpression<T1, T2, R>,
 {
     pub phantom: PhantomData<(T1, T2, R, F)>,
@@ -33,9 +33,9 @@ where
 
 impl<T1, T2, R, F> ExpressionInstruction for Binary<T1, T2, R, F>
 where
-    T1: DBValue,
-    T2: DBValue,
-    R: DBValue,
+    T1: NativeValueConvertible,
+    T2: NativeValueConvertible,
+    R: NativeValueConvertible,
     F: BinaryExpression<T1, T2, R>,
 {
     const OP_CODE: ExpressionOpCode = F::OP_CODE;
@@ -43,9 +43,9 @@ where
 
 impl<T1, T2, R, F> CompilableExpression for Binary<T1, T2, R, F>
 where
-    T1: DBValue,
-    T2: DBValue,
-    R: DBValue,
+    T1: NativeValueConvertible,
+    T2: NativeValueConvertible,
+    R: NativeValueConvertible,
     F: BinaryExpression<T1, T2, R>,
 {
     fn return_value_category(&self) -> Option<ValueTypeCategory> {

--- a/compiler/expression/instructions/load_cast.rs
+++ b/compiler/expression/instructions/load_cast.rs
@@ -12,7 +12,7 @@
 
 use std::marker::PhantomData;
 
-use encoding::value::{value::DBValue, value_type::ValueTypeCategory};
+use encoding::value::{value::NativeValueConvertible, value_type::ValueTypeCategory};
 
 use crate::expression::{
     expression_compiler::ExpressionCompilationContext,
@@ -42,30 +42,30 @@ impl ExpressionInstruction for LoadConstant {
 }
 
 // Casts
-pub trait ImplicitCast<From: DBValue>: DBValue {
+pub trait ImplicitCast<From: NativeValueConvertible>: NativeValueConvertible {
     const CAST_UNARY_OPCODE: ExpressionOpCode;
     const CAST_LEFT_OPCODE: ExpressionOpCode;
     const CAST_RIGHT_OPCODE: ExpressionOpCode;
     fn cast(from: From) -> Result<Self, ExpressionEvaluationError>;
 }
 
-pub struct CastUnary<From: DBValue, To: ImplicitCast<From>> {
+pub struct CastUnary<From: NativeValueConvertible, To: ImplicitCast<From>> {
     phantom: PhantomData<(From, To)>,
 }
 
-pub struct CastBinaryLeft<From: DBValue, To: ImplicitCast<From>> {
+pub struct CastBinaryLeft<From: NativeValueConvertible, To: ImplicitCast<From>> {
     phantom: PhantomData<(From, To)>,
 }
 
-pub struct CastBinaryRight<From: DBValue, To: ImplicitCast<From>> {
+pub struct CastBinaryRight<From: NativeValueConvertible, To: ImplicitCast<From>> {
     phantom: PhantomData<(From, To)>,
 }
 
-impl<From: DBValue, To: ImplicitCast<From>> ExpressionInstruction for CastUnary<From, To> {
+impl<From: NativeValueConvertible, To: ImplicitCast<From>> ExpressionInstruction for CastUnary<From, To> {
     const OP_CODE: ExpressionOpCode = To::CAST_UNARY_OPCODE;
 }
 
-impl<From: DBValue, To: ImplicitCast<From>> CompilableExpression for CastUnary<From, To> {
+impl<From: NativeValueConvertible, To: ImplicitCast<From>> CompilableExpression for CastUnary<From, To> {
     fn return_value_category(&self) -> Option<ValueTypeCategory> {
         Some(To::VALUE_TYPE_CATEGORY)
     }
@@ -82,11 +82,11 @@ impl<From: DBValue, To: ImplicitCast<From>> CompilableExpression for CastUnary<F
     }
 }
 
-impl<From: DBValue, To: ImplicitCast<From>> ExpressionInstruction for CastBinaryLeft<From, To> {
+impl<From: NativeValueConvertible, To: ImplicitCast<From>> ExpressionInstruction for CastBinaryLeft<From, To> {
     const OP_CODE: ExpressionOpCode = To::CAST_LEFT_OPCODE;
 }
 
-impl<From: DBValue, To: ImplicitCast<From>> CompilableExpression for CastBinaryLeft<From, To> {
+impl<From: NativeValueConvertible, To: ImplicitCast<From>> CompilableExpression for CastBinaryLeft<From, To> {
     fn return_value_category(&self) -> Option<ValueTypeCategory> {
         Some(To::VALUE_TYPE_CATEGORY)
     }
@@ -105,11 +105,11 @@ impl<From: DBValue, To: ImplicitCast<From>> CompilableExpression for CastBinaryL
     }
 }
 
-impl<From: DBValue, To: ImplicitCast<From>> ExpressionInstruction for CastBinaryRight<From, To> {
+impl<From: NativeValueConvertible, To: ImplicitCast<From>> ExpressionInstruction for CastBinaryRight<From, To> {
     const OP_CODE: ExpressionOpCode = To::CAST_RIGHT_OPCODE;
 }
 
-impl<From: DBValue, To: ImplicitCast<From>> CompilableExpression for CastBinaryRight<From, To> {
+impl<From: NativeValueConvertible, To: ImplicitCast<From>> CompilableExpression for CastBinaryRight<From, To> {
     fn return_value_category(&self) -> Option<ValueTypeCategory> {
         Some(To::VALUE_TYPE_CATEGORY)
     }

--- a/compiler/expression/instructions/unary.rs
+++ b/compiler/expression/instructions/unary.rs
@@ -6,19 +6,19 @@
 
 use std::marker::PhantomData;
 
-use encoding::value::{value::DBValue, value_type::ValueTypeCategory};
+use encoding::value::{value::NativeValueConvertible, value_type::ValueTypeCategory};
 
 use crate::expression::{expression_compiler::ExpressionCompilationContext, ExpressionCompileError};
 
-pub trait UnaryExpression<T1: DBValue, R: DBValue> {
+pub trait UnaryExpression<T1: NativeValueConvertible, R: NativeValueConvertible> {
     const OP_CODE: ExpressionOpCode;
     fn evaluate(a1: T1) -> Result<R, ExpressionEvaluationError>;
 }
 
 pub struct Unary<T1, R, F>
 where
-    T1: DBValue,
-    R: DBValue,
+    T1: NativeValueConvertible,
+    R: NativeValueConvertible,
     F: UnaryExpression<T1, R>,
 {
     phantom: PhantomData<(T1, R, F)>,
@@ -26,8 +26,8 @@ where
 
 impl<T1, R, F> ExpressionInstruction for Unary<T1, R, F>
 where
-    T1: DBValue,
-    R: DBValue,
+    T1: NativeValueConvertible,
+    R: NativeValueConvertible,
     F: UnaryExpression<T1, R>,
 {
     const OP_CODE: ExpressionOpCode = F::OP_CODE;
@@ -35,8 +35,8 @@ where
 
 impl<T1, R, F> CompilableExpression for Unary<T1, R, F>
 where
-    T1: DBValue,
-    R: DBValue,
+    T1: NativeValueConvertible,
+    R: NativeValueConvertible,
     F: UnaryExpression<T1, R>,
 {
     fn return_value_category(&self) -> Option<ValueTypeCategory> {

--- a/compiler/expression/mod.rs
+++ b/compiler/expression/mod.rs
@@ -19,7 +19,7 @@ pub mod compiled_expression;
 pub mod expression_compiler;
 pub mod instructions;
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum ExpressionCompileError {
     ConceptRead {
         source: ConceptReadError,

--- a/concept/tests/test_statistics.rs
+++ b/concept/tests/test_statistics.rs
@@ -249,12 +249,12 @@ fn delete_twice() {
     thing_manager.finalise(&mut snapshot).unwrap();
     let create_commit_seq = snapshot.commit().unwrap().unwrap();
 
-    let mut snapshot = storage.clone().open_snapshot_write_at(create_commit_seq).unwrap();
+    let mut snapshot = storage.clone().open_snapshot_write_at(create_commit_seq);
     person.clone().delete(&mut snapshot, &thing_manager).unwrap();
     thing_manager.finalise(&mut snapshot).unwrap();
     snapshot.commit().unwrap().unwrap();
 
-    let mut snapshot = storage.clone().open_snapshot_write_at(create_commit_seq).unwrap();
+    let mut snapshot = storage.clone().open_snapshot_write_at(create_commit_seq);
     person.clone().delete(&mut snapshot, &thing_manager).unwrap();
     thing_manager.finalise(&mut snapshot).unwrap();
     snapshot.commit().unwrap().unwrap();
@@ -284,12 +284,12 @@ fn put_has_twice() {
     thing_manager.finalise(&mut snapshot).unwrap();
     let create_commit_seq = snapshot.commit().unwrap().unwrap();
 
-    let mut snapshot = storage.clone().open_snapshot_write_at(create_commit_seq).unwrap();
+    let mut snapshot = storage.clone().open_snapshot_write_at(create_commit_seq);
     person.set_has_unordered(&mut snapshot, &thing_manager, name.as_reference()).unwrap();
     thing_manager.finalise(&mut snapshot).unwrap();
     snapshot.commit().unwrap().unwrap();
 
-    let mut snapshot = storage.clone().open_snapshot_write_at(create_commit_seq).unwrap();
+    let mut snapshot = storage.clone().open_snapshot_write_at(create_commit_seq);
     person.set_has_unordered(&mut snapshot, &thing_manager, name.as_reference()).unwrap();
     thing_manager.finalise(&mut snapshot).unwrap();
     snapshot.commit().unwrap().unwrap();
@@ -332,7 +332,7 @@ fn put_plays() {
     thing_manager.finalise(&mut snapshot).unwrap();
     let create_commit_seq = snapshot.commit().unwrap().unwrap();
 
-    let mut snapshot = storage.clone().open_snapshot_write_at(create_commit_seq).unwrap();
+    let mut snapshot = storage.clone().open_snapshot_write_at(create_commit_seq);
     let person_2 = thing_manager.create_entity(&mut snapshot, person_type.clone()).unwrap();
     friendship.add_player(&mut snapshot, &thing_manager, friend_role.clone(), person_2.into_owned_object()).unwrap();
     thing_manager.finalise(&mut snapshot).unwrap();

--- a/concept/thing/statistics.rs
+++ b/concept/thing/statistics.rs
@@ -443,7 +443,7 @@ struct CommittedWrites {
     operations: OperationsBuffer,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum StatisticsError {
     DurablyWrite { source: DurabilityClientError },
     ReloadCommitData { source: CommitRecoveryError },

--- a/concept/type_/mod.rs
+++ b/concept/type_/mod.rs
@@ -6,6 +6,7 @@
 
 use std::{
     collections::{HashMap, HashSet},
+    fmt::{Display, Formatter},
     hash::Hash,
 };
 
@@ -379,6 +380,15 @@ pub enum Ordering {
     // ##########################################################################
     Unordered,
     Ordered,
+}
+
+impl Display for Ordering {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Ordering::Unordered => write!(f, ""),
+            Ordering::Ordered => write!(f, "[]"),
+        }
+    }
 }
 
 impl Ordering {

--- a/concept/type_/plays.rs
+++ b/concept/type_/plays.rs
@@ -21,7 +21,7 @@ use crate::{
         object_type::ObjectType,
         role_type::RoleType,
         type_manager::TypeManager,
-        Capability, TypeAPI,
+        Capability, Ordering, TypeAPI,
     },
 };
 

--- a/concept/type_/relates.rs
+++ b/concept/type_/relates.rs
@@ -23,7 +23,7 @@ use crate::{
         relation_type::RelationType,
         role_type::RoleType,
         type_manager::TypeManager,
-        Capability, TypeAPI,
+        Capability, Ordering, TypeAPI,
     },
 };
 

--- a/concept/type_/type_manager/type_cache/type_cache.rs
+++ b/concept/type_/type_manager/type_cache/type_cache.rs
@@ -15,7 +15,7 @@ use encoding::{
     graph::definition::{definition_key::DefinitionKey, r#struct::StructDefinition},
     value::{label::Label, value_type::ValueType},
 };
-use storage::{sequence_number::SequenceNumber, MVCCStorage, ReadSnapshotOpenError};
+use storage::{sequence_number::SequenceNumber, MVCCStorage};
 
 use crate::type_::{
     annotation::AnnotationIndependent,
@@ -87,12 +87,10 @@ impl TypeCache {
         storage: Arc<MVCCStorage<D>>,
         open_sequence_number: SequenceNumber,
     ) -> Result<Self, TypeCacheCreateError> {
-        use TypeCacheCreateError::SnapshotOpen;
         // note: since we will parse out many heterogenous properties/edges from the schema, we will scan once into a vector,
         //       then go through it again to pull out the type information.
 
-        let snapshot =
-            storage.open_snapshot_read_at(open_sequence_number).map_err(|error| SnapshotOpen { source: error })?;
+        let snapshot = storage.open_snapshot_read_at(open_sequence_number);
 
         let entity_type_caches = EntityTypeCache::create(&snapshot);
         let relation_type_caches = RelationTypeCache::create(&snapshot);
@@ -486,23 +484,17 @@ impl TypeCache {
     }
 }
 
-#[derive(Debug)]
-pub enum TypeCacheCreateError {
-    SnapshotOpen { source: ReadSnapshotOpenError },
-}
+#[derive(Debug, Clone)]
+pub enum TypeCacheCreateError {}
 
 impl fmt::Display for TypeCacheCreateError {
     fn fmt(&self, _f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Self::SnapshotOpen { .. } => todo!(),
-        }
+        todo!()
     }
 }
 
 impl Error for TypeCacheCreateError {
     fn source(&self) -> Option<&(dyn Error + 'static)> {
-        match self {
-            Self::SnapshotOpen { source } => Some(source),
-        }
+        todo!()
     }
 }

--- a/database/BUILD
+++ b/database/BUILD
@@ -14,6 +14,7 @@ rust_library(
         "//common/concurrency",
         "//common/logger",
         "//common/options",
+        "//common/error",
         "//concept",
         "//encoding",
         "//function",

--- a/database/database_manager.rs
+++ b/database/database_manager.rs
@@ -27,12 +27,12 @@ impl DatabaseManager {
         let databases = fs::read_dir(data_directory)
             .map_err(|error| DatabaseOpenError::CouldNotReadDataDirectory {
                 path: data_directory.to_owned(),
-                source: error,
+                source: Arc::new(error),
             })?
             .map(|entry| {
                 let entry = entry.map_err(|error| DatabaseOpenError::CouldNotReadDataDirectory {
                     path: data_directory.to_owned(),
-                    source: error,
+                    source: Arc::new(error),
                 })?;
                 let database = Database::<WALClient>::open(&entry.path())?;
                 Ok((database.name().to_owned(), Arc::new(database)))

--- a/database/transaction.rs
+++ b/database/transaction.rs
@@ -164,7 +164,7 @@ impl<D: DurabilityClient> TransactionWrite<D> {
 }
 
 // TODO this should be a TypeDB error, although it can contain many errors!?
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum DataCommitError {
     ConceptWriteErrors { source: Vec<ConceptWriteError> },
     SnapshotError { source: SnapshotError },
@@ -304,7 +304,7 @@ impl<D: DurabilityClient> TransactionSchema<D> {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum SchemaCommitError {
     ConceptWrite { errors: Vec<ConceptWriteError> },
     TypeCacheUpdate { source: TypeCacheCreateError },

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -22,7 +22,7 @@ def vaticle_typeql():
     git_repository(
         name = "vaticle_typeql",
         remote = "https://github.com/typedb/typeql",
-        commit = "6908d2af53d954dc146c604726a2896a04b895c9",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typeql
+        commit = "13dfd915a4924865d221e3a5940f673298959cc9",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typeql
     )
 
 def vaticle_typedb_common():

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -22,7 +22,7 @@ def vaticle_typeql():
     git_repository(
         name = "vaticle_typeql",
         remote = "https://github.com/typedb/typeql",
-        commit = "13dfd915a4924865d221e3a5940f673298959cc9",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typeql
+        commit = "b94e8d3bcce98c55998e6caa738b746eca79110d",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typeql
     )
 
 def vaticle_typedb_common():

--- a/durability/durability.rs
+++ b/durability/durability.rs
@@ -12,6 +12,7 @@ use std::{
     error::Error,
     fmt, io,
     ops::{Add, AddAssign, Sub},
+    sync::Arc,
 };
 
 use serde::{Deserialize, Serialize};
@@ -153,20 +154,20 @@ impl Sub<DurabilitySequenceNumber> for DurabilitySequenceNumber {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum DurabilityServiceError {
     // #[non_exhaustive]
     // BincodeSerialize { source: bincode::Error },
     #[non_exhaustive]
     IO {
-        source: io::Error,
+        source: Arc<io::Error>,
     },
     WAL {
         source: WALError,
     },
 
     DeleteFailed {
-        source: io::Error,
+        source: Arc<io::Error>,
     },
 }
 
@@ -184,7 +185,7 @@ impl fmt::Display for DurabilityServiceError {
 
 impl From<io::Error> for DurabilityServiceError {
     fn from(source: io::Error) -> Self {
-        Self::IO { source }
+        Self::IO { source: Arc::new(source) }
     }
 }
 

--- a/encoding/BUILD
+++ b/encoding/BUILD
@@ -40,6 +40,7 @@ rust_library(
         "@crates//:bincode",
         "@crates//:chrono",
         "@crates//:chrono-tz",
+        "@crates//:itertools",
         "@crates//:tracing",
         "@crates//:seahash",
         "@crates//:serde",

--- a/encoding/graph/definition/struct.rs
+++ b/encoding/graph/definition/struct.rs
@@ -4,7 +4,10 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-use std::collections::{hash_map::Entry, HashMap};
+use std::{
+    collections::{hash_map::Entry, HashMap},
+    fmt::{Display, Formatter},
+};
 
 use bytes::{byte_reference::ByteReference, Bytes};
 use resource::constants::{encoding::StructFieldIDUInt, snapshot::BUFFER_VALUE_INLINE};
@@ -27,6 +30,12 @@ pub struct StructDefinitionField {
     pub index: StructFieldIDUInt,
     pub optional: bool,
     pub value_type: ValueType,
+}
+
+impl Display for StructDefinitionField {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "Value type: {}, optional: {}", self.value_type, self.optional)
+    }
 }
 
 impl StructDefinition {

--- a/encoding/graph/type_/mod.rs
+++ b/encoding/graph/type_/mod.rs
@@ -37,6 +37,12 @@ impl std::fmt::Debug for Kind {
     }
 }
 
+impl std::fmt::Display for Kind {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
+        write!(f, "{}", self.name())
+    }
+}
+
 #[derive(Copy, Clone)]
 pub enum CapabilityKind {
     Relates,
@@ -45,7 +51,7 @@ pub enum CapabilityKind {
 }
 
 impl CapabilityKind {
-    fn name(&self) -> &'static str {
+    pub fn name(&self) -> &'static str {
         match self {
             CapabilityKind::Relates => "relates",
             CapabilityKind::Plays => "plays",

--- a/encoding/value/duration_value.rs
+++ b/encoding/value/duration_value.rs
@@ -259,7 +259,7 @@ mod tests {
 
     use chrono::{NaiveDate, NaiveDateTime, NaiveTime};
     use chrono_tz::Europe::London;
-    use rand::{Rng, rngs::SmallRng, SeedableRng, thread_rng};
+    use rand::{rngs::SmallRng, thread_rng, Rng, SeedableRng};
 
     use super::{Duration, MAX_YEAR, MIN_YEAR};
 

--- a/encoding/value/duration_value.rs
+++ b/encoding/value/duration_value.rs
@@ -259,7 +259,7 @@ mod tests {
 
     use chrono::{NaiveDate, NaiveDateTime, NaiveTime};
     use chrono_tz::Europe::London;
-    use rand::{rngs::SmallRng, thread_rng, Rng, SeedableRng};
+    use rand::{Rng, rngs::SmallRng, SeedableRng, thread_rng};
 
     use super::{Duration, MAX_YEAR, MIN_YEAR};
 

--- a/encoding/value/label.rs
+++ b/encoding/value/label.rs
@@ -83,6 +83,15 @@ impl<'a> Label<'a> {
         self.scoped_name.as_reference()
     }
 
+    // TODO: replace all usages of &Label<'_> with Label<'_>, then update all call sites/usages to use .as_reference() instead of clone()
+    pub fn as_reference(&self) -> Label<'_> {
+        Label {
+            name: self.name.as_reference(),
+            scope: self.scope.as_ref().map(|string_bytes| string_bytes.as_reference()),
+            scoped_name: self.scoped_name.as_reference(),
+        }
+    }
+
     pub fn into_owned(self) -> Label<'static> {
         Label {
             name: self.name.into_owned(),
@@ -107,12 +116,6 @@ impl<'a> TypeVertexPropertyEncoding<'a> for Label<'a> {
 
 impl<'a> fmt::Display for Label<'a> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "Label[name={}, scope={}, scoped_name={}]",
-            self.name(),
-            self.scope().map(|s| format!("{}", s)).unwrap_or_default(),
-            self.scoped_name()
-        )
+        write!(f, "{}", self.scoped_name())
     }
 }

--- a/encoding/value/value_struct.rs
+++ b/encoding/value/value_struct.rs
@@ -6,12 +6,15 @@
 
 use std::{
     collections::HashMap,
+    fmt,
+    fmt::Formatter,
     hash::{Hash, Hasher},
     ops::Range,
     sync::Arc,
 };
 
 use bytes::{byte_array::ByteArray, byte_reference::ByteReference, Bytes};
+use itertools::Itertools;
 use primitive::either::Either;
 use resource::constants::{
     encoding::StructFieldIDUInt,
@@ -152,6 +155,17 @@ impl<'a> Hash for StructValue<'a> {
             Hash::hash(id, state);
             Hash::hash(value, state);
         }
+    }
+}
+
+// Prints struct with inner values, but without the right labels, since these are not available inline
+impl<'a> fmt::Display for StructValue<'a> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(f, "{{")?;
+        for (field_id, value) in self.fields.iter().sorted_by_key(|(id, _)| **id) {
+            write!(f, "_{field_id}: {value}")?;
+        }
+        write!(f, "}}")
     }
 }
 

--- a/encoding/value/value_type.rs
+++ b/encoding/value/value_type.rs
@@ -91,6 +91,12 @@ impl ValueType {
     }
 }
 
+impl Display for ValueType {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.category().name())
+    }
+}
+
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
 pub enum ValueTypeCategory {
     Boolean,
@@ -174,11 +180,26 @@ impl ValueTypeCategory {
             ValueTypeCategory::Struct => None,
         }
     }
+
+    const fn name(&self) -> &'static str {
+        match self {
+            ValueTypeCategory::Boolean => "boolean",
+            ValueTypeCategory::Long => "long",
+            ValueTypeCategory::Double => "double",
+            ValueTypeCategory::Decimal => "decimal",
+            ValueTypeCategory::Date => "date",
+            ValueTypeCategory::DateTime => "datetime",
+            ValueTypeCategory::DateTimeTZ => "datetime_tz",
+            ValueTypeCategory::Duration => "duration",
+            ValueTypeCategory::String => "string",
+            ValueTypeCategory::Struct => "struct",
+        }
+    }
 }
 
 impl Display for ValueTypeCategory {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        write!(f, "{:?}", self)
+        write!(f, "{}", self.name())
     }
 }
 

--- a/executor/BUILD
+++ b/executor/BUILD
@@ -31,6 +31,7 @@ rust_library(
 
         "@crates//:itertools",
         "@crates//:tracing",
+        "@crates//:tokio",
     ],
 )
 

--- a/executor/error.rs
+++ b/executor/error.rs
@@ -1,0 +1,17 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+use concept::error::ConceptReadError;
+use error::typedb_error;
+
+typedb_error!(
+    pub ReadExecutionError(domain = "ReadExecution", prefix = "REX") {
+        Interrupted(1, "Execution was interrupted."),
+        ConceptRead(2, "Concept read error.", ( source: ConceptReadError )),
+        CreatingIterator(3, "Error creating iterator from {instruction_name} instruction.", instruction_name: String, ( source: ConceptReadError )),
+        AdvancingIteratorTo(4, "Error moving iterator (by steps or seek) to target value.", ( source: ConceptReadError )),
+    }
+);

--- a/executor/expression_executor.rs
+++ b/executor/expression_executor.rs
@@ -22,7 +22,7 @@ use compiler::expression::{
         ExpressionEvaluationError,
     },
 };
-use encoding::value::value::{DBValue, Value};
+use encoding::value::value::{NativeValueConvertible, Value};
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub enum ExpressionValue {
@@ -142,9 +142,9 @@ pub trait ExpressionEvaluation {
 
 impl<T1, T2, R, F> ExpressionEvaluation for Binary<T1, T2, R, F>
 where
-    T1: DBValue,
-    T2: DBValue,
-    R: DBValue,
+    T1: NativeValueConvertible,
+    T2: NativeValueConvertible,
+    R: NativeValueConvertible,
     F: BinaryExpression<T1, T2, R>,
 {
     fn evaluate(state: &mut ExpressionExecutorState<'_>) -> Result<(), ExpressionEvaluationError> {
@@ -213,7 +213,7 @@ impl ExpressionEvaluation for LoadConstant {
     }
 }
 
-impl<From: DBValue, To: ImplicitCast<From>> ExpressionEvaluation for CastUnary<From, To> {
+impl<From: NativeValueConvertible, To: ImplicitCast<From>> ExpressionEvaluation for CastUnary<From, To> {
     fn evaluate(state: &mut ExpressionExecutorState<'_>) -> Result<(), ExpressionEvaluationError> {
         let value_before = From::from_db_value(state.pop_value()).unwrap();
         let value_after = To::cast(value_before)?.to_db_value();
@@ -222,7 +222,7 @@ impl<From: DBValue, To: ImplicitCast<From>> ExpressionEvaluation for CastUnary<F
     }
 }
 
-impl<From: DBValue, To: ImplicitCast<From>> ExpressionEvaluation for CastBinaryLeft<From, To> {
+impl<From: NativeValueConvertible, To: ImplicitCast<From>> ExpressionEvaluation for CastBinaryLeft<From, To> {
     fn evaluate(state: &mut ExpressionExecutorState<'_>) -> Result<(), ExpressionEvaluationError> {
         let right = state.pop_value();
         let left_before = From::from_db_value(state.pop_value()).unwrap();
@@ -233,7 +233,7 @@ impl<From: DBValue, To: ImplicitCast<From>> ExpressionEvaluation for CastBinaryL
     }
 }
 
-impl<From: DBValue, To: ImplicitCast<From>> ExpressionEvaluation for CastBinaryRight<From, To> {
+impl<From: NativeValueConvertible, To: ImplicitCast<From>> ExpressionEvaluation for CastBinaryRight<From, To> {
     fn evaluate(state: &mut ExpressionExecutorState<'_>) -> Result<(), ExpressionEvaluationError> {
         let right_before = From::from_db_value(state.pop_value()).unwrap();
         let right_after = To::cast(right_before)?.to_db_value();
@@ -244,8 +244,8 @@ impl<From: DBValue, To: ImplicitCast<From>> ExpressionEvaluation for CastBinaryR
 
 impl<T1, R, F> ExpressionEvaluation for Unary<T1, R, F>
 where
-    T1: DBValue,
-    R: DBValue,
+    T1: NativeValueConvertible,
+    R: NativeValueConvertible,
     F: UnaryExpression<T1, R>,
 {
     fn evaluate(state: &mut ExpressionExecutorState<'_>) -> Result<(), ExpressionEvaluationError> {

--- a/executor/instruction/mod.rs
+++ b/executor/instruction/mod.rs
@@ -181,6 +181,15 @@ impl InstructionExecutor {
             InstructionExecutor::Links(_) => "links",
             InstructionExecutor::LinksReverse(_) => "links_reverse",
             InstructionExecutor::FunctionCallBinding(_) => "fn_call_binding",
+            InstructionExecutor::TypeList(_) => "[internal]type_list",
+            InstructionExecutor::Sub(_) => "sub",
+            InstructionExecutor::SubReverse(_) => "sub_reverse",
+            InstructionExecutor::Owns(_) => "owns",
+            InstructionExecutor::OwnsReverse(_) => "owns_reverse",
+            InstructionExecutor::Relates(_) => "relates",
+            InstructionExecutor::RelatesReverse(_) => "relates_reverse",
+            InstructionExecutor::Plays(_) => "plays",
+            InstructionExecutor::PlaysReverse(_) => "plays_reverse",
         }
     }
 }

--- a/executor/instruction/mod.rs
+++ b/executor/instruction/mod.rs
@@ -171,6 +171,18 @@ impl InstructionExecutor {
             Self::FunctionCallBinding(_executor) => todo!(),
         }
     }
+
+    pub(crate) const fn name(&self) -> &'static str {
+        match self {
+            InstructionExecutor::Isa(_) => "isa",
+            InstructionExecutor::IsaReverse(_) => "isa_reverse",
+            InstructionExecutor::Has(_) => "has",
+            InstructionExecutor::HasReverse(_) => "has_reverse",
+            InstructionExecutor::Links(_) => "links",
+            InstructionExecutor::LinksReverse(_) => "links_reverse",
+            InstructionExecutor::FunctionCallBinding(_) => "fn_call_binding",
+        }
+    }
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]

--- a/executor/pattern_executor.rs
+++ b/executor/pattern_executor.rs
@@ -103,7 +103,7 @@ impl PatternExecutor {
         loop {
             // TODO: inject interrupt into Checkers that could filter out many rows without ending as well.
             if interrupt.check() {
-                return Err(ReadExecutionError::Interrupted {})
+                return Err(ReadExecutionError::Interrupted {});
             }
 
             match direction {

--- a/executor/pattern_executor.rs
+++ b/executor/pattern_executor.rs
@@ -22,9 +22,10 @@ use storage::snapshot::ReadableSnapshot;
 
 use crate::{
     batch::{FixedBatch, FixedBatchRowIterator},
+    error::ReadExecutionError,
     instruction::{iterator::TupleIterator, InstructionExecutor},
     row::{MaybeOwnedRow, Row},
-    SelectedPositions, VariablePosition,
+    ExecutionInterrupt, SelectedPositions, VariablePosition,
 };
 
 pub(crate) struct PatternExecutor {
@@ -74,9 +75,10 @@ impl PatternExecutor {
         self,
         snapshot: Arc<Snapshot>,
         thing_manager: Arc<ThingManager>,
+        interrupt: ExecutionInterrupt,
     ) -> PatternIterator<Snapshot> {
         PatternIterator::new(
-            AsLendingIterator::new(BatchIterator::new(self, snapshot.clone(), thing_manager.clone()))
+            AsLendingIterator::new(BatchIterator::new(self, snapshot.clone(), thing_manager.clone(), interrupt))
                 .flat_map(FixedBatchRowIterator::new),
             snapshot,
             thing_manager,
@@ -87,7 +89,8 @@ impl PatternExecutor {
         &mut self,
         snapshot: &Arc<impl ReadableSnapshot + 'static>,
         thing_manager: &Arc<ThingManager>,
-    ) -> Result<Option<FixedBatch>, ConceptReadError> {
+        interrupt: &mut ExecutionInterrupt,
+    ) -> Result<Option<FixedBatch>, ReadExecutionError> {
         let programs_len = self.program_executors.len();
 
         let (mut current_program, mut last_program_batch, mut direction) = if self.initialised {
@@ -98,6 +101,11 @@ impl PatternExecutor {
         };
 
         loop {
+            // TODO: inject interrupt into Checkers that could filter out many rows without ending as well.
+            if interrupt.check() {
+                return Err(ReadExecutionError::Interrupted {})
+            }
+
             match direction {
                 Direction::Forward => {
                     if current_program >= programs_len {
@@ -155,7 +163,7 @@ enum Direction {
 type PatternRowIterator<Snapshot> = FlatMap<
     AsLendingIterator<BatchIterator<Snapshot>>,
     FixedBatchRowIterator,
-    fn(Result<FixedBatch, ConceptReadError>) -> FixedBatchRowIterator,
+    fn(Result<FixedBatch, ReadExecutionError>) -> FixedBatchRowIterator,
 >;
 
 pub(crate) struct PatternIterator<Snapshot: ReadableSnapshot + 'static> {
@@ -171,7 +179,7 @@ impl<Snapshot: ReadableSnapshot> PatternIterator<Snapshot> {
 }
 
 impl<Snapshot: ReadableSnapshot + 'static> LendingIterator for PatternIterator<Snapshot> {
-    type Item<'a> = Result<MaybeOwnedRow<'a>, &'a ConceptReadError>;
+    type Item<'a> = Result<MaybeOwnedRow<'a>, &'a ReadExecutionError>;
 
     fn next(&mut self) -> Option<Self::Item<'_>> {
         self.iterator.next()
@@ -182,19 +190,25 @@ pub(crate) struct BatchIterator<Snapshot: ReadableSnapshot> {
     executor: PatternExecutor,
     snapshot: Arc<Snapshot>,
     thing_manager: Arc<ThingManager>,
+    interrupt: ExecutionInterrupt,
 }
 
 impl<Snapshot: ReadableSnapshot> BatchIterator<Snapshot> {
-    pub(crate) fn new(executor: PatternExecutor, snapshot: Arc<Snapshot>, thing_manager: Arc<ThingManager>) -> Self {
-        Self { executor, snapshot, thing_manager }
+    pub(crate) fn new(
+        executor: PatternExecutor,
+        snapshot: Arc<Snapshot>,
+        thing_manager: Arc<ThingManager>,
+        interrupt: ExecutionInterrupt,
+    ) -> Self {
+        Self { executor, snapshot, thing_manager, interrupt }
     }
 }
 
 impl<Snapshot: ReadableSnapshot + 'static> Iterator for BatchIterator<Snapshot> {
-    type Item = Result<FixedBatch, ConceptReadError>;
+    type Item = Result<FixedBatch, ReadExecutionError>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        let batch = self.executor.compute_next_batch(&self.snapshot, &self.thing_manager);
+        let batch = self.executor.compute_next_batch(&self.snapshot, &self.thing_manager, &mut self.interrupt);
         batch.transpose()
     }
 }
@@ -265,7 +279,7 @@ impl ProgramExecutor {
         input_batch: FixedBatch,
         snapshot: &Arc<impl ReadableSnapshot + 'static>,
         thing_manager: &Arc<ThingManager>,
-    ) -> Result<Option<FixedBatch>, ConceptReadError> {
+    ) -> Result<Option<FixedBatch>, ReadExecutionError> {
         match self {
             ProgramExecutor::SortedJoin(sorted) => sorted.batch_from(input_batch, snapshot, thing_manager),
             ProgramExecutor::UnsortedJoin(unsorted) => unsorted.batch_from(input_batch),
@@ -280,7 +294,7 @@ impl ProgramExecutor {
         &mut self,
         snapshot: &Arc<impl ReadableSnapshot + 'static>,
         thing_manager: &Arc<ThingManager>,
-    ) -> Result<Option<FixedBatch>, ConceptReadError> {
+    ) -> Result<Option<FixedBatch>, ReadExecutionError> {
         match self {
             ProgramExecutor::SortedJoin(sorted) => sorted.batch_continue(snapshot, thing_manager),
             ProgramExecutor::UnsortedJoin(unsorted) => todo!(), // unsorted.batch_continue(snapshot, thing_manager),
@@ -352,7 +366,7 @@ impl IntersectionExecutor {
         input_batch: FixedBatch,
         snapshot: &Arc<impl ReadableSnapshot + 'static>,
         thing_manager: &Arc<ThingManager>,
-    ) -> Result<Option<FixedBatch>, ConceptReadError> {
+    ) -> Result<Option<FixedBatch>, ReadExecutionError> {
         debug_assert!(self.output.is_none() && (self.input.is_none() || self.input.as_mut().unwrap().peek().is_none()));
         self.input = Some(Peekable::new(FixedBatchRowIterator::new(Ok(input_batch))));
         debug_assert!(self.input.as_mut().unwrap().peek().is_some());
@@ -365,7 +379,7 @@ impl IntersectionExecutor {
         &mut self,
         snapshot: &Arc<impl ReadableSnapshot + 'static>,
         thing_manager: &Arc<ThingManager>,
-    ) -> Result<Option<FixedBatch>, ConceptReadError> {
+    ) -> Result<Option<FixedBatch>, ReadExecutionError> {
         debug_assert!(self.output.is_none());
         // TODO: this may not have to reopen iterators
         self.may_create_intersection_iterators(snapshot, thing_manager)?;
@@ -377,7 +391,7 @@ impl IntersectionExecutor {
         &mut self,
         snapshot: &Arc<impl ReadableSnapshot + 'static>,
         thing_manager: &Arc<ThingManager>,
-    ) -> Result<(), ConceptReadError> {
+    ) -> Result<(), ReadExecutionError> {
         if self.compute_next_row(snapshot, thing_manager)? {
             // don't allocate batch until 1 answer is confirmed
             let mut batch = FixedBatch::new(self.output_width);
@@ -402,7 +416,7 @@ impl IntersectionExecutor {
         &mut self,
         snapshot: &Arc<impl ReadableSnapshot + 'static>,
         thing_manager: &Arc<ThingManager>,
-    ) -> Result<bool, ConceptReadError> {
+    ) -> Result<bool, ReadExecutionError> {
         if self.cartesian_iterator.is_active() {
             let found = self.cartesian_iterator.find_next(snapshot, thing_manager, &self.instruction_executors)?;
             if found {
@@ -411,8 +425,13 @@ impl IntersectionExecutor {
                 // advance the first iterator past the intersection point to move to the next intersection
                 let intersection = &self.intersection_row[self.sort_variable.as_usize()];
                 let iter = &mut self.iterators[0];
-                while iter.peek_first_unbound_value().transpose()?.is_some_and(|value| value == intersection) {
-                    iter.advance_single()?;
+                while iter
+                    .peek_first_unbound_value()
+                    .transpose()
+                    .map_err(|err| ReadExecutionError::ConceptRead { source: err })?
+                    .is_some_and(|value| value == intersection)
+                {
+                    iter.advance_single().map_err(|err| ReadExecutionError::ConceptRead { source: err })?;
                 }
                 self.compute_next_row(snapshot, thing_manager)
             }
@@ -426,7 +445,7 @@ impl IntersectionExecutor {
                     return Ok(true);
                 } else {
                     self.iterators.clear();
-                    let _ = self.input.as_mut().unwrap().next().unwrap().map_err(|err| err.clone())?;
+                    let _ = self.input.as_mut().unwrap().next().unwrap().map_err(|err| err.clone());
                     if self.input.as_mut().unwrap().peek().is_some() {
                         self.may_create_intersection_iterators(snapshot, thing_manager)?;
                     }
@@ -436,7 +455,7 @@ impl IntersectionExecutor {
         }
     }
 
-    fn find_intersection(&mut self) -> Result<bool, ConceptReadError> {
+    fn find_intersection(&mut self) -> Result<bool, ReadExecutionError> {
         debug_assert!(!self.iterators.is_empty());
         if self.iterators.len() == 1 {
             // if there's only 1 iterator, we can just use it without any intersection
@@ -470,7 +489,7 @@ impl IntersectionExecutor {
                         break;
                     }
                     Some(Ok(value)) => current_max.partial_cmp(value).unwrap(),
-                    Some(Err(err)) => return Err(err.clone()),
+                    Some(Err(err)) => return Err(ReadExecutionError::ConceptRead { source: err.clone() }),
                 };
 
                 match max_cmp_peek {
@@ -481,8 +500,9 @@ impl IntersectionExecutor {
                     Ordering::Equal => {}
                     Ordering::Greater => {
                         let iter_i = &mut containing_i[i_index];
-                        let next_value_cmp =
-                            iter_i.advance_until_index_is(iter_i.first_unbound_index(), current_max)?;
+                        let next_value_cmp = iter_i
+                            .advance_until_index_is(iter_i.first_unbound_index(), current_max)
+                            .map_err(|err| ReadExecutionError::ConceptRead { source: err })?;
                         match next_value_cmp {
                             None => {
                                 failed = true;
@@ -514,22 +534,27 @@ impl IntersectionExecutor {
         &mut self,
         snapshot: &Arc<impl ReadableSnapshot + 'static>,
         thing_manager: &Arc<ThingManager>,
-    ) -> Result<(), ConceptReadError> {
+    ) -> Result<(), ReadExecutionError> {
         debug_assert!(self.iterators.is_empty());
         let peek = self.input.as_mut().unwrap().peek();
         if let Some(input) = peek {
             let next_row: &MaybeOwnedRow<'_> = input.as_ref().map_err(|err| (*err).clone())?;
             for executor in &self.instruction_executors {
-                self.iterators.push(executor.get_iterator(snapshot, thing_manager, next_row.as_reference())?);
+                self.iterators.push(executor.get_iterator(snapshot, thing_manager, next_row.as_reference()).map_err(
+                    |err| ReadExecutionError::CreatingIterator {
+                        instruction_name: executor.name().to_string(),
+                        source: err,
+                    },
+                )?);
             }
         }
         Ok(())
     }
 
-    fn advance_intersection_iterators_with_multiplicity(&mut self) -> Result<(), ConceptReadError> {
+    fn advance_intersection_iterators_with_multiplicity(&mut self) -> Result<(), ReadExecutionError> {
         let mut multiplicity: u64 = 1;
         for iter in &mut self.iterators {
-            multiplicity *= iter.advance_past()? as u64;
+            multiplicity *= iter.advance_past().map_err(|err| ReadExecutionError::ConceptRead { source: err })? as u64;
         }
         self.intersection_multiplicity = multiplicity;
         Ok(())
@@ -545,7 +570,7 @@ impl IntersectionExecutor {
         rest.iter_mut().all(|iter| iter.peek_first_unbound_value().unwrap().unwrap() == peek_0)
     }
 
-    fn record_intersection(&mut self) -> Result<(), ConceptReadError> {
+    fn record_intersection(&mut self) -> Result<(), ReadExecutionError> {
         self.intersection_row.fill(VariableValue::Empty);
         let mut row = Row::new(&mut self.intersection_row, &mut self.intersection_multiplicity);
         for iter in &mut self.iterators {
@@ -566,7 +591,7 @@ impl IntersectionExecutor {
         &mut self,
         snapshot: &Arc<impl ReadableSnapshot + 'static>,
         thing_manager: &Arc<ThingManager>,
-    ) -> Result<(), ConceptReadError> {
+    ) -> Result<(), ReadExecutionError> {
         if self.iterators.len() == 1 {
             // don't delegate to cartesian iterator and incur new iterator costs if there cannot be a cartesian product
             return Ok(());
@@ -575,7 +600,8 @@ impl IntersectionExecutor {
         for iter in &mut self.iterators {
             if iter
                 .peek_first_unbound_value()
-                .transpose()?
+                .transpose()
+                .map_err(|err| ReadExecutionError::ConceptRead { source: err })?
                 .is_some_and(|value| value == &self.intersection_row[self.sort_variable.as_usize()])
             {
                 cartesian = true;
@@ -629,7 +655,7 @@ impl CartesianIterator {
         source_intersection: &[VariableValue<'static>],
         source_multiplicity: u64,
         intersection_iterators: &mut Vec<TupleIterator>,
-    ) -> Result<(), ConceptReadError> {
+    ) -> Result<(), ReadExecutionError> {
         debug_assert!(source_intersection.len() == self.intersection_source.len());
         self.is_active = true;
         self.intersection_source.clone_from_slice(source_intersection);
@@ -640,7 +666,12 @@ impl CartesianIterator {
 
         let intersection = &source_intersection[self.sort_variable_position.as_usize()];
         for (index, iter) in intersection_iterators.iter_mut().enumerate() {
-            if iter.peek_first_unbound_value().transpose()?.is_some_and(|value| value == intersection) {
+            if iter
+                .peek_first_unbound_value()
+                .transpose()
+                .map_err(|err| ReadExecutionError::ConceptRead { source: err })?
+                .is_some_and(|value| value == intersection)
+            {
                 self.cartesian_executor_indices.push(index);
 
                 // reopen/move existing cartesian iterators forward to the intersection point
@@ -649,7 +680,9 @@ impl CartesianIterator {
                     None => self.reopen_iterator(snapshot, thing_manager, &iterator_executors[index])?,
                     Some(mut iter) => {
                         // TODO: use seek()
-                        let next_value_cmp = iter.advance_until_index_is(iter.first_unbound_index(), intersection)?;
+                        let next_value_cmp = iter
+                            .advance_until_index_is(iter.first_unbound_index(), intersection)
+                            .map_err(|err| ReadExecutionError::ConceptRead { source: err })?;
                         debug_assert!(next_value_cmp.is_some() && next_value_cmp.unwrap().is_eq());
                         iter
                     }
@@ -665,7 +698,7 @@ impl CartesianIterator {
         snapshot: &Arc<impl ReadableSnapshot + 'static>,
         thing_manager: &Arc<ThingManager>,
         executors: &[InstructionExecutor],
-    ) -> Result<bool, ConceptReadError> {
+    ) -> Result<bool, ReadExecutionError> {
         debug_assert!(self.is_active);
         // precondition: all required iterators are open to the intersection point
 
@@ -674,8 +707,13 @@ impl CartesianIterator {
         loop {
             let iterator_index = self.cartesian_executor_indices[executor_index];
             let iter = (&mut self.iterators)[iterator_index].as_mut().unwrap();
-            iter.advance_single()?;
-            if !iter.peek_first_unbound_value().transpose()?.is_some_and(|value| value == intersection) {
+            iter.advance_single().map_err(|err| ReadExecutionError::ConceptRead { source: err })?;
+            if !iter
+                .peek_first_unbound_value()
+                .transpose()
+                .map_err(|err| ReadExecutionError::ConceptRead { source: err })?
+                .is_some_and(|value| value == intersection)
+            {
                 if executor_index == 0 {
                     self.is_active = false;
                     return Ok(false);
@@ -695,15 +733,19 @@ impl CartesianIterator {
         snapshot: &Arc<impl ReadableSnapshot + 'static>,
         thing_manager: &Arc<ThingManager>,
         executor: &InstructionExecutor,
-    ) -> Result<TupleIterator, ConceptReadError> {
-        let mut reopened = executor.get_iterator(
-            snapshot,
-            thing_manager,
-            MaybeOwnedRow::new_borrowed(&self.intersection_source, &self.intersection_multiplicity),
-        )?;
+    ) -> Result<TupleIterator, ReadExecutionError> {
+        let mut reopened = executor
+            .get_iterator(
+                snapshot,
+                thing_manager,
+                MaybeOwnedRow::new_borrowed(&self.intersection_source, &self.intersection_multiplicity),
+            )
+            .map_err(|err| ReadExecutionError::ConceptRead { source: err })?;
         let intersection = &self.intersection_source[self.sort_variable_position.as_usize()];
         // TODO: use seek()
-        reopened.advance_until_index_is(reopened.first_unbound_index(), intersection)?;
+        reopened
+            .advance_until_index_is(reopened.first_unbound_index(), intersection)
+            .map_err(|err| ReadExecutionError::AdvancingIteratorTo { source: err })?;
         Ok(reopened)
     }
 
@@ -738,7 +780,7 @@ impl UnsortedJoinExecutor {
         Self { iterate, checks, output_width: total_vars, output: None }
     }
 
-    fn batch_from(&mut self, input_batch: FixedBatch) -> Result<Option<FixedBatch>, ConceptReadError> {
+    fn batch_from(&mut self, input_batch: FixedBatch) -> Result<Option<FixedBatch>, ReadExecutionError> {
         todo!()
     }
 
@@ -753,7 +795,7 @@ struct AssignExecutor {
 }
 
 impl AssignExecutor {
-    fn batch_from(&mut self, input_batch: FixedBatch) -> Result<Option<FixedBatch>, ConceptReadError> {
+    fn batch_from(&mut self, input_batch: FixedBatch) -> Result<Option<FixedBatch>, ReadExecutionError> {
         todo!()
     }
 }
@@ -770,11 +812,11 @@ impl DisjunctionExecutor {
         Self { executors }
     }
 
-    fn batch_from(&mut self, input_batch: FixedBatch) -> Result<Option<FixedBatch>, ConceptReadError> {
+    fn batch_from(&mut self, input_batch: FixedBatch) -> Result<Option<FixedBatch>, ReadExecutionError> {
         todo!()
     }
 
-    fn batch_continue(&mut self) -> Result<Option<FixedBatch>, ConceptReadError> {
+    fn batch_continue(&mut self) -> Result<Option<FixedBatch>, ReadExecutionError> {
         todo!()
     }
 }
@@ -788,7 +830,7 @@ impl NegationExecutor {
         Self { executor }
     }
 
-    fn batch_from(&mut self, input_batch: FixedBatch) -> Result<Option<FixedBatch>, ConceptReadError> {
+    fn batch_from(&mut self, input_batch: FixedBatch) -> Result<Option<FixedBatch>, ReadExecutionError> {
         todo!()
     }
 }
@@ -802,11 +844,11 @@ impl OptionalExecutor {
         Self { executor }
     }
 
-    fn batch_from(&mut self, input_batch: FixedBatch) -> Result<Option<FixedBatch>, ConceptReadError> {
+    fn batch_from(&mut self, input_batch: FixedBatch) -> Result<Option<FixedBatch>, ReadExecutionError> {
         todo!()
     }
 
-    fn batch_continue(&mut self) -> Result<Option<FixedBatch>, ConceptReadError> {
+    fn batch_continue(&mut self) -> Result<Option<FixedBatch>, ReadExecutionError> {
         todo!()
     }
 }

--- a/executor/pipeline/initial.rs
+++ b/executor/pipeline/initial.rs
@@ -14,6 +14,7 @@ use storage::snapshot::ReadableSnapshot;
 use crate::{
     pipeline::{PipelineExecutionError, StageAPI, StageIterator},
     row::MaybeOwnedRow,
+    ExecutionInterrupt,
 };
 
 pub struct InitialStage<Snapshot: ReadableSnapshot + 'static> {
@@ -33,7 +34,10 @@ impl<Snapshot: ReadableSnapshot + 'static> StageAPI<Snapshot> for InitialStage<S
         HashMap::new()
     }
 
-    fn into_iterator(self) -> Result<(Self::OutputIterator, Arc<Snapshot>), (Arc<Snapshot>, PipelineExecutionError)> {
+    fn into_iterator(
+        self,
+        interrupt: ExecutionInterrupt,
+    ) -> Result<(Self::OutputIterator, Arc<Snapshot>), (Arc<Snapshot>, PipelineExecutionError)> {
         Ok((InitialIterator::new(), self.snapshot))
     }
 }

--- a/executor/program_executor.rs
+++ b/executor/program_executor.rs
@@ -14,7 +14,8 @@ use lending_iterator::LendingIterator;
 use storage::snapshot::ReadableSnapshot;
 
 use crate::{
-    function_executor::FunctionExecutor, pattern_executor::PatternExecutor, row::MaybeOwnedRow, VariablePosition,
+    error::ReadExecutionError, function_executor::FunctionExecutor, pattern_executor::PatternExecutor,
+    row::MaybeOwnedRow, ExecutionInterrupt, VariablePosition,
 };
 
 pub struct ProgramExecutor {
@@ -48,7 +49,8 @@ impl ProgramExecutor {
         self,
         snapshot: Arc<impl ReadableSnapshot + 'static>,
         thing_manager: Arc<ThingManager>,
-    ) -> impl for<'a> LendingIterator<Item<'a> = Result<MaybeOwnedRow<'a>, &'a ConceptReadError>> {
-        self.entry.into_iterator(snapshot, thing_manager)
+        interrupt: ExecutionInterrupt,
+    ) -> impl for<'a> LendingIterator<Item<'a> = Result<MaybeOwnedRow<'a>, &'a ReadExecutionError>> {
+        self.entry.into_iterator(snapshot, thing_manager, interrupt)
     }
 }

--- a/executor/tests/compile_execute.rs
+++ b/executor/tests/compile_execute.rs
@@ -18,7 +18,7 @@ use concept::{
     },
 };
 use encoding::value::{label::Label, value::Value, value_type::ValueType};
-use executor::program_executor::ProgramExecutor;
+use executor::{program_executor::ProgramExecutor, ExecutionInterrupt};
 use ir::{
     program::function_signature::HashMapFunctionSignatureIndex,
     translation::{match_::translate_match, TranslationContext},
@@ -123,7 +123,7 @@ fn test_has_planning_traversal() {
     );
     let program_plan = ProgramPlan::new(pattern_plan, HashMap::new(), HashMap::new());
     let executor = ProgramExecutor::new(&program_plan, &snapshot, &thing_manager).unwrap();
-    let iterator = executor.into_iterator(snapshot, thing_manager);
+    let iterator = executor.into_iterator(snapshot, thing_manager, ExecutionInterrupt::new_uninterruptible());
 
     let rows = iterator
         .map_static(|row| row.map(|row| row.into_owned()).map_err(|err| err.clone()))
@@ -260,7 +260,7 @@ fn test_links_planning_traversal() {
     );
     let program_plan = ProgramPlan::new(pattern_plan, HashMap::new(), HashMap::new());
     let executor = ProgramExecutor::new(&program_plan, &snapshot, &thing_manager).unwrap();
-    let iterator = executor.into_iterator(snapshot, thing_manager);
+    let iterator = executor.into_iterator(snapshot, thing_manager, ExecutionInterrupt::new_uninterruptible());
 
     let rows = iterator
         .map_static(|row| row.map(|row| row.into_owned()).map_err(|err| err.clone()))

--- a/executor/tests/execute_has.rs
+++ b/executor/tests/execute_has.rs
@@ -21,12 +21,11 @@ use compiler::{
     VariablePosition,
 };
 use concept::{
-    error::ConceptReadError,
     thing::object::ObjectAPI,
     type_::{annotation::AnnotationCardinality, owns::OwnsAnnotation, OwnerAPI},
 };
 use encoding::value::{label::Label, value::Value, value_type::ValueType};
-use executor::{program_executor::ProgramExecutor, row::MaybeOwnedRow};
+use executor::{error::ReadExecutionError, program_executor::ProgramExecutor, row::MaybeOwnedRow, ExecutionInterrupt};
 use ir::{pattern::constraint::IsaKind, program::block::FunctionalBlock, translation::TranslationContext};
 use lending_iterator::LendingIterator;
 use storage::{
@@ -163,9 +162,9 @@ fn traverse_has_unbounded_sorted_from() {
     // Executor
     let executor = ProgramExecutor::new(&program_plan, &snapshot, &thing_manager).unwrap();
 
-    let iterator = executor.into_iterator(snapshot, thing_manager);
+    let iterator = executor.into_iterator(snapshot, thing_manager, ExecutionInterrupt::new_uninterruptible());
 
-    let rows: Vec<Result<MaybeOwnedRow<'static>, ConceptReadError>> =
+    let rows: Vec<Result<MaybeOwnedRow<'static>, ReadExecutionError>> =
         iterator.map_static(|row| row.map(|row| row.clone().into_owned()).map_err(|err| err.clone())).collect();
     assert_eq!(rows.len(), 7);
 
@@ -260,9 +259,9 @@ fn traverse_has_bounded_sorted_from_chain_intersect() {
     // Executor
     let executor = ProgramExecutor::new(&program_plan, &snapshot, &thing_manager).unwrap();
 
-    let iterator = executor.into_iterator(snapshot, thing_manager);
+    let iterator = executor.into_iterator(snapshot, thing_manager, ExecutionInterrupt::new_uninterruptible());
 
-    let rows: Vec<Result<MaybeOwnedRow<'static>, ConceptReadError>> =
+    let rows: Vec<Result<MaybeOwnedRow<'static>, ReadExecutionError>> =
         iterator.map_static(|row| row.map(|row| row.clone().into_owned()).map_err(|err| err.clone())).collect();
     assert_eq!(rows.len(), 3); // $person-1 is $person-2, one per name
 
@@ -348,9 +347,9 @@ fn traverse_has_unbounded_sorted_from_intersect() {
     let snapshot = Arc::new(snapshot);
     let executor = ProgramExecutor::new(&program_plan, &snapshot, &thing_manager).unwrap();
 
-    let iterator = executor.into_iterator(snapshot, thing_manager);
+    let iterator = executor.into_iterator(snapshot, thing_manager, ExecutionInterrupt::new_uninterruptible());
 
-    let rows: Vec<Result<MaybeOwnedRow<'static>, ConceptReadError>> =
+    let rows: Vec<Result<MaybeOwnedRow<'static>, ReadExecutionError>> =
         iterator.map_static(|row| row.map(|row| row.clone().into_owned()).map_err(|err| err.clone())).collect();
     assert_eq!(rows.len(), 7);
 
@@ -418,9 +417,9 @@ fn traverse_has_unbounded_sorted_to_merged() {
 
     let variable_positions = executor.entry_variable_positions().clone();
 
-    let iterator = executor.into_iterator(snapshot, thing_manager);
+    let iterator = executor.into_iterator(snapshot, thing_manager, ExecutionInterrupt::new_uninterruptible());
 
-    let rows: Vec<Result<MaybeOwnedRow<'static>, ConceptReadError>> =
+    let rows: Vec<Result<MaybeOwnedRow<'static>, ReadExecutionError>> =
         iterator.map_static(|row| row.map(|row| row.as_reference().into_owned()).map_err(|err| err.clone())).collect();
 
     // person 1 - has age 1, has age 2, has age 3, has name 1, has name 2 => 5 answers
@@ -506,9 +505,9 @@ fn traverse_has_reverse_unbounded_sorted_from() {
     // Executor
     let snapshot = Arc::new(snapshot);
     let executor = ProgramExecutor::new(&program_plan, &snapshot, &thing_manager).unwrap();
-    let iterator = executor.into_iterator(snapshot, thing_manager);
+    let iterator = executor.into_iterator(snapshot, thing_manager, ExecutionInterrupt::new_uninterruptible());
 
-    let rows: Vec<Result<MaybeOwnedRow<'static>, ConceptReadError>> =
+    let rows: Vec<Result<MaybeOwnedRow<'static>, ReadExecutionError>> =
         iterator.map_static(|row| row.map(|row| row.clone().into_owned()).map_err(|err| err.clone())).collect();
     assert_eq!(rows.len(), 7);
 

--- a/executor/tests/execute_isa.rs
+++ b/executor/tests/execute_isa.rs
@@ -20,9 +20,8 @@ use compiler::{
     },
     VariablePosition,
 };
-use concept::error::ConceptReadError;
 use encoding::value::label::Label;
-use executor::{program_executor::ProgramExecutor, row::MaybeOwnedRow};
+use executor::{error::ReadExecutionError, program_executor::ProgramExecutor, row::MaybeOwnedRow, ExecutionInterrupt};
 use ir::{pattern::constraint::IsaKind, program::block::FunctionalBlock, translation::TranslationContext};
 use lending_iterator::LendingIterator;
 use storage::{durability_client::WALClient, snapshot::CommittableSnapshot, MVCCStorage};
@@ -113,9 +112,9 @@ fn traverse_isa_unbounded_sorted_thing() {
     let snapshot = Arc::new(storage.clone().open_snapshot_read());
     let executor = ProgramExecutor::new(&program_plan, &snapshot, &thing_manager).unwrap();
 
-    let iterator = executor.into_iterator(snapshot, thing_manager);
+    let iterator = executor.into_iterator(snapshot, thing_manager, ExecutionInterrupt::new_uninterruptible());
 
-    let rows: Vec<Result<MaybeOwnedRow<'static>, ConceptReadError>> =
+    let rows: Vec<Result<MaybeOwnedRow<'static>, ReadExecutionError>> =
         iterator.map_static(|row| row.map(|row| row.into_owned()).map_err(|err| err.clone())).collect();
     assert_eq!(rows.len(), 3);
 
@@ -180,9 +179,9 @@ fn traverse_isa_unbounded_sorted_type() {
     let snapshot = Arc::new(storage.clone().open_snapshot_read());
     let executor = ProgramExecutor::new(&program_plan, &snapshot, &thing_manager).unwrap();
 
-    let iterator = executor.into_iterator(snapshot, thing_manager);
+    let iterator = executor.into_iterator(snapshot, thing_manager, ExecutionInterrupt::new_uninterruptible());
 
-    let rows: Vec<Result<MaybeOwnedRow<'static>, ConceptReadError>> =
+    let rows: Vec<Result<MaybeOwnedRow<'static>, ReadExecutionError>> =
         iterator.map_static(|row| row.map(|row| row.into_owned()).map_err(|err| err.clone())).collect();
     assert_eq!(rows.len(), 3);
 
@@ -261,9 +260,9 @@ fn traverse_isa_bounded_thing() {
     let snapshot = Arc::new(storage.clone().open_snapshot_read());
     let executor = ProgramExecutor::new(&program_plan, &snapshot, &thing_manager).unwrap();
 
-    let iterator = executor.into_iterator(snapshot, thing_manager);
+    let iterator = executor.into_iterator(snapshot, thing_manager, ExecutionInterrupt::new_uninterruptible());
 
-    let rows: Vec<Result<MaybeOwnedRow<'static>, ConceptReadError>> =
+    let rows: Vec<Result<MaybeOwnedRow<'static>, ReadExecutionError>> =
         iterator.map_static(|row| row.map(|row| row.into_owned()).map_err(|err| err.clone())).collect();
     assert_eq!(rows.len(), 6);
 
@@ -328,9 +327,9 @@ fn traverse_isa_reverse_unbounded_sorted_thing() {
     let snapshot = Arc::new(storage.clone().open_snapshot_read());
     let executor = ProgramExecutor::new(&program_plan, &snapshot, &thing_manager).unwrap();
 
-    let iterator = executor.into_iterator(snapshot, thing_manager);
+    let iterator = executor.into_iterator(snapshot, thing_manager, ExecutionInterrupt::new_uninterruptible());
 
-    let rows: Vec<Result<MaybeOwnedRow<'static>, ConceptReadError>> =
+    let rows: Vec<Result<MaybeOwnedRow<'static>, ReadExecutionError>> =
         iterator.map_static(|row| row.map(|row| row.into_owned()).map_err(|err| err.clone())).collect();
     assert_eq!(rows.len(), 3);
 
@@ -395,9 +394,9 @@ fn traverse_isa_reverse_unbounded_sorted_type() {
     let snapshot = Arc::new(storage.clone().open_snapshot_read());
     let executor = ProgramExecutor::new(&program_plan, &snapshot, &thing_manager).unwrap();
 
-    let iterator = executor.into_iterator(snapshot, thing_manager);
+    let iterator = executor.into_iterator(snapshot, thing_manager, ExecutionInterrupt::new_uninterruptible());
 
-    let rows: Vec<Result<MaybeOwnedRow<'static>, ConceptReadError>> =
+    let rows: Vec<Result<MaybeOwnedRow<'static>, ReadExecutionError>> =
         iterator.map_static(|row| row.map(|row| row.into_owned()).map_err(|err| err.clone())).collect();
     assert_eq!(rows.len(), 3);
 
@@ -475,9 +474,9 @@ fn traverse_isa_reverse_bounded_type() {
     let snapshot = Arc::new(storage.clone().open_snapshot_read());
     let executor = ProgramExecutor::new(&program_plan, &snapshot, &thing_manager).unwrap();
 
-    let iterator = executor.into_iterator(snapshot, thing_manager);
+    let iterator = executor.into_iterator(snapshot, thing_manager, ExecutionInterrupt::new_uninterruptible());
 
-    let rows: Vec<Result<MaybeOwnedRow<'static>, ConceptReadError>> =
+    let rows: Vec<Result<MaybeOwnedRow<'static>, ReadExecutionError>> =
         iterator.map_static(|row| row.map(|row| row.into_owned()).map_err(|err| err.clone())).collect();
 
     // 2x animal => 4x (animal x animal)

--- a/executor/tests/execute_links.rs
+++ b/executor/tests/execute_links.rs
@@ -21,7 +21,6 @@ use compiler::{
     VariablePosition,
 };
 use concept::{
-    error::ConceptReadError,
     thing::object::ObjectAPI,
     type_::{
         annotation::AnnotationCardinality, owns::OwnsAnnotation, relates::RelatesAnnotation, Ordering, OwnerAPI,
@@ -29,7 +28,7 @@ use concept::{
     },
 };
 use encoding::value::{label::Label, value::Value, value_type::ValueType};
-use executor::{program_executor::ProgramExecutor, row::MaybeOwnedRow};
+use executor::{error::ReadExecutionError, program_executor::ProgramExecutor, row::MaybeOwnedRow, ExecutionInterrupt};
 use ir::{pattern::constraint::IsaKind, program::block::FunctionalBlock, translation::TranslationContext};
 use lending_iterator::LendingIterator;
 use storage::{durability_client::WALClient, snapshot::CommittableSnapshot, MVCCStorage};
@@ -256,9 +255,9 @@ fn traverse_links_unbounded_sorted_from() {
     // Executor
     let snapshot = Arc::new(snapshot);
     let executor = ProgramExecutor::new(&program_plan, &snapshot, &thing_manager).unwrap();
-    let iterator = executor.into_iterator(snapshot, thing_manager);
+    let iterator = executor.into_iterator(snapshot, thing_manager, ExecutionInterrupt::new_uninterruptible());
 
-    let rows: Vec<Result<MaybeOwnedRow<'static>, ConceptReadError>> =
+    let rows: Vec<Result<MaybeOwnedRow<'static>, ReadExecutionError>> =
         iterator.map_static(|row| row.map(|row| row.as_reference().into_owned()).map_err(|err| err.clone())).collect();
     assert_eq!(rows.len(), 2);
 
@@ -340,9 +339,9 @@ fn traverse_links_unbounded_sorted_to() {
     // Executor
     let snapshot = Arc::new(snapshot);
     let executor = ProgramExecutor::new(&program_plan, &snapshot, &thing_manager).unwrap();
-    let iterator = executor.into_iterator(snapshot, thing_manager);
+    let iterator = executor.into_iterator(snapshot, thing_manager, ExecutionInterrupt::new_uninterruptible());
 
-    let rows: Vec<Result<MaybeOwnedRow<'static>, ConceptReadError>> =
+    let rows: Vec<Result<MaybeOwnedRow<'static>, ReadExecutionError>> =
         iterator.map_static(|row| row.map(|row| row.as_reference().into_owned()).map_err(|err| err.clone())).collect();
     assert_eq!(rows.len(), 2);
 
@@ -437,9 +436,9 @@ fn traverse_links_bounded_relation() {
     // Executor
     let snapshot = Arc::new(snapshot);
     let executor = ProgramExecutor::new(&program_plan, &snapshot, &thing_manager).unwrap();
-    let iterator = executor.into_iterator(snapshot, thing_manager);
+    let iterator = executor.into_iterator(snapshot, thing_manager, ExecutionInterrupt::new_uninterruptible());
 
-    let rows: Vec<Result<MaybeOwnedRow<'static>, ConceptReadError>> =
+    let rows: Vec<Result<MaybeOwnedRow<'static>, ReadExecutionError>> =
         iterator.map_static(|row| row.map(|row| row.as_reference().into_owned()).map_err(|err| err.clone())).collect();
     assert_eq!(rows.len(), 2);
 
@@ -547,9 +546,9 @@ fn traverse_links_bounded_relation_player() {
     // Executor
     let snapshot = Arc::new(snapshot);
     let executor = ProgramExecutor::new(&program_plan, &snapshot, &thing_manager).unwrap();
-    let iterator = executor.into_iterator(snapshot, thing_manager);
+    let iterator = executor.into_iterator(snapshot, thing_manager, ExecutionInterrupt::new_uninterruptible());
 
-    let rows: Vec<Result<MaybeOwnedRow<'static>, ConceptReadError>> =
+    let rows: Vec<Result<MaybeOwnedRow<'static>, ReadExecutionError>> =
         iterator.map_static(|row| row.map(|row| row.as_reference().into_owned()).map_err(|err| err.clone())).collect();
     assert_eq!(rows.len(), 2);
 
@@ -630,9 +629,9 @@ fn traverse_links_reverse_unbounded_sorted_from() {
 
     // Executor
     let executor = ProgramExecutor::new(&program_plan, &snapshot, &thing_manager).unwrap();
-    let iterator = executor.into_iterator(snapshot, thing_manager);
+    let iterator = executor.into_iterator(snapshot, thing_manager, ExecutionInterrupt::new_uninterruptible());
 
-    let rows: Vec<Result<MaybeOwnedRow<'static>, ConceptReadError>> =
+    let rows: Vec<Result<MaybeOwnedRow<'static>, ReadExecutionError>> =
         iterator.map_static(|row| row.map(|row| row.as_reference().into_owned()).map_err(|err| err.clone())).collect();
     assert_eq!(rows.len(), 2);
 
@@ -714,9 +713,9 @@ fn traverse_links_reverse_unbounded_sorted_to() {
 
     // Executor
     let executor = ProgramExecutor::new(&program_plan, &snapshot, &thing_manager).unwrap();
-    let iterator = executor.into_iterator(snapshot, thing_manager);
+    let iterator = executor.into_iterator(snapshot, thing_manager, ExecutionInterrupt::new_uninterruptible());
 
-    let rows: Vec<Result<MaybeOwnedRow<'static>, ConceptReadError>> =
+    let rows: Vec<Result<MaybeOwnedRow<'static>, ReadExecutionError>> =
         iterator.map_static(|row| row.map(|row| row.as_reference().into_owned()).map_err(|err| err.clone())).collect();
     assert_eq!(rows.len(), 2);
 
@@ -810,9 +809,9 @@ fn traverse_links_reverse_bounded_player() {
     // Executor
     let snapshot = Arc::new(snapshot);
     let executor = ProgramExecutor::new(&program_plan, &snapshot, &thing_manager).unwrap();
-    let iterator = executor.into_iterator(snapshot, thing_manager);
+    let iterator = executor.into_iterator(snapshot, thing_manager, ExecutionInterrupt::new_uninterruptible());
 
-    let rows: Vec<Result<MaybeOwnedRow<'static>, ConceptReadError>> =
+    let rows: Vec<Result<MaybeOwnedRow<'static>, ReadExecutionError>> =
         iterator.map_static(|row| row.map(|row| row.as_reference().into_owned()).map_err(|err| err.clone())).collect();
     assert_eq!(rows.len(), 2);
 
@@ -920,9 +919,9 @@ fn traverse_links_reverse_bounded_player_relation() {
     // Executor
     let snapshot = Arc::new(snapshot);
     let executor = ProgramExecutor::new(&program_plan, &snapshot, &thing_manager).unwrap();
-    let iterator = executor.into_iterator(snapshot, thing_manager);
+    let iterator = executor.into_iterator(snapshot, thing_manager, ExecutionInterrupt::new_uninterruptible());
 
-    let rows: Vec<Result<MaybeOwnedRow<'static>, ConceptReadError>> =
+    let rows: Vec<Result<MaybeOwnedRow<'static>, ReadExecutionError>> =
         iterator.map_static(|row| row.map(|row| row.as_reference().into_owned()).map_err(|err| err.clone())).collect();
     assert_eq!(rows.len(), 2);
 

--- a/executor/tests/execute_select.rs
+++ b/executor/tests/execute_select.rs
@@ -18,12 +18,11 @@ use compiler::{
     VariablePosition,
 };
 use concept::{
-    error::ConceptReadError,
     thing::object::ObjectAPI,
     type_::{annotation::AnnotationCardinality, owns::OwnsAnnotation, OwnerAPI},
 };
 use encoding::value::{label::Label, value::Value, value_type::ValueType};
-use executor::{program_executor::ProgramExecutor, row::MaybeOwnedRow};
+use executor::{error::ReadExecutionError, program_executor::ProgramExecutor, row::MaybeOwnedRow, ExecutionInterrupt};
 use ir::{pattern::constraint::IsaKind, program::block::FunctionalBlock, translation::TranslationContext};
 use lending_iterator::LendingIterator;
 use storage::{
@@ -188,8 +187,8 @@ fn anonymous_vars_not_enumerated_or_counted() {
     let (_, thing_manager) = load_managers(storage.clone());
     let executor = ProgramExecutor::new(&program_plan, &snapshot, &thing_manager).unwrap();
 
-    let iterator = executor.into_iterator(snapshot, thing_manager);
-    let rows: Vec<Result<MaybeOwnedRow<'static>, ConceptReadError>> =
+    let iterator = executor.into_iterator(snapshot, thing_manager, ExecutionInterrupt::new_uninterruptible());
+    let rows: Vec<Result<MaybeOwnedRow<'static>, ReadExecutionError>> =
         iterator.map_static(|row| row.map(|row| row.as_reference().into_owned()).map_err(|err| err.clone())).collect();
 
     // person1, <something>
@@ -268,8 +267,8 @@ fn unselected_named_vars_counted() {
     let (_, thing_manager) = load_managers(storage.clone());
     let executor = ProgramExecutor::new(&program_plan, &snapshot, &thing_manager).unwrap();
 
-    let iterator = executor.into_iterator(snapshot, thing_manager);
-    let rows: Vec<Result<MaybeOwnedRow<'static>, ConceptReadError>> =
+    let iterator = executor.into_iterator(snapshot, thing_manager, ExecutionInterrupt::new_uninterruptible());
+    let rows: Vec<Result<MaybeOwnedRow<'static>, ReadExecutionError>> =
         iterator.map_static(|row| row.map(|row| row.as_reference().into_owned()).map_err(|err| err.clone())).collect();
 
     // 7x person 1, <something>
@@ -368,8 +367,8 @@ fn cartesian_named_counted_checked() {
     let (_, thing_manager) = load_managers(storage.clone());
     let executor = ProgramExecutor::new(&program_plan, &snapshot, &thing_manager).unwrap();
 
-    let iterator = executor.into_iterator(snapshot, thing_manager);
-    let rows: Vec<Result<MaybeOwnedRow<'static>, ConceptReadError>> =
+    let iterator = executor.into_iterator(snapshot, thing_manager, ExecutionInterrupt::new_uninterruptible());
+    let rows: Vec<Result<MaybeOwnedRow<'static>, ReadExecutionError>> =
         iterator.map_static(|row| row.map(|row| row.as_reference().into_owned()).map_err(|err| err.clone())).collect();
 
     // 2x person 1, age_1, <name something>, <email something>

--- a/executor/tests/pipelines.rs
+++ b/executor/tests/pipelines.rs
@@ -11,7 +11,10 @@ use encoding::{
     graph::definition::definition_key_generator::DefinitionKeyGenerator,
     value::{label::Label, value::Value},
 };
-use executor::pipeline::{StageAPI, StageIterator};
+use executor::{
+    pipeline::{StageAPI, StageIterator},
+    ExecutionInterrupt,
+};
 use function::function_manager::FunctionManager;
 use lending_iterator::LendingIterator;
 use query::query_manager::QueryManager;
@@ -74,7 +77,7 @@ fn test_insert() {
             &query,
         )
         .unwrap();
-    let (mut iterator, snapshot) = pipeline.into_iterator().unwrap();
+    let (mut iterator, snapshot) = pipeline.into_iterator(ExecutionInterrupt::new_uninterruptible()).unwrap();
     assert!(matches!(iterator.next(), Some(Ok(_))));
     assert!(matches!(iterator.next(), None));
     let snapshot = Arc::into_inner(snapshot).unwrap();
@@ -150,7 +153,7 @@ fn test_match() {
             &query,
         )
         .unwrap();
-    let (mut iterator, snapshot) = pipeline.into_iterator().unwrap();
+    let (mut iterator, snapshot) = pipeline.into_iterator(ExecutionInterrupt::new_uninterruptible()).unwrap();
     let _ = iterator.count();
     // must consume iterator to ensure operation completed
     let snapshot = Arc::into_inner(snapshot).unwrap();
@@ -169,7 +172,7 @@ fn test_match() {
             &match_,
         )
         .unwrap();
-    let (iterator, snapshot) = pipeline.into_iterator().unwrap();
+    let (iterator, snapshot) = pipeline.into_iterator(ExecutionInterrupt::new_uninterruptible()).unwrap();
     let batch = iterator.collect_owned().unwrap();
     assert_eq!(batch.len(), 3);
 
@@ -185,7 +188,7 @@ fn test_match() {
             &match_,
         )
         .unwrap();
-    let (iterator, snapshot) = pipeline.into_iterator().unwrap();
+    let (iterator, snapshot) = pipeline.into_iterator(ExecutionInterrupt::new_uninterruptible()).unwrap();
     let batch = iterator.collect_owned().unwrap();
     assert_eq!(batch.len(), 1);
     let snapshot = Arc::into_inner(snapshot);
@@ -212,7 +215,7 @@ fn test_match_delete_has() {
             &insert_query,
         )
         .unwrap();
-    let (mut iterator, snapshot) = insert_pipeline.into_iterator().unwrap();
+    let (mut iterator, snapshot) = insert_pipeline.into_iterator(ExecutionInterrupt::new_uninterruptible()).unwrap();
 
     assert!(matches!(iterator.next(), Some(Ok(_))));
     assert!(matches!(iterator.next(), None));
@@ -236,7 +239,7 @@ fn test_match_delete_has() {
             &delete_query,
         )
         .unwrap();
-    let (mut iterator, snapshot) = delete_pipeline.into_iterator().unwrap();
+    let (mut iterator, snapshot) = delete_pipeline.into_iterator(ExecutionInterrupt::new_uninterruptible()).unwrap();
 
     assert!(matches!(iterator.next(), Some(Ok(_))));
     assert!(matches!(iterator.next(), None));

--- a/function/BUILD
+++ b/function/BUILD
@@ -16,6 +16,7 @@ rust_library(
         "//answer",
         "//common/bytes",
         "//common/primitive",
+        "//common/error",
         "//resource",
         "//concept",
         "//compiler",

--- a/function/function.rs
+++ b/function/function.rs
@@ -30,7 +30,7 @@ impl<FunctionIDType: FunctionIDAPI> Function<FunctionIDType> {
 impl<FunctionIDType: FunctionIDAPI> Function<FunctionIDType> {
     pub(crate) fn build(function_id: FunctionIDType, definition: FunctionDefinition) -> Result<Self, FunctionError> {
         let parsed = typeql::parse_definition_function(definition.as_str().as_str())
-            .map_err(|source| FunctionError::ParseError { source })?;
+            .map_err(|source| FunctionError::CommittedFunctionParseError { typedb_source: source })?;
         Ok(Self { function_id, parsed })
     }
 }

--- a/function/lib.rs
+++ b/function/lib.rs
@@ -4,46 +4,26 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-use std::{error::Error, fmt};
+use std::error::Error;
 
-use compiler::match_::inference::TypeInferenceError;
+use compiler::match_::inference::FunctionTypeInferenceError;
 use encoding::error::EncodingError;
-use ir::program::{FunctionDefinitionError, FunctionReadError};
-use storage::{snapshot::SnapshotGetError, ReadSnapshotOpenError};
+use error::typedb_error;
+use ir::program::{FunctionReadError, FunctionRepresentationError};
 
 pub mod function;
 pub mod function_cache;
 pub mod function_manager;
 
-#[derive(Debug)]
-pub enum FunctionError {
-    SnapshotOpen { source: ReadSnapshotOpenError },
-    SnapshotGet { source: SnapshotGetError },
-    TypeInference { source: TypeInferenceError },
-    FunctionDefinition { source: FunctionDefinitionError },
-    FunctionAlreadyExists { name: String },
-    Encoding { source: EncodingError },
-    FunctionRead { source: FunctionReadError },
-    ParseError { source: typeql::Error },
-}
-
-impl fmt::Display for FunctionError {
-    fn fmt(&self, _: &mut fmt::Formatter<'_>) -> fmt::Result {
-        todo!()
+typedb_error!(
+    pub FunctionError(domain = "Function", prefix = "FUN") {
+        FunctionNotFound(1, "Function was not found"),
+        AllFunctionsTypeCheckFailure(2, "Type checking all functions currently defined failed.", ( source: FunctionTypeInferenceError )),
+        CommittedFunctionsTypeCheck(3, "Type checking stored functions failed.", ( source: FunctionTypeInferenceError )),
+        FunctionTranslation(4, "Failed to translate TypeQL function into internal representation", ( typedb_source: FunctionRepresentationError )),
+        FunctionAlreadyExists(5, "A function with name '{name}' already exists", name: String),
+        CreateFunctionEncoding(6, "Encoding error while trying to create function.", ( source: EncodingError )),
+        FunctionRetrieval(7, "Error retrieving function.", (  source: FunctionReadError )),
+        CommittedFunctionParseError(8, "Error while parsing committed.", ( typedb_source: typeql::Error )),
     }
-}
-
-impl Error for FunctionError {
-    fn source(&self) -> Option<&(dyn Error + 'static)> {
-        match self {
-            Self::SnapshotOpen { source } => Some(source),
-            Self::SnapshotGet { source } => Some(source),
-            Self::FunctionDefinition { source } => Some(source),
-            Self::Encoding { source } => Some(source),
-            Self::FunctionRead { source } => Some(source),
-            Self::ParseError { source } => Some(source),
-            Self::TypeInference { source } => Some(source),
-            Self::FunctionAlreadyExists { .. } => None,
-        }
-    }
-}
+);

--- a/ir/BUILD
+++ b/ir/BUILD
@@ -20,11 +20,12 @@ rust_library(
     ]),
     deps = [
         "//answer",
+        "//common/primitive",
+        "//common/error",
         "//concept",
         "//durability",
         "//encoding",
         "//storage",
-        "//common/primitive",
 
         "@vaticle_typeql//rust:typeql",
 

--- a/ir/lib.rs
+++ b/ir/lib.rs
@@ -17,6 +17,7 @@ use typeql::{
     token,
     value::StringLiteral,
 };
+use error::typedb_error;
 
 use crate::{
     pattern::{constraint::Constraint, expression::ExpressionDefinitionError, variable_category::VariableCategory},
@@ -26,101 +27,106 @@ use crate::{
 pub mod pattern;
 pub mod program;
 pub mod translation;
-#[derive(Debug, Clone)]
-pub enum PatternDefinitionError {
-    DisjointVariableReuse {
-        variable_name: String,
-    },
-    VariableCategoryMismatch {
-        variable: Variable,
-        variable_name: Option<String>,
-        category_1: VariableCategory,
-        category_1_source: Constraint<Variable>,
-        category_2: VariableCategory,
-        category_2_source: Constraint<Variable>,
-    },
-    FunctionCallReturnCountMismatch {
-        assigned_var_count: usize,
-        function_return_count: usize,
-    },
-    FunctionCallArgumentCountMismatch {
-        expected: usize,
-        actual: usize,
-    },
-    UnresolvedFunction {
-        function_name: String,
-    },
-    ExpectedStreamReceivedSingle {
-        function_name: String,
-    },
-    ExpectedSingeReceivedStream {
-        function_name: String,
-    },
-    OptionalVariableForRequiredArgument {
-        function_name: String,
-        index: usize,
-    },
-    InAssignmentMustBeListOrStream {
-        in_assignment: InIterable,
-    },
-    FunctionRead {
-        source: FunctionReadError,
-    },
-    ParseError {
-        source: typeql::Error,
-    },
-    LiteralParseError {
-        literal: String,
-        source: LiteralParseError,
-    },
-    ExpressionDefinition {
-        source: ExpressionDefinitionError,
-    },
-    ExpressionAssignmentMustOneVariable {
-        assigned: Vec<Variable>,
-    },
-    ExpressionBuiltinArgumentCountMismatch {
-        builtin: token::Function,
-        expected: usize,
-        actual: usize,
-    },
-    UnimplementedStructAssignment {
-        deconstruct: StructDeconstruct,
-    },
-    ScopedRoleNameInRelation {
-        role_player: RolePlayer,
-    },
-}
 
-impl fmt::Display for PatternDefinitionError {
-    fn fmt(&self, _: &mut fmt::Formatter<'_>) -> fmt::Result {
-        todo!()
+// TODO: include declaration source for each error message
+typedb_error!(
+    pub PatternDefinitionError(domain = "Representation", prefix = "PRP") {
+        DisjointVariableReuse(
+            0,
+            "Variable '{name}' is re-used across different branches of the query. Variables that do not represent the same concept must be named uniquely, to prevent clashes within answers.",
+            name: String
+        ),
+        VariableCategoryMismatch(
+            1,
+            "The variable '{variable_name}' cannot be declared as both a '{category_1}' and as a '{category_2}'.",
+            variable_name: String,
+            category_1: VariableCategory,
+            // category_1_source: Constraint<Variable>,
+            category_2: VariableCategory
+            // category_2_source: Constraint<Variable>,
+        ),
+        FunctionCallReturnCountMismatch(
+            2,
+            "Invalid call to function '{name}', which returns '{function_return_count}' outputs but only '{assigned_var_count}' were assigned.",
+            name: String,
+            assigned_var_count: usize,
+            function_return_count: usize
+        ),
+        FunctionCallArgumentCountMismatch(
+            3,
+            "Invalid call to function '{name}', which requires '{expected}' arguments but only '{actual}' were provided.",
+            name: String,
+            expected: usize,
+            actual: usize
+        ),
+        UnresolvedFunction(4, "Could not resolve function with name '{function_name}'.", function_name: String),
+        ExpectedStreamFunctionReturnsSingle(
+            5,
+            "Invalid invocation of function '{function_name}' in an iterable assignment ('in'), since it returns a non-iterable single answer. Use the single-answer assignment '=' instead.",
+            function_name: String
+        ),
+        ExpectedSingleFunctionReturnsStream(
+            6,
+            "Invalid invocation of function '{function_name}' in a single-answer assignment (=), since it returns an iterable stream of answers. Use the iterable assignment 'in' instead.",
+            function_name: String
+        ),
+        OptionalVariableForRequiredArgument(
+            7,
+            "Optionally present variable '{input_var}' cannot be used as the non-optional argument '{arg_name}' in function '{name}'.",
+            name: String,
+            arg_name: String,
+            input_var: String
+        ),
+        InAssignmentMustBeListOrStream(
+            8,
+            "Iterable assignments ('in') must have an iterable stream or list on the right hand side.\nSource:\n{declaration}",
+            declaration: InIterable
+        ),
+        FunctionRead(
+            9,
+            "Error reading function.",
+            source: FunctionReadError
+        ),
+        ParseError(
+            10,
+            "Error parsing query.",
+            source: typeql::Error
+        ),
+        LiteralParseError(
+            11,
+            "Error parsing literal '{literal}'.",
+            literal: String,
+            ( source: LiteralParseError )
+        ),
+        ExpressionDefinition(
+            12,
+            "Expression error.",
+            ( source: ExpressionDefinitionError )
+        ),
+        ExpressionAssignmentMustOneVariable(
+            13,
+            "Expressions must be assigned to a single variable, received {assigned_count} instead.",
+            assigned_count: usize
+        ),
+        ExpressionBuiltinArgumentCountMismatch(
+            14,
+            "Built-in expression function '{builtin}' expects '{expected}' arguments but received '{actual}' arguments.",
+            builtin: token::Function,
+            expected: usize,
+            actual: usize
+        ),
+        UnimplementedStructAssignment(
+            15,
+            "Destructuring structs via assignment is not yet implemented.\nSource:\n{declaration}",
+            declaration: StructDeconstruct
+        ),
+        ScopedRoleNameInRelation(
+            16,
+            "Relation's declared role types should not contain scopes (':').\nSource:\n{declaration}",
+            declaration: typeql::statement::thing::RolePlayer
+        ),
     }
-}
-
-impl Error for PatternDefinitionError {
-    fn source(&self) -> Option<&(dyn Error + 'static)> {
-        match self {
-            | Self::DisjointVariableReuse { .. }
-            | Self::VariableCategoryMismatch { .. }
-            | Self::FunctionCallReturnCountMismatch { .. }
-            | Self::FunctionCallArgumentCountMismatch { .. }
-            | Self::UnresolvedFunction { .. }
-            | Self::ExpectedStreamReceivedSingle { .. }
-            | Self::ExpectedSingeReceivedStream { .. }
-            | Self::OptionalVariableForRequiredArgument { .. }
-            | Self::LiteralParseError { .. }
-            | Self::ExpressionBuiltinArgumentCountMismatch { .. }
-            | Self::InAssignmentMustBeListOrStream { .. }
-            | Self::ExpressionAssignmentMustOneVariable { .. }
-            | Self::ScopedRoleNameInRelation { .. }
-            | Self::UnimplementedStructAssignment { .. } => None,
-            Self::ParseError { source } => Some(source),
-            Self::FunctionRead { source } => Some(source),
-            Self::ExpressionDefinition { source } => Some(source),
-        }
-    }
-}
+);
 
 #[derive(Debug, Clone)]
 pub enum LiteralParseError {

--- a/ir/lib.rs
+++ b/ir/lib.rs
@@ -26,7 +26,7 @@ use crate::{
 pub mod pattern;
 pub mod program;
 pub mod translation;
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum PatternDefinitionError {
     DisjointVariableReuse {
         variable_name: String,
@@ -122,7 +122,7 @@ impl Error for PatternDefinitionError {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum LiteralParseError {
     FragmentParseError { fragment: String },
     ScientificNotationNotAllowedForDecimal { literal: String },

--- a/ir/pattern/expression.rs
+++ b/ir/pattern/expression.rs
@@ -232,7 +232,7 @@ impl<ID: IrID> Display for Expression<ID> {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum ExpressionDefinitionError {
     ExpectedValueArgumentReceivedList,
     ExpectedListArgumentReceivedValue,

--- a/ir/pattern/expression.rs
+++ b/ir/pattern/expression.rs
@@ -255,7 +255,7 @@ impl Error for ExpressionDefinitionError {
             Self::ExpectedListArgumentReceivedValue => None,
             Self::ArgumentNotBound => None,
             Self::SubExpressionNotDefined => None,
-            Self::PatternDefinition { source } => Some(source),
+            Self::PatternDefinition { source } => todo!(),
             Self::EmptyExpressionTree { .. } => None,
         }
     }

--- a/ir/program/block.rs
+++ b/ir/program/block.rs
@@ -179,12 +179,11 @@ impl VariableRegistry {
                 let narrowest = existing_category.narrowest(category);
                 match narrowest {
                     None => Err(PatternDefinitionError::VariableCategoryMismatch {
-                        variable,
-                        variable_name: self.variable_names.get(&variable).cloned(),
+                        variable_name: self.variable_names.get(&variable).unwrap().clone(),
                         category_1: category,
-                        category_1_source: source,
+                        // category_1_source: source,
                         category_2: *existing_category,
-                        category_2_source: existing_source.clone(),
+                        // category_2_source: existing_source.clone(),
                     }),
                     Some(narrowed) => {
                         if narrowed == *existing_category {
@@ -310,7 +309,7 @@ impl<'a> BlockContext<'a> {
                     *existing_scope = scope;
                     Ok(*existing_variable)
                 } else {
-                    Err(PatternDefinitionError::DisjointVariableReuse { variable_name: name.to_string() })
+                    Err(PatternDefinitionError::DisjointVariableReuse { name: name.to_string() })
                 }
             }
         }

--- a/ir/program/function.rs
+++ b/ir/program/function.rs
@@ -17,6 +17,7 @@ pub type PlaceholderTypeQLReturnOperation = String;
 
 #[derive(Debug, Clone)]
 pub struct Function {
+    name: String,
     // Variable categories for args & return can be read from the block's context.
     arguments: Vec<Variable>,
     block: FunctionalBlock,
@@ -26,12 +27,17 @@ pub struct Function {
 
 impl Function {
     pub fn new(
+        name: &str,
         block: FunctionalBlock,
         variable_registry: VariableRegistry,
         arguments: Vec<Variable>,
         return_operation: ReturnOperation,
     ) -> Self {
-        Self { block, variable_registry, arguments, return_operation }
+        Self { name: name.to_string(), block, variable_registry, arguments, return_operation }
+    }
+
+    pub fn name(&self) -> &str {
+        &self.name
     }
 
     pub fn arguments(&self) -> &[Variable] {

--- a/ir/program/function.rs
+++ b/ir/program/function.rs
@@ -60,7 +60,7 @@ impl Function {
 #[derive(Debug, Clone)]
 pub enum ReturnOperation {
     Stream(Vec<Variable>),
-    Single(Vec<Reducer>),
+    Reduce(Vec<Reducer>),
 }
 
 impl ReturnOperation {
@@ -75,7 +75,7 @@ impl ReturnOperation {
                     .map(|types_as_arced_hashset| BTreeSet::from_iter(types_as_arced_hashset.iter().cloned()))
                     .collect()
             }
-            ReturnOperation::Single(_) => {
+            ReturnOperation::Reduce(_) => {
                 todo!()
             }
         }
@@ -86,7 +86,7 @@ impl ReturnOperation {
     pub(crate) fn is_stream(&self) -> bool {
         match self {
             Self::Stream(_) => true,
-            Self::Single(_) => false,
+            Self::Reduce(_) => false,
         }
     }
 }

--- a/ir/program/mod.rs
+++ b/ir/program/mod.rs
@@ -58,7 +58,7 @@ typedb_error!(
             3,
             "Function pattern contains an error.\nSource:\n{declaration}",
             declaration: Function,
-            ( source: PatternDefinitionError )
+            ( typedb_source : PatternDefinitionError )
         ),
     }
 );

--- a/ir/program/mod.rs
+++ b/ir/program/mod.rs
@@ -6,7 +6,9 @@
 
 use std::{error::Error, fmt, fmt::Display, sync::Arc};
 
+use error::typedb_error;
 use storage::snapshot::{iterator::SnapshotIteratorError, SnapshotGetError};
+use typeql::schema::definable::function::{Function, ReturnStream};
 
 use crate::{program::function_signature::FunctionID, PatternDefinitionError};
 
@@ -15,11 +17,11 @@ pub mod function;
 pub mod function_signature;
 pub mod modifier;
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum FunctionReadError {
     FunctionNotFound { function_id: FunctionID },
-    SnapshotGet { source: SnapshotGetError },
-    SnapshotIterate { source: Arc<SnapshotIteratorError> },
+    FunctionRetrieval { source: SnapshotGetError },
+    FunctionsScan { source: Arc<SnapshotIteratorError> },
 }
 
 impl Display for FunctionReadError {
@@ -31,57 +33,32 @@ impl Display for FunctionReadError {
 impl Error for FunctionReadError {
     fn source(&self) -> Option<&(dyn Error + 'static)> {
         match self {
-            Self::SnapshotGet { source } => Some(source),
-            Self::SnapshotIterate { source } => Some(source),
+            Self::FunctionRetrieval { source } => Some(source),
+            Self::FunctionsScan { source } => Some(source),
             Self::FunctionNotFound { .. } => None,
         }
     }
 }
 
-#[derive(Debug)]
-pub enum ProgramDefinitionError {
-    FunctionRead { source: FunctionReadError },
-    FunctionDefinition { source: FunctionDefinitionError },
-    PatternDefinition { source: PatternDefinitionError },
-}
-
-impl Display for ProgramDefinitionError {
-    fn fmt(&self, _: &mut fmt::Formatter<'_>) -> fmt::Result {
-        todo!()
+typedb_error!(
+    pub FunctionRepresentationError(domain = "Representation", prefix = "FRP") {
+        FunctionArgumentUnused(
+            1,
+            "Function argument variable '{argument_variable}' is unused.\nSource:\n{declaration}",
+            argument_variable: String,
+            declaration: Function
+        ),
+        ReturnVariableUnavailable(
+            2,
+            "Function return variable '{return_variable}' is not available or defined.\nSource:\n{declaration:?}", // TODO: formatted
+            return_variable: String,
+            declaration: ReturnStream
+        ),
+        PatternDefinition(
+            3,
+            "Function pattern contains an error.\nSource:\n{declaration}",
+            declaration: Function,
+            ( source: PatternDefinitionError )
+        ),
     }
-}
-
-impl Error for ProgramDefinitionError {
-    fn source(&self) -> Option<&(dyn Error + 'static)> {
-        match self {
-            ProgramDefinitionError::FunctionRead { source } => Some(source),
-            ProgramDefinitionError::FunctionDefinition { source } => Some(source),
-            ProgramDefinitionError::PatternDefinition { source } => Some(source),
-        }
-    }
-}
-
-#[derive(Debug)]
-pub enum FunctionDefinitionError {
-    FunctionArgumentUnused { argument_variable: String },
-    ReturnVariableUnavailable { variable: String },
-    PatternDefinition { source: PatternDefinitionError },
-    ParseError { source: typeql::Error },
-}
-
-impl fmt::Display for FunctionDefinitionError {
-    fn fmt(&self, _: &mut fmt::Formatter<'_>) -> fmt::Result {
-        todo!()
-    }
-}
-
-impl Error for FunctionDefinitionError {
-    fn source(&self) -> Option<&(dyn Error + 'static)> {
-        match self {
-            Self::FunctionArgumentUnused { .. } => None,
-            Self::ReturnVariableUnavailable { .. } => None,
-            Self::PatternDefinition { source } => Some(source),
-            Self::ParseError { source } => Some(source),
-        }
-    }
-}
+);

--- a/ir/translation/constraints.rs
+++ b/ir/translation/constraints.rs
@@ -6,13 +6,7 @@
 
 use answer::variable::Variable;
 use encoding::value::label::Label;
-use typeql::{
-    expression::{FunctionCall, FunctionName},
-    statement::{comparison::ComparisonStatement, Assignment, AssignmentPattern, InIterable},
-    token::Kind,
-    type_::NamedType,
-    ScopedLabel, TypeRef, TypeRefAny,
-};
+use typeql::{expression::{FunctionCall, FunctionName}, statement::{comparison::ComparisonStatement, Assignment, AssignmentPattern, InIterable}, token::Kind, type_::NamedType, ScopedLabel, TypeRef, TypeRefAny, Function};
 
 use crate::{
     pattern::{
@@ -48,7 +42,7 @@ pub(super) fn add_statement(
         typeql::Statement::Assignment(Assignment { lhs, rhs, .. }) => {
             let assigned = assignment_pattern_to_variables(constraints, lhs)?;
             let [assigned] = *assigned else {
-                return Err(PatternDefinitionError::ExpressionAssignmentMustOneVariable { assigned });
+                return Err(PatternDefinitionError::ExpressionAssignmentMustOneVariable { assigned_count: assigned.len() });
             };
             add_typeql_expression(function_index, constraints, assigned, rhs)?
         }
@@ -333,7 +327,7 @@ pub(super) fn add_typeql_relation(
                     TypeRefAny::Type(TypeRef::Variable(var)) => register_typeql_var(constraints, var)?,
                     TypeRefAny::Type(TypeRef::Named(NamedType::Role(name))) => {
                         return Err(PatternDefinitionError::ScopedRoleNameInRelation {
-                            role_player: role_player.clone(),
+                            declaration: role_player.clone(),
                         });
                     }
                     TypeRefAny::Optional(_) => todo!(),
@@ -393,13 +387,13 @@ pub(super) fn add_function_call_binding_user(
         match (must_be_stream, callee.return_is_stream) {
             (true, true) | (false, false) => {}
             (false, true) => {
-                Err(PatternDefinitionError::ExpectedSingeReceivedStream { function_name: function_name.to_owned() })?
+                Err(PatternDefinitionError::ExpectedSingleFunctionReturnsStream { function_name: function_name.to_owned() })?
             }
             (true, false) => {
-                Err(PatternDefinitionError::ExpectedStreamReceivedSingle { function_name: function_name.to_owned() })?
+                Err(PatternDefinitionError::ExpectedStreamFunctionReturnsSingle { function_name: function_name.to_owned() })?
             }
         }
-        constraints.add_function_binding(assigned, &callee, arguments)?;
+        constraints.add_function_binding(assigned, &callee, arguments, function_name)?;
         Ok(())
     } else {
         Err(PatternDefinitionError::UnresolvedFunction { function_name: function_name.to_owned() })
@@ -413,7 +407,7 @@ fn assignment_pattern_to_variables(
     match assignment {
         AssignmentPattern::Variables(vars) => assignment_typeql_vars_to_variables(constraints, vars),
         AssignmentPattern::Deconstruct(struct_deconstruct) => {
-            Err(PatternDefinitionError::UnimplementedStructAssignment { deconstruct: struct_deconstruct.clone() })
+            Err(PatternDefinitionError::UnimplementedStructAssignment { declaration: struct_deconstruct.clone() })
         }
     }
 }

--- a/ir/translation/expression.rs
+++ b/ir/translation/expression.rs
@@ -109,7 +109,7 @@ pub(super) fn add_user_defined_function_call(
     let Some(callee) = callee else {
         return Err(PatternDefinitionError::UnresolvedFunction { function_name: function_name.to_owned() });
     };
-    constraints.add_function_binding(assigned, &callee, arguments)?;
+    constraints.add_function_binding(assigned, &callee, arguments, &function_name)?;
     Ok(())
 }
 

--- a/ir/translation/function.rs
+++ b/ir/translation/function.rs
@@ -6,9 +6,10 @@
 
 use answer::variable::Variable;
 use typeql::{
-    schema::definable::function::{Output, ReturnSingle, ReturnStatement, ReturnStream, SingleOutput},
+    schema::definable::function::{Output, ReturnStatement, ReturnStream},
     TypeRefAny,
 };
+use typeql::query::stage::reduce::Reduction;
 
 use crate::{
     pattern::{
@@ -31,11 +32,11 @@ pub fn translate_function(
     let mut context = TranslationContext::new();
     let mut builder = FunctionalBlock::builder(context.next_block_context());
     add_patterns(function_index, &mut builder.conjunction_mut(), &function.body.patterns)
-        .map_err(|source| FunctionRepresentationError::PatternDefinition { declaration: function.clone(), source })?;
+        .map_err(|source| FunctionRepresentationError::PatternDefinition { declaration: function.clone(), typedb_source: source })?;
 
     let return_operation = match &function.return_stmt {
         ReturnStatement::Stream(stream) => build_return_stream(builder.context_mut(), stream),
-        ReturnStatement::Single(single) => build_return_single(builder.context_mut(), single),
+        ReturnStatement::Reduce(reduction) => build_return_reduce(builder.context_mut(), reduction),
     }?;
     let arguments: Vec<Variable> = function
         .signature
@@ -106,22 +107,11 @@ fn build_return_stream(
     Ok(ReturnOperation::Stream(variables))
 }
 
-fn build_return_single(
+fn build_return_reduce(
     context: &BlockContext<'_>,
-    single: &ReturnSingle,
+    reduction: &Reduction,
 ) -> Result<ReturnOperation, FunctionRepresentationError> {
-    let reducers = single
-        .outputs
-        .iter()
-        .map(|output| build_return_single_output(context, output))
-        .collect::<Result<Vec<Reducer>, FunctionRepresentationError>>()?;
-    Ok(ReturnOperation::Single(reducers))
-}
-
-fn build_return_single_output(
-    context: &BlockContext<'_>,
-    single_output: &SingleOutput,
-) -> Result<Reducer, FunctionRepresentationError> {
+    // Ok(ReturnOperation::Reduction(reducers))
     todo!()
 }
 

--- a/ir/translation/function.rs
+++ b/ir/translation/function.rs
@@ -19,7 +19,7 @@ use crate::{
         block::{BlockContext, FunctionalBlock},
         function::{Function, Reducer, ReturnOperation},
         function_signature::{FunctionID, FunctionSignature, FunctionSignatureIndex},
-        FunctionDefinitionError,
+        FunctionRepresentationError,
     },
     translation::{match_::add_patterns, TranslationContext},
 };
@@ -27,11 +27,11 @@ use crate::{
 pub fn translate_function(
     function_index: &impl FunctionSignatureIndex,
     function: &typeql::Function,
-) -> Result<Function, FunctionDefinitionError> {
+) -> Result<Function, FunctionRepresentationError> {
     let mut context = TranslationContext::new();
     let mut builder = FunctionalBlock::builder(context.next_block_context());
     add_patterns(function_index, &mut builder.conjunction_mut(), &function.body.patterns)
-        .map_err(|source| FunctionDefinitionError::PatternDefinition { source })?;
+        .map_err(|source| FunctionRepresentationError::PatternDefinition { declaration: function.clone(), source })?;
 
     let return_operation = match &function.return_stmt {
         ReturnStatement::Stream(stream) => build_return_stream(builder.context_mut(), stream),
@@ -43,12 +43,21 @@ pub fn translate_function(
         .iter()
         .map(|typeql_arg| {
             get_variable_in_block_root(builder.context_mut(), &typeql_arg.var, |var| {
-                FunctionDefinitionError::FunctionArgumentUnused { argument_variable: var.name().unwrap().to_string() }
+                FunctionRepresentationError::FunctionArgumentUnused {
+                    argument_variable: var.name().unwrap().to_string(),
+                    declaration: function.clone(),
+                }
             })
         })
-        .collect::<Result<Vec<_>, FunctionDefinitionError>>()?;
+        .collect::<Result<Vec<_>, FunctionRepresentationError>>()?;
 
-    Ok(Function::new(builder.finish(), context.variable_registry, arguments, return_operation))
+    Ok(Function::new(
+        function.signature.ident.as_str(),
+        builder.finish(),
+        context.variable_registry,
+        arguments,
+        return_operation,
+    ))
 }
 
 pub fn build_signature(function_id: FunctionID, function: &typeql::Function) -> FunctionSignature {
@@ -81,35 +90,38 @@ fn type_any_to_category_and_optionality(type_any: &TypeRefAny) -> (VariableCateg
 fn build_return_stream(
     context: &BlockContext<'_>,
     stream: &ReturnStream,
-) -> Result<ReturnOperation, FunctionDefinitionError> {
+) -> Result<ReturnOperation, FunctionRepresentationError> {
     let variables = stream
         .vars
         .iter()
         .map(|typeql_var| {
-            get_variable_in_block_root(context, typeql_var, |var| FunctionDefinitionError::ReturnVariableUnavailable {
-                variable: var.name().unwrap().to_string(),
+            get_variable_in_block_root(context, typeql_var, |var| {
+                FunctionRepresentationError::ReturnVariableUnavailable {
+                    return_variable: var.name().unwrap().to_string(),
+                    declaration: stream.clone(),
+                }
             })
         })
-        .collect::<Result<Vec<Variable>, FunctionDefinitionError>>()?;
+        .collect::<Result<Vec<Variable>, FunctionRepresentationError>>()?;
     Ok(ReturnOperation::Stream(variables))
 }
 
 fn build_return_single(
     context: &BlockContext<'_>,
     single: &ReturnSingle,
-) -> Result<ReturnOperation, FunctionDefinitionError> {
+) -> Result<ReturnOperation, FunctionRepresentationError> {
     let reducers = single
         .outputs
         .iter()
         .map(|output| build_return_single_output(context, output))
-        .collect::<Result<Vec<Reducer>, FunctionDefinitionError>>()?;
+        .collect::<Result<Vec<Reducer>, FunctionRepresentationError>>()?;
     Ok(ReturnOperation::Single(reducers))
 }
 
 fn build_return_single_output(
     context: &BlockContext<'_>,
     single_output: &SingleOutput,
-) -> Result<Reducer, FunctionDefinitionError> {
+) -> Result<Reducer, FunctionRepresentationError> {
     todo!()
 }
 
@@ -117,9 +129,9 @@ fn get_variable_in_block_root<F>(
     context: &BlockContext<'_>,
     typeql_var: &typeql::Variable,
     err: F,
-) -> Result<Variable, FunctionDefinitionError>
+) -> Result<Variable, FunctionRepresentationError>
 where
-    F: FnOnce(&typeql::Variable) -> FunctionDefinitionError,
+    F: FnOnce(&typeql::Variable) -> FunctionRepresentationError,
 {
     context
         .get_variable_named(typeql_var.name().unwrap(), ScopeId::ROOT)

--- a/query/BUILD
+++ b/query/BUILD
@@ -25,6 +25,8 @@ rust_library(
         "//storage",
 
         "@vaticle_typeql//rust:typeql",
+
+        "@crates//:tokio",
     ],
 )
 

--- a/query/annotation.rs
+++ b/query/annotation.rs
@@ -73,7 +73,7 @@ pub(super) fn infer_types_for_pipeline(
 ) -> Result<AnnotatedPipeline, QueryError> {
     let annotated_preamble =
         infer_types_for_functions(translated_preamble, snapshot, type_manager, schema_function_annotations)
-            .map_err(|source| QueryError::TypeInference { source })?;
+            .map_err(|source| QueryError::FunctionTypeInference { source })?;
 
     let mut running_variable_annotations: HashMap<Variable, Arc<HashSet<answer::Type>>> = HashMap::new();
     let mut annotated_stages = Vec::with_capacity(translated_stages.len());
@@ -129,7 +129,7 @@ fn annotate_stage(
                 schema_function_annotations,
                 preamble_function_annotations,
             )
-            .map_err(|source| QueryError::TypeInference { source })?;
+            .map_err(|source| QueryError::QueryTypeInference { source })?;
             block_annotations.variable_annotations().iter().for_each(|(k, v)| {
                 running_variable_annotations.insert(*k, v.clone());
             });
@@ -148,7 +148,7 @@ fn annotate_stage(
                 &IndexedAnnotatedFunctions::empty(),
                 &AnnotatedUnindexedFunctions::empty(),
             )
-            .map_err(|source| QueryError::TypeInference { source })?;
+            .map_err(|source| QueryError::QueryTypeInference { source })?;
             block.conjunction().constraints().iter().for_each(|constraint| match constraint {
                 Constraint::Isa(isa) => {
                     running_variable_annotations
@@ -171,7 +171,7 @@ fn annotate_stage(
                 running_constraint_annotations,
                 &insert_annotations,
             )
-            .map_err(|source| QueryError::TypeInference { source })?;
+            .map_err(|source| QueryError::QueryTypeInference { source })?;
 
             Ok(AnnotatedStage::Insert { block, annotations: insert_annotations })
         }
@@ -185,7 +185,7 @@ fn annotate_stage(
                 &IndexedAnnotatedFunctions::empty(),
                 &AnnotatedUnindexedFunctions::empty(),
             )
-            .map_err(|source| QueryError::TypeInference { source })?;
+            .map_err(|source| QueryError::QueryTypeInference { source })?;
             deleted_variables.iter().for_each(|v| {
                 running_variable_annotations.remove(v);
             });

--- a/query/definable_status.rs
+++ b/query/definable_status.rs
@@ -140,7 +140,7 @@ pub(crate) fn get_type_annotation_status<'a, T: KindAPI<'a>>(
 pub(crate) fn get_capability_annotation_status<'a, CAP: Capability<'a>>(
     snapshot: &impl ReadableSnapshot,
     type_manager: &TypeManager,
-    capability: CAP,
+    capability: &CAP,
     annotation: &CAP::AnnotationType,
     annotation_category: AnnotationCategory,
 ) -> Result<DefinableStatus<CAP::AnnotationType>, ConceptReadError> {
@@ -177,7 +177,7 @@ pub(crate) fn get_sub_status<'a, T: TypeAPI<'a>>(
 pub(crate) fn get_override_status<'a, CAP: Capability<'a>>(
     snapshot: &impl ReadableSnapshot,
     type_manager: &TypeManager,
-    capability: CAP,
+    capability: &CAP,
     new_override: CAP,
 ) -> Result<DefinableStatus<CAP>, ConceptReadError> {
     let existing_override_opt = capability.get_override(snapshot, type_manager)?.clone();

--- a/query/error.rs
+++ b/query/error.rs
@@ -25,7 +25,7 @@ typedb_error!(
         Undefine(4, "Failed to execute undefine query.", ( typedb_source: UndefineError )),
         FunctionDefinition(5, "Error in provided function. ", ( typedb_source: FunctionRepresentationError )),
         FunctionRetrieval(6, "Failed to retrieve function. ",  ( typedb_source: FunctionError )),
-        PatternDefinition(7, "Error in provided pattern. ", ( source: PatternDefinitionError )),
+        PatternDefinition(7, "Error in provided pattern. ", ( typedb_source: PatternDefinitionError )),
         QueryTypeInference(8, "Error during query type inference. ", ( source: TypeInferenceError )),
         FunctionTypeInference(9, "Error during function type inference. ", ( source: FunctionTypeInferenceError )),
         WriteCompilation(10, "Error while compiling write query.", ( source: WriteCompilationError )),

--- a/query/error.rs
+++ b/query/error.rs
@@ -5,12 +5,14 @@
  */
 
 use compiler::{
-    expression::ExpressionCompileError, insert::WriteCompilationError, match_::inference::TypeInferenceError,
+    expression::ExpressionCompileError,
+    insert::WriteCompilationError,
+    match_::inference::{FunctionTypeInferenceError, TypeInferenceError},
 };
 use error::typedb_error;
 use executor::pipeline::PipelineExecutionError;
 use function::FunctionError;
-use ir::{program::FunctionDefinitionError, PatternDefinitionError};
+use ir::{program::FunctionRepresentationError, PatternDefinitionError};
 
 use crate::{define::DefineError, redefine::RedefineError, undefine::UndefineError};
 
@@ -18,18 +20,18 @@ typedb_error!(
     pub QueryError(domain = "Query", prefix = "QRY") {
         // TODO: decide if we want to include whole query
         ParseError(1, "Failed to parse TypeQL query.", query: String, ( typedb_source: typeql::Error )),
-        // TODO: move these to typedb_source once all errors are implemented
-        Define(2, "Failed to execute define query.", ( source: DefineError )),
-        Redefine(3, "Failed to execute redefine query.", ( source: RedefineError )),
-        Undefine(4, "Failed to execute undefine query.", ( source: UndefineError )),
-        FunctionDefinition(5, "Error in provided function. ", ( source: FunctionDefinitionError )),
-        FunctionRetrieval(6, "Failed to retrieve function. ",  ( source: FunctionError )),
+        Define(2, "Failed to execute define query.", ( typedb_source: DefineError )),
+        Redefine(3, "Failed to execute redefine query.", ( typedb_source: RedefineError )),
+        Undefine(4, "Failed to execute undefine query.", ( typedb_source: UndefineError )),
+        FunctionDefinition(5, "Error in provided function. ", ( typedb_source: FunctionRepresentationError )),
+        FunctionRetrieval(6, "Failed to retrieve function. ",  ( typedb_source: FunctionError )),
         PatternDefinition(7, "Error in provided pattern. ", ( source: PatternDefinitionError )),
-        TypeInference(8, "Error during type inference. ", ( source: TypeInferenceError )),
-        WriteCompilation(9, "Error while compiling write query.", ( source: WriteCompilationError )),
-        ExpressionCompilation(10, "Error while compiling expression.", ( source: ExpressionCompileError )),
-        WritePipelineExecutionError(11, "Error while execution write pipeline.", ( typedb_source: PipelineExecutionError )),
-        ReadPipelineExecutionError(12, "Error while executing read pipeline.", ( typedb_source: PipelineExecutionError )),
-        QueryExecutionClosedEarly(13, "Query execution was closed before it finished, possibly due to transaction close, rollback, or commit."),
+        QueryTypeInference(8, "Error during query type inference. ", ( source: TypeInferenceError )),
+        FunctionTypeInference(9, "Error during function type inference. ", ( source: FunctionTypeInferenceError )),
+        WriteCompilation(10, "Error while compiling write query.", ( source: WriteCompilationError )),
+        ExpressionCompilation(11, "Error while compiling expression.", ( source: ExpressionCompileError )),
+        WritePipelineExecutionError(12, "Error while execution write pipeline.", ( typedb_source: PipelineExecutionError )),
+        ReadPipelineExecutionError(13, "Error while executing read pipeline.", ( typedb_source: PipelineExecutionError )),
+        QueryExecutionClosedEarly(14, "Query execution was closed before it finished, possibly due to transaction close, rollback, or commit."),
     }
 );

--- a/query/lib.rs
+++ b/query/lib.rs
@@ -3,10 +3,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
-use concept::error::ConceptReadError;
-use encoding::{graph::type_::Kind, value::label::Label};
-use typeql::schema::definable::type_::Capability;
-
 mod annotation;
 mod compilation;
 mod definable_resolution;
@@ -17,12 +13,3 @@ pub mod query_manager;
 mod redefine;
 mod translation;
 mod undefine;
-
-#[derive(Debug)]
-pub enum SymbolResolutionError {
-    TypeNotFound { label: Label<'static> },
-    KindMismatch { label: Label<'static>, expected: Kind, actual: Kind, capability: Capability },
-    ValueTypeNotFound { name: String },
-    IllegalValueTypeName { scope: String, name: String },
-    UnexpectedConceptRead { source: ConceptReadError },
-}

--- a/query/query_manager.rs
+++ b/query/query_manager.rs
@@ -48,11 +48,11 @@ impl QueryManager {
     ) -> Result<(), QueryError> {
         match query {
             SchemaQuery::Define(define) => define::execute(snapshot, type_manager, thing_manager, define)
-                .map_err(|err| QueryError::Define { source: err }),
+                .map_err(|err| QueryError::Define { typedb_source: err }),
             SchemaQuery::Redefine(redefine) => redefine::execute(snapshot, type_manager, thing_manager, redefine)
-                .map_err(|err| QueryError::Redefine { source: err }),
+                .map_err(|err| QueryError::Redefine { typedb_source: err }),
             SchemaQuery::Undefine(undefine) => undefine::execute(snapshot, type_manager, thing_manager, undefine)
-                .map_err(|err| QueryError::Undefine { source: err }),
+                .map_err(|err| QueryError::Undefine { typedb_source: err }),
         }
     }
 
@@ -72,7 +72,7 @@ impl QueryManager {
 
         let annotated_functions = function_manager
             .get_annotated_functions(snapshot.as_ref(), &type_manager)
-            .map_err(|err| QueryError::FunctionRetrieval { source: err })?;
+            .map_err(|err| QueryError::FunctionRetrieval { typedb_source: err })?;
 
         // 2: Annotate
         let AnnotatedPipeline { annotated_preamble, annotated_stages } = infer_types_for_pipeline(
@@ -145,7 +145,7 @@ impl QueryManager {
 
         let annotated_functions = match function_manager.get_annotated_functions(&snapshot, &type_manager) {
             Ok(annotated_functions) => annotated_functions,
-            Err(err) => return Err((snapshot, QueryError::FunctionRetrieval { source: err })),
+            Err(err) => return Err((snapshot, QueryError::FunctionRetrieval { typedb_source: err })),
         };
 
         // 2: Annotate

--- a/query/redefine.rs
+++ b/query/redefine.rs
@@ -734,7 +734,14 @@ fn redefine_owns_override(
         let overridden_owns = resolve_owns(snapshot, type_manager, owns.owner(), overridden_attribute_type)
             .map_err(|source| RedefineError::DefinitionResolution { typedb_source: source })?;
 
-        check_can_redefine_override(snapshot, type_manager, owner_label, owns.clone(), overridden_owns.clone(), todo!())?;
+        check_can_redefine_override(
+            snapshot,
+            type_manager,
+            owner_label,
+            owns.clone(),
+            overridden_owns.clone(),
+            todo!(),
+        )?;
         error_if_anything_redefined_else_set_true(anything_redefined)?;
         owns.set_override(snapshot, type_manager, thing_manager, overridden_owns).map_err(|source| {
             RedefineError::SetRelatesOverride {
@@ -856,7 +863,14 @@ fn redefine_plays_override(
         let overridden_plays = resolve_plays_role_label(snapshot, type_manager, plays.player(), &overridden_label)
             .map_err(|source| RedefineError::DefinitionResolution { typedb_source: source })?;
 
-        check_can_redefine_override(snapshot, type_manager, player_label, plays.clone(), overridden_plays.clone(), todo!())?;
+        check_can_redefine_override(
+            snapshot,
+            type_manager,
+            player_label,
+            plays.clone(),
+            overridden_plays.clone(),
+            todo!(),
+        )?;
         error_if_anything_redefined_else_set_true(anything_redefined)?;
         plays.set_override(snapshot, type_manager, thing_manager, overridden_plays).map_err(|source| {
             RedefineError::SetRelatesOverride {
@@ -925,7 +939,7 @@ fn check_can_redefine_override<'a, CAP: concept::type_::Capability<'a>>(
                 .get_label_cloned(snapshot, type_manager)
                 .map_err(|source| RedefineError::UnexpectedConceptRead { source })?
                 .into_owned(),
-            declaration: typeql_relates.clone()
+            declaration: typeql_relates.clone(),
         }),
         DefinableStatus::ExistsSame(_) => Err(RedefineError::CapabilityOverrideRemainsSame {
             label: label.clone().into_owned(),
@@ -934,7 +948,7 @@ fn check_can_redefine_override<'a, CAP: concept::type_::Capability<'a>>(
                 .get_label_cloned(snapshot, type_manager)
                 .map_err(|source| RedefineError::UnexpectedConceptRead { source })?
                 .into_owned(),
-            declaration: typeql_relates.clone()
+            declaration: typeql_relates.clone(),
         }),
         DefinableStatus::ExistsDifferent(_) => Ok(()),
     }

--- a/query/redefine.rs
+++ b/query/redefine.rs
@@ -24,6 +24,7 @@ use encoding::{
     graph::type_::Kind,
     value::{label::Label, value_type::ValueType},
 };
+use error::typedb_error;
 use ir::{translation::tokens::translate_annotation, LiteralParseError};
 use storage::snapshot::{ReadableSnapshot, WritableSnapshot};
 use typeql::{
@@ -53,12 +54,16 @@ use crate::{
     },
 };
 
-macro_rules! verify_empty_annotations_for_capability {
+macro_rules! verify_no_annotations_for_capability {
     ($capability:ident, $annotation_error:path) => {
         if let Some(typeql_annotation) = &$capability.annotations.first() {
             let annotation = translate_annotation(typeql_annotation)
                 .map_err(|source| RedefineError::LiteralParseError { source })?;
-            Err(RedefineError::IllegalAnnotation { source: $annotation_error(annotation.category()) })
+            Err(RedefineError::IllegalCapabilityAnnotation {
+                declaration: $capability.clone(),
+                source: $annotation_error(annotation.category()),
+                annotation: annotation,
+            })
         } else {
             Ok(())
         }
@@ -76,7 +81,7 @@ pub(crate) fn execute(
     let redefined_functions = process_function_redefinitions(snapshot, type_manager, &redefine.definables)?;
 
     if !redefined_structs && !redefined_types && !redefined_functions {
-        Err(RedefineError::RedefinedNothing {})
+        Err(RedefineError::NothingRedefined {})
     } else {
         Ok(())
     }
@@ -147,11 +152,11 @@ fn redefine_struct_fields(
 ) -> Result<(), RedefineError> {
     let name = struct_definable.ident.as_str();
     let struct_key = resolve_struct_definition_key(snapshot, type_manager, name)
-        .map_err(|source| RedefineError::DefinitionResolution { source })?;
+        .map_err(|source| RedefineError::DefinitionResolution { typedb_source: source })?;
 
     for field in &struct_definable.fields {
         let (value_type, optional) = get_struct_field_value_type_optionality(snapshot, type_manager, field)
-            .map_err(|source| RedefineError::DefinitionResolution { source })?;
+            .map_err(|source| RedefineError::DefinitionResolution { typedb_source: source })?;
 
         let definition_status = get_struct_field_status(
             snapshot,
@@ -164,10 +169,10 @@ fn redefine_struct_fields(
         .map_err(|source| RedefineError::UnexpectedConceptRead { source })?;
         match definition_status {
             DefinableStatus::DoesNotExist => {
-                return Err(RedefineError::StructFieldDoesNotExist { field: field.to_owned() });
+                return Err(RedefineError::StructFieldDoesNotExist { declaration: field.to_owned() });
             }
             DefinableStatus::ExistsSame(_) => {
-                return Err(RedefineError::StructFieldRemainsSame { field: field.to_owned() });
+                return Err(RedefineError::StructFieldRemainsSame { declaration: field.to_owned() });
             }
             DefinableStatus::ExistsDifferent(_) => {}
         }
@@ -175,18 +180,18 @@ fn redefine_struct_fields(
         error_if_anything_redefined_else_set_true(anything_redefined)?;
         type_manager.delete_struct_field(snapshot, thing_manager, struct_key.clone(), field.key.as_str()).map_err(
             |err| RedefineError::StructFieldDeleteError {
-                source: err,
                 struct_name: name.to_owned(),
-                struct_field: field.clone(),
+                declaration: field.clone(),
+                source: err,
             },
         )?;
 
         type_manager
             .create_struct_field(snapshot, struct_key.clone(), field.key.as_str(), value_type, optional)
             .map_err(|err| RedefineError::StructFieldCreateError {
-                source: err,
                 struct_name: name.to_owned(),
-                struct_field: field.clone(),
+                declaration: field.clone(),
+                source: err,
             })?;
     }
     Ok(())
@@ -201,7 +206,7 @@ fn redefine_type_annotations(
 ) -> Result<(), RedefineError> {
     let label = Label::parse_from(type_declaration.label.ident.as_str());
     let type_ = resolve_typeql_type(snapshot, type_manager, &label)
-        .map_err(|source| RedefineError::DefinitionResolution { source })?;
+        .map_err(|source| RedefineError::DefinitionResolution { typedb_source: source })?;
     for typeql_annotation in &type_declaration.annotations {
         let annotation =
             translate_annotation(typeql_annotation).map_err(|source| RedefineError::LiteralParseError { source })?;
@@ -213,10 +218,16 @@ fn redefine_type_annotations(
                     &label,
                     entity.clone(),
                     annotation.clone(),
+                    type_declaration,
                 )? {
                     error_if_anything_redefined_else_set_true(anything_redefined)?;
                     entity.set_annotation(snapshot, type_manager, thing_manager, converted).map_err(|source| {
-                        RedefineError::SetAnnotation { source, label: label.to_owned(), annotation }
+                        RedefineError::SetTypeAnnotation {
+                            label: label.to_owned(),
+                            annotation,
+                            declaration: type_declaration.clone(),
+                            source,
+                        }
                     })?;
                 }
             }
@@ -227,10 +238,16 @@ fn redefine_type_annotations(
                     &label,
                     relation.clone(),
                     annotation.clone(),
+                    type_declaration,
                 )? {
                     error_if_anything_redefined_else_set_true(anything_redefined)?;
                     relation.set_annotation(snapshot, type_manager, thing_manager, converted).map_err(|source| {
-                        RedefineError::SetAnnotation { source, label: label.to_owned(), annotation }
+                        RedefineError::SetTypeAnnotation {
+                            label: label.to_owned(),
+                            annotation,
+                            declaration: type_declaration.clone(),
+                            source,
+                        }
                     })?;
                 }
             }
@@ -241,15 +258,24 @@ fn redefine_type_annotations(
                     &label,
                     attribute.clone(),
                     annotation.clone(),
+                    type_declaration,
                 )? {
                     if converted.is_value_type_annotation() {
-                        return Err(RedefineError::IllegalAnnotation {
+                        return Err(RedefineError::IllegalTypeAnnotation {
+                            label: label.to_owned(),
+                            annotation: annotation.clone(),
+                            declaration: type_declaration.clone(),
                             source: AnnotationError::UnsupportedAnnotationForAttributeType(annotation.category()),
                         });
                     }
                     error_if_anything_redefined_else_set_true(anything_redefined)?;
                     attribute.set_annotation(snapshot, type_manager, thing_manager, converted).map_err(|source| {
-                        RedefineError::SetAnnotation { source, label: label.to_owned(), annotation }
+                        RedefineError::SetTypeAnnotation {
+                            label: label.to_owned(),
+                            annotation,
+                            declaration: type_declaration.clone(),
+                            source,
+                        }
                     })?;
                 }
             }
@@ -269,7 +295,7 @@ fn redefine_alias(
         .capabilities
         .iter()
         .filter_map(|capability| try_unwrap!(CapabilityBase::Alias = &capability.base))
-        .try_for_each(|_| Err(RedefineError::Unimplemented))?;
+        .try_for_each(|_| Err(RedefineError::Unimplemented { description: "Aliases redefinition.".to_string() }))?;
 
     // TODO: Uncomment when alias is implemented
     // redefine_alias_annotations(capability)?;
@@ -278,7 +304,8 @@ fn redefine_alias(
 }
 
 fn redefine_alias_annotations(typeql_capability: &Capability) -> Result<(), RedefineError> {
-    verify_empty_annotations_for_capability!(typeql_capability, AnnotationError::UnsupportedAnnotationForAlias)
+    Err(RedefineError::Unimplemented { description: "Alias redefinition is not yet implmented.".to_string() })
+    // verify_empty_annotations_for_capability!(typeql_capability, AnnotationError::UnsupportedAnnotationForAlias)
 }
 
 fn redefine_sub(
@@ -290,7 +317,7 @@ fn redefine_sub(
 ) -> Result<(), RedefineError> {
     let label = Label::parse_from(type_declaration.label.ident.as_str());
     let type_ = resolve_typeql_type(snapshot, type_manager, &label)
-        .map_err(|source| RedefineError::DefinitionResolution { source })?;
+        .map_err(|source| RedefineError::DefinitionResolution { typedb_source: source })?;
 
     for capability in &type_declaration.capabilities {
         let CapabilityBase::Sub(sub) = &capability.base else {
@@ -299,7 +326,7 @@ fn redefine_sub(
 
         let supertype_label = Label::parse_from(sub.supertype_label.ident.as_str());
         let supertype = resolve_typeql_type(snapshot, type_manager, &supertype_label)
-            .map_err(|source| RedefineError::DefinitionResolution { source })?;
+            .map_err(|source| RedefineError::DefinitionResolution { typedb_source: source })?;
         if type_.kind() != supertype.kind() {
             Err(err_capability_kind_mismatch(&label, &supertype_label, capability, type_.kind(), supertype.kind()))?;
         }
@@ -310,21 +337,21 @@ fn redefine_sub(
                 error_if_anything_redefined_else_set_true(anything_redefined)?;
                 type_
                     .set_supertype(snapshot, type_manager, thing_manager, supertype)
-                    .map_err(|source| RedefineError::SetSupertype { sub: sub.clone(), source })?;
+                    .map_err(|source| RedefineError::SetSupertype { declaration: sub.clone(), source })?;
             }
             (TypeEnum::Relation(type_), TypeEnum::Relation(supertype)) => {
                 check_can_redefine_sub(snapshot, type_manager, &label, type_.clone(), supertype.clone())?;
                 error_if_anything_redefined_else_set_true(anything_redefined)?;
                 type_
                     .set_supertype(snapshot, type_manager, thing_manager, supertype)
-                    .map_err(|source| RedefineError::SetSupertype { sub: sub.clone(), source })?;
+                    .map_err(|source| RedefineError::SetSupertype { declaration: sub.clone(), source })?;
             }
             (TypeEnum::Attribute(type_), TypeEnum::Attribute(supertype)) => {
                 check_can_redefine_sub(snapshot, type_manager, &label, type_.clone(), supertype.clone())?;
                 error_if_anything_redefined_else_set_true(anything_redefined)?;
                 type_
                     .set_supertype(snapshot, type_manager, thing_manager, supertype)
-                    .map_err(|source| RedefineError::SetSupertype { sub: sub.clone(), source })?;
+                    .map_err(|source| RedefineError::SetSupertype { declaration: sub.clone(), source })?;
             }
             (TypeEnum::RoleType(_), TypeEnum::RoleType(_)) => {
                 return Err(err_unsupported_capability(&label, Kind::Role, capability));
@@ -338,7 +365,7 @@ fn redefine_sub(
 }
 
 fn redefine_sub_annotations(typeql_capability: &Capability) -> Result<(), RedefineError> {
-    verify_empty_annotations_for_capability!(typeql_capability, AnnotationError::UnsupportedAnnotationForSub)
+    verify_no_annotations_for_capability!(typeql_capability, AnnotationError::UnsupportedAnnotationForSub)
 }
 
 fn redefine_value_type(
@@ -350,7 +377,7 @@ fn redefine_value_type(
 ) -> Result<(), RedefineError> {
     let label = Label::parse_from(type_declaration.label.ident.as_str());
     let type_ = resolve_typeql_type(snapshot, type_manager, &label)
-        .map_err(|source| RedefineError::DefinitionResolution { source })?;
+        .map_err(|source| RedefineError::DefinitionResolution { typedb_source: source })?;
     for capability in &type_declaration.capabilities {
         let CapabilityBase::ValueType(value_type_statement) = &capability.base else {
             continue;
@@ -360,7 +387,7 @@ fn redefine_value_type(
         };
 
         let value_type = resolve_value_type(snapshot, type_manager, &value_type_statement.value_type)
-            .map_err(|source| RedefineError::AttributeTypeBadValueType { source })?;
+            .map_err(|source| RedefineError::ValueTypeSymbolResolution { typedb_source: source })?;
 
         let definition_status =
             get_value_type_status(snapshot, type_manager, attribute_type.clone(), value_type.clone())
@@ -388,6 +415,7 @@ fn redefine_value_type(
             attribute_type.clone(),
             &label,
             capability,
+            type_declaration,
         )?;
     }
     Ok(())
@@ -401,6 +429,7 @@ fn redefine_value_type_annotations<'a>(
     attribute_type: AttributeType<'a>,
     attribute_type_label: &Label<'a>,
     typeql_capability: &Capability,
+    typeql_type_declaration: &Type,
 ) -> Result<(), RedefineError> {
     for typeql_annotation in &typeql_capability.annotations {
         let annotation =
@@ -411,16 +440,19 @@ fn redefine_value_type_annotations<'a>(
             attribute_type_label,
             attribute_type.clone(),
             annotation.clone(),
+            typeql_type_declaration,
         )? {
             if !converted.is_value_type_annotation() {
-                return Err(RedefineError::IllegalAnnotation {
+                return Err(RedefineError::IllegalCapabilityAnnotation {
+                    declaration: typeql_capability.clone(),
                     source: AnnotationError::UnsupportedAnnotationForValueType(annotation.category()),
+                    annotation,
                 });
             }
 
             error_if_anything_redefined_else_set_true(anything_redefined)?;
             attribute_type.set_annotation(snapshot, type_manager, thing_manager, converted).map_err(|source| {
-                RedefineError::SetAnnotation { source, label: attribute_type_label.clone().into_owned(), annotation }
+                RedefineError::SetCapabilityAnnotation { declaration: typeql_capability.clone(), annotation, source }
             })?;
         }
     }
@@ -436,7 +468,7 @@ fn redefine_relates(
 ) -> Result<(), RedefineError> {
     let label = Label::parse_from(type_declaration.label.ident.as_str());
     let type_ = resolve_typeql_type(snapshot, type_manager, &label)
-        .map_err(|source| RedefineError::DefinitionResolution { source })?;
+        .map_err(|source| RedefineError::DefinitionResolution { typedb_source: source })?;
     for capability in &type_declaration.capabilities {
         let CapabilityBase::Relates(typeql_relates) = &capability.base else {
             continue;
@@ -446,7 +478,7 @@ fn redefine_relates(
         };
 
         let (role_label, ordering) = type_ref_to_label_and_ordering(&label, &typeql_relates.related)
-            .map_err(|source| RedefineError::DefinitionResolution { source })?;
+            .map_err(|source| RedefineError::DefinitionResolution { typedb_source: source })?;
 
         let definition_status =
             get_relates_status(snapshot, type_manager, relation_type.clone(), &role_label, ordering)
@@ -455,16 +487,21 @@ fn redefine_relates(
             DefinableStatus::DoesNotExist => {
                 return Err(RedefineError::RelatesIsNotDefined {
                     label: label.clone(),
+                    role: role_label.name.to_string(),
                     declaration: capability.to_owned(),
                     ordering,
-                })
+                });
             }
             DefinableStatus::ExistsSame(None) => unreachable!("Existing relates concept expected"),
             DefinableStatus::ExistsSame(Some((existing_relates, _))) => existing_relates, // is not a leaf of redefine query, don't error
             DefinableStatus::ExistsDifferent((existing_relates, _)) => {
                 error_if_anything_redefined_else_set_true(anything_redefined)?;
                 existing_relates.role().set_ordering(snapshot, type_manager, thing_manager, ordering).map_err(
-                    |source| RedefineError::SetRelatesOrdering { source, relates: typeql_relates.to_owned() },
+                    |source| RedefineError::SetRelatesOrdering {
+                        label: label.clone().into_owned(),
+                        declaration: typeql_relates.to_owned(),
+                        source,
+                    },
                 )?;
                 existing_relates
             }
@@ -478,6 +515,7 @@ fn redefine_relates(
             &label,
             relates.clone(),
             capability,
+            type_declaration,
         )?;
         redefine_relates_override(
             snapshot,
@@ -500,6 +538,7 @@ fn redefine_relates_annotations(
     relation_label: &Label<'_>,
     relates: Relates<'static>,
     typeql_capability: &Capability,
+    typeql_type_declaration: &Type,
 ) -> Result<(), RedefineError> {
     for typeql_annotation in &typeql_capability.annotations {
         let annotation =
@@ -510,15 +549,16 @@ fn redefine_relates_annotations(
             relation_label,
             relates.clone(),
             annotation.clone(),
+            typeql_capability,
         );
         match converted_for_relates {
             Ok(Some(relates_annotation)) => {
                 error_if_anything_redefined_else_set_true(anything_redefined)?;
                 relates.set_annotation(snapshot, type_manager, thing_manager, relates_annotation).map_err(
-                    |source| RedefineError::SetAnnotation {
-                        label: relation_label.clone().into_owned(),
-                        source,
+                    |source| RedefineError::SetCapabilityAnnotation {
                         annotation,
+                        declaration: typeql_capability.clone(),
+                        source,
                     },
                 )?;
             }
@@ -530,13 +570,14 @@ fn redefine_relates_annotations(
                     relation_label,
                     relates.role(),
                     annotation.clone(),
+                    typeql_type_declaration,
                 )? {
                     error_if_anything_redefined_else_set_true(anything_redefined)?;
                     relates.role().set_annotation(snapshot, type_manager, thing_manager, converted_for_role).map_err(
-                        |source| RedefineError::SetAnnotation {
-                            label: relation_label.clone().into_owned(),
-                            source,
+                        |source| RedefineError::SetCapabilityAnnotation {
+                            declaration: typeql_capability.clone(),
                             annotation,
+                            source,
                         },
                     )?;
                 }
@@ -558,7 +599,7 @@ fn redefine_relates_override(
     if let Some(overridden_label) = &typeql_relates.overridden {
         let overridden_relates =
             resolve_relates(snapshot, type_manager, relates.relation(), overridden_label.ident.as_str())
-                .map_err(|source| RedefineError::DefinitionResolution { source })?;
+                .map_err(|source| RedefineError::DefinitionResolution { typedb_source: source })?;
 
         check_can_redefine_override(
             snapshot,
@@ -566,11 +607,16 @@ fn redefine_relates_override(
             relation_label,
             relates.clone(),
             overridden_relates.clone(),
+            typeql_relates,
         )?;
         error_if_anything_redefined_else_set_true(anything_redefined)?;
-        relates
-            .set_override(snapshot, type_manager, thing_manager, overridden_relates)
-            .map_err(|source| RedefineError::SetOverride { label: relation_label.clone().into_owned(), source })?;
+        relates.set_override(snapshot, type_manager, thing_manager, overridden_relates).map_err(|source| {
+            RedefineError::SetRelatesOverride {
+                label: relation_label.clone().into_owned(),
+                declaration: typeql_relates.clone(),
+                source,
+            }
+        })?;
     }
     Ok(())
 }
@@ -584,16 +630,16 @@ fn redefine_owns(
 ) -> Result<(), RedefineError> {
     let label = Label::parse_from(type_declaration.label.ident.as_str());
     let type_ = resolve_typeql_type(snapshot, type_manager, &label)
-        .map_err(|source| RedefineError::DefinitionResolution { source })?;
+        .map_err(|source| RedefineError::DefinitionResolution { typedb_source: source })?;
     for capability in &type_declaration.capabilities {
         let CapabilityBase::Owns(typeql_owns) = &capability.base else {
             continue;
         };
 
         let (attr_label, ordering) = type_ref_to_label_and_ordering(&label, &typeql_owns.owned)
-            .map_err(|source| RedefineError::DefinitionResolution { source })?;
+            .map_err(|source| RedefineError::DefinitionResolution { typedb_source: source })?;
         let attribute_type = resolve_attribute_type(snapshot, type_manager, &attr_label)
-            .map_err(|source| RedefineError::DefinitionResolution { source })?;
+            .map_err(|source| RedefineError::DefinitionResolution { typedb_source: source })?;
 
         let object_type =
             type_to_object_type(&type_).map_err(|_| err_unsupported_capability(&label, type_.kind(), capability))?;
@@ -605,17 +651,26 @@ fn redefine_owns(
             DefinableStatus::DoesNotExist => {
                 return Err(RedefineError::OwnsIsNotDefined {
                     label: label.clone(),
+                    attribute: attribute_type
+                        .get_label(snapshot, type_manager)
+                        .map_err(|err| RedefineError::UnexpectedConceptRead { source: err })?
+                        .as_reference()
+                        .into_owned(),
                     declaration: capability.to_owned(),
                     ordering,
-                })
+                });
             }
             DefinableStatus::ExistsSame(None) => unreachable!("Existing owns concept expected"),
             DefinableStatus::ExistsSame(Some((existing_owns, _))) => existing_owns, // is not a leaf of redefine query, don't error
             DefinableStatus::ExistsDifferent((existing_owns, _)) => {
                 error_if_anything_redefined_else_set_true(anything_redefined)?;
-                existing_owns
-                    .set_ordering(snapshot, type_manager, thing_manager, ordering)
-                    .map_err(|source| RedefineError::SetOwnsOrdering { owns: typeql_owns.clone(), source })?;
+                existing_owns.set_ordering(snapshot, type_manager, thing_manager, ordering).map_err(|source| {
+                    RedefineError::SetOwnsOrdering {
+                        label: label.clone().into_owned(),
+                        declaration: typeql_owns.clone(),
+                        source,
+                    }
+                })?;
                 existing_owns
             }
         };
@@ -652,10 +707,11 @@ fn redefine_owns_annotations(
             owner_label,
             owns.clone(),
             annotation.clone(),
+            typeql_capability,
         )? {
             error_if_anything_redefined_else_set_true(anything_redefined)?;
             owns.set_annotation(snapshot, type_manager, thing_manager, converted).map_err(|source| {
-                RedefineError::SetAnnotation { label: owner_label.clone().into_owned(), source, annotation }
+                RedefineError::SetCapabilityAnnotation { declaration: typeql_capability.clone(), annotation, source }
             })?;
         }
     }
@@ -674,14 +730,20 @@ fn redefine_owns_override(
     if let Some(overridden_label) = &typeql_owns.overridden {
         let overridden_label = Label::parse_from(overridden_label.ident.as_str());
         let overridden_attribute_type = resolve_attribute_type(snapshot, type_manager, &overridden_label)
-            .map_err(|source| RedefineError::DefinitionResolution { source })?;
+            .map_err(|source| RedefineError::DefinitionResolution { typedb_source: source })?;
         let overridden_owns = resolve_owns(snapshot, type_manager, owns.owner(), overridden_attribute_type)
-            .map_err(|source| RedefineError::DefinitionResolution { source })?;
+            .map_err(|source| RedefineError::DefinitionResolution { typedb_source: source })?;
 
-        check_can_redefine_override(snapshot, type_manager, owner_label, owns.clone(), overridden_owns.clone())?;
+        check_can_redefine_override(snapshot, type_manager, owner_label, owns.clone(), overridden_owns.clone(), todo!())?;
         error_if_anything_redefined_else_set_true(anything_redefined)?;
-        owns.set_override(snapshot, type_manager, thing_manager, overridden_owns)
-            .map_err(|source| RedefineError::SetOverride { label: owner_label.clone().into_owned(), source })?
+        owns.set_override(snapshot, type_manager, thing_manager, overridden_owns).map_err(|source| {
+            RedefineError::SetRelatesOverride {
+                // TODO: this should happen after merge
+                label: owner_label.clone().into_owned(),
+                declaration: todo!(),
+                source,
+            }
+        })?
     }
     Ok(())
 }
@@ -695,7 +757,7 @@ fn redefine_plays(
 ) -> Result<(), RedefineError> {
     let label = Label::parse_from(type_declaration.label.ident.as_str());
     let type_ = resolve_typeql_type(snapshot, type_manager, &label)
-        .map_err(|source| RedefineError::DefinitionResolution { source })?;
+        .map_err(|source| RedefineError::DefinitionResolution { typedb_source: source })?;
     for capability in &type_declaration.capabilities {
         let CapabilityBase::Plays(typeql_plays) = &capability.base else {
             continue;
@@ -704,7 +766,7 @@ fn redefine_plays(
         let role_label =
             Label::build_scoped(typeql_plays.role.name.ident.as_str(), typeql_plays.role.scope.ident.as_str());
         let role_type = resolve_role_type(snapshot, type_manager, &role_label)
-            .map_err(|source| RedefineError::DefinitionResolution { source })?;
+            .map_err(|source| RedefineError::DefinitionResolution { typedb_source: source })?;
 
         let object_type =
             type_to_object_type(&type_).map_err(|_| err_unsupported_capability(&label, type_.kind(), capability))?;
@@ -715,8 +777,13 @@ fn redefine_plays(
             DefinableStatus::DoesNotExist => {
                 return Err(RedefineError::PlaysIsNotDefined {
                     label: label.clone(),
+                    role_label: role_type
+                        .get_label(snapshot, type_manager)
+                        .map_err(|err| RedefineError::UnexpectedConceptRead { source: err })?
+                        .as_reference()
+                        .into_owned(),
                     declaration: capability.to_owned(),
-                })
+                });
             }
             DefinableStatus::ExistsSame(Some(existing_plays)) => existing_plays,
             DefinableStatus::ExistsSame(None) => unreachable!("Existing plays concept expected"),
@@ -763,10 +830,11 @@ fn redefine_plays_annotations(
             player_label,
             plays.clone(),
             annotation.clone(),
+            typeql_capability,
         )? {
             error_if_anything_redefined_else_set_true(anything_redefined)?;
             plays.set_annotation(snapshot, type_manager, thing_manager, converted).map_err(|source| {
-                RedefineError::SetAnnotation { label: player_label.clone().into_owned(), source, annotation }
+                RedefineError::SetCapabilityAnnotation { declaration: todo!(), annotation, source }
             })?;
         }
     }
@@ -784,15 +852,20 @@ fn redefine_plays_override(
 ) -> Result<(), RedefineError> {
     if let Some(overridden_type_name) = &typeql_plays.overridden {
         let overridden_label = named_type_to_label(overridden_type_name)
-            .map_err(|source| RedefineError::DefinitionResolution { source })?;
+            .map_err(|source| RedefineError::DefinitionResolution { typedb_source: source })?;
         let overridden_plays = resolve_plays_role_label(snapshot, type_manager, plays.player(), &overridden_label)
-            .map_err(|source| RedefineError::DefinitionResolution { source })?;
+            .map_err(|source| RedefineError::DefinitionResolution { typedb_source: source })?;
 
-        check_can_redefine_override(snapshot, type_manager, player_label, plays.clone(), overridden_plays.clone())?;
+        check_can_redefine_override(snapshot, type_manager, player_label, plays.clone(), overridden_plays.clone(), todo!())?;
         error_if_anything_redefined_else_set_true(anything_redefined)?;
-        plays
-            .set_override(snapshot, type_manager, thing_manager, overridden_plays)
-            .map_err(|source| RedefineError::SetOverride { label: player_label.clone().into_owned(), source })?
+        plays.set_override(snapshot, type_manager, thing_manager, overridden_plays).map_err(|source| {
+            RedefineError::SetRelatesOverride {
+                // TODO: this should be removed after merge
+                label: player_label.clone().into_owned(),
+                declaration: todo!(),
+                source,
+            }
+        })?;
     }
     Ok(())
 }
@@ -803,7 +876,7 @@ fn redefine_functions(
     anything_redefined: &mut bool,
     function_declaration: &Function,
 ) -> Result<(), RedefineError> {
-    Err(RedefineError::Unimplemented)
+    Err(RedefineError::Unimplemented { description: "Function redefinition.".to_string() })
 }
 
 fn check_can_redefine_sub<'a, T: TypeAPI<'a>>(
@@ -818,14 +891,14 @@ fn check_can_redefine_sub<'a, T: TypeAPI<'a>>(
     match definition_status {
         DefinableStatus::DoesNotExist => Err(RedefineError::TypeSubIsNotDefined {
             label: label.clone().into_owned(),
-            supertype: new_supertype
+            new_supertype_label: new_supertype
                 .get_label_cloned(snapshot, type_manager)
                 .map_err(|source| RedefineError::UnexpectedConceptRead { source })?
                 .into_owned(),
         }),
         DefinableStatus::ExistsSame(_) => Err(RedefineError::TypeSubRemainsSame {
             label: label.clone().into_owned(),
-            supertype: new_supertype
+            supertype_label: new_supertype
                 .get_label_cloned(snapshot, type_manager)
                 .map_err(|source| RedefineError::UnexpectedConceptRead { source })?
                 .into_owned(),
@@ -840,25 +913,28 @@ fn check_can_redefine_override<'a, CAP: concept::type_::Capability<'a>>(
     label: &Label<'a>,
     capability: CAP,
     new_override: CAP,
+    typeql_relates: &TypeQLRelates,
 ) -> Result<(), RedefineError> {
-    let definition_status = get_override_status(snapshot, type_manager, capability, new_override.clone())
+    let definition_status = get_override_status(snapshot, type_manager, &capability, new_override.clone())
         .map_err(|source| RedefineError::UnexpectedConceptRead { source })?;
     match definition_status {
         DefinableStatus::DoesNotExist => Err(RedefineError::CapabilityOverrideIsNotDefined {
             label: label.clone().into_owned(),
-            overridden_interface: new_override
+            new_override_type: new_override
                 .interface()
                 .get_label_cloned(snapshot, type_manager)
                 .map_err(|source| RedefineError::UnexpectedConceptRead { source })?
                 .into_owned(),
+            declaration: typeql_relates.clone()
         }),
         DefinableStatus::ExistsSame(_) => Err(RedefineError::CapabilityOverrideRemainsSame {
             label: label.clone().into_owned(),
-            overridden_interface: new_override
+            overridden_label: new_override
                 .interface()
                 .get_label_cloned(snapshot, type_manager)
                 .map_err(|source| RedefineError::UnexpectedConceptRead { source })?
                 .into_owned(),
+            declaration: typeql_relates.clone()
         }),
         DefinableStatus::ExistsDifferent(_) => Ok(()),
     }
@@ -870,11 +946,17 @@ fn type_convert_and_validate_annotation_redefinition_need<'a, T: KindAPI<'a>>(
     label: &Label<'a>,
     type_: T,
     annotation: Annotation,
+    typeql_declaration: &Type,
 ) -> Result<Option<T::AnnotationType>, RedefineError> {
     error_if_not_redefinable(label, annotation.clone())?;
 
-    let converted = T::AnnotationType::try_from(annotation.clone())
-        .map_err(|source| RedefineError::IllegalAnnotation { source })?;
+    let converted =
+        T::AnnotationType::try_from(annotation.clone()).map_err(|source| RedefineError::IllegalTypeAnnotation {
+            label: label.as_reference().into_owned(),
+            annotation: annotation.clone(),
+            declaration: typeql_declaration.clone(),
+            source,
+        })?;
 
     let definition_status =
         get_type_annotation_status(snapshot, type_manager, type_, &converted, annotation.category())
@@ -896,21 +978,27 @@ fn capability_convert_and_validate_annotation_redefinition_need<'a, CAP: concept
     label: &Label<'a>,
     capability: CAP,
     annotation: Annotation,
+    typeql_capability: &Capability,
 ) -> Result<Option<CAP::AnnotationType>, RedefineError> {
     error_if_not_redefinable(label, annotation.clone())?;
 
-    let converted = CAP::AnnotationType::try_from(annotation.clone())
-        .map_err(|source| RedefineError::IllegalAnnotation { source })?;
+    let converted = CAP::AnnotationType::try_from(annotation.clone()).map_err(|source| {
+        RedefineError::IllegalCapabilityAnnotation {
+            declaration: typeql_capability.clone(),
+            annotation: annotation.clone(),
+            source,
+        }
+    })?;
 
     let definition_status =
-        get_capability_annotation_status(snapshot, type_manager, capability, &converted, annotation.category())
+        get_capability_annotation_status(snapshot, type_manager, &capability, &converted, annotation.category())
             .map_err(|source| RedefineError::UnexpectedConceptRead { source })?;
     match definition_status {
         DefinableStatus::DoesNotExist => {
-            Err(RedefineError::CapabilityAnnotationIsNotDefined { label: label.clone().into_owned(), annotation })
+            Err(RedefineError::CapabilityAnnotationIsNotDefined { declaration: typeql_capability.clone(), annotation })
         }
         DefinableStatus::ExistsSame(_) => {
-            Err(RedefineError::CapabilityAnnotationRemainsSame { label: label.clone().into_owned(), annotation })
+            Err(RedefineError::CapabilityAnnotationRemainsSame { declaration: typeql_capability.clone(), annotation })
         }
         DefinableStatus::ExistsDifferent(_) => Ok(Some(converted)),
     }
@@ -918,24 +1006,27 @@ fn capability_convert_and_validate_annotation_redefinition_need<'a, CAP: concept
 
 fn error_if_not_redefinable(label: &Label<'_>, annotation: Annotation) -> Result<(), RedefineError> {
     match annotation.category().has_parameter() {
-        false => Err(RedefineError::AnnotationCannotBeRedefined { label: label.clone().into_owned(), annotation }),
+        false => Err(RedefineError::ParameterFreeAnnotationCannotBeRedefined {
+            label: label.clone().into_owned(),
+            annotation,
+        }),
         true => Ok(()),
     }
 }
 
 fn err_capability_kind_mismatch(
-    capability_receiver: &Label<'_>,
-    capability_provider: &Label<'_>,
+    left: &Label<'_>,
+    right: &Label<'_>,
     capability: &Capability,
-    expected_kind: Kind,
-    actual_kind: Kind,
+    left_kind: Kind,
+    right_kind: Kind,
 ) -> RedefineError {
     RedefineError::CapabilityKindMismatch {
-        capability_receiver: capability_receiver.clone().into_owned(),
-        capability_provider: capability_provider.clone().into_owned(),
-        capability: capability.clone(),
-        expected_kind,
-        actual_kind,
+        left: left.clone().into_owned(),
+        right: right.clone().into_owned(),
+        left_kind,
+        right_kind,
+        declaration: capability.clone(),
     }
 }
 
@@ -948,144 +1039,347 @@ fn error_if_anything_redefined_else_set_true(anything_redefined: &mut bool) -> R
         }
     }
 }
+//
+// #[derive(Debug, Clone)]
+// pub enum RedefineError {
+//     Unimplemented,
+//     UnexpectedConceptRead {
+//         source: ConceptReadError,
+//     },
+//     DefinitionResolution {
+//         source: SymbolResolutionError,
+//     },
+//     LiteralParseError {
+//         source: LiteralParseError,
+//     },
+//     CanOnlyRedefineOneThingPerQuery {},
+//     RedefinedNothing {},
+//     StructFieldDoesNotExist {
+//         field: Field,
+//     },
+//     StructFieldRemainsSame {
+//         field: Field,
+//     },
+//     StructFieldDeleteError {
+//         source: ConceptWriteError,
+//         struct_name: String,
+//         struct_field: Field,
+//     },
+//     StructFieldCreateError {
+//         source: ConceptWriteError,
+//         struct_name: String,
+//         struct_field: Field,
+//     },
+//     SetSupertype {
+//         sub: typeql::schema::definable::type_::capability::Sub,
+//         source: ConceptWriteError,
+//     },
+//     TypeCannotHaveCapability {
+//         label: Label<'static>,
+//         kind: Kind,
+//         capability: Capability,
+//     },
+//     AttributeTypeBadValueType {
+//         source: SymbolResolutionError,
+//     },
+//     TypeSubIsNotDefined {
+//         label: Label<'static>,
+//         supertype: Label<'static>,
+//     },
+//     TypeSubRemainsSame {
+//         label: Label<'static>,
+//         supertype: Label<'static>,
+//     },
+//     RelatesIsNotDefined {
+//         label: Label<'static>,
+//         declaration: Capability,
+//         ordering: Ordering,
+//     },
+//     OwnsIsNotDefined {
+//         label: Label<'static>,
+//         declaration: Capability,
+//         ordering: Ordering,
+//     },
+//     PlaysIsNotDefined {
+//         label: Label<'static>,
+//         declaration: Capability,
+//     },
+//     CapabilityOverrideIsNotDefined {
+//         label: Label<'static>,
+//         overridden_interface: Label<'static>,
+//     },
+//     CapabilityOverrideRemainsSame {
+//         label: Label<'static>,
+//         overridden_interface: Label<'static>,
+//     },
+//     AttributeTypeValueTypeIsNotDefined {
+//         label: Label<'static>,
+//         value_type: ValueType,
+//     },
+//     AttributeTypeValueTypeRemainsSame {
+//         label: Label<'static>,
+//         value_type: ValueType,
+//     },
+//     // Careful with the error message as it is also used for value types (stored on their attribute type)!
+//     TypeAnnotationIsNotDefined {
+//         label: Label<'static>,
+//         annotation: Annotation,
+//     },
+//     TypeAnnotationRemainsSame {
+//         label: Label<'static>,
+//         annotation: Annotation,
+//     },
+//     CapabilityAnnotationIsNotDefined {
+//         label: Label<'static>,
+//         annotation: Annotation,
+//     },
+//     CapabilityAnnotationRemainsSame {
+//         label: Label<'static>,
+//         annotation: Annotation,
+//     },
+//     AnnotationCannotBeRedefined {
+//         label: Label<'static>,
+//         annotation: Annotation,
+//     },
+//     SetValueType {
+//         label: Label<'static>,
+//         value_type: ValueType,
+//         source: ConceptWriteError,
+//     },
+//     SetRelatesOrdering {
+//         relates: TypeQLRelates,
+//         source: ConceptWriteError,
+//     },
+//     SetOwnsOrdering {
+//         owns: TypeQLOwns,
+//         source: ConceptWriteError,
+//     },
+//     IllegalAnnotation {
+//         source: AnnotationError,
+//     },
+//     SetAnnotation {
+//         source: ConceptWriteError,
+//         label: Label<'static>,
+//         annotation: Annotation,
+//     },
+//     SetOverride {
+//         source: ConceptWriteError,
+//         label: Label<'static>,
+//     },
+//     CapabilityKindMismatch {
+//         capability_receiver: Label<'static>,
+//         capability_provider: Label<'static>,
+//         capability: Capability,
+//         expected_kind: Kind,
+//         actual_kind: Kind,
+//     },
+// }
 
-#[derive(Debug)]
-pub enum RedefineError {
-    Unimplemented,
-    UnexpectedConceptRead {
-        source: ConceptReadError,
-    },
-    DefinitionResolution {
-        source: SymbolResolutionError,
-    },
-    LiteralParseError {
-        source: LiteralParseError,
-    },
-    CanOnlyRedefineOneThingPerQuery {},
-    RedefinedNothing {},
-    StructFieldDoesNotExist {
-        field: Field,
-    },
-    StructFieldRemainsSame {
-        field: Field,
-    },
-    StructFieldDeleteError {
-        source: ConceptWriteError,
-        struct_name: String,
-        struct_field: Field,
-    },
-    StructFieldCreateError {
-        source: ConceptWriteError,
-        struct_name: String,
-        struct_field: Field,
-    },
-    SetSupertype {
-        sub: typeql::schema::definable::type_::capability::Sub,
-        source: ConceptWriteError,
-    },
-    TypeCannotHaveCapability {
-        label: Label<'static>,
-        kind: Kind,
-        capability: Capability,
-    },
-    AttributeTypeBadValueType {
-        source: SymbolResolutionError,
-    },
-    TypeSubIsNotDefined {
-        label: Label<'static>,
-        supertype: Label<'static>,
-    },
-    TypeSubRemainsSame {
-        label: Label<'static>,
-        supertype: Label<'static>,
-    },
-    RelatesIsNotDefined {
-        label: Label<'static>,
-        declaration: Capability,
-        ordering: Ordering,
-    },
-    OwnsIsNotDefined {
-        label: Label<'static>,
-        declaration: Capability,
-        ordering: Ordering,
-    },
-    PlaysIsNotDefined {
-        label: Label<'static>,
-        declaration: Capability,
-    },
-    CapabilityOverrideIsNotDefined {
-        label: Label<'static>,
-        overridden_interface: Label<'static>,
-    },
-    CapabilityOverrideRemainsSame {
-        label: Label<'static>,
-        overridden_interface: Label<'static>,
-    },
-    AttributeTypeValueTypeIsNotDefined {
-        label: Label<'static>,
-        value_type: ValueType,
-    },
-    AttributeTypeValueTypeRemainsSame {
-        label: Label<'static>,
-        value_type: ValueType,
-    },
-    // Careful with the error message as it is also used for value types (stored on their attribute type)!
-    TypeAnnotationIsNotDefined {
-        label: Label<'static>,
-        annotation: Annotation,
-    },
-    TypeAnnotationRemainsSame {
-        label: Label<'static>,
-        annotation: Annotation,
-    },
-    CapabilityAnnotationIsNotDefined {
-        label: Label<'static>,
-        annotation: Annotation,
-    },
-    CapabilityAnnotationRemainsSame {
-        label: Label<'static>,
-        annotation: Annotation,
-    },
-    AnnotationCannotBeRedefined {
-        label: Label<'static>,
-        annotation: Annotation,
-    },
-    SetValueType {
-        label: Label<'static>,
-        value_type: ValueType,
-        source: ConceptWriteError,
-    },
-    SetRelatesOrdering {
-        relates: TypeQLRelates,
-        source: ConceptWriteError,
-    },
-    SetOwnsOrdering {
-        owns: TypeQLOwns,
-        source: ConceptWriteError,
-    },
-    IllegalAnnotation {
-        source: AnnotationError,
-    },
-    SetAnnotation {
-        source: ConceptWriteError,
-        label: Label<'static>,
-        annotation: Annotation,
-    },
-    SetOverride {
-        source: ConceptWriteError,
-        label: Label<'static>,
-    },
-    CapabilityKindMismatch {
-        capability_receiver: Label<'static>,
-        capability_provider: Label<'static>,
-        capability: Capability,
-        expected_kind: Kind,
-        actual_kind: Kind,
-    },
-}
+typedb_error!(
+    pub RedefineError(domain = "Redefine", prefix = "RDF") {
+        Unimplemented(1, "Unimplemented redefine functionality: {description}", description: String),
+        UnexpectedConceptRead(2, "Concept read error during redefine query execution.", ( source: ConceptReadError )),
+        NothingRedefined(3, "Nothing was redefined."),
+        DefinitionResolution(4, "Could not find symbol in redefine query.", ( typedb_source: SymbolResolutionError )),
+        LiteralParseError(5, "Error parsing literal in redefine query.", ( source : LiteralParseError )),
+        CanOnlyRedefineOneThingPerQuery(6, "Redefine queries can currently only mutate exactly one schema element per query."),
+        StructFieldDoesNotExist(7, "Struct field used in redefine query does not exist.\nSource:\n{declaration}", declaration: Field),
+        StructFieldRemainsSame(8, "Struct field in redefine was not changed. Redefine queries are required to update the schema.\nSource:\n{declaration}", declaration: Field),
+        StructFieldDeleteError(
+            9,
+            "Error removing field from struct type '{struct_name}'.\nSource:\n{declaration}",
+            struct_name: String,
+            declaration: Field,
+            ( source: ConceptWriteError )
+        ),
+        StructFieldCreateError(
+            10,
+            "Error creating new field in struct type '{struct_name}'.\nSource:\n{declaration}",
+            struct_name: String,
+            declaration: Field,
+            ( source: ConceptWriteError )
+        ),
+        SetSupertype(
+            11,
+            "Error setting supertype during redefine.\nSource:\n{declaration}",
+            declaration: typeql::schema::definable::type_::capability::Sub,
+            ( source: ConceptWriteError )
+        ),
+        TypeCannotHaveCapability(
+            12,
+            "Invalid redefine - the type '{label}' of kind '{kind}', which is not allowed to declare:\n'{declaration}'",
+            label: Label<'static>,
+            kind: Kind,
+            declaration: Capability
+        ),
+        ValueTypeSymbolResolution(
+            13,
+            "Error resolving value type in redefine query.",
+            ( typedb_source: SymbolResolutionError )
+        ),
+        TypeSubIsNotDefined(
+            14,
+            "Redefining the supertype of '{label}' to '{new_supertype_label}' failed, since there is no supertype to replace. Use define to set instead of replace the supertype.",
+            label: Label<'static>,
+            new_supertype_label: Label<'static>
+        ),
+        TypeSubRemainsSame(
+            15,
+            "Redefining the supertype of '{label}' to '{supertype_label}' failed, since this is already the supertype. Redefine can only replace existing schema elements.",
+            label: Label<'static>,
+            supertype_label: Label<'static>
+        ),
+        RelatesIsNotDefined(
+            16,
+            "On type '{label}', redefining 'relates {role}{ordering}' failed since it this 'relates' doesn't yet exist. Redefine can only replace existing schema elements.\nSource:\n{declaration}",
+            label: Label<'static>,
+            role: String,
+            ordering: Ordering,
+            declaration: Capability
+        ),
+        OwnsIsNotDefined(
+            17,
+            "On type '{label}', redefining 'owns {attribute}{ordering}' failed since this 'owns' doesn't exist yet. Redefine can only replace existing schema elements.\nSource:\n{declaration}",
+            label: Label<'static>,
+            attribute: Label<'static>,
+            declaration: Capability,
+            ordering: Ordering
+        ),
+        PlaysIsNotDefined(
+            18,
+            "On type '{label}', redefining 'plays {role_label}' failed since this 'plays' doesn't exist yet. Redefine can only replace existing schema elements.\nSource:\n{declaration}",
+            label: Label<'static>,
+            role_label: Label<'static>,
+            declaration: Capability
+        ),
+        CapabilityOverrideIsNotDefined(
+            19,
+            "For type '{label}', redefining override 'as {new_override_type}' failed as no override exists yet. Redefine can only replace existing schema elements.\nSource:\n{declaration}",
+            label: Label<'static>,
+            new_override_type: Label<'static>,
+            declaration: TypeQLRelates
+        ),
+        CapabilityOverrideRemainsSame(
+            20,
+            "For type '{label}', redefining override 'as {overridden_label}' failed since this override already exists. Redefine can only replace existing schema elements.\nSource:\n{declaration}",
+            label: Label<'static>,
+            overridden_label: Label<'static>,
+            declaration: TypeQLRelates
+        ),
+        AttributeTypeValueTypeIsNotDefined(
+            21,
+            "For attribute type '{label}', redefining value type '{value_type}' failed since no value type exists yet. Redefine can only replace existing schema elements.",
+            label: Label<'static>,
+            value_type: ValueType
+        ),
+        AttributeTypeValueTypeRemainsSame(
+            22,
+            "For attribute type '{label}', redefining value type '{value_type}' failed since this value type already exists. Redefine can only replace existing schema elements.",
+            label: Label<'static>,
+            value_type: ValueType
+        ),
+        TypeAnnotationIsNotDefined(
+            23,
+            "For type '{label}', redefining annotation '{annotation}' failed since this annotation doesn't exist yet. Redefine can only replace existing schema elements.",
+            label: Label<'static>,
+            annotation: Annotation
+        ),
+        TypeAnnotationRemainsSame(
+            24,
+            "For type '{label}', redefining annotation '{annotation}' failed since this annotation already exist identically. Redefine can only replace existing schema elements.",
+            label: Label<'static>,
+            annotation: Annotation
+        ),
+        CapabilityAnnotationIsNotDefined(
+            25,
+            "Redefining annotation '{annotation}' failed since this annotation doesn't exist yet. Redefine can only replace existing schema elements.\nSource:\n{declaration}",
+            declaration: Capability,
+            annotation: Annotation
+        ),
+        CapabilityAnnotationRemainsSame(
+            26,
+            "Redefining annotation '{annotation}' failed since this annotation exists identically. Redefine can only replace existing schema elements.\nSource:\n{declaration}",
+            declaration: Capability,
+            annotation: Annotation
+        ),
+        ParameterFreeAnnotationCannotBeRedefined(
+            27,
+            "For type '{label}', annotation '{annotation}' can never be redefined as it carries no parameters. Redefine can only replace existing schema elements.",
+            label: Label<'static>,
+            annotation: Annotation
+        ),
+        SetValueType(
+            28,
+            "Redefining '{label}' to have value type '{value_type}' failed.",
+            label: Label<'static>,
+            value_type: ValueType,
+            ( source: ConceptWriteError )
+        ),
+        SetRelatesOrdering(
+            29,
+            "Redefining '{label}' to have an updated 'relates' ordering failed.\nSource:\n{declaration}",
+            label: Label<'static>,
+            declaration: TypeQLRelates,
+            ( source: ConceptWriteError )
+        ),
+        SetOwnsOrdering(
+            30,
+            "Redefining '{label}' to have an updated 'owns' ordering failed.\nSource:\n{declaration}",
+            label: Label<'static>,
+            declaration: TypeQLOwns,
+            ( source: ConceptWriteError )
+        ),
+        IllegalTypeAnnotation(
+            31,
+            "Redefining '{label}' to have annotation '{annotation}' failed as this is an illegal annotation.\nSource:\n:{declaration}",
+            label: Label<'static>,
+            annotation: Annotation,
+            declaration: Type,
+            ( source: AnnotationError )
+        ),
+        IllegalCapabilityAnnotation(
+            32,
+            "Redefining to have annotation '{annotation}' failed.\nSource:\n{declaration}",
+            annotation: Annotation,
+            declaration: Capability,
+            ( source: AnnotationError )
+        ),
+        SetTypeAnnotation(
+            33,
+            "Redefining '{label}' to have annotation '{annotation}' failed.\nSource:\n{declaration}",
+            label: Label<'static>,
+            annotation: Annotation,
+            declaration: Type,
+            ( source: ConceptWriteError )
+        ),
+        SetCapabilityAnnotation(
+            34,
+            "Redefining '{annotation}' failed.\nSource:\n{declaration}",
+            annotation: Annotation,
+            declaration: Capability,
+            ( source: ConceptWriteError )
+        ),
+        SetRelatesOverride(
+            35,
+            "For relation type '{label}', redefining 'relates' failed.\nSource:\n{declaration}",
+            label: Label<'static>,
+            declaration: TypeQLRelates,
+            ( source: ConceptWriteError )
+        ),
+        CapabilityKindMismatch(
+            36,
+            "Redefine failed because the left type '{left}' is of kind '{left_kind}' isn't the same kind as the right type '{right}' which has kind '{right_kind}'.\nSource:\n{declaration}",
+            left: Label<'static>,
+            right: Label<'static>,
+            left_kind: Kind,
+            right_kind: Kind,
+            declaration: Capability
+        ),
+    }
+);
 
 fn err_unsupported_capability(label: &Label<'static>, kind: Kind, capability: &Capability) -> RedefineError {
-    RedefineError::TypeCannotHaveCapability { label: label.to_owned(), kind, capability: capability.clone() }
+    RedefineError::TypeCannotHaveCapability { label: label.to_owned(), kind, declaration: capability.clone() }
 }
 
 impl fmt::Display for RedefineError {

--- a/query/translation.rs
+++ b/query/translation.rs
@@ -58,7 +58,7 @@ pub(super) fn translate_pipeline(
         .iter()
         .map(|preamble| translate_function(&all_function_signatures, &preamble.function))
         .collect::<Result<Vec<_>, _>>()
-        .map_err(|source| QueryError::FunctionDefinition { source })?;
+        .map_err(|source| QueryError::FunctionDefinition { typedb_source: source })?;
 
     let mut translation_context = TranslationContext::new();
     let mut translated_stages: Vec<TranslatedStage> = Vec::with_capacity(query.stages.len());

--- a/query/translation.rs
+++ b/query/translation.rs
@@ -88,5 +88,5 @@ fn translate_stage(
             .map(|(block, deleted_variables)| TranslatedStage::Delete { block, deleted_variables }),
         _ => todo!(),
     }
-    .map_err(|source| QueryError::PatternDefinition { source })
+    .map_err(|source| QueryError::PatternDefinition { typedb_source: source })
 }

--- a/query/undefine.rs
+++ b/query/undefine.rs
@@ -4,9 +4,8 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-use std::{error::Error, fmt};
-
 use concept::{thing::thing_manager::ThingManager, type_::type_manager::TypeManager};
+use error::typedb_error;
 use storage::snapshot::WritableSnapshot;
 use typeql::query::schema::Undefine;
 
@@ -16,22 +15,11 @@ pub(crate) fn execute(
     thing_manager: &ThingManager,
     undefine: Undefine,
 ) -> Result<(), UndefineError> {
-    todo!()
+    Err(UndefineError::Unimplemented { description: "Undefine queries are not yet implemented.".to_string() })
 }
 
-#[derive(Debug)]
-pub enum UndefineError {
-    Unimplemented,
-}
-
-impl fmt::Display for UndefineError {
-    fn fmt(&self, _: &mut fmt::Formatter<'_>) -> fmt::Result {
-        todo!()
+typedb_error!(
+    pub UndefineError(domain = "Undefine", prefix = "UDF") {
+        Unimplemented(1, "Unimplemented undefine functionality: {description}", description: String),
     }
-}
-
-impl Error for UndefineError {
-    fn source(&self) -> Option<&(dyn Error + 'static)> {
-        todo!()
-    }
-}
+);

--- a/server/service/mod.rs
+++ b/server/service/mod.rs
@@ -6,6 +6,7 @@
 
 mod answer;
 mod error;
+mod response_builders;
 pub(crate) mod transaction_service;
 pub(crate) mod typedb_service;
 

--- a/server/service/response_builders.rs
+++ b/server/service/response_builders.rs
@@ -1,0 +1,165 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+use uuid::Uuid;
+
+pub(crate) fn query_res_ok_empty() -> typedb_protocol::query::res::ok::Ok {
+    typedb_protocol::query::res::ok::Ok::Empty(typedb_protocol::query::res::ok::Empty {})
+}
+
+pub(crate) fn query_res_ok_values(
+    values: Vec<typedb_protocol::query::res::ok::values::OptionalValue>,
+) -> typedb_protocol::query::res::ok::Ok {
+    typedb_protocol::query::res::ok::Ok::Values(typedb_protocol::query::res::ok::Values { values })
+}
+
+pub(crate) fn query_res_ok_concept_row_stream(
+    column_variable_names: Vec<String>,
+) -> typedb_protocol::query::res::ok::Ok {
+    typedb_protocol::query::res::ok::Ok::ConceptMapStream(typedb_protocol::query::res::ok::AnswerRowStream {
+        column_variable_names,
+    })
+}
+
+pub(crate) fn query_res_ok_readable_concept_tree_stream() -> typedb_protocol::query::res::ok::Ok {
+    typedb_protocol::query::res::ok::Ok::ReadableConceptTreeStream(
+        typedb_protocol::query::res::ok::ReadableConceptTreeStream {},
+    )
+}
+
+pub(crate) fn query_res_ok_from_query_res_ok_ok(
+    message: typedb_protocol::query::res::ok::Ok,
+) -> typedb_protocol::query::res::Ok {
+    typedb_protocol::query::res::Ok { ok: Some(message) }
+}
+
+pub(crate) fn query_res_from_query_res_ok(message: typedb_protocol::query::res::Ok) -> typedb_protocol::query::Res {
+    typedb_protocol::query::Res { res: Some(typedb_protocol::query::res::Res::Ok(message)) }
+}
+
+pub(crate) fn query_res_from_error(error: typedb_protocol::Error) -> typedb_protocol::query::Res {
+    typedb_protocol::query::Res { res: Some(typedb_protocol::query::res::Res::Error(error)) }
+}
+
+pub(crate) fn query_res_part_from_res_part_res(
+    message: typedb_protocol::query::res_part::res::Res,
+) -> typedb_protocol::query::res_part::Res {
+    typedb_protocol::query::res_part::Res { res: Some(message) }
+}
+
+pub(crate) fn query_res_part_from_concept_tree() {
+    todo!()
+}
+
+pub(crate) fn query_res_part_from_parts(
+    messages: Vec<typedb_protocol::query::res_part::Res>,
+) -> typedb_protocol::query::ResPart {
+    typedb_protocol::query::ResPart { res: messages }
+}
+
+// -----------
+
+#[inline]
+fn transaction_res_part_query_res_part_parts(
+    messages: Vec<typedb_protocol::query::res_part::Res>,
+) -> typedb_protocol::transaction::res_part::ResPart {
+    typedb_protocol::transaction::res_part::ResPart::QueryRes(typedb_protocol::query::ResPart { res: messages })
+}
+
+#[inline]
+fn transaction_res_part_res_part_stream_signal_done() -> typedb_protocol::transaction::res_part::ResPart {
+    typedb_protocol::transaction::res_part::ResPart::StreamRes(typedb_protocol::transaction::stream_signal::ResPart {
+        state: Some(typedb_protocol::transaction::stream_signal::res_part::State::Done(
+            typedb_protocol::transaction::stream_signal::res_part::Done {},
+        )),
+    })
+}
+
+#[inline]
+fn transaction_res_part_res_part_stream_signal_continue() -> typedb_protocol::transaction::res_part::ResPart {
+    typedb_protocol::transaction::res_part::ResPart::StreamRes(typedb_protocol::transaction::stream_signal::ResPart {
+        state: Some(typedb_protocol::transaction::stream_signal::res_part::State::Continue(
+            typedb_protocol::transaction::stream_signal::res_part::Continue {},
+        )),
+    })
+}
+
+#[inline]
+fn transaction_res_part_res_part_stream_signal_error(
+    error_message: typedb_protocol::Error,
+) -> typedb_protocol::transaction::res_part::ResPart {
+    typedb_protocol::transaction::res_part::ResPart::StreamRes(typedb_protocol::transaction::stream_signal::ResPart {
+        state: Some(typedb_protocol::transaction::stream_signal::res_part::State::Error(error_message)),
+    })
+}
+
+#[inline]
+pub(crate) fn transaction_res_query_res(
+    message: typedb_protocol::query::res::Res,
+) -> typedb_protocol::transaction::res::Res {
+    typedb_protocol::transaction::res::Res::QueryRes(typedb_protocol::query::Res { res: Some(message) })
+}
+
+#[inline]
+fn transaction_server_res(
+    req_id: Uuid,
+    message: typedb_protocol::transaction::res::Res,
+) -> typedb_protocol::transaction::Server {
+    typedb_protocol::transaction::Server {
+        server: Some(typedb_protocol::transaction::server::Server::Res(typedb_protocol::transaction::Res {
+            req_id: req_id.as_bytes().to_vec(),
+            res: Some(message),
+        })),
+    }
+}
+
+#[inline]
+fn transaction_server_res_part(
+    req_id: Uuid,
+    message: typedb_protocol::transaction::res_part::ResPart,
+) -> typedb_protocol::transaction::Server {
+    typedb_protocol::transaction::Server {
+        server: Some(typedb_protocol::transaction::server::Server::ResPart(typedb_protocol::transaction::ResPart {
+            req_id: req_id.as_bytes().to_vec(),
+            res_part: Some(message),
+        })),
+    }
+}
+
+// helpers
+
+pub(crate) fn transaction_server_res_query_res(
+    req_id: Uuid,
+    message: typedb_protocol::query::Res,
+) -> typedb_protocol::transaction::Server {
+    transaction_server_res(req_id, typedb_protocol::transaction::res::Res::QueryRes(message))
+}
+
+#[inline]
+pub(crate) fn transaction_server_res_parts_query_part(
+    req_id: Uuid,
+    res_parts: Vec<typedb_protocol::query::res_part::Res>,
+) -> typedb_protocol::transaction::Server {
+    transaction_server_res_part(req_id, transaction_res_part_query_res_part_parts(res_parts))
+}
+
+#[inline]
+pub(crate) fn transaction_server_res_part_stream_signal_continue(req_id: Uuid) -> typedb_protocol::transaction::Server {
+    transaction_server_res_part(req_id, transaction_res_part_res_part_stream_signal_continue())
+}
+
+#[inline]
+pub(crate) fn transaction_server_res_part_stream_signal_done(req_id: Uuid) -> typedb_protocol::transaction::Server {
+    transaction_server_res_part(req_id, transaction_res_part_res_part_stream_signal_done())
+}
+
+#[inline]
+pub(crate) fn transaction_server_res_part_stream_signal_error(
+    req_id: Uuid,
+    error: typedb_protocol::Error,
+) -> typedb_protocol::transaction::Server {
+    transaction_server_res_part(req_id, transaction_res_part_res_part_stream_signal_error(error))
+}

--- a/server/service/transaction_service.rs
+++ b/server/service/transaction_service.rs
@@ -27,6 +27,7 @@ use executor::{
         stage::{ReadPipelineStage, WriteStageIterator},
         PipelineExecutionError, StageAPI, StageIterator,
     },
+    ExecutionInterrupt,
 };
 use function::function_manager::FunctionManager;
 use itertools::Itertools;
@@ -48,7 +49,7 @@ use tokio::{
 use tokio_stream::StreamExt;
 use tonic::{Status, Streaming};
 use tracing::{event, Level};
-use typedb_protocol::transaction::stream_signal::Req;
+use typedb_protocol::transaction::{stream_signal::Req, Server};
 use typeql::{
     parse_query,
     query::{stage::Stage, Pipeline, SchemaQuery},
@@ -59,9 +60,15 @@ use uuid::Uuid;
 use crate::service::{
     answer::encode_row,
     error::{IntoGRPCStatus, IntoProtocolErrorMessage, ProtocolError},
+    response_builders::{
+        query_res_from_error, query_res_from_query_res_ok, query_res_ok_concept_row_stream, query_res_ok_empty,
+        query_res_ok_from_query_res_ok_ok, query_res_part_from_res_part_res,
+        transaction_server_res_part_stream_signal_continue, transaction_server_res_part_stream_signal_done,
+        transaction_server_res_part_stream_signal_error, transaction_server_res_parts_query_part,
+        transaction_server_res_query_res,
+    },
 };
 
-// TODO: where does this belong?
 #[derive(Debug)]
 pub enum Transaction {
     Read(TransactionRead<WALClient>),
@@ -85,10 +92,8 @@ pub(crate) struct TransactionService {
 
     request_stream: Streaming<typedb_protocol::transaction::Client>,
     response_sender: Sender<Result<typedb_protocol::transaction::Server, Status>>,
-    read_responder_interrupt_sender: broadcast::Sender<()>,
-    read_responder_interrupt_receiver: broadcast::Receiver<()>,
-    write_responder_interrupt_sender: broadcast::Sender<()>,
-    write_responder_interrupt_receiver: broadcast::Receiver<()>,
+    query_interrupt_sender: broadcast::Sender<()>,
+    query_interrupt_receiver: ExecutionInterrupt,
 
     transaction_timeout_millis: Option<u64>,
     schema_lock_acquire_timeout_millis: Option<u64>,
@@ -98,10 +103,10 @@ pub(crate) struct TransactionService {
     is_open: bool,
     transaction: Option<Transaction>,
     request_queue: Vec<(Uuid, Pipeline)>,
-    read_responders:
-        HashMap<Uuid, (JoinHandle<()>, JoinHandle<ControlFlow<(), (Uuid, Receiver<Option<QueryResponse>>)>>)>,
-    write_responders: HashMap<Uuid, JoinHandle<()>>,
-    active_write_query: Option<(Uuid, JoinHandle<(Transaction, Result<Batch, QueryError>)>)>,
+    read_responders: HashMap<Uuid, (JoinHandle<()>, StreamTransmitter)>,
+    write_responders: HashMap<Uuid, (JoinHandle<()>, StreamTransmitter)>,
+    running_write_query:
+        Option<(Uuid, JoinHandle<(Transaction, Result<(StreamQueryOutputDescriptor, Batch), QueryError>)>)>,
 }
 
 macro_rules! close_service {
@@ -120,87 +125,14 @@ macro_rules! close_service_with_error {
     }};
 }
 
-macro_rules! unwrap_or_submit_error_and_return {
-    ($match_: expr, $sender: expr, |$err:ident| $err_mapper: expr) => {{
+macro_rules! unwrap_or_execute_and_return {
+    ($match_: expr, |$err:ident| $err_mapper: block) => {{
         match $match_ {
             Ok(inner) => inner,
             Err($err) => {
-                Self::submit_error_and_terminator($sender, $err_mapper);
+                $err_mapper
                 return;
             }
-        }
-    }};
-}
-
-macro_rules! query_res_ok {
-    ($message: expr) => {{
-        typedb_protocol::query::res::Ok { ok: Some($message) }
-    }};
-}
-
-macro_rules! query_res_part_res {
-    ($message: expr) => {{
-        typedb_protocol::query::res_part::Res { res: Some($message) }
-    }};
-}
-
-macro_rules! transaction_server_res_part_query_res {
-    ($messages: expr) => {{
-        typedb_protocol::transaction::res_part::ResPart::QueryRes(typedb_protocol::query::ResPart { res: $messages })
-    }};
-}
-
-macro_rules! transaction_res_part_stream_signal_done {
-    () => {{
-        typedb_protocol::transaction::res_part::ResPart::StreamRes(
-            typedb_protocol::transaction::stream_signal::ResPart {
-                state: Some(typedb_protocol::transaction::stream_signal::res_part::State::Done(
-                    typedb_protocol::transaction::stream_signal::res_part::Done {},
-                )),
-            },
-        )
-    }};
-}
-
-macro_rules! transaction_res_part_stream_signal_continue {
-    () => {{
-        typedb_protocol::transaction::res_part::ResPart::StreamRes(
-            typedb_protocol::transaction::stream_signal::ResPart {
-                state: Some(typedb_protocol::transaction::stream_signal::res_part::State::Continue(
-                    typedb_protocol::transaction::stream_signal::res_part::Continue {},
-                )),
-            },
-        )
-    }};
-}
-
-macro_rules! transaction_res_part_stream_signal_error {
-    ($error_message: expr) => {{
-        typedb_protocol::transaction::res_part::ResPart::StreamRes(
-            typedb_protocol::transaction::stream_signal::ResPart {
-                state: Some(typedb_protocol::transaction::stream_signal::res_part::State::Error($error_message)),
-            },
-        )
-    }};
-}
-
-macro_rules! transaction_server_res {
-    ($req_id: expr, $message: expr) => {{
-        typedb_protocol::transaction::Server {
-            server: Some(typedb_protocol::transaction::server::Server::Res(typedb_protocol::transaction::Res {
-                req_id: $req_id.as_bytes().to_vec(),
-                res: Some($message),
-            })),
-        }
-    }};
-}
-
-macro_rules! transaction_server_res_part {
-    ($req_id: expr, $message: expr) => {{
-        typedb_protocol::transaction::Server {
-            server: Some(typedb_protocol::transaction::server::Server::ResPart(
-                typedb_protocol::transaction::ResPart { req_id: $req_id.as_bytes().to_vec(), res_part: Some($message) },
-            )),
         }
     }};
 }
@@ -209,15 +141,56 @@ macro_rules! send_ok_message_else_return_break {
     ($response_sender: expr, $message: expr) => {{
         if let Err(err) = $response_sender.send(Ok($message)).await {
             event!(Level::TRACE, "Submit message failed: {:?}", err);
-            return ControlFlow::Break(());
+            return Break(());
         }
     }};
 }
 
-enum QueryResponse {
+enum ImmediateQueryResponse {
+    NonFatalErr(typedb_protocol::Error),
     ResOk(typedb_protocol::query::res::Ok),
-    ResErr(typedb_protocol::Error),
-    ResPartRes(typedb_protocol::query::res_part::Res),
+}
+
+impl ImmediateQueryResponse {
+    fn non_fatal_err(error: impl IntoProtocolErrorMessage) -> Self {
+        Self::NonFatalErr(error.into_error_message())
+    }
+
+    fn ok(ok_message: typedb_protocol::query::res::ok::Ok) -> Self {
+        ImmediateQueryResponse::ResOk(typedb_protocol::query::res::Ok { ok: Some(ok_message) })
+    }
+}
+
+type StreamQueryOutputDescriptor = Vec<(String, VariablePosition)>;
+
+enum StreamQueryResponse {
+    // initial open response
+    Init(typedb_protocol::query::res::Ok),
+    // stream responses
+    NextRow(typedb_protocol::query::res_part::Res),
+    DoneOk(),
+    DoneErr(typedb_protocol::Error),
+}
+
+impl StreamQueryResponse {
+    fn done_ok() -> Self {
+        Self::DoneOk()
+    }
+
+    fn done_err(error: impl IntoProtocolErrorMessage) -> Self {
+        Self::DoneErr(error.into_error_message())
+    }
+
+    fn init(columns: &StreamQueryOutputDescriptor) -> Self {
+        let columns = columns.iter().map(|(name, _)| name.to_string()).collect();
+        let message = query_res_ok_concept_row_stream(columns);
+        Self::Init(query_res_ok_from_query_res_ok_ok(message))
+    }
+
+    fn next_row(row: typedb_protocol::AnswerRow) -> Self {
+        let res_part_res_row = typedb_protocol::query::res_part::res::Res::AnswerRow(row);
+        Self::NextRow(query_res_part_from_res_part_res(res_part_res_row))
+    }
 }
 
 enum StreamingCondition {
@@ -242,18 +215,15 @@ impl TransactionService {
         response_sender: Sender<Result<typedb_protocol::transaction::Server, Status>>,
         database_manager: Arc<DatabaseManager>,
     ) -> Self {
-        let (read_interrupt_sender, read_interrupt_receiver) = broadcast::channel(1);
-        let (write_interrupt_sender, write_interrupt_receiver) = broadcast::channel(1);
+        let (query_interrupt_sender, query_interrupt_receiver) = broadcast::channel(1);
 
         Self {
             database_manager,
 
             request_stream,
             response_sender,
-            read_responder_interrupt_sender: read_interrupt_sender,
-            read_responder_interrupt_receiver: read_interrupt_receiver,
-            write_responder_interrupt_sender: write_interrupt_sender,
-            write_responder_interrupt_receiver: write_interrupt_receiver,
+            query_interrupt_sender,
+            query_interrupt_receiver: ExecutionInterrupt::new(query_interrupt_receiver),
 
             transaction_timeout_millis: None,
             schema_lock_acquire_timeout_millis: None,
@@ -265,60 +235,90 @@ impl TransactionService {
             request_queue: Vec::with_capacity(20),
             read_responders: HashMap::new(),
             write_responders: HashMap::new(),
-            active_write_query: None,
+            running_write_query: None,
         }
     }
 
     pub(crate) async fn listen(&mut self) {
         loop {
-            let next = self.request_stream.next().await; // TODO: await active write query. If finished, move to responders and unblock other queries!
-            match next {
-                None => {
-                    close_service!();
+            let result = if self.running_write_query.is_some() {
+                let (req_id, write_query_worker) = self.running_write_query.as_mut().unwrap();
+                tokio::select! { biased;
+                    write_query_result = write_query_worker => {
+                        let req_id = *req_id;
+                        self.running_write_query = None;
+                        let (transaction, result) = write_query_result.unwrap();
+                        self.write_query_finished(req_id, transaction, result)
+                            .map(|empty| ControlFlow::Continue(()))
+                    }
+                    next = self.request_stream.next() => {
+                        self.handle_next(next).await
+                    }
                 }
-                Some(Err(error)) => {
-                    event!(Level::DEBUG, ?error, "GRPC error");
-                    close_service!();
-                }
-                Some(Ok(message)) => {
-                    for request in message.reqs {
-                        let request_id = Uuid::from_slice(&request.req_id).unwrap();
-                        let metadata = request.metadata;
-                        match request.req {
-                            None => {
-                                close_service_with_error!(
-                                    self,
-                                    ProtocolError::MissingField {
-                                        name: "req",
-                                        description: "Transaction message must contain a request.",
-                                    }
-                                    .into_status()
-                                );
-                            }
-                            Some(req) => {
-                                // TODO:
-                                //  If we get a Write query,
-                                //      if the queue is non-empty, we queue request, and check if we need to execute from the queue
-                                //      else if there's running read queries, we queue it only (SWAP WITH ABOVE?)
-                                //      if there's no running read queries, we execute + await it immediately, and add the output iterator into the Iterators map
-                                //  if we get a Read query
-                                //      if the queue is non-empty, we queue the request, and check if we need to execute from the queue
-                                //      else if there's running or no running read queries, we execute it and add it to the running read queries
+            } else {
+                let next = self.request_stream.next().await;
+                self.handle_next(next).await
+            };
 
-                                let result = self.handle_request(request_id, req).await;
-                                match result {
-                                    Ok(Continue(())) => {}
-                                    Ok(Break(())) => {
-                                        close_service!();
-                                    }
-                                    Err(err) => {
-                                        close_service_with_error!(self, err);
-                                    }
-                                }
+            match result {
+                Ok(Continue(())) => {}
+                Ok(Break(())) => {
+                    return;
+                }
+                Err(status) => {
+                    let result = self.response_sender.send(Err(status)).await;
+                    if let Err(send_error) = result {
+                        event!(Level::DEBUG, ?send_error, "Failed to send error to client");
+                    }
+                    return;
+                }
+            }
+        }
+    }
+
+    // TODO: any method using `Result<ControlFlow<(), ()>, Status>` should really be `ControlFlow<Result<(), Status>, ()>`
+    async fn handle_next(&mut self, next: Option<Result<typedb_protocol::transaction::Client, Status>>) -> Result<ControlFlow<(), ()>, Status> {
+        match next {
+            None => {
+                Ok(Break(()))
+            }
+            Some(Err(error)) => {
+                event!(Level::DEBUG, ?error, "GRPC error");
+                Ok(Break(()))
+            },
+            Some(Ok(message)) => {
+                for request in message.reqs {
+                    let request_id = Uuid::from_slice(&request.req_id).unwrap();
+                    let metadata = request.metadata;
+                    match request.req {
+                        None => {
+                            return Err(ProtocolError::MissingField {
+                                name: "req",
+                                description: "Transaction message must contain a request.",
+                            }.into_status());
+                            //
+                            // let result = self.response_sender.send(Err(error)).await;
+                            // if let Err(send_error) = result {
+                            //     event!(Level::DEBUG, ?send_error, "Failed to send error to client");
+                            // }
+                            // return Ok();
+                            //
+                            //
+                            // close_service_with_error!(
+                            //         self,
+                            //
+                            //     );
+                        }
+                        Some(req) => {
+                            match self.handle_request(request_id, req).await {
+                                Err(err) => return Err(err),
+                                Ok(Break(())) => return Ok(Break(())),
+                                Ok(Continue(())) => {}
                             }
                         }
                     }
                 }
+                Ok(Continue(()))
             }
         }
     }
@@ -329,26 +329,33 @@ impl TransactionService {
         req: typedb_protocol::transaction::req::Req,
     ) -> Result<ControlFlow<(), ()>, Status> {
         match (self.is_open, req) {
-            (false, typedb_protocol::transaction::req::Req::OpenReq(open_req)) => {
-                // Eagerly executed in main loop
-                match self.handle_open(open_req) {
-                    Ok(_) => {
-                        event!(Level::TRACE, "Transaction opened, request ID: {:?}", &request_id);
-                        Ok(Continue(()))
-                    }
-                    Err(status) => Err(status),
+            (false, typedb_protocol::transaction::req::Req::OpenReq(open_req)) => match self.handle_open(open_req) {
+                Ok(_) => {
+                    event!(Level::TRACE, "Transaction opened, request ID: {:?}", &request_id);
+                    Ok(Continue(()))
                 }
-            }
+                Err(status) => Err(status),
+            },
             (true, typedb_protocol::transaction::req::Req::OpenReq(_)) => {
                 Err(ProtocolError::TransactionAlreadyOpen {}.into_status())
             }
             (true, typedb_protocol::transaction::req::Req::QueryReq(query_req)) => {
-                // TODO: not every query error -> Status needs to abort the transaction!
-                self.handle_query(request_id, query_req).await?;
-                Ok(Continue(()))
+                let query_response = self.handle_query(request_id, query_req).await?;
+                if let Some(query_response) = query_response {
+                    return Ok(Self::respond_query_response(&self.response_sender, request_id, query_response).await);
+                } else {
+                    return Ok(Continue(()));
+                }
             }
             (true, typedb_protocol::transaction::req::Req::StreamReq(stream_req)) => {
-                self.handle_stream_continue(request_id, stream_req).await.map(|_| Continue(()))
+                match self.handle_stream_continue(request_id, stream_req).await {
+                    None => return Ok(Continue(())),
+                    Some(query_response) => {
+                        return Ok(
+                            Self::respond_query_response(&self.response_sender, request_id, query_response).await
+                        );
+                    }
+                }
             }
             (true, typedb_protocol::transaction::req::Req::CommitReq(commit_req)) => {
                 // Eagerly executed in main loop
@@ -356,16 +363,36 @@ impl TransactionService {
                 Ok(Break(()))
             }
             (true, typedb_protocol::transaction::req::Req::RollbackReq(rollback_req)) => {
-                // Eagerly executed in main loop
-                self.handle_rollback(rollback_req)?;
-                Ok(Continue(()))
+                self.handle_rollback(rollback_req).await
             }
             (true, typedb_protocol::transaction::req::Req::CloseReq(close_req)) => {
-                // Eagerly executed in main loop
-                self.handle_close(close_req)?;
+                self.handle_close(close_req).await;
                 Ok(Break(()))
             }
             (false, _) => Err(ProtocolError::TransactionClosed {}.into_status()),
+        }
+    }
+
+    async fn respond_query_response(
+        response_sender: &Sender<Result<typedb_protocol::transaction::Server, Status>>,
+        req_id: Uuid,
+        immediate_query_response: ImmediateQueryResponse,
+    ) -> ControlFlow<(), ()> {
+        match immediate_query_response {
+            ImmediateQueryResponse::NonFatalErr(err) => {
+                send_ok_message_else_return_break!(
+                    response_sender,
+                    transaction_server_res_query_res(req_id, query_res_from_error(err))
+                );
+                Continue(())
+            }
+            ImmediateQueryResponse::ResOk(res) => {
+                send_ok_message_else_return_break!(
+                    response_sender,
+                    transaction_server_res_query_res(req_id, query_res_from_query_res_ok(res))
+                );
+                Continue(())
+            }
         }
     }
 
@@ -385,9 +412,8 @@ impl TransactionService {
                 options.transaction_timeout_millis.or(Some(DEFAULT_TRANSACTION_TIMEOUT_MILLIS));
         }
 
-        let transaction_type = typedb_protocol::transaction::Type::try_from(open_req.r#type).map_err(|err| {
-            ProtocolError::UnrecognisedTransactionType { enum_variant: open_req.r#type }.into_status()
-        })?;
+        let transaction_type = typedb_protocol::transaction::Type::try_from(open_req.r#type)
+            .map_err(|_| ProtocolError::UnrecognisedTransactionType { enum_variant: open_req.r#type }.into_status())?;
 
         let database_name = open_req.database;
         let database = self.database_manager.database(database_name.as_ref()).ok_or_else(|| {
@@ -410,14 +436,22 @@ impl TransactionService {
         Ok(())
     }
 
-    async fn handle_commit(&mut self, commit_req: typedb_protocol::transaction::commit::Req) -> Result<(), Status> {
-        // Interrupt all running read queries
-        // Await all read query join handles, then clear all read responders
-        // Await currently running write query, then clear all write responders
-        // Drain queue: skip all reads, execute all writes
-        // Execute commit
+    async fn handle_commit(&mut self, _commit_req: typedb_protocol::transaction::commit::Req) -> Result<(), Status> {
+        // finish any running write query, interrupt running queries, clear all running/queued reads, finish all writes
+        //   note: if any write query errors, the whole transaction errors
+        // finish any active write query
+        self.finish_running_write_query().await?;
 
-        // TODO: take mut
+        // interrupt active queries and close write transmitters
+        self.query_interrupt_sender.send(()).unwrap();
+        self.await_running_read_queries().await;
+        if let Break(()) = self.cancel_queued_read_queries().await {
+            return Err(TransactionServiceError::ServiceClosingFailedQueueCleanup {}.into_error_message().into_status());
+        }
+        self.await_transmitting_write_queries().await;
+
+        // finish executing any remaining writes so they make it into the commit
+        self.finish_queued_write_queries().await?;
 
         match self.transaction.take().unwrap() {
             Transaction::Read(_) => {
@@ -436,192 +470,214 @@ impl TransactionService {
         }
     }
 
-    fn handle_rollback(&mut self, rollback_req: typedb_protocol::transaction::rollback::Req) -> Result<(), Status> {
-        // Interrupt all running read queries and any running write query
-        // Await all read query join handles, then clear all read responders
-        // Await all running write responders, then clear all write responders
-        // Clear queue
-        // Execute rollback
+    async fn handle_rollback(
+        &mut self,
+        _rollback_req: typedb_protocol::transaction::rollback::Req,
+    ) -> Result<ControlFlow<(), ()>, Status> {
+        // interrupt all queries, cancel writes, then rollback
+        self.query_interrupt_sender.send(()).unwrap();
+        self.await_transmitting_write_queries().await;
+        self.await_running_read_queries().await;
+        if let Break(_) = self.cancel_queued_read_queries().await {
+            return Ok(Break(()));
+        }
+
+        self.finish_running_write_query().await?;
+        if let Break(_) = self.cancel_queued_write_queries().await {
+            return Ok(Break(()));
+        }
 
         match self.transaction.take().unwrap() {
             Transaction::Read(_) => {
                 return Err(TransactionServiceError::CannotRollbackReadTransaction {}
                     .into_error_message()
-                    .into_status())
+                    .into_status());
             }
             Transaction::Write(mut transaction) => transaction.rollback(),
             Transaction::Schema(mut transaction) => transaction.rollback(),
         };
-        Ok(())
+        Ok(Continue(()))
     }
 
-    fn handle_close(&mut self, close_req: typedb_protocol::transaction::close::Req) -> Result<(), Status> {
-        // Interrupt all running read queries and any running write query
-        // Await all read query join handles, then clear all read responders
-        // Await all running write responders, then clear all write responders
-        // Clear queue
-        // Execute close
+    async fn handle_close(&mut self, _close_req: typedb_protocol::transaction::close::Req) {
+        self.query_interrupt_sender.send(()).unwrap();
+        self.await_transmitting_write_queries().await;
+        self.await_running_read_queries().await;
+        let _ = self.cancel_queued_read_queries().await;
+
+        let _ = self.finish_running_write_query().await;
+        let _ = self.cancel_queued_write_queries().await;
 
         match self.transaction.take().unwrap() {
             Transaction::Read(transaction) => transaction.close(),
             Transaction::Write(transaction) => transaction.close(),
             Transaction::Schema(transaction) => transaction.close(),
         };
+    }
+
+    async fn await_running_read_queries(&mut self) {
+        for (_, (worker, transmitter)) in self.read_responders.drain() {
+            if let Err(err) = worker.await {
+                event!(Level::DEBUG, "Awaiting read query worker returned error: {:?}", err);
+            }
+            transmitter.finish().await
+        }
+    }
+
+    async fn await_transmitting_write_queries(&mut self) {
+        for (_, (worker, transmitter)) in self.write_responders.drain() {
+            if let Err(err) = worker.await {
+                event!(Level::DEBUG, "Awaiting dummy write worker returned error: {:?}", err);
+            }
+            transmitter.finish().await
+        }
+    }
+
+    async fn cancel_queued_read_queries(&mut self) -> ControlFlow<(), ()> {
+        let mut write_queries = Vec::with_capacity(self.request_queue.len());
+        for (req_id, pipeline) in self.request_queue.drain(0..self.request_queue.len()) {
+            if Self::is_write_pipeline(&pipeline) {
+                write_queries.push((req_id, pipeline));
+            }
+            Self::respond_query_response(
+                &self.response_sender,
+                req_id,
+                ImmediateQueryResponse::NonFatalErr(TransactionServiceError::QueryInterrupted {}.into_error_message()),
+            )
+            .await?;
+        }
+
+        self.request_queue = write_queries;
+        Continue(())
+    }
+
+    async fn finish_running_write_query(&mut self) -> Result<(), Status> {
+        if let Some((req_id, worker)) = self.running_write_query.take() {
+            let (transaction, result) = worker.await.unwrap();
+            self.write_query_finished(req_id, transaction, result)
+        } else {
+            Ok(())
+        }
+    }
+
+    fn write_query_finished(
+        &mut self,
+        req_id: Uuid,
+        transaction: Transaction,
+        result: Result<(StreamQueryOutputDescriptor, Batch), QueryError>
+    ) -> Result<(), Status> {
+        self.transaction = Some(transaction);
+        match result {
+            Ok((output_descriptor, batch)) => {
+                self.activate_write_transmitter(req_id, output_descriptor, batch);
+                return Ok(());
+            }
+            Err(err) => {
+                // we promote write errors to fatal status errors
+                return Err(err.into_error_message().into_status());
+            }
+        }
+    }
+
+    async fn cancel_queued_write_queries(&mut self) -> ControlFlow<(), ()> {
+        let mut read_queries = Vec::with_capacity(self.request_queue.len());
+        for (req_id, pipeline) in self.request_queue.drain(0..self.request_queue.len()) {
+            if Self::is_write_pipeline(&pipeline) {
+                Self::respond_query_response(
+                    &self.response_sender,
+                    req_id,
+                    ImmediateQueryResponse::NonFatalErr(
+                        TransactionServiceError::QueryInterrupted {}.into_error_message(),
+                    ),
+                )
+                .await?;
+            } else {
+                read_queries.push((req_id, pipeline));
+            }
+        }
+        self.request_queue = read_queries;
+        Continue(())
+    }
+
+    async fn finish_queued_write_queries(&mut self) -> Result<(), Status> {
+        self.finish_running_write_query().await?;
+
+        let requests: Vec<_> = self.request_queue.drain(0..self.request_queue.len()).collect();
+        for (req_id, pipeline) in requests.into_iter() {
+            if Self::is_write_pipeline(&pipeline) {
+                match self.run_write_query(req_id, pipeline) {
+                    Ok(_) => self.finish_running_write_query().await?,
+                    Err(err) => {
+                        Self::respond_query_response(
+                            &self.response_sender,
+                            req_id,
+                            ImmediateQueryResponse::non_fatal_err(err),
+                        )
+                        .await;
+                    }
+                }
+            } else {
+                self.request_queue.push((req_id, pipeline));
+            }
+        }
         Ok(())
     }
 
-    async fn handle_query(&mut self, req_id: Uuid, query_req: typedb_protocol::query::Req) -> Result<(), Status> {
-        // TODO: compile query, create executor, respond with initial message and then await initial answers to send
-        let query_string = &query_req.query;
+    async fn handle_query(
+        &mut self,
+        req_id: Uuid,
+        query_req: typedb_protocol::query::Req,
+    ) -> Result<Option<ImmediateQueryResponse>, Status> {
         let query_options = &query_req.options; // TODO: pass query options
-        let parsed = parse_query(query_string).map_err(|err| {
-            TransactionServiceError::QueryParseFailed { source: err }.into_error_message().into_status()
-        })?;
+        let parsed = match parse_query(&query_req.query) {
+            Ok(parsed) => parsed,
+            Err(err) => {
+                // non-fatal error
+                return Ok(Some(ImmediateQueryResponse::non_fatal_err(TransactionServiceError::QueryParseFailed {
+                    typedb_source: err,
+                })));
+            }
+        };
         match parsed {
-            Query::Schema(schema_query) => self.handle_query_schema(schema_query).await,
+            Query::Schema(schema_query) => {
+                // schema queries are handled immediately so there is a query response or a fatal Status
+                self.handle_query_schema(schema_query).await.map(|response| Some(response))
+            }
             Query::Pipeline(pipeline) => {
-                let is_write = pipeline.stages.iter().any(Self::is_write_stage);
+                let is_write = Self::is_write_pipeline(&pipeline);
                 if is_write {
                     if !self.request_queue.is_empty()
                         || !self.read_responders.is_empty()
-                        || self.active_write_query.is_some()
+                        || self.running_write_query.is_some()
                     {
                         self.request_queue.push((req_id, pipeline));
-                        Ok(())
+                        // queued queries are not handled yet so there will be no query response yet
+                        Ok(None)
                     } else {
-                        // TODO: inject interrupt signal
-                        let handle = self.blocking_execute_write_query(pipeline)?;
-                        self.active_write_query = Some((req_id, tokio::spawn(async move { handle.await.unwrap() })));
-                        Ok(())
+                        match self.run_write_query(req_id, pipeline) {
+                            Ok(_) => {
+                                // running write queries have no valid response yet (until they finish) and will respond asynchronously
+                                Ok(None)
+                            }
+                            Err(err) => Ok(Some(ImmediateQueryResponse::non_fatal_err(err))),
+                        }
                     }
                 } else {
-                    if !self.request_queue.is_empty() || self.active_write_query.is_some() {
+                    if !self.request_queue.is_empty() || self.running_write_query.is_some() {
                         self.request_queue.push((req_id, pipeline));
-                        Ok(())
+                        // queued queries are not handled yet so there will be no query response yet
+                        Ok(None)
                     } else {
-                        let (sender, receiver) = channel(self.prefetch_size.unwrap() as usize);
-                        let worker_handle = self.blocking_execute_read_query(pipeline, sender);
-                        let transmitter_handle = tokio::spawn(Self::stream_parts(
-                            self.response_sender.clone(),
-                            self.prefetch_size.unwrap() as usize,
-                            self.network_latency_millis.unwrap() as usize,
-                            req_id,
-                            receiver,
-                        ));
-                        self.read_responders.insert(req_id, (worker_handle, transmitter_handle));
-                        Ok(())
+                        self.run_and_activate_read_transmitter(req_id, pipeline);
+                        // running read queries have no response on the main loop and will respond asynchronously
+                        Ok(None)
                     }
                 }
             }
         }
     }
 
-    async fn stream_parts(
-        response_sender: Sender<Result<typedb_protocol::transaction::Server, Status>>,
-        prefetch_size: usize,
-        network_latency_millis: usize,
-        req_id: Uuid,
-        query_response_receiver: Receiver<Option<QueryResponse>>,
-    ) -> ControlFlow<(), (Uuid, Receiver<Option<QueryResponse>>)> {
-        // stream PREFETCH answers in one big message (increases message throughput. Note: tested in Java impl)
-        let (req_id, query_response_receiver) = Self::stream_while_or_finish(
-            &response_sender,
-            req_id,
-            query_response_receiver,
-            StreamingCondition::Count(prefetch_size),
-        )
-        .await?;
-        send_ok_message_else_return_break!(response_sender, Self::message_stream_signal_continue(req_id));
-
-        // stream LATENCY number of answers
-        let (req_id, query_response_receiver) = Self::stream_while_or_finish(
-            &response_sender,
-            req_id,
-            query_response_receiver,
-            StreamingCondition::Duration(SystemTime::now(), network_latency_millis),
-        )
-        .await?;
-        ControlFlow::Continue((req_id, query_response_receiver))
-    }
-
-    async fn stream_while_or_finish(
-        response_sender: &Sender<Result<typedb_protocol::transaction::Server, Status>>,
-        req_id: Uuid,
-        mut query_response_receiver: Receiver<Option<QueryResponse>>,
-        streaming_condition: StreamingCondition,
-    ) -> ControlFlow<(), (Uuid, Receiver<Option<QueryResponse>>)> {
-        let mut res_parts_batch = Vec::new();
-        let mut iteration = 0;
-        while streaming_condition.continue_(iteration) {
-            match query_response_receiver.recv().await {
-                None => {
-                    send_ok_message_else_return_break!(
-                        response_sender,
-                        Self::message_stream_signal_error(
-                            req_id,
-                            QueryError::QueryExecutionClosedEarly {}.into_error_message()
-                        )
-                    );
-                    return ControlFlow::Break(());
-                }
-                Some(response) => match response {
-                    None => {
-                        send_ok_message_else_return_break!(response_sender, Self::message_stream_signal_done(req_id));
-                        return ControlFlow::Break(());
-                    }
-                    Some(query_response) => match query_response {
-                        QueryResponse::ResOk(_) => unreachable!("Streams should only respond ResPart or Error"),
-                        QueryResponse::ResErr(res_error) => {
-                            if !res_parts_batch.is_empty() {
-                                send_ok_message_else_return_break!(
-                                    response_sender,
-                                    Self::message_stream_res_parts(req_id, res_parts_batch)
-                                );
-                            }
-                            send_ok_message_else_return_break!(
-                                response_sender,
-                                Self::message_stream_signal_error(req_id, res_error)
-                            );
-                            return ControlFlow::Break(());
-                        }
-                        QueryResponse::ResPartRes(res_part) => res_parts_batch.push(res_part),
-                    },
-                },
-            }
-            iteration += 1;
-        }
-        if !res_parts_batch.is_empty() {
-            send_ok_message_else_return_break!(
-                response_sender,
-                Self::message_stream_res_parts(req_id, res_parts_batch)
-            );
-        }
-        ControlFlow::Continue((req_id, query_response_receiver))
-    }
-
-    fn message_stream_res_parts(
-        req_id: Uuid,
-        res_parts: Vec<typedb_protocol::query::res_part::Res>,
-    ) -> typedb_protocol::transaction::Server {
-        transaction_server_res_part!(req_id, transaction_server_res_part_query_res!(res_parts))
-    }
-
-    fn message_stream_signal_continue(req_id: Uuid) -> typedb_protocol::transaction::Server {
-        transaction_server_res_part!(req_id, transaction_res_part_stream_signal_continue!())
-    }
-
-    fn message_stream_signal_done(req_id: Uuid) -> typedb_protocol::transaction::Server {
-        transaction_server_res_part!(req_id, transaction_res_part_stream_signal_done!())
-    }
-
-    fn message_stream_signal_error(
-        req_id: Uuid,
-        error: typedb_protocol::Error,
-    ) -> typedb_protocol::transaction::Server {
-        transaction_server_res_part!(req_id, transaction_res_part_stream_signal_error!(error))
-    }
-
-    async fn handle_query_schema(&mut self, query: SchemaQuery) -> Result<(), Status> {
+    async fn handle_query_schema(&mut self, query: SchemaQuery) -> Result<ImmediateQueryResponse, Status> {
         if let Some(Transaction::Schema(schema_transaction)) = self.transaction.take() {
             let TransactionSchema {
                 snapshot,
@@ -633,18 +689,17 @@ impl TransactionService {
             } = schema_transaction;
             let mut snapshot = Arc::into_inner(snapshot).unwrap();
             let (snapshot, type_manager, thing_manager, result) = spawn_blocking(move || {
-                let result = QueryManager::new()
-                    .execute_schema(&mut snapshot, &type_manager, &thing_manager, query)
-                    .map_err(|err| {
-                        TransactionServiceError::QueryExecutionFailed { typedb_source: err }
-                            .into_error_message()
-                            .into_status()
-                    });
+                let result = QueryManager::new().execute_schema(&mut snapshot, &type_manager, &thing_manager, query);
                 (snapshot, type_manager, thing_manager, result)
             })
             .await
             .unwrap();
-            result?;
+            let message_ok_empty = result.map(|_| query_res_ok_empty()).map_err(|err| {
+                TransactionServiceError::TxnAbortSchemaQueryFailed { typedb_source: err }
+                    .into_error_message()
+                    .into_status()
+            })?;
+
             let transaction = TransactionSchema::from(
                 snapshot,
                 type_manager,
@@ -654,26 +709,67 @@ impl TransactionService {
                 transaction_options,
             );
             self.transaction = Some(Transaction::Schema(transaction));
-            Ok(())
+            Ok(ImmediateQueryResponse::ok(message_ok_empty))
         } else {
-            // TODO: this doesn't need to be fatal!
-            Err(TransactionServiceError::SchemaQueryRequiresSchemaTransaction {}.into_error_message().into_status())
+            Ok(ImmediateQueryResponse::non_fatal_err(TransactionServiceError::SchemaQueryRequiresSchemaTransaction {}))
         }
+    }
+
+    fn run_write_query(&mut self, req_id: Uuid, pipeline: Pipeline) -> Result<(), TransactionServiceError> {
+        debug_assert!(self.running_write_query.is_none());
+        let handle = self.blocking_execute_write_query(pipeline)?;
+        self.running_write_query = Some((req_id, tokio::spawn(async move { handle.await.unwrap() })));
+        Ok(())
+    }
+
+    fn activate_write_transmitter(
+        &mut self,
+        req_id: Uuid,
+        output_descriptor: StreamQueryOutputDescriptor,
+        batch: Batch,
+    ) {
+        let (sender, receiver) = channel(self.prefetch_size.unwrap() as usize);
+        let interrupt = self.query_interrupt_receiver.clone();
+        let batch_reader = self.write_query_batch_reader(output_descriptor, batch, sender, interrupt);
+        let stream_transmitter = StreamTransmitter::start_new(
+            self.response_sender.clone(),
+            receiver,
+            req_id,
+            self.prefetch_size.unwrap() as usize,
+            self.network_latency_millis.unwrap() as usize,
+        );
+        self.write_responders.insert(req_id, (batch_reader, stream_transmitter));
+    }
+
+    fn run_and_activate_read_transmitter(&mut self, req_id: Uuid, pipeline: Pipeline) {
+        let (sender, receiver) = channel(self.prefetch_size.unwrap() as usize);
+        let worker_handle = self.blocking_read_query_worker(pipeline, sender);
+        let stream_transmitter = StreamTransmitter::start_new(
+            self.response_sender.clone(),
+            receiver,
+            req_id,
+            self.prefetch_size.unwrap() as usize,
+            self.network_latency_millis.unwrap() as usize,
+        );
+        self.read_responders.insert(req_id, (worker_handle, stream_transmitter));
     }
 
     fn blocking_execute_write_query(
         &mut self,
         pipeline: Pipeline,
-    ) -> Result<JoinHandle<(Transaction, Result<Batch, QueryError>)>, Status> {
+    ) -> Result<
+        JoinHandle<(Transaction, Result<(StreamQueryOutputDescriptor, Batch), QueryError>)>,
+        TransactionServiceError,
+    > {
         debug_assert!(
             self.request_queue.is_empty()
                 && self.read_responders.is_empty()
-                && self.active_write_query.is_none()
+                && self.running_write_query.is_none()
                 && self.transaction.is_some()
         );
+        let interrupt = self.query_interrupt_receiver.clone();
         if let Some(Transaction::Schema(schema_transaction)) = self.transaction.take() {
             Ok(spawn_blocking(move || {
-                // TODO: pass in Interrupt Receiver
                 let TransactionSchema {
                     snapshot,
                     type_manager,
@@ -689,6 +785,7 @@ impl TransactionService {
                     thing_manager.clone(),
                     &function_manager,
                     &pipeline,
+                    interrupt,
                 );
 
                 let transaction = Transaction::Schema(TransactionSchema::from(
@@ -703,7 +800,6 @@ impl TransactionService {
             }))
         } else if let Some(Transaction::Write(write_transaction)) = self.transaction.take() {
             Ok(spawn_blocking(move || {
-                // TODO: pass in Interrupt Receiver
                 let TransactionWrite {
                     snapshot,
                     type_manager,
@@ -719,6 +815,7 @@ impl TransactionService {
                     thing_manager.clone(),
                     &function_manager,
                     &pipeline,
+                    interrupt,
                 );
 
                 let transaction = Transaction::Write(TransactionWrite::from(
@@ -732,9 +829,7 @@ impl TransactionService {
                 (transaction, result)
             }))
         } else {
-            return Err(TransactionServiceError::SchemaQueryRequiresSchemaTransaction {}
-                .into_error_message()
-                .into_status());
+            Err(TransactionServiceError::SchemaQueryRequiresSchemaTransaction {})
         }
     }
 
@@ -744,7 +839,8 @@ impl TransactionService {
         thing_manager: Arc<ThingManager>,
         function_manager: &FunctionManager,
         pipeline: &Pipeline,
-    ) -> (Snapshot, Result<Batch, QueryError>) {
+        interrupt: ExecutionInterrupt,
+    ) -> (Snapshot, Result<(StreamQueryOutputDescriptor, Batch), QueryError>) {
         let result = QueryManager::new().prepare_write_pipeline(
             snapshot,
             type_manager,
@@ -752,24 +848,31 @@ impl TransactionService {
             &function_manager,
             &pipeline,
         );
-        let pipeline = match result {
-            Ok(pipeline) => pipeline,
+        let (query_output_descriptor, pipeline) = match result {
+            Ok(executor) => {
+                let named_outputs: StreamQueryOutputDescriptor = executor
+                    .named_selected_outputs()
+                    .into_iter()
+                    .map(|(position, name)| (name, position))
+                    .sorted()
+                    .collect();
+                (named_outputs, executor)
+            }
             Err((snapshot, err)) => return (snapshot, Err(err)),
         };
 
-        let (iterator, snapshot) = match pipeline.into_iterator() {
+        let (iterator, snapshot) = match pipeline.into_iterator(interrupt) {
             Ok((iterator, snapshot)) => (iterator, snapshot),
             Err((snapshot, err)) => {
                 return (
                     Arc::into_inner(snapshot).unwrap(),
                     Err(QueryError::WritePipelineExecutionError { typedb_source: err }),
-                )
+                );
             }
         };
 
-        // collect so the snapshot Arc is no longer held by the iterator
         match iterator.collect_owned() {
-            Ok(batch) => (Arc::into_inner(snapshot).unwrap(), Ok(batch)),
+            Ok(batch) => (Arc::into_inner(snapshot).unwrap(), Ok((query_output_descriptor, batch))),
             Err(err) => (
                 Arc::into_inner(snapshot).unwrap(),
                 Err(QueryError::WritePipelineExecutionError { typedb_source: err }),
@@ -777,10 +880,59 @@ impl TransactionService {
         }
     }
 
-    fn blocking_execute_read_query(&self, pipeline: Pipeline, sender: Sender<Option<QueryResponse>>) -> JoinHandle<()> {
-        debug_assert!(self.request_queue.is_empty() && self.active_write_query.is_none() && self.transaction.is_some());
-
+    // Write query is already executed, but for simplicity, we convert it to something that conform to the same API as the read path
+    fn write_query_batch_reader(
+        &self,
+        output_descriptor: StreamQueryOutputDescriptor,
+        batch: Batch,
+        sender: Sender<StreamQueryResponse>,
+        mut interrupt: ExecutionInterrupt,
+    ) -> JoinHandle<()> {
         with_readable_transaction!(self.transaction.as_ref().unwrap(), |transaction| {
+            let snapshot = transaction.snapshot.clone();
+            let type_manager = transaction.type_manager.clone();
+            let thing_manager = transaction.thing_manager.clone();
+            tokio::spawn(async move {
+                let mut as_lending_iter = batch.into_iterator();
+                Self::submit_response_async(&sender, StreamQueryResponse::init(&output_descriptor)).await;
+
+                while let Some(row) = as_lending_iter.next() {
+                    if interrupt.check() {
+                        Self::submit_response_async(
+                            &sender,
+                            StreamQueryResponse::done_err(TransactionServiceError::QueryInterrupted {}),
+                        )
+                        .await;
+                        return;
+                    }
+
+                    let encoded_row =
+                        encode_row(row, &output_descriptor, snapshot.as_ref(), &type_manager, &thing_manager);
+                    match encoded_row {
+                        Ok(encoded_row) => {
+                            Self::submit_response_async(&sender, StreamQueryResponse::next_row(encoded_row)).await;
+                        }
+                        Err(err) => {
+                            Self::submit_response_async(
+                                &sender,
+                                StreamQueryResponse::done_err(PipelineExecutionError::ConceptRead { source: err }),
+                            )
+                            .await;
+                            return;
+                        }
+                    }
+                }
+                Self::submit_response_async(&sender, StreamQueryResponse::done_ok()).await
+            })
+        })
+    }
+
+    fn blocking_read_query_worker(&self, pipeline: Pipeline, sender: Sender<StreamQueryResponse>) -> JoinHandle<()> {
+        debug_assert!(
+            self.request_queue.is_empty() && self.running_write_query.is_none() && self.transaction.is_some()
+        );
+        let mut interrupt = self.query_interrupt_receiver.clone();
+        let handle = with_readable_transaction!(self.transaction.as_ref().unwrap(), |transaction| {
             let snapshot = transaction.snapshot.clone();
             let type_manager = transaction.type_manager.clone();
             let thing_manager = transaction.thing_manager.clone();
@@ -794,67 +946,60 @@ impl TransactionService {
                     &pipeline,
                 );
 
-                let executor = unwrap_or_submit_error_and_return!(executor, &sender, |err| err);
+                let executor = unwrap_or_execute_and_return!(executor, |err| {
+                    Self::submit_response_sync(&sender, StreamQueryResponse::done_err(err));
+                });
 
-                let named_outputs: Vec<(String, VariablePosition)> = executor
+                let descriptor: StreamQueryOutputDescriptor = executor
                     .named_selected_outputs()
                     .into_iter()
                     .map(|(position, name)| (name, position))
                     .sorted()
                     .collect();
-
-                Self::submit_stream_row_descriptor(&sender, &named_outputs);
+                let response = StreamQueryResponse::init(&descriptor);
+                Self::submit_response_sync(&sender, response);
 
                 let (mut iterator, _) =
-                    unwrap_or_submit_error_and_return!(executor.into_iterator(), &sender, |snapshot_and_err| {
-                        QueryError::ReadPipelineExecutionError { typedb_source: snapshot_and_err.1 }
+                    unwrap_or_execute_and_return!(executor.into_iterator(interrupt.clone()), |snapshot_and_err| {
+                        Self::submit_response_sync(
+                            &sender,
+                            StreamQueryResponse::done_err(QueryError::ReadPipelineExecutionError {
+                                typedb_source: snapshot_and_err.1,
+                            }),
+                        );
                     });
 
                 while let Some(next) = iterator.next() {
-                    let row = unwrap_or_submit_error_and_return!(next, &sender, |err| err);
-                    let encoded = encode_row(row, &named_outputs, snapshot.as_ref(), &type_manager, &thing_manager);
-                    match encoded {
-                        Ok(encoded) => Self::submit_stream_row(&sender, encoded),
+                    if interrupt.check() {
+                        Self::submit_response_sync(
+                            &sender,
+                            StreamQueryResponse::done_err(TransactionServiceError::QueryInterrupted {}),
+                        );
+                        return;
+                    }
+
+                    let row = unwrap_or_execute_and_return!(next, |err| {
+                        Self::submit_response_sync(&sender, StreamQueryResponse::done_err(err));
+                    });
+
+                    let encoded_row = encode_row(row, &descriptor, snapshot.as_ref(), &type_manager, &thing_manager);
+                    match encoded_row {
+                        Ok(encoded_row) => {
+                            Self::submit_response_sync(&sender, StreamQueryResponse::next_row(encoded_row))
+                        }
                         Err(err) => {
-                            Self::submit_error_and_terminator(
+                            Self::submit_response_sync(
                                 &sender,
-                                PipelineExecutionError::ConceptRead { source: err },
+                                StreamQueryResponse::done_err(PipelineExecutionError::ConceptRead { source: err }),
                             );
                             return;
                         }
                     }
                 }
-                Self::submit_terminator(&sender);
+                Self::submit_response_sync(&sender, StreamQueryResponse::done_ok())
             })
-        })
-    }
-
-    fn submit_stream_row_descriptor(sender: &Sender<Option<QueryResponse>>, columns: &[(String, VariablePosition)]) {
-        let mut header = typedb_protocol::query::res::ok::AnswerRowStream::default();
-        header.column_variable_names.extend(columns.iter().map(|(name, _)| name.to_string()));
-        let response =
-            QueryResponse::ResOk(query_res_ok!(typedb_protocol::query::res::ok::Ok::ConceptMapStream(header)));
-        sender.blocking_send(Some(response)).unwrap()
-    }
-
-    fn submit_stream_row(sender: &Sender<Option<QueryResponse>>, row: typedb_protocol::AnswerRow) {
-        let res_part_res_row = typedb_protocol::query::res_part::res::Res::AnswerRow(row);
-        let response = QueryResponse::ResPartRes(query_res_part_res!(res_part_res_row));
-        sender.blocking_send(Some(response)).unwrap()
-    }
-
-    fn submit_error_and_terminator(sender: &Sender<Option<QueryResponse>>, error: impl IntoProtocolErrorMessage) {
-        let response = QueryResponse::ResErr(error.into_error_message());
-        match sender.blocking_send(Some(response)) {
-            Ok(_) => Self::submit_terminator(sender),
-            Err(err) => event!(Level::ERROR, "Worker failed to send error message: {:?}", err),
-        }
-    }
-
-    fn submit_terminator(sender: &Sender<Option<QueryResponse>>) {
-        if let Err(err) = sender.blocking_send(None) {
-            event!(Level::DEBUG, "Worker failed to send final empty message after error message: {:?}", err)
-        }
+        });
+        handle
     }
 
     fn prepare_read_query_in<Snapshot: ReadableSnapshot + 'static>(
@@ -867,64 +1012,213 @@ impl TransactionService {
         QueryManager::new().prepare_read_pipeline(snapshot, type_manager, thing_manager, &function_manager, &pipeline)
     }
 
-    async fn handle_stream_continue(&mut self, request_id: Uuid, stream_req: Req) -> Result<(), Status> {
-        todo!()
-        // debug_assert!(
-        //     self.read_responders.contains_key(&request_id) || self.write_responders.contains_key(&request_id)
-        // );
-        // let read_responder = self.read_responders.get_mut(&request_id);
-        // if let Some(responder) = read_responder {
-        //     match responder {
-        //         Responder::Active(handle) => {
-        //             if !handle.is_finished() {
-        //                 event!(
-        //                     Level::DEBUG,
-        //                     "Responder is already active, and received a Stream Continue request.\
-        //                          Unexpected behaviour, but not an error state."
-        //                 );
-        //             } else {
-        //                 handle.await.unwrap();
-        //                 // TODO: recreate a task to stream back out from the iterator and set the handle
-        //                 // *handle = ..
-        //             }
-        //         }
-        //         Responder::Waiting(()) => {
-        //             todo!()
-        //         }
-        //     }
-        // } else {
-        //     let write_responder = self.write_responders.get_mut(&request_id);
-        //     if let Some(responder) = write_responder {
-        //         match responder {
-        //             Responder::Active(handle) => {
-        //                 if !handle.is_finished() {
-        //                     event!(
-        //                         Level::DEBUG,
-        //                         "Responder is already active, and received a Stream Continue request.\
-        //                          Unexpected behaviour, but not an error state."
-        //                     );
-        //                 } else {
-        //                     handle.await.unwrap();
-        //                     // TODO: recreate a task to stream back out from the iterator and set the handle
-        //                     // *handle = ..
-        //                 }
-        //             }
-        //             Responder::Waiting(()) => {
-        //                 todo!()
-        //             }
-        //         }
-        //     } else {
-        //         return Err(ProtocolError::QueryStreamNotFound { query_request_id: request_id }.into_status());
-        //     }
-        // }
-        // Ok(())
+    fn submit_response_sync(sender: &Sender<StreamQueryResponse>, response: StreamQueryResponse) {
+        if let Err(err) = sender.blocking_send(response) {
+            event!(Level::ERROR, "Failed to send error message: {:?}", err)
+        }
     }
 
-    fn is_write_stage(stage: &Stage) -> bool {
-        match stage {
-            Stage::Insert(_) | Stage::Put(_) | Stage::Delete(_) | Stage::Update(_) => true,
-            Stage::Fetch(_) | Stage::Reduce(_) | Stage::Modifier(_) | Stage::Match(_) => false,
+    async fn submit_response_async(sender: &Sender<StreamQueryResponse>, response: StreamQueryResponse) {
+        if let Err(err) = sender.send(response).await {
+            event!(Level::ERROR, "Failed to send error message: {:?}", err)
         }
+    }
+
+    async fn handle_stream_continue(&mut self, request_id: Uuid, _stream_req: Req) -> Option<ImmediateQueryResponse> {
+        debug_assert!(
+            self.read_responders.contains_key(&request_id) || self.write_responders.contains_key(&request_id)
+        );
+        let read_responder = self.read_responders.get_mut(&request_id);
+        if let Some((worker_handle, stream_transmitter)) = read_responder {
+            if stream_transmitter.check_finished_else_continue().await {
+                debug_assert!(worker_handle.is_finished());
+                drop(read_responder);
+                self.read_responders.remove(&request_id);
+            }
+            // valid query stream responses and control are reported by the transmitter directly, so no response here
+            None
+        } else {
+            let write_responder = self.write_responders.get_mut(&request_id);
+            if let Some((worker_handle, stream_transmitter)) = write_responder {
+                if stream_transmitter.check_finished_else_continue().await {
+                    debug_assert!(worker_handle.is_finished());
+                    drop(write_responder);
+                    self.write_responders.remove(&request_id);
+                }
+                // valid query stream responses and control are reported by the transmitter directly, so no response here
+                None
+            } else {
+                // This could be a valid state - if the driver requests Continuing a stream that has already been
+                //       finished & removed, or the user committed/rolled back/closed and we cleaned up streams eagerly
+                Some(ImmediateQueryResponse::NonFatalErr(
+                    TransactionServiceError::QueryStreamNotFound { query_request_id: request_id }.into_error_message(),
+                ))
+            }
+        }
+    }
+
+    fn is_write_pipeline(pipeline: &Pipeline) -> bool {
+        for stage in &pipeline.stages {
+            match stage {
+                Stage::Insert(_) | Stage::Put(_) | Stage::Delete(_) | Stage::Update(_) => return true,
+                Stage::Fetch(_) | Stage::Reduce(_) | Stage::Modifier(_) | Stage::Match(_) => {}
+            }
+        }
+        false
+    }
+}
+
+#[derive(Debug)]
+struct StreamTransmitter {
+    response_sender: Sender<Result<Server, Status>>,
+    req_id: Uuid,
+    prefetch_size: usize,
+    network_latency_millis: usize,
+
+    transmitter_task: Option<JoinHandle<ControlFlow<(), Receiver<StreamQueryResponse>>>>,
+}
+
+impl StreamTransmitter {
+    fn start_new(
+        response_sender: Sender<Result<Server, Status>>,
+        query_response_receiver: Receiver<StreamQueryResponse>,
+        req_id: Uuid,
+        prefetch_size: usize,
+        network_latency_millis: usize,
+    ) -> Self {
+        let transmitter_task = tokio::spawn(Self::respond_stream_parts(
+            response_sender.clone(),
+            prefetch_size,
+            network_latency_millis,
+            req_id,
+            query_response_receiver,
+        ));
+        Self {
+            response_sender,
+            req_id,
+            prefetch_size,
+            network_latency_millis,
+            transmitter_task: Some(transmitter_task),
+        }
+    }
+
+    async fn check_finished_else_continue(&mut self) -> bool {
+        let task = self.transmitter_task.take().unwrap();
+        if task.is_finished() {
+            // Should be immediate and safe to unwrap: cancelled or panicked are the only cases
+            let control = task.await.unwrap();
+            match control {
+                Continue(query_response_receiver) => {
+                    self.transmitter_task = Some(tokio::spawn(Self::respond_stream_parts(
+                        self.response_sender.clone(),
+                        self.prefetch_size,
+                        self.network_latency_millis,
+                        self.req_id,
+                        query_response_receiver,
+                    )));
+                    false
+                }
+                Break(_) => true,
+            }
+        } else {
+            false
+        }
+    }
+
+    async fn finish(self) {
+        if let Some(task) = self.transmitter_task {
+            let _ = task.await;
+        }
+    }
+
+    async fn respond_stream_parts(
+        response_sender: Sender<Result<typedb_protocol::transaction::Server, Status>>,
+        prefetch_size: usize,
+        network_latency_millis: usize,
+        req_id: Uuid,
+        query_response_receiver: Receiver<StreamQueryResponse>,
+    ) -> ControlFlow<(), Receiver<StreamQueryResponse>> {
+        // stream PREFETCH answers in one big message (increases message throughput. Note: tested in Java impl)
+        let query_response_receiver = Self::respond_stream_while_or_finish(
+            &response_sender,
+            req_id,
+            query_response_receiver,
+            StreamingCondition::Count(prefetch_size),
+        )
+        .await?;
+        send_ok_message_else_return_break!(response_sender, transaction_server_res_part_stream_signal_continue(req_id));
+
+        // stream LATENCY number of answers
+        let query_response_receiver = Self::respond_stream_while_or_finish(
+            &response_sender,
+            req_id,
+            query_response_receiver,
+            StreamingCondition::Duration(SystemTime::now(), network_latency_millis),
+        )
+        .await?;
+        Continue(query_response_receiver)
+    }
+
+    async fn respond_stream_while_or_finish(
+        response_sender: &Sender<Result<typedb_protocol::transaction::Server, Status>>,
+        req_id: Uuid,
+        mut query_response_receiver: Receiver<StreamQueryResponse>,
+        streaming_condition: StreamingCondition,
+    ) -> ControlFlow<(), Receiver<StreamQueryResponse>> {
+        let mut res_parts_batch = Vec::new();
+        let mut iteration = 0;
+        while streaming_condition.continue_(iteration) {
+            match query_response_receiver.recv().await {
+                None => {
+                    send_ok_message_else_return_break!(
+                        response_sender,
+                        transaction_server_res_part_stream_signal_error(
+                            req_id,
+                            QueryError::QueryExecutionClosedEarly {}.into_error_message()
+                        )
+                    );
+                    return Break(());
+                }
+                Some(response) => match response {
+                    StreamQueryResponse::Init(res) => {
+                        // header message
+                        send_ok_message_else_return_break!(
+                            response_sender,
+                            transaction_server_res_query_res(req_id, query_res_from_query_res_ok(res))
+                        );
+                    }
+                    StreamQueryResponse::DoneOk() => {
+                        send_ok_message_else_return_break!(
+                            response_sender,
+                            transaction_server_res_part_stream_signal_done(req_id)
+                        );
+                        return Break(());
+                    }
+                    StreamQueryResponse::DoneErr(res_error) => {
+                        if !res_parts_batch.is_empty() {
+                            send_ok_message_else_return_break!(
+                                response_sender,
+                                transaction_server_res_parts_query_part(req_id, res_parts_batch)
+                            );
+                        }
+                        send_ok_message_else_return_break!(
+                            response_sender,
+                            transaction_server_res_part_stream_signal_error(req_id, res_error)
+                        );
+                        return Break(());
+                    }
+                    StreamQueryResponse::NextRow(res_part) => res_parts_batch.push(res_part),
+                },
+            }
+            iteration += 1;
+        }
+        if !res_parts_batch.is_empty() {
+            send_ok_message_else_return_break!(
+                response_sender,
+                transaction_server_res_parts_query_part(req_id, res_parts_batch)
+            );
+        }
+        Continue(query_response_receiver)
     }
 }
 
@@ -936,9 +1230,19 @@ typedb_error!(
         // TODO: these should be typedb_source
         DataCommitFailed(4, "Data transaction commit failed.", ( source : DataCommitError )),
         SchemaCommitFailed(5, "Schema transaction commit failed.", ( source : SchemaCommitError )),
-        QueryParseFailed(6, "Query parsing failed.", ( source : typeql::Error )),
+        QueryParseFailed(6, "Query parsing failed.", ( typedb_source: typeql::Error )),
         SchemaQueryRequiresSchemaTransaction(7, "Schema modification queries require schema transactions."),
         WriteQueryRequiresSchemaOrWriteTransaction(8, "Data modification queries require either write or schema transactions."),
-        QueryExecutionFailed(9, "Query execution failed.", ( typedb_source : QueryError )),
+        TxnAbortSchemaQueryFailed(9, "Aborting transaction due to failed schema query.", ( typedb_source : QueryError )),
+        QueryInterrupted(10, "Query was interrupted by a transaction close, rollback, or commit."),
+        QueryStreamNotFound(
+            11,
+            r#"
+            Query stream with id '{query_request_id}' was not found in the transaction.
+            The stream could have already finished, or the transaction could be closed, committed, rolled back (or this is a bug).
+            "#,
+            query_request_id: Uuid
+        ),
+        ServiceClosingFailedQueueCleanup(12, "The operation failed since the service is closing."),
     }
 );

--- a/storage/isolation_manager.rs
+++ b/storage/isolation_manager.rs
@@ -296,7 +296,7 @@ fn handle_dependency(commit_dependency: CommitDependency) -> Option<IsolationCon
     None
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 enum DependentPut {
     Deleted { reinsert: Arc<AtomicBool> },
     Inserted { reinsert: Arc<AtomicBool> },
@@ -318,14 +318,14 @@ enum CommitDependency {
     Conflict(IsolationConflict),
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum IsolationConflict {
     DeletingRequiredKey,
     RequireDeletedKey,
     ExclusiveLock,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub(crate) struct ExpectedWindowError {
     sequence_number: SequenceNumber,
 }

--- a/storage/recovery/checkpoint.rs
+++ b/storage/recovery/checkpoint.rs
@@ -10,6 +10,7 @@ use std::{
     fs::{self, File},
     io::{self, Read, Write},
     path::{Path, PathBuf},
+    sync::Arc,
 };
 
 use chrono::Utc;
@@ -41,12 +42,12 @@ impl Checkpoint {
         let checkpoint_dir = storage_path.join(Self::CHECKPOINT_DIR_NAME);
         if !checkpoint_dir.exists() {
             fs::create_dir_all(&checkpoint_dir)
-                .map_err(|error| CheckpointDirCreate { dir: checkpoint_dir.clone(), source: error })?
+                .map_err(|error| CheckpointDirCreate { dir: checkpoint_dir.clone(), source: Arc::new(error) })?
         }
 
         let current_checkpoint_dir = checkpoint_dir.join(format!("{}", Utc::now().timestamp_micros()));
         fs::create_dir_all(&current_checkpoint_dir)
-            .map_err(|error| CheckpointDirCreate { dir: checkpoint_dir.clone(), source: error })?;
+            .map_err(|error| CheckpointDirCreate { dir: checkpoint_dir.clone(), source: Arc::new(error) })?;
 
         Ok(Checkpoint { directory: current_checkpoint_dir })
     }
@@ -59,11 +60,11 @@ impl Checkpoint {
 
         let metadata_file_path = self.directory.join(Self::STORAGE_METADATA_FILE_NAME);
         let mut metadata_file = File::create(&metadata_file_path)
-            .map_err(|error| MetadataFileCreate { file_path: metadata_file_path.clone(), source: error })?;
+            .map_err(|error| MetadataFileCreate { file_path: metadata_file_path.clone(), source: Arc::new(error) })?;
         metadata_file
             .write_all(watermark.number().to_string().as_bytes())
             .and_then(|()| metadata_file.sync_all())
-            .map_err(|error| MetadataWrite { file_path: metadata_file_path.clone(), source: error })?;
+            .map_err(|error| MetadataWrite { file_path: metadata_file_path.clone(), source: Arc::new(error) })?;
         Ok(())
     }
 
@@ -75,9 +76,11 @@ impl Checkpoint {
             return Err(ExtensionDuplicate { name: T::NAME.to_string() });
         }
 
-        let mut file = File::create(path).map_err(|err| ExtensionIO { name: T::NAME.to_string(), source: err })?;
+        let mut file =
+            File::create(path).map_err(|err| ExtensionIO { name: T::NAME.to_string(), source: Arc::new(err) })?;
 
-        data.serialise_into(&mut file).map_err(|err| ExtensionSerialise { name: T::NAME.to_string(), source: err })?;
+        data.serialise_into(&mut file)
+            .map_err(|err| ExtensionSerialise { name: T::NAME.to_string(), source: Arc::new(err) })?;
 
         Ok(())
     }
@@ -96,11 +99,11 @@ impl Checkpoint {
                     .filter(|path| path.is_ok() && path.as_ref().unwrap() != &self.directory)
                     .try_collect()
             })
-            .map_err(|error| CheckpointDirRead { dir: self.directory.clone(), source: error })?;
+            .map_err(|error| CheckpointDirRead { dir: self.directory.clone(), source: Arc::new(error) })?;
 
         for previous_checkpoint in previous_checkpoints {
             fs::remove_dir_all(&previous_checkpoint)
-                .map_err(|error| OldCheckpointRemove { dir: previous_checkpoint, source: error })?
+                .map_err(|error| OldCheckpointRemove { dir: previous_checkpoint, source: Arc::new(error) })?
         }
 
         Ok(())
@@ -120,10 +123,11 @@ impl Checkpoint {
             return Err(ExtensionNotFound { name: T::NAME.to_string() });
         }
 
-        let mut file = File::open(path).map_err(|err| ExtensionIO { name: T::NAME.to_string(), source: err })?;
+        let mut file =
+            File::open(path).map_err(|err| ExtensionIO { name: T::NAME.to_string(), source: Arc::new(err) })?;
 
         let deserialised = T::deserialise_from(&mut file)
-            .map_err(|err| ExtensionDeserialise { name: T::NAME.to_string(), source: err })?;
+            .map_err(|err| ExtensionDeserialise { name: T::NAME.to_string(), source: Arc::new(err) })?;
         Ok(deserialised)
     }
 
@@ -138,7 +142,7 @@ impl Checkpoint {
             let keyspace_dir = keyspaces_dir.join(keyspace.name());
             let keyspace_checkpoint_dir = self.directory.join(keyspace.name());
             restore_storage_from_checkpoint(keyspace_dir, keyspace_checkpoint_dir)
-                .map_err(|error| CheckpointRestore { dir: self.directory.clone(), source: error })?;
+                .map_err(|error| CheckpointRestore { dir: self.directory.clone(), source: Arc::new(error) })?;
         }
 
         let keyspaces = Keyspaces::open::<KS>(&keyspaces_dir).map_err(|error| KeyspaceOpen { source: error })?;
@@ -157,7 +161,7 @@ impl Checkpoint {
 
         let metadata_file_path = self.directory.join(Self::STORAGE_METADATA_FILE_NAME);
         let metadata = fs::read_to_string(metadata_file_path)
-            .map_err(|error| MetadataRead { dir: self.directory.clone(), source: error })?;
+            .map_err(|error| MetadataRead { dir: self.directory.clone(), source: Arc::new(error) })?;
         Ok(SequenceNumber::new(
             metadata.parse().expect("Could not read METADATA file (could try to restore from previous checkpoint)"),
         ))
@@ -193,7 +197,10 @@ fn find_latest_checkpoint(checkpoint_dir: &Path) -> Result<Option<PathBuf>, Chec
 
     fs::read_dir(checkpoint_dir)
         .and_then(|mut entries| entries.try_fold(None, |cur, entry| Ok(cur.max(Some(entry?.path())))))
-        .map_err(|error| CheckpointLoadError::CheckpointRead { dir: checkpoint_dir.to_owned(), source: error })
+        .map_err(|error| CheckpointLoadError::CheckpointRead {
+            dir: checkpoint_dir.to_owned(),
+            source: Arc::new(error),
+        })
 }
 
 pub trait CheckpointExtension: Sized {
@@ -202,23 +209,23 @@ pub trait CheckpointExtension: Sized {
     fn deserialise_from(reader: &mut impl Read) -> bincode::Result<Self>;
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum CheckpointCreateError {
-    CheckpointDirCreate { dir: PathBuf, source: io::Error },
-    CheckpointDirRead { dir: PathBuf, source: io::Error },
+    CheckpointDirCreate { dir: PathBuf, source: Arc<io::Error> },
+    CheckpointDirRead { dir: PathBuf, source: Arc<io::Error> },
 
     MissingStorageData { dir: PathBuf },
 
     KeyspaceCheckpoint { dir: PathBuf, source: KeyspaceCheckpointError },
 
-    MetadataFileCreate { file_path: PathBuf, source: io::Error },
-    MetadataWrite { file_path: PathBuf, source: io::Error },
+    MetadataFileCreate { file_path: PathBuf, source: Arc<io::Error> },
+    MetadataWrite { file_path: PathBuf, source: Arc<io::Error> },
 
     ExtensionDuplicate { name: String },
-    ExtensionIO { name: String, source: io::Error },
-    ExtensionSerialise { name: String, source: bincode::Error },
+    ExtensionIO { name: String, source: Arc<io::Error> },
+    ExtensionSerialise { name: String, source: Arc<bincode::Error> },
 
-    OldCheckpointRemove { dir: PathBuf, source: io::Error },
+    OldCheckpointRemove { dir: PathBuf, source: Arc<io::Error> },
 }
 
 impl fmt::Display for CheckpointCreateError {
@@ -244,19 +251,19 @@ impl Error for CheckpointCreateError {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum CheckpointLoadError {
-    CheckpointRead { dir: PathBuf, source: io::Error },
-    MetadataRead { dir: PathBuf, source: io::Error },
+    CheckpointRead { dir: PathBuf, source: Arc<io::Error> },
+    MetadataRead { dir: PathBuf, source: Arc<io::Error> },
     CheckpointNotFound { dir: PathBuf },
     CommitRecoveryFailed { source: CommitRecoveryError },
-    CheckpointRestore { dir: PathBuf, source: io::Error },
+    CheckpointRestore { dir: PathBuf, source: Arc<io::Error> },
     CommitPending { source: StorageCommitError },
     KeyspaceOpen { source: KeyspaceOpenError },
 
     ExtensionNotFound { name: String },
-    ExtensionIO { name: String, source: io::Error },
-    ExtensionDeserialise { name: String, source: bincode::Error },
+    ExtensionIO { name: String, source: Arc<io::Error> },
+    ExtensionDeserialise { name: String, source: Arc<bincode::Error> },
 }
 
 impl fmt::Display for CheckpointLoadError {

--- a/storage/snapshot/snapshot.rs
+++ b/storage/snapshot/snapshot.rs
@@ -510,7 +510,7 @@ impl<D: DurabilityClient> CommittableSnapshot<D> for SchemaSnapshot<D> {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum SnapshotError {
     Commit { source: StorageCommitError },
 }

--- a/storage/tests/test_isolation.rs
+++ b/storage/tests/test_isolation.rs
@@ -639,14 +639,14 @@ fn isolation_manager_reads_evicted_from_disk() {
     }
 
     {
-        let mut snapshot_passes = storage.clone().open_snapshot_write_at(watermark_after_0).unwrap();
+        let mut snapshot_passes = storage.clone().open_snapshot_write_at(watermark_after_0);
         snapshot_passes.put_val(key_2.clone().into_owned_array(), value_1.clone());
         let snapshot_passes_result = snapshot_passes.commit();
 
         assert!(snapshot_passes_result.is_ok());
     }
     {
-        let mut snapshot_conflicts = storage.open_snapshot_write_at(watermark_after_0).unwrap();
+        let mut snapshot_conflicts = storage.open_snapshot_write_at(watermark_after_0);
         snapshot_conflicts.get_required(key_1.clone()).unwrap();
         snapshot_conflicts.put_val(key_2.clone().into_owned_array(), value_1.clone());
         let snapshot_conflicts_result = snapshot_conflicts.commit();

--- a/storage/tests/test_mvcc.rs
+++ b/storage/tests/test_mvcc.rs
@@ -94,7 +94,7 @@ fn test_reading_snapshots() {
     snapshot_read_0.close_resources();
 
     // Read from further in the past.
-    let snapshot_read_02 = storage.open_snapshot_read_at(watermark_0).unwrap();
+    let snapshot_read_02 = storage.open_snapshot_read_at(watermark_0);
     assert_eq!(snapshot_read_02.get::<128>(key_1.as_reference()).unwrap().unwrap().bytes(), VALUE_0);
     snapshot_read_02.close_resources();
 }
@@ -129,7 +129,7 @@ fn test_conflicting_update_fails() {
 
     {
         // Try the same, with the snapshot opened in the past
-        let mut snapshot_write_at_0 = storage.open_snapshot_write_at(watermark_after_initial_write).unwrap();
+        let mut snapshot_write_at_0 = storage.open_snapshot_write_at(watermark_after_initial_write);
         snapshot_write_at_0.get_required(key_1.clone()).unwrap();
         snapshot_write_at_0.put_val(key_2.clone().into_owned_array(), ByteArray::copy(&VALUE_2));
         let result_write_at_0 = snapshot_write_at_0.commit();
@@ -158,7 +158,7 @@ fn test_open_snapshot_write_at() {
     assert_eq!(snapshot_read_0.get::<128>(key_1.as_reference()).unwrap().unwrap().bytes(), VALUE_0);
     snapshot_read_0.close_resources();
 
-    let mut snapshot_write_1 = storage.clone().open_snapshot_write_at(watermark_init).unwrap();
+    let mut snapshot_write_1 = storage.clone().open_snapshot_write_at(watermark_init);
     snapshot_write_1.put_val(StorageKeyArray::new(Keyspace, ByteArray::copy(&KEY_1)), ByteArray::copy(&VALUE_1));
     snapshot_write_1.commit().unwrap();
 

--- a/tests/behaviour/steps/BUILD
+++ b/tests/behaviour/steps/BUILD
@@ -13,9 +13,10 @@ rust_library(
     crate_root = "lib.rs",
     deps = [
         "//answer:answer",
-        "//common/primitive",
+        "//common/error",
         "//common/lending_iterator",
         "//common/options",
+        "//common/primitive",
         "//compiler:compiler",
         "//concept:concept",
         "//database:database",

--- a/tests/behaviour/steps/query/typeql.rs
+++ b/tests/behaviour/steps/query/typeql.rs
@@ -18,9 +18,11 @@ use concept::{thing::object::ObjectAPI, type_::TypeAPI};
 use cucumber::gherkin::Step;
 use encoding::value::label::Label;
 use executor::{
+    error::ReadExecutionError,
     program_executor::ProgramExecutor,
     row::Row,
     write::{insert::InsertExecutor, WriteError},
+    ExecutionInterrupt,
 };
 use ir::{
     program::function_signature::HashMapFunctionSignatureIndex,
@@ -70,10 +72,11 @@ fn execute_match_query(
         );
 
         let program_plan = ProgramPlan::new(match_plan, HashMap::new(), HashMap::new());
-        let executor = ProgramExecutor::new(&program_plan, &tx.snapshot, &tx.thing_manager)?;
+        let executor = ProgramExecutor::new(&program_plan, &tx.snapshot, &tx.thing_manager)
+            .map_err(|err| Either::Second(ReadExecutionError::ConceptRead { source: err }))?;
         variable_position_index = executor.entry_variable_positions_index().to_owned();
         executor
-            .into_iterator(tx.snapshot.clone(), tx.thing_manager.clone())
+            .into_iterator(tx.snapshot.clone(), tx.thing_manager.clone(), ExecutionInterrupt::new_uninterruptible())
             .map_static(|row| row.map(|row| row.into_owned()).map_err(|err| err.clone()))
             .into_iter()
             .try_collect::<_, Vec<_>, _>()?
@@ -275,7 +278,7 @@ fn does_key_match(var: &str, id: &str, var_value: &VariableValue<'_>, context: &
             }
             Thing::Attribute(_) => return false,
         };
-        let (mut attr, count) = has_iter
+        let (attr, count) = has_iter
             .next()
             .unwrap_or_else(|| panic!("no attributes of type {key_label} found for {var}: {thing}"))
             .unwrap();
@@ -306,7 +309,7 @@ fn does_attribute_match(id: &str, var_value: &VariableValue<'_>, context: &Conte
                 .unwrap()
                 .unwrap_or_else(|| panic!("expected the key type {label} to have a value type")),
         );
-        let mut attr = attr.as_reference();
+        let attr = attr.as_reference();
         let actual = attr.get_value(&*tx.snapshot, &tx.thing_manager).unwrap();
         actual == expected
     })

--- a/tests/behaviour/steps/query/typeql.rs
+++ b/tests/behaviour/steps/query/typeql.rs
@@ -31,6 +31,7 @@ use ir::{
 use itertools::{izip, Itertools};
 use lending_iterator::LendingIterator;
 use macro_rules_attribute::apply;
+use error::TypeDBError;
 use primitive::either::Either;
 use query::query_manager::QueryManager;
 
@@ -45,7 +46,7 @@ use crate::{
 fn execute_match_query(
     context: &mut Context,
     query: typeql::Query,
-) -> Result<Vec<HashMap<String, VariableValue<'static>>>, Box<dyn Error>> {
+) -> Result<Vec<HashMap<String, VariableValue<'static>>>, Box<dyn TypeDBError>> {
     let mut translation_context = TranslationContext::new();
     let typeql_match = query.into_pipeline().stages.pop().unwrap().into_match();
     let block =


### PR DESCRIPTION
## Release notes: product changes

Finish implementing the transaction service, including transaction commit/close/rollback, single write query/many read query execution, and interrupt mechanisms.

We also migrate several error message types from being the previous `impl Error` variants to the `typedb_error!` macro.
