### PR TITLE
Implement grpc Database endpoints

### DIFF
--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -36,7 +36,7 @@ def vaticle_typedb_protocol():
     git_repository(
         name = "vaticle_typedb_protocol",
         remote = "https://github.com/typedb/typedb-protocol",
-        commit = "14a9392a9a7d411043e70a81b75da949bb880f4e",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_protocol
+        commit = "34e64e7a48af44b3b6b07a5924430f03409dac27",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_protocol
     )
 
 def vaticle_typedb_behaviour():

--- a/main.rs
+++ b/main.rs
@@ -9,14 +9,20 @@
 
 use logger::initialise_logging;
 use resource::constants::server::ASCII_LOGO;
+use server::parameters::config::Config;
 
 #[tokio::main]
 async fn main() {
     print_ascii_logo(); // very important
-
     let _guard = initialise_logging();
 
-    server::typedb::Server::open("runtimedata/server/data").unwrap().serve().await.unwrap()
+    let config = get_configuration();
+
+    server::typedb::Server::open(config).unwrap().serve().await.unwrap()
+}
+
+fn get_configuration() -> Config {
+    Config::new()
 }
 
 fn print_ascii_logo() {

--- a/server/BUILD
+++ b/server/BUILD
@@ -10,6 +10,7 @@ rust_library(
     name = "server",
     srcs = glob([
         "*.rs",
+        "parameters/**/*.rs",
         "service/*.rs",
     ]),
     deps = [

--- a/server/parameters/config.rs
+++ b/server/parameters/config.rs
@@ -1,0 +1,40 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+use std::{
+    net::SocketAddr,
+    path::{Path, PathBuf},
+    str::FromStr,
+};
+
+pub struct Config {
+    pub(crate) server: ServerConfig,
+    pub(crate) storage: StorageConfig,
+}
+
+impl Config {
+    pub fn new() -> Self {
+        Self {
+            server: ServerConfig { address: SocketAddr::from_str("localhost:1729").unwrap() },
+            storage: StorageConfig { data: "runtimedata/server/data".into() },
+        }
+    }
+
+    pub fn new_with_data_directory(data_directory: &Path) -> Self {
+        Self {
+            server: ServerConfig { address: SocketAddr::from_str("localhost:1729").unwrap() },
+            storage: StorageConfig { data: data_directory.into() },
+        }
+    }
+}
+
+pub(crate) struct ServerConfig {
+    pub(crate) address: SocketAddr,
+}
+
+pub(crate) struct StorageConfig {
+    pub(crate) data: PathBuf,
+}

--- a/server/parameters/mod.rs
+++ b/server/parameters/mod.rs
@@ -4,9 +4,4 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-#![deny(unused_must_use)]
-#![deny(elided_lifetimes_in_paths)]
-
-pub mod parameters;
-mod service;
-pub mod typedb;
+pub mod config;

--- a/server/service/mod.rs
+++ b/server/service/mod.rs
@@ -10,4 +10,4 @@ mod response_builders;
 pub(crate) mod transaction_service;
 pub(crate) mod typedb_service;
 
-pub(crate) type RequestID = [u8; 16];
+pub(crate) type ConnectionID = uuid::Bytes;

--- a/server/service/response_builders.rs
+++ b/server/service/response_builders.rs
@@ -4,162 +4,236 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-use uuid::Uuid;
+pub(crate) mod connection {
+    use crate::service::ConnectionID;
 
-pub(crate) fn query_res_ok_empty() -> typedb_protocol::query::res::ok::Ok {
-    typedb_protocol::query::res::ok::Ok::Empty(typedb_protocol::query::res::ok::Empty {})
-}
-
-pub(crate) fn query_res_ok_values(
-    values: Vec<typedb_protocol::query::res::ok::values::OptionalValue>,
-) -> typedb_protocol::query::res::ok::Ok {
-    typedb_protocol::query::res::ok::Ok::Values(typedb_protocol::query::res::ok::Values { values })
-}
-
-pub(crate) fn query_res_ok_concept_row_stream(
-    column_variable_names: Vec<String>,
-) -> typedb_protocol::query::res::ok::Ok {
-    typedb_protocol::query::res::ok::Ok::ConceptMapStream(typedb_protocol::query::res::ok::AnswerRowStream {
-        column_variable_names,
-    })
-}
-
-pub(crate) fn query_res_ok_readable_concept_tree_stream() -> typedb_protocol::query::res::ok::Ok {
-    typedb_protocol::query::res::ok::Ok::ReadableConceptTreeStream(
-        typedb_protocol::query::res::ok::ReadableConceptTreeStream {},
-    )
-}
-
-pub(crate) fn query_res_ok_from_query_res_ok_ok(
-    message: typedb_protocol::query::res::ok::Ok,
-) -> typedb_protocol::query::res::Ok {
-    typedb_protocol::query::res::Ok { ok: Some(message) }
-}
-
-pub(crate) fn query_res_from_query_res_ok(message: typedb_protocol::query::res::Ok) -> typedb_protocol::query::Res {
-    typedb_protocol::query::Res { res: Some(typedb_protocol::query::res::Res::Ok(message)) }
-}
-
-pub(crate) fn query_res_from_error(error: typedb_protocol::Error) -> typedb_protocol::query::Res {
-    typedb_protocol::query::Res { res: Some(typedb_protocol::query::res::Res::Error(error)) }
-}
-
-pub(crate) fn query_res_part_from_res_part_res(
-    message: typedb_protocol::query::res_part::res::Res,
-) -> typedb_protocol::query::res_part::Res {
-    typedb_protocol::query::res_part::Res { res: Some(message) }
-}
-
-pub(crate) fn query_res_part_from_concept_tree() {
-    todo!()
-}
-
-pub(crate) fn query_res_part_from_parts(
-    messages: Vec<typedb_protocol::query::res_part::Res>,
-) -> typedb_protocol::query::ResPart {
-    typedb_protocol::query::ResPart { res: messages }
-}
-
-// -----------
-
-#[inline]
-fn transaction_res_part_query_res_part_parts(
-    messages: Vec<typedb_protocol::query::res_part::Res>,
-) -> typedb_protocol::transaction::res_part::ResPart {
-    typedb_protocol::transaction::res_part::ResPart::QueryRes(typedb_protocol::query::ResPart { res: messages })
-}
-
-#[inline]
-fn transaction_res_part_res_part_stream_signal_done() -> typedb_protocol::transaction::res_part::ResPart {
-    typedb_protocol::transaction::res_part::ResPart::StreamRes(typedb_protocol::transaction::stream_signal::ResPart {
-        state: Some(typedb_protocol::transaction::stream_signal::res_part::State::Done(
-            typedb_protocol::transaction::stream_signal::res_part::Done {},
-        )),
-    })
-}
-
-#[inline]
-fn transaction_res_part_res_part_stream_signal_continue() -> typedb_protocol::transaction::res_part::ResPart {
-    typedb_protocol::transaction::res_part::ResPart::StreamRes(typedb_protocol::transaction::stream_signal::ResPart {
-        state: Some(typedb_protocol::transaction::stream_signal::res_part::State::Continue(
-            typedb_protocol::transaction::stream_signal::res_part::Continue {},
-        )),
-    })
-}
-
-#[inline]
-fn transaction_res_part_res_part_stream_signal_error(
-    error_message: typedb_protocol::Error,
-) -> typedb_protocol::transaction::res_part::ResPart {
-    typedb_protocol::transaction::res_part::ResPart::StreamRes(typedb_protocol::transaction::stream_signal::ResPart {
-        state: Some(typedb_protocol::transaction::stream_signal::res_part::State::Error(error_message)),
-    })
-}
-
-#[inline]
-pub(crate) fn transaction_res_query_res(
-    message: typedb_protocol::query::res::Res,
-) -> typedb_protocol::transaction::res::Res {
-    typedb_protocol::transaction::res::Res::QueryRes(typedb_protocol::query::Res { res: Some(message) })
-}
-
-#[inline]
-fn transaction_server_res(
-    req_id: Uuid,
-    message: typedb_protocol::transaction::res::Res,
-) -> typedb_protocol::transaction::Server {
-    typedb_protocol::transaction::Server {
-        server: Some(typedb_protocol::transaction::server::Server::Res(typedb_protocol::transaction::Res {
-            req_id: req_id.as_bytes().to_vec(),
-            res: Some(message),
-        })),
+    pub(crate) fn connection_open_res(connection_id: ConnectionID) -> typedb_protocol::connection::open::Res {
+        typedb_protocol::connection::open::Res {
+            connection_id: Some(typedb_protocol::ConnectionId { id: Vec::from(connection_id) }),
+        }
     }
 }
 
-#[inline]
-fn transaction_server_res_part(
-    req_id: Uuid,
-    message: typedb_protocol::transaction::res_part::ResPart,
-) -> typedb_protocol::transaction::Server {
-    typedb_protocol::transaction::Server {
-        server: Some(typedb_protocol::transaction::server::Server::ResPart(typedb_protocol::transaction::ResPart {
-            req_id: req_id.as_bytes().to_vec(),
-            res_part: Some(message),
-        })),
+pub(crate) mod database_manager {
+    use std::net::SocketAddr;
+
+    pub(crate) fn database_get_res(
+        server_address: &SocketAddr,
+        database_name: String,
+    ) -> typedb_protocol::database_manager::get::Res {
+        typedb_protocol::database_manager::get::Res {
+            database: Some(typedb_protocol::DatabaseReplicas {
+                name: database_name,
+                replicas: Vec::from([typedb_protocol::database_replicas::Replica {
+                    address: server_address.to_string(),
+                    primary: true,
+                    preferred: true,
+                    term: 0,
+                }]),
+            }),
+        }
+    }
+
+    pub(crate) fn database_all_res(
+        server_address: &SocketAddr,
+        database_names: Vec<String>,
+    ) -> typedb_protocol::database_manager::all::Res {
+        typedb_protocol::database_manager::all::Res {
+            databases: database_names
+                .into_iter()
+                .map(|name| typedb_protocol::DatabaseReplicas {
+                    name: name,
+                    replicas: Vec::from([typedb_protocol::database_replicas::Replica {
+                        address: server_address.to_string(),
+                        primary: true,
+                        preferred: true,
+                        term: 0,
+                    }]),
+                })
+                .collect(),
+        }
+    }
+
+    pub(crate) fn database_contains_res(contains: bool) -> typedb_protocol::database_manager::contains::Res {
+        typedb_protocol::database_manager::contains::Res { contains }
+    }
+
+    pub(crate) fn database_create_res() -> typedb_protocol::database_manager::create::Res {
+        typedb_protocol::database_manager::create::Res {}
     }
 }
 
-// helpers
-
-pub(crate) fn transaction_server_res_query_res(
-    req_id: Uuid,
-    message: typedb_protocol::query::Res,
-) -> typedb_protocol::transaction::Server {
-    transaction_server_res(req_id, typedb_protocol::transaction::res::Res::QueryRes(message))
+pub(crate) mod database {
+    pub(crate) fn database_delete_res() -> typedb_protocol::database::delete::Res {
+        typedb_protocol::database::delete::Res {}
+    }
 }
 
-#[inline]
-pub(crate) fn transaction_server_res_parts_query_part(
-    req_id: Uuid,
-    res_parts: Vec<typedb_protocol::query::res_part::Res>,
-) -> typedb_protocol::transaction::Server {
-    transaction_server_res_part(req_id, transaction_res_part_query_res_part_parts(res_parts))
-}
+pub(crate) mod transaction {
+    use uuid::Uuid;
 
-#[inline]
-pub(crate) fn transaction_server_res_part_stream_signal_continue(req_id: Uuid) -> typedb_protocol::transaction::Server {
-    transaction_server_res_part(req_id, transaction_res_part_res_part_stream_signal_continue())
-}
+    pub(crate) fn query_res_ok_empty() -> typedb_protocol::query::res::ok::Ok {
+        typedb_protocol::query::res::ok::Ok::Empty(typedb_protocol::query::res::ok::Empty {})
+    }
 
-#[inline]
-pub(crate) fn transaction_server_res_part_stream_signal_done(req_id: Uuid) -> typedb_protocol::transaction::Server {
-    transaction_server_res_part(req_id, transaction_res_part_res_part_stream_signal_done())
-}
+    pub(crate) fn query_res_ok_values(
+        values: Vec<typedb_protocol::query::res::ok::values::OptionalValue>,
+    ) -> typedb_protocol::query::res::ok::Ok {
+        typedb_protocol::query::res::ok::Ok::Values(typedb_protocol::query::res::ok::Values { values })
+    }
 
-#[inline]
-pub(crate) fn transaction_server_res_part_stream_signal_error(
-    req_id: Uuid,
-    error: typedb_protocol::Error,
-) -> typedb_protocol::transaction::Server {
-    transaction_server_res_part(req_id, transaction_res_part_res_part_stream_signal_error(error))
+    pub(crate) fn query_res_ok_concept_row_stream(
+        column_variable_names: Vec<String>,
+    ) -> typedb_protocol::query::res::ok::Ok {
+        typedb_protocol::query::res::ok::Ok::ConceptRowStream(typedb_protocol::query::res::ok::AnswerRowStream {
+            column_variable_names,
+        })
+    }
+
+    pub(crate) fn query_res_ok_readable_concept_tree_stream() -> typedb_protocol::query::res::ok::Ok {
+        typedb_protocol::query::res::ok::Ok::ReadableConceptTreeStream(
+            typedb_protocol::query::res::ok::ReadableConceptTreeStream {},
+        )
+    }
+
+    pub(crate) fn query_res_ok_from_query_res_ok_ok(
+        message: typedb_protocol::query::res::ok::Ok,
+    ) -> typedb_protocol::query::res::Ok {
+        typedb_protocol::query::res::Ok { ok: Some(message) }
+    }
+
+    pub(crate) fn query_res_from_query_res_ok(message: typedb_protocol::query::res::Ok) -> typedb_protocol::query::Res {
+        typedb_protocol::query::Res { res: Some(typedb_protocol::query::res::Res::Ok(message)) }
+    }
+
+    pub(crate) fn query_res_from_error(error: typedb_protocol::Error) -> typedb_protocol::query::Res {
+        typedb_protocol::query::Res { res: Some(typedb_protocol::query::res::Res::Error(error)) }
+    }
+
+    pub(crate) fn query_res_part_from_res_part_res(
+        message: typedb_protocol::query::res_part::res::Res,
+    ) -> typedb_protocol::query::res_part::Res {
+        typedb_protocol::query::res_part::Res { res: Some(message) }
+    }
+
+    pub(crate) fn query_res_part_from_concept_tree() {
+        todo!()
+    }
+
+    pub(crate) fn query_res_part_from_parts(
+        messages: Vec<typedb_protocol::query::res_part::Res>,
+    ) -> typedb_protocol::query::ResPart {
+        typedb_protocol::query::ResPart { res: messages }
+    }
+
+    // -----------
+
+    #[inline]
+    fn transaction_res_part_query_res_part_parts(
+        messages: Vec<typedb_protocol::query::res_part::Res>,
+    ) -> typedb_protocol::transaction::res_part::ResPart {
+        typedb_protocol::transaction::res_part::ResPart::QueryRes(typedb_protocol::query::ResPart { res: messages })
+    }
+
+    #[inline]
+    fn transaction_res_part_res_part_stream_signal_done() -> typedb_protocol::transaction::res_part::ResPart {
+        typedb_protocol::transaction::res_part::ResPart::StreamRes(
+            typedb_protocol::transaction::stream_signal::ResPart {
+                state: Some(typedb_protocol::transaction::stream_signal::res_part::State::Done(
+                    typedb_protocol::transaction::stream_signal::res_part::Done {},
+                )),
+            },
+        )
+    }
+
+    #[inline]
+    fn transaction_res_part_res_part_stream_signal_continue() -> typedb_protocol::transaction::res_part::ResPart {
+        typedb_protocol::transaction::res_part::ResPart::StreamRes(
+            typedb_protocol::transaction::stream_signal::ResPart {
+                state: Some(typedb_protocol::transaction::stream_signal::res_part::State::Continue(
+                    typedb_protocol::transaction::stream_signal::res_part::Continue {},
+                )),
+            },
+        )
+    }
+
+    #[inline]
+    fn transaction_res_part_res_part_stream_signal_error(
+        error_message: typedb_protocol::Error,
+    ) -> typedb_protocol::transaction::res_part::ResPart {
+        typedb_protocol::transaction::res_part::ResPart::StreamRes(
+            typedb_protocol::transaction::stream_signal::ResPart {
+                state: Some(typedb_protocol::transaction::stream_signal::res_part::State::Error(error_message)),
+            },
+        )
+    }
+
+    #[inline]
+    pub(crate) fn transaction_res_query_res(
+        message: typedb_protocol::query::res::Res,
+    ) -> typedb_protocol::transaction::res::Res {
+        typedb_protocol::transaction::res::Res::QueryRes(typedb_protocol::query::Res { res: Some(message) })
+    }
+
+    #[inline]
+    fn transaction_server_res(
+        req_id: Uuid,
+        message: typedb_protocol::transaction::res::Res,
+    ) -> typedb_protocol::transaction::Server {
+        typedb_protocol::transaction::Server {
+            server: Some(typedb_protocol::transaction::server::Server::Res(typedb_protocol::transaction::Res {
+                req_id: req_id.as_bytes().to_vec(),
+                res: Some(message),
+            })),
+        }
+    }
+
+    #[inline]
+    fn transaction_server_res_part(
+        req_id: Uuid,
+        message: typedb_protocol::transaction::res_part::ResPart,
+    ) -> typedb_protocol::transaction::Server {
+        typedb_protocol::transaction::Server {
+            server: Some(typedb_protocol::transaction::server::Server::ResPart(
+                typedb_protocol::transaction::ResPart { req_id: req_id.as_bytes().to_vec(), res_part: Some(message) },
+            )),
+        }
+    }
+
+    // helpers
+
+    pub(crate) fn transaction_server_res_query_res(
+        req_id: Uuid,
+        message: typedb_protocol::query::Res,
+    ) -> typedb_protocol::transaction::Server {
+        transaction_server_res(req_id, typedb_protocol::transaction::res::Res::QueryRes(message))
+    }
+
+    #[inline]
+    pub(crate) fn transaction_server_res_parts_query_part(
+        req_id: Uuid,
+        res_parts: Vec<typedb_protocol::query::res_part::Res>,
+    ) -> typedb_protocol::transaction::Server {
+        transaction_server_res_part(req_id, transaction_res_part_query_res_part_parts(res_parts))
+    }
+
+    #[inline]
+    pub(crate) fn transaction_server_res_part_stream_signal_continue(
+        req_id: Uuid,
+    ) -> typedb_protocol::transaction::Server {
+        transaction_server_res_part(req_id, transaction_res_part_res_part_stream_signal_continue())
+    }
+
+    #[inline]
+    pub(crate) fn transaction_server_res_part_stream_signal_done(req_id: Uuid) -> typedb_protocol::transaction::Server {
+        transaction_server_res_part(req_id, transaction_res_part_res_part_stream_signal_done())
+    }
+
+    #[inline]
+    pub(crate) fn transaction_server_res_part_stream_signal_error(
+        req_id: Uuid,
+        error: typedb_protocol::Error,
+    ) -> typedb_protocol::transaction::Server {
+        transaction_server_res_part(req_id, transaction_res_part_res_part_stream_signal_error(error))
+    }
 }

--- a/server/service/typedb_service.rs
+++ b/server/service/typedb_service.rs
@@ -4,33 +4,48 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-use std::{pin::Pin, sync::Arc};
+use std::{net::SocketAddr, pin::Pin, sync::Arc};
 
 use database::database_manager::DatabaseManager;
+use error::typedb_error;
 use tokio::sync::mpsc::channel;
 use tokio_stream::wrappers::ReceiverStream;
 use tonic::{Request, Response, Status, Streaming};
 use typedb_protocol::{
     self,
-    connection::pulse::{Req, Res},
     transaction::{Client, Server},
 };
+use uuid::Uuid;
 
-use crate::service::transaction_service::TransactionService;
+use crate::service::{
+    error::{IntoGRPCStatus, IntoProtocolErrorMessage, ProtocolError},
+    response_builders::{
+        connection::connection_open_res,
+        database::database_delete_res,
+        database_manager::{database_all_res, database_contains_res, database_create_res, database_get_res},
+    },
+    transaction_service::TransactionService,
+    ConnectionID,
+};
 
 #[derive(Debug)]
 pub(crate) struct TypeDBService {
+    address: SocketAddr,
     database_manager: Arc<DatabaseManager>,
     // map of connection ID to ConnectionService
 }
 
 impl TypeDBService {
-    pub(crate) fn new(database_manager: DatabaseManager) -> Self {
-        Self { database_manager: Arc::new(database_manager) }
+    pub(crate) fn new(address: &SocketAddr, database_manager: DatabaseManager) -> Self {
+        Self { address: address.clone(), database_manager: Arc::new(database_manager) }
     }
 
     pub(crate) fn database_manager(&self) -> &DatabaseManager {
         &self.database_manager
+    }
+
+    fn generate_connection_id(&self) -> ConnectionID {
+        Uuid::new_v4().into_bytes()
     }
 }
 
@@ -40,60 +55,84 @@ impl typedb_protocol::type_db_server::TypeDb for TypeDBService {
         &self,
         request: Request<typedb_protocol::connection::open::Req>,
     ) -> Result<Response<typedb_protocol::connection::open::Res>, Status> {
-        todo!()
-    }
-
-    async fn connection_pulse(&self, request: Request<Req>) -> Result<Response<Res>, Status> {
-        todo!()
+        let message = request.into_inner();
+        if message.version != typedb_protocol::Version::Version as i32 {
+            return Err(ProtocolError::IncompatibleProtocolVersion {
+                server_protocol_version: typedb_protocol::Version::Version as i32,
+                driver_protocol_version: message.version,
+                driver_lang: message.driver_lang.clone(),
+                driver_version: message.driver_version.clone(),
+            }
+            .into_status());
+        } else {
+            // generate a connection ID per 'connection_open' to be able to trace different connections by the same user
+            Ok(Response::new(connection_open_res(self.generate_connection_id())))
+        }
     }
 
     async fn databases_get(
         &self,
         request: Request<typedb_protocol::database_manager::get::Req>,
     ) -> Result<Response<typedb_protocol::database_manager::get::Res>, Status> {
-        todo!()
+        let message = request.into_inner();
+        let database = self.database_manager.database(&message.name);
+        match database {
+            None => Err(ServiceError::DatabaseDoesNotExist { name: message.name }.into_error_message().into_status()),
+            Some(_database) => Ok(Response::new(database_get_res(&self.address, message.name))),
+        }
     }
 
     async fn databases_all(
         &self,
-        request: Request<typedb_protocol::database_manager::all::Req>,
+        _request: Request<typedb_protocol::database_manager::all::Req>,
     ) -> Result<Response<typedb_protocol::database_manager::all::Res>, Status> {
-        todo!()
+        Ok(Response::new(database_all_res(&self.address, self.database_manager.database_names())))
     }
 
     async fn databases_contains(
         &self,
         request: Request<typedb_protocol::database_manager::contains::Req>,
     ) -> Result<Response<typedb_protocol::database_manager::contains::Res>, Status> {
-        todo!()
+        let message = request.into_inner();
+        Ok(Response::new(database_contains_res(self.database_manager.database(&message.name).is_some())))
     }
 
     async fn databases_create(
         &self,
         request: Request<typedb_protocol::database_manager::create::Req>,
     ) -> Result<Response<typedb_protocol::database_manager::create::Res>, Status> {
-        todo!()
-    }
-
-    async fn database_schema(
-        &self,
-        request: Request<typedb_protocol::database::schema::Req>,
-    ) -> Result<Response<typedb_protocol::database::schema::Res>, Status> {
-        todo!()
-    }
-
-    async fn database_type_schema(
-        &self,
-        request: Request<typedb_protocol::database::type_schema::Req>,
-    ) -> Result<Response<typedb_protocol::database::type_schema::Res>, Status> {
-        todo!()
+        let message = request.into_inner();
+        self.database_manager.create_database(message.name);
+        Ok(Response::new(database_create_res()))
     }
 
     async fn database_delete(
         &self,
         request: Request<typedb_protocol::database::delete::Req>,
     ) -> Result<Response<typedb_protocol::database::delete::Res>, Status> {
-        todo!()
+        let message = request.into_inner();
+        self.database_manager
+            .delete_database(message.name)
+            .map(|_| Response::new(database_delete_res()))
+            .map_err(|err| err.into_error_message().into_status())
+    }
+
+    async fn database_schema(
+        &self,
+        _request: Request<typedb_protocol::database::schema::Req>,
+    ) -> Result<Response<typedb_protocol::database::schema::Res>, Status> {
+        Err(ServiceError::Unimplemented { description: "Database schema retrieval.".to_string() }
+            .into_error_message()
+            .into_status())
+    }
+
+    async fn database_type_schema(
+        &self,
+        _request: Request<typedb_protocol::database::type_schema::Req>,
+    ) -> Result<Response<typedb_protocol::database::type_schema::Res>, Status> {
+        Err(ServiceError::Unimplemented { description: "Database schema (types only) retrieval.".to_string() }
+            .into_error_message()
+            .into_status())
     }
 
     type transactionStream = Pin<Box<ReceiverStream<Result<typedb_protocol::transaction::Server, tonic::Status>>>>;
@@ -110,3 +149,10 @@ impl typedb_protocol::type_db_server::TypeDb for TypeDBService {
         Ok(Response::new(Box::pin(stream)))
     }
 }
+
+typedb_error!(
+    ServiceError(domain="Service", prefix = "SRV") {
+        Unimplemented(1, "Not implemented: {description}", description: String),
+        DatabaseDoesNotExist(2, "Database '{name}' does not exist.", name: String),
+    }
+);

--- a/tests/behaviour/steps/concept/type_/mod.rs
+++ b/tests/behaviour/steps/concept/type_/mod.rs
@@ -23,7 +23,7 @@ pub enum BehaviourConceptTestExecutionError {
 }
 
 impl fmt::Display for BehaviourConceptTestExecutionError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    fn fmt(&self, _f: &mut fmt::Formatter<'_>) -> fmt::Result {
         todo!()
     }
 }

--- a/tests/behaviour/steps/connection/mod.rs
+++ b/tests/behaviour/steps/connection/mod.rs
@@ -7,7 +7,7 @@
 use std::sync::{Arc, Mutex, OnceLock};
 
 use macro_rules_attribute::apply;
-use server::typedb;
+use server::{parameters::config::Config, typedb};
 use test_utils::{create_tmp_dir, TempDir};
 
 use crate::{generic_step, Context};
@@ -22,7 +22,8 @@ static TYPEDB: OnceLock<(TempDir, Arc<Mutex<typedb::Server>>)> = OnceLock::new()
 pub async fn typedb_starts(context: &mut Context) {
     let (_, server) = TYPEDB.get_or_init(|| {
         let server_dir = create_tmp_dir();
-        let server = typedb::Server::open(&server_dir).unwrap();
+        let config = Config::new_with_data_directory(server_dir.as_ref());
+        let server = typedb::Server::open(config).unwrap();
         (server_dir, Arc::new(Mutex::new(server)))
     });
 


### PR DESCRIPTION
## Release notes: product changes
We implement the GRPC endpoints for database manipulation, and convert two more relevant errors into `typedb_error!()`s.