### PR TITLE
Introduce deployment jobs on CircleCI

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -4,6 +4,6 @@
 
 try-import ./.bazel-remote-cache.rc
 
-build --incompatible_strict_action_env # --@io_bazel_rules_docker//transitions:enable=false
+build --incompatible_strict_action_env --@io_bazel_rules_docker//transitions:enable=false
 run --incompatible_strict_action_env
 test --incompatible_strict_action_env --test_env=PATH

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -93,7 +93,7 @@ commands:
     steps:
       - run: |
           bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-          bazel build //:assemble-typedb-server
+          bazel build --jobs=8 //:assemble-typedb-server --compilation_mode=opt
           bazel test //tests/assembly:test_assembly --test_output=errors
 
   deploy-snapshot-unix:
@@ -120,8 +120,8 @@ commands:
       - run: |
           docker login -u $REPO_DOCKER_USERNAME -p $REPO_DOCKER_PASSWORD
           bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-          bazel run  --@io_bazel_rules_docker//transitions:enable=false --platforms=//docker:linux-<<parameters.image-arch>> \
-            //:deploy-docker-release-<<parameters.image-arch>>
+          bazel run --jobs=8 --@io_bazel_rules_docker//transitions:enable=false --platforms=//docker:linux-<<parameters.image-arch>> \
+            //:deploy-docker-release-<<parameters.image-arch>> --compilation_mode=opt
           # TODO after beta: bazel run //:deploy-docker-release-overwrite-latest-tag
 
   # TODO: Migrate to bazel sh_binary

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,19 +5,27 @@
 version: 2.1
 
 orbs:
-  win: circleci/windows@2.0.0
-
+  win: circleci/windows@5.0
+  macos: circleci/macos@2.4.0
 
 executors:
-  linux-arm64:
-    machine:
-      image: ubuntu-2004:current
-      resource_class: arm.medium
+  linux-arm64-amazonlinux-2:
+    docker:
+      - image: amazonlinux:2
+    resource_class: arm.large
     working_directory: ~/typedb
 
-  linux-x86_64:
-    machine:
-      image: ubuntu-2004:current
+  # All builds go on amazon-linux.
+  linux-x86_64-amazonlinux-2:
+    docker:
+      - image: amazonlinux:2
+    resource_class: large
+    working_directory: ~/typedb
+
+  linux-x86_64-ubuntu-2204:
+    docker:
+      - image: ubuntu:22.04
+    resource_class: large
     working_directory: ~/typedb
 
   mac-arm64:
@@ -26,107 +34,289 @@ executors:
     resource_class: macos.m1.medium.gen1
     working_directory: ~/typedb
 
-  mac-x86_64:
-    macos:
-      xcode: "13.4.1"
-    working_directory: ~/typedb
+  win-x86_64:
+    resource_class: windows.xlarge
+    machine:
+      image: windows-server-2022-gui:2024.01.1
+    shell: cmd.exe
 
 
 commands:
 
-  install-bazel-linux-x86_64:
+  ######################
+  # common setup steps #
+  ######################
+
+  install-deps-yum:
+    parameters:
+      bazel-arch:
+        type: string
     steps:
       - run: |
-          curl -OL "https://github.com/bazelbuild/bazelisk/releases/download/v1.17.0/bazelisk-linux-amd64"
-          sudo mv "bazelisk-linux-amd64" /usr/local/bin/bazel
+          amazon-linux-extras install python3.8 java-openjdk11 docker -y
+          yum install -y git tar gcc gcc-c++ file lsof which procps llvm-devel clang-devel
+          curl -OL "https://github.com/bazelbuild/bazelisk/releases/download/v1.17.0/bazelisk-linux-<<parameters.bazel-arch>>"
+          mv "bazelisk-linux-<<parameters.bazel-arch>>" /usr/local/bin/bazel
           chmod a+x /usr/local/bin/bazel
 
-  install-bazel-linux-arm64:
+  install-deps-apt:
+    parameters:
+      bazel-arch:
+        type: string
     steps:
       - run: |
-          curl -OL "https://github.com/bazelbuild/bazelisk/releases/download/v1.17.0/bazelisk-linux-arm64"
-          sudo mv "bazelisk-linux-arm64" /usr/local/bin/bazel
+          apt update -y
+          DEBIAN_FRONTEND=noninteractive apt install -y --no-install-recommends tzdata
+          apt install -y curl build-essential git python3 python3-pip default-jre lsof cmake file wget libclang-dev
+          curl -OL "https://github.com/bazelbuild/bazelisk/releases/download/v1.17.0/bazelisk-linux-<<parameters.bazel-arch>>"
+          mv "bazelisk-linux-<<parameters.bazel-arch>>" /usr/local/bin/bazel
           chmod a+x /usr/local/bin/bazel
 
-  install-bazel-mac:
+  install-deps-brew:
+    parameters:
+      bazel-arch:
+        type: string
     steps:
-      - run: brew install bazelisk
+      - run: |
+          brew install python@3.8
+          curl -OL "https://github.com/bazelbuild/bazelisk/releases/download/v1.17.0/bazelisk-darwin-<<parameters.bazel-arch>>"
+          sudo mv "bazelisk-darwin-<<parameters.bazel-arch>>" /usr/local/bin/bazel
+          chmod a+x /usr/local/bin/bazel
+
+  install-brew-rosetta:
+    steps:
+      - run: arch -x86_64 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+
+
+  # deploy & test steps
+  test-assembly-unix:
+    steps:
+      - run: |
+          bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+          bazel build //:assemble-typedb-server
+          bazel test //tests/assembly:test_assembly --test_output=errors
+
+  deploy-snapshot-unix:
+    steps:
+      - run: |
+          export DEPLOY_ARTIFACT_USERNAME=$REPO_TYPEDB_USERNAME
+          export DEPLOY_ARTIFACT_PASSWORD=$REPO_TYPEDB_PASSWORD
+          bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+          bazel run --jobs=8 --define version=$(git rev-parse HEAD) //:deploy-typedb-server --compilation_mode=opt -- snapshot
+
+  deploy-release-unix:
+    steps:
+      - run: |
+          export DEPLOY_ARTIFACT_USERNAME=$REPO_TYPEDB_USERNAME
+          export DEPLOY_ARTIFACT_PASSWORD=$REPO_TYPEDB_PASSWORD
+          bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+          bazel run --jobs=8 --define version=$(cat VERSION) //:deploy-typedb-server --compilation_mode=opt -- release
+
+  deploy-docker-for-arch:
+    parameters:
+      image-arch:
+        type: string
+    steps:
+      - run: |
+          docker login -u $REPO_DOCKER_USERNAME -p $REPO_DOCKER_PASSWORD
+          bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+          bazel run  --@io_bazel_rules_docker//transitions:enable=false --platforms=//docker:linux-<<parameters.image-arch>> \
+            //:deploy-docker-release-<<parameters.image-arch>>
+          # TODO after beta: bazel run //:deploy-docker-release-overwrite-latest-tag
+
+  # TODO: Migrate to bazel sh_binary
+  deploy-docker-release-multiarch:
+    steps:
+      - run: |
+          docker login -u $REPO_DOCKER_USERNAME -p $REPO_DOCKER_PASSWORD
+          export VERSION=$(cat VERSION)
+          export DOCKER_REPO="typedb"
+          docker manifest create vaticle/$DOCKER_REPO:$VERSION --amend vaticle/$DOCKER_REPO:$VERSION-x86_64 --amend vaticle/$DOCKER_REPO:$VERSION-arm64
+          docker manifest push vaticle/$DOCKER_REPO:$VERSION
+          # TODO: After beta: docker manifest push vaticle/$DOCKER_REPO:latest
 
 jobs:
-  test-assembly-mac-x86_64-zip:
-    executor: mac-x86_64
-    working_directory: ~/typedb
+  # per platform snapshot deployment
+  test-deploy-snapshot-linux-x86_64:
+    executor: linux-x86_64-amazonlinux-2
     steps:
       - checkout
-      - install-bazel-mac
-      - run: bazel test //test/assembly:assembly --test_output=errors
+      - install-deps-yum:
+          bazel-arch: amd64
+      - test-assembly-unix
+      - deploy-snapshot-unix
 
-  test-assembly-mac-arm64-zip:
+  test-deploy-snapshot-linux-arm64:
+    executor: linux-arm64-amazonlinux-2
+    steps:
+      - checkout
+      - install-deps-yum:
+          bazel-arch: arm64
+      - test-assembly-unix
+      - deploy-snapshot-unix
+
+  test-deploy-snapshot-mac-x86_64:
     executor: mac-arm64
-    resource_class: macos.m1.medium.gen1
-    working_directory: ~/typedb
     steps:
+      - macos/install-rosetta
       - checkout
-      - install-bazel-mac
-      - run: bazel test //test/assembly:assembly --test_output=errors
+      - install-brew-rosetta
+      - install-deps-brew:
+          bazel-arch: amd64
+      - test-assembly-unix
+      - deploy-snapshot-unix
 
-  test-assembly-linux-arm64-zip:
-    executor: linux-arm64
-    working_directory: ~/typedb
+  test-deploy-snapshot-mac-arm64:
+    executor: mac-arm64
     steps:
       - checkout
-      - install-bazel-linux-arm64
-      - run: bazel test //test/assembly:assembly --test_output=errors
+      - install-deps-brew:
+          bazel-arch: arm64
+      - test-assembly-unix
+      - deploy-snapshot-unix
 
-  test-assembly-linux-x86_64-zip:
-    executor: linux-x86_64
-    working_directory: ~/typedb
+  # per platform release deployment
+  deploy-release-linux-x86_64:
+    executor: linux-x86_64-amazonlinux-2
     steps:
       - checkout
-      - install-bazel-linux-x86_64
-      - run: bazel test //test/assembly:assembly --test_output=errors
+      - install-deps-yum:
+          bazel-arch: amd64
+      - deploy-release-unix
 
-  test-assembly-windows-zip:
-    executor:
-      name: win/default
-      shell: cmd.exe
-    working_directory: ~/typedb
+  deploy-release-linux-arm64:
+    executor: linux-arm64-amazonlinux-2
     steps:
       - checkout
-      - run: .circleci\windows\prepare.bat
-      - run: .circleci\windows\test-assembly.bat
+      - install-deps-yum:
+          bazel-arch: arm64
+      - deploy-release-unix
+
+  deploy-release-mac-x86_64:
+    executor: mac-arm64
+    steps:
+      - macos/install-rosetta
+      - checkout
+      - install-brew-rosetta
+      - install-deps-brew:
+          bazel-arch: amd64
+      - deploy-release-unix
+
+  deploy-release-mac-arm64:
+    executor: mac-arm64
+    steps:
+      - checkout
+      - install-deps-brew:
+          bazel-arch: arm64
+      - deploy-release-unix
+
+  deploy-docker-release-x86_64:
+    executor: linux-x86_64-amazonlinux-2
+    steps:
+      - checkout
+      - install-deps-yum:
+          bazel-arch: amd64
+      - deploy-docker-for-arch:
+          image-arch: x86_64
+
+  deploy-docker-release-arm64:
+    executor: linux-arm64-amazonlinux-2
+    steps:
+      - checkout
+      - install-deps-yum:
+          bazel-arch: arm64
+      - deploy-docker-for-arch:
+          image-arch: arm64
+
+  deploy-docker-release-multiarch:
+    executor: linux-x86_64-amazonlinux-2
+    steps:
+      - checkout
+      - install-deps-yum:
+          bazel-arch: x86_64
+      - deploy-docker-release-multiarch
+
+  # generic
+  release-cleanup:
+    executor: linux-x86_64-ubuntu-2204
+    steps:
+      - checkout
+      - run: |
+          apt update -y
+          apt install -y git
+          git push --delete https://$REPO_GITHUB_TOKEN@github.com/typedb/typedb-driver.git $CIRCLE_BRANCH
 
 
 workflows:
-#  typedb:
-#    jobs:
-#      - test-assembly-mac-x86_64-zip:
-#          filters:
-#            branches:
-#              only:
-#                - master
-#                - development
-#      - test-assembly-mac-arm64-zip:
-#          filters:
-#            branches:
-#              only:
-#                - master
-#                - development
-#      - test-assembly-linux-x86_64-zip:
-#          filters:
-#            branches:
-#              only:
-#                - master
-#                - development
-#      - test-assembly-linux-arm64-zip:
-#          filters:
-#            branches:
-#              only:
-#                - master
-#                - development
-#      - test-assembly-windows-zip:
-#          filters:
-#            branches:
-#              only:
-#                - master
-#                - development
+  typedb-snapshot:
+    jobs:
+      - test-deploy-snapshot-linux-x86_64:
+          filters:
+            branches:
+              only: [ "3.0" ]
+
+      - test-deploy-snapshot-linux-arm64:
+          filters:
+            branches:
+              only: [ "3.0" ]
+
+      - test-deploy-snapshot-mac-x86_64:
+          filters:
+            branches:
+              only: [ "3.0" ]
+
+      - test-deploy-snapshot-mac-arm64:
+          filters:
+            branches:
+              only: [ "3.0" ]
+
+  release:
+    jobs:
+      - deploy-release-linux-x86_64:
+          filters:
+            branches:
+              only: [ release ]
+
+      - deploy-release-linux-arm64:
+          filters:
+            branches:
+              only: [ release ]
+
+      - deploy-release-mac-x86_64:
+          filters:
+            branches:
+              only: [ release ]
+
+      - deploy-release-mac-arm64:
+          filters:
+            branches:
+              only: [ release ]
+
+      - deploy-docker-release-x86_64:
+          filters:
+            branches:
+              only: [ release ]
+
+      - deploy-docker-release-arm64:
+          filters:
+            branches:
+              only: [ release ]
+
+      - deploy-docker-release-multiarch:
+          filters:
+            branches:
+              only: [ release ]
+          requires:
+            - deploy-docker-release-x86_64
+            - deploy-docker-release-arm64
+
+      - release-cleanup:
+          filters:
+            branches:
+              only: [ release ]
+          requires:
+            - deploy-release-linux-x86_64
+            - deploy-release-linux-arm64
+            - deploy-release-mac-x86_64
+            - deploy-release-mac-arm64
+            - deploy-docker-release-multiarch

--- a/.factory/automation.yml
+++ b/.factory/automation.yml
@@ -7,7 +7,6 @@ config:
   dependencies:
     dependencies: [build]
     typeql: [build, release]
-    typedb-common: [build, release]
     typedb-protocol: [build, release]
     typedb-behaviour: [build]
 
@@ -37,22 +36,28 @@ build:
 #        dependencies/maven/update.sh
 #        git diff --exit-code dependencies/maven/artifacts.snapshot
 #        bazel run @vaticle_dependencies//tool/unuseddeps:unused-deps -- list
-#    test-unit:
-#      image: vaticle-ubuntu-22.04
-#      dependencies: [build]
-#      command: |
-#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-#        bazel test //common/... --test_output=streamed
-#        bazel test //pattern/... --test_output=streamed
-#        bazel test //logic/... --test_output=streamed
-#        bazel test //reasoner/... --test_output=streamed
-#        bazel test //server/... --test_output=streamed
-#    test-integration:
-#      image: vaticle-ubuntu-22.04
-#      dependencies: [build]
-#      command: |
-#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-#        bazel test //test/integration/... --test_output=streamed
+##    test-unit:
+##      image: vaticle-ubuntu-22.04
+##      dependencies: [build]
+##      command: |
+##        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+##        # TODO
+    test-integration:
+      image: vaticle-ubuntu-22.04
+      dependencies: [build]
+      command: |
+        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+#        # TODO: Uncomment!
+#        bazel test //compiler/tests/... --test_output=streamed
+#        bazel test //concept/tests/... --test_output=streamed
+#        bazel test //database/tests/... --test_output=streamed
+#        bazel test //durability/tests/... --test_output=streamed
+#        bazel test //encoding/tests/... --test_output=streamed
+#        bazel test //executor/tests/... --test_output=streamed
+#        bazel test //function/tests/... --test_output=streamed
+#        bazel test //ir/tests/... --test_output=streamed
+#        bazel test //query/tests/... --test_output=streamed
+#        bazel test //storage/tests/... --test_output=streamed
 #    test-behaviour-connection:
 #      image: vaticle-ubuntu-22.04
 #      dependencies: [build]
@@ -70,196 +75,53 @@ build:
 #      dependencies: [build]
 #      command: |
 #        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-#        bazel test //test/behaviour/query/language/match/... --test_output=streamed
-#        bazel test //test/behaviour/query/language/expression/... --test_output=streamed
-#        bazel test //test/behaviour/query/language/modifiers/... --test_output=streamed
-#        bazel test //test/behaviour/query/language/get/... --test_output=streamed
-#        bazel test //test/behaviour/query/language/fetch/... --test_output=streamed
+#        bazel test //test/behaviour/query/language:test_match --test_output=streamed
+#        bazel test //test/behaviour/query/language:test_expressions --test_output=streamed
+#        bazel test //test/behaviour/query/language:test_modifiers --test_output=streamed
+#        bazel test //test/behaviour/query/language:test_get --test_output=streamed
+#        bazel test //test/behaviour/query/language:test_fetch --test_output=streamed
 #    test-behaviour-query-write:
 #      image: vaticle-ubuntu-22.04
 #      dependencies: [build]
 #      command: |
 #        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-#        bazel test //test/behaviour/query/language/insert/... --test_output=streamed
-#        bazel test //test/behaviour/query/language/delete/... --test_output=streamed
-#        bazel test //test/behaviour/query/language/update/... --test_output=streamed
+#        bazel test //test/behaviour/query/language:test_insert --test_output=streamed
+#        bazel test //test/behaviour/query/language:test_delete --test_output=streamed
+#        bazel test //test/behaviour/query/language:test_update --test_output=streamed
+#        bazel test //test/behaviour/query/language:test_pipelines --test_output=streamed
 #    test-behaviour-query-definable:
 #      image: vaticle-ubuntu-22.04
 #      dependencies: [build]
 #      command: |
 #        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-#        bazel test //test/behaviour/query/language/define/... --test_output=streamed
-#        bazel test //test/behaviour/query/language/undefine/... --test_output=streamed
-#        bazel test //test/behaviour/query/language/rule_validation/... --test_output=streamed
-#    test-behaviour-reasoner:
+#        bazel test //test/behaviour/query/language:test_define --test_output=streamed
+#        bazel test //test/behaviour/query/language:test_undefine --test_output=streamed
+#        bazel test //test/behaviour/query/language:test_redefine --test_output=streamed
+#    test-behaviour-functions:
 #      image: vaticle-ubuntu-22.04
 #      dependencies: [build]
 #      command: |
 #        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-#        bazel test //test/behaviour/reasoner/tests/attribute_attachment:test --test_output=streamed
-#        bazel test //test/behaviour/reasoner/tests/compound_queries:test --test_output=streamed
-#        bazel test //test/behaviour/reasoner/tests/concept_inequality:test --test_output=streamed
-#        bazel test //test/behaviour/reasoner/tests/negation:test --test_output=streamed
-#        bazel test //test/behaviour/reasoner/tests/recursion:test --test_output=streamed
-#        bazel test //test/behaviour/reasoner/tests/relation_inference:test --test_output=streamed
-#        bazel test //test/behaviour/reasoner/tests/rule_interaction:test --test_output=streamed
-#        bazel test //test/behaviour/reasoner/tests/schema_queries:test --test_output=streamed
-#        bazel test //test/behaviour/reasoner/tests/type_hierarchy:test --test_output=streamed
-#        bazel test //test/behaviour/reasoner/tests/value_predicate:test --test_output=streamed
-#        bazel test //test/behaviour/reasoner/tests/variable_roles:test --test_output=streamed
-#    test-benchmark-reasoner:
-#      image: vaticle-ubuntu-22.04
-#      filter:
-#        owner: typedb
-#        branch: [master, development]
-#      dependencies: [build]
-#      command: |
-#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-#        bazel test //test/benchmark/reasoner/iam/basic:test-basic --test_output=streamed
-#        bazel test //test/benchmark/reasoner/iam/complex:test-conjunction-structure --test_output=streamed
-#        bazel test //test/benchmark/reasoner/iam/complex:test-complex-rule-graph --test_output=streamed
-#        bazel test //test/benchmark/reasoner/iam/complex:test-language-features --test_output=streamed
-#        bazel test //test/benchmark/reasoner/iam/complex:test-large-data --test_output=streamed
-#        bazel test //test/benchmark/reasoner/iam/complex:test-real-queries --test_output=streamed
-#    test-assembly-linux-targz:
-#      image: vaticle-ubuntu-20.04
-#      filter:
-#        owner: typedb
-#        branch: [master, development]
-#      dependencies: [build, build-dependency, test-unit, test-integration, test-behaviour-connection, test-behaviour-concept, test-behaviour-query-read, test-behaviour-query-write, test-behaviour-query-definable, test-behaviour-reasoner]
-#      command: |
-#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-#        bazel test //test/assembly:assembly --test_output=streamed
-#    test-assembly-docker:
-#      image: vaticle-ubuntu-22.04
-#      filter:
-#        owner: typedb
-#        branch: [master, development]
-#      dependencies: [build, build-dependency, test-unit, test-integration, test-behaviour-connection, test-behaviour-concept, test-behaviour-query-read, test-behaviour-query-write, test-behaviour-query-definable, test-behaviour-reasoner]
-#      command: |
-#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-#        bazel test //test/assembly:docker --test_output=streamed
-#    deploy-artifact-snapshot:
-#      image: vaticle-ubuntu-22.04
-#      filter:
-#        owner: typedb
-#        branch: [master, development]
-#      dependencies: [test-assembly-linux-targz]
-#      command: |
-#        export DEPLOY_ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-#        export DEPLOY_ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-#        bazel run --define version=$(git rev-parse HEAD) //server:deploy-linux-arm64-targz -- snapshot
-#        bazel run --define version=$(git rev-parse HEAD) //server:deploy-linux-x86_64-targz -- snapshot
-#        bazel run --define version=$(git rev-parse HEAD) //server:deploy-mac-arm64-zip -- snapshot
-#        bazel run --define version=$(git rev-parse HEAD) //server:deploy-mac-x86_64-zip -- snapshot
-#        bazel run --define version=$(git rev-parse HEAD) //server:deploy-windows-x86_64-zip -- snapshot
-#        bazel run --define version=$(git rev-parse HEAD) //:deploy-linux-arm64-targz -- snapshot
-#        bazel run --define version=$(git rev-parse HEAD) //:deploy-linux-x86_64-targz -- snapshot
-#        bazel run --define version=$(git rev-parse HEAD) //:deploy-mac-arm64-zip -- snapshot
-#        bazel run --define version=$(git rev-parse HEAD) //:deploy-mac-x86_64-zip -- snapshot
-#        bazel run --define version=$(git rev-parse HEAD) //:deploy-windows-x86_64-zip -- snapshot
-#    deploy-apt-snapshot:
-#      image: vaticle-ubuntu-22.04
-#      filter:
-#        owner: typedb
-#        branch: [master, development]
-#      dependencies: [test-assembly-linux-targz]
-#      command: |
-#        export DEPLOY_APT_USERNAME=$REPO_VATICLE_USERNAME
-#        export DEPLOY_APT_PASSWORD=$REPO_VATICLE_PASSWORD
-#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-#        bazel run --define version=$(git rev-parse HEAD) //:deploy-apt-x86_64 -- snapshot
-#        bazel run --define version=$(git rev-parse HEAD) //:deploy-apt-arm64 -- snapshot
-##    deploy-brew-snapshot:
-##      image: vaticle-ubuntu-22.04
-##      filter:
-##        owner: typedb
-##        branch: master
-##      command: |
-##        export DEPLOY_BREW_TOKEN=$REPO_GITHUB_TOKEN DEPLOY_BREW_USERNAME=$REPO_GITHUB_USERNAME DEPLOY_BREW_EMAIL=$REPO_GITHUB_EMAIL
-##        bazel run --define version=$(cat VERSION) //:deploy-brew -- snapshot
-#    test-deployment-apt-x86_64:
-#      image: vaticle-ubuntu-22.04 # use LTS for apt tests
-#      filter:
-#        owner: typedb
-#        branch: [master, development]
-#      dependencies: [deploy-apt-snapshot]
-#      command: |
-#        export TEST_DEPLOYMENT_APT_COMMIT=$FACTORY_COMMIT
-#        bazel test //test/deployment:apt --action_env=TEST_DEPLOYMENT_APT_COMMIT --test_output=streamed
-#release:
-#  filter:
-#    owner: typedb
-#    branch: master
-#  validation:
-#    validate-dependencies:
-#      image: vaticle-ubuntu-22.04
-#      command: bazel test //:release-validate-deps --test_output=streamed
-#    validate-release-notes:
-#      image: vaticle-ubuntu-22.04
-#      command: |
-#        export NOTES_VALIDATE_TOKEN=$REPO_GITHUB_TOKEN
-#        bazel run @vaticle_dependencies//tool/release/notes:validate --test_output=streamed -- $FACTORY_OWNER $FACTORY_REPO ./RELEASE_NOTES_LATEST.md
-#  deployment:
-#    deploy-github:
-#      image: vaticle-ubuntu-22.04
-#      filter:
-#        owner: typedb
-#        branch: master
-#      command: |
-#        export DEPLOY_GITHUB_TOKEN=$REPO_GITHUB_TOKEN
-#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-#        bazel run --define version=$(cat VERSION) //:deploy-github -- $FACTORY_COMMIT
-#    deploy-brew:
-#      image: vaticle-ubuntu-22.04
-#      dependencies: [deploy-github]
-#      filter:
-#        owner: typedb
-#        branch: master
-#      command: |
-#        export DEPLOY_BREW_TOKEN=$REPO_GITHUB_TOKEN DEPLOY_BREW_USERNAME=$REPO_GITHUB_USERNAME DEPLOY_BREW_EMAIL=$REPO_GITHUB_EMAIL
-#        bazel run --define version=$(cat VERSION) //:deploy-brew -- release
-#    deploy-apt-release:
-#      image: vaticle-ubuntu-22.04
-#      filter:
-#        owner: typedb
-#        branch: master
-#      dependencies: [deploy-github]
-#      command: |
-#        export DEPLOY_APT_USERNAME=$REPO_VATICLE_USERNAME
-#        export DEPLOY_APT_PASSWORD=$REPO_VATICLE_PASSWORD
-#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-#        bazel run --define version=$(cat VERSION) //:deploy-apt-x86_64 -- release
-#        bazel run --define version=$(cat VERSION) //:deploy-apt-arm64 -- release
-#    deploy-docker:
-#      image: vaticle-ubuntu-22.04
-#      filter:
-#        owner: typedb
-#        branch: master
-#      dependencies: [deploy-github]
-#      command: |
-#        docker login -u $REPO_DOCKER_USERNAME -p $REPO_DOCKER_PASSWORD
-#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-#        bazel run //:deploy-docker-release
-#        bazel run //:deploy-docker-release-overwrite-latest-tag
-#    deploy-artifact-release:
-#      image: vaticle-ubuntu-22.04
-#      filter:
-#        owner: typedb
-#        branch: master
-#      dependencies: [deploy-github]
-#      command: |
-#        export DEPLOY_ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-#        export DEPLOY_ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
-#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-#        bazel run --define version=$(cat VERSION) //server:deploy-linux-arm64-targz -- release
-#        bazel run --define version=$(cat VERSION) //server:deploy-linux-x86_64-targz -- release
-#        bazel run --define version=$(cat VERSION) //server:deploy-mac-arm64-zip -- release
-#        bazel run --define version=$(cat VERSION) //server:deploy-mac-x86_64-zip -- release
-#        bazel run --define version=$(cat VERSION) //server:deploy-windows-x86_64-zip -- release
-#        bazel run --define version=$(cat VERSION) //:deploy-linux-arm64-targz -- release
-#        bazel run --define version=$(cat VERSION) //:deploy-linux-x86_64-targz -- release
-#        bazel run --define version=$(cat VERSION) //:deploy-mac-arm64-zip -- release
-#        bazel run --define version=$(cat VERSION) //:deploy-mac-x86_64-zip -- release
-#        bazel run --define version=$(cat VERSION) //:deploy-windows-x86_64-zip -- release
+
+release:
+  filter:
+    owner: vaticle
+    branch: [master]
+  validation:
+    validate-dependencies:
+      image: vaticle-ubuntu-22.04
+      command: |
+        bazel test //:release-validate-deps --test_output=streamed
+    validate-release-notes:
+      image: vaticle-ubuntu-22.04
+      command: |
+        export NOTES_VALIDATE_TOKEN=$REPO_GITHUB_TOKEN
+        bazel run @vaticle_dependencies//tool/release/notes:validate --test_output=streamed -- $FACTORY_OWNER $FACTORY_REPO RELEASE_NOTES_LATEST.md
+
+  deployment:
+    trigger-release-circleci:
+      image: vaticle-ubuntu-22.04
+      command: |
+        git checkout -b release
+        git push -f origin release
+        echo "Successfully pushed branch 'release', which triggers a release workflow in CircleCI. The progress of the release can be tracked there."

--- a/.factory/automation.yml
+++ b/.factory/automation.yml
@@ -42,11 +42,11 @@ build:
 ##      command: |
 ##        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
 ##        # TODO
-    test-integration:
-      image: vaticle-ubuntu-22.04
-      dependencies: [build]
-      command: |
-        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+#    test-integration:
+#      image: vaticle-ubuntu-22.04
+#      dependencies: [build]
+#      command: |
+#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
 #        # TODO: Uncomment!
 #        bazel test //compiler/tests/... --test_output=streamed
 #        bazel test //concept/tests/... --test_output=streamed

--- a/.factory/automation.yml
+++ b/.factory/automation.yml
@@ -106,7 +106,7 @@ build:
 release:
   filter:
     owner: vaticle
-    branch: [master]
+    branch: [master, "3.0"]
   validation:
     validate-dependencies:
       image: vaticle-ubuntu-22.04

--- a/BUILD
+++ b/BUILD
@@ -3,9 +3,19 @@
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 load("@vaticle_dependencies//distribution:deployment.bzl", "deployment")
+load("//:deployment.bzl", deployment_docker = "deployment", deployment_github = "deployment")
 load("@vaticle_dependencies//tool/checkstyle:rules.bzl", "checkstyle_test")
 load("@vaticle_dependencies//tool/release/deps:rules.bzl", "release_validate_deps")
 
+load("@vaticle_bazel_distribution//artifact:rules.bzl", "deploy_artifact")
+load("@vaticle_bazel_distribution//common:rules.bzl", "assemble_targz", "assemble_versioned", "assemble_zip")
+load("@vaticle_bazel_distribution//platform:constraints.bzl", "constraint_linux_arm64", "constraint_linux_x86_64",
+     "constraint_mac_arm64", "constraint_mac_x86_64", "constraint_win_x86_64")
+
+load("@io_bazel_rules_docker//container:image.bzl", docker_container_image = "container_image")
+load("@io_bazel_rules_docker//container:container.bzl", docker_container_push = "container_push")
+
+load("@rules_pkg//:pkg.bzl", "pkg_tar")
 load("@rules_rust//rust:defs.bzl", "rust_binary")
 
 exports_files(
@@ -27,6 +37,207 @@ rust_binary(
     ],
 )
 
+# Assembly
+assemble_files = {
+    "//resource:logo": "resource/typedb-ascii.txt",
+    "//:LICENSE": "LICENSE",
+}
+empty_directories = [
+    "server/data",
+]
+permissions = {
+    "server/conf/config.yml": "0755",
+    "server/data": "0755",
+}
+
+pkg_tar(
+    name = "package-typedb",
+    srcs = ["//:typedb_server_bin"],
+)
+
+assemble_zip(
+    name = "assemble-mac-x86_64-zip",
+    additional_files = assemble_files,
+    empty_directories = empty_directories,
+    output_filename = "typedb-all-mac-x86_64",
+    permissions = permissions,
+    targets = ["//:package-typedb"],
+    visibility = ["//tests/assembly:__subpackages__"],
+    target_compatible_with = constraint_mac_x86_64,
+)
+
+assemble_zip(
+    name = "assemble-mac-arm64-zip",
+    additional_files = assemble_files,
+    empty_directories = empty_directories,
+    output_filename = "typedb-all-mac-arm64",
+    permissions = permissions,
+    targets = ["//:package-typedb"],
+    visibility = ["//tests/assembly:__subpackages__"],
+    target_compatible_with = constraint_mac_arm64,
+)
+
+assemble_targz(
+    name = "assemble-linux-x86_64-targz",
+    additional_files = assemble_files,
+    empty_directories = empty_directories,
+    output_filename = "typedb-all-linux-x86_64",
+    permissions = permissions,
+    targets = ["//:package-typedb"],
+    visibility = ["//tests/assembly:__subpackages__"],
+    target_compatible_with = constraint_linux_x86_64,
+)
+
+assemble_targz(
+    name = "assemble-linux-arm64-targz",
+    additional_files = assemble_files,
+    empty_directories = empty_directories,
+    output_filename = "typedb-all-linux-arm64",
+    permissions = permissions,
+    targets = ["//:package-typedb"],
+    visibility = ["//tests/assembly:__subpackages__"],
+    target_compatible_with = constraint_linux_arm64,
+)
+
+deploy_artifact(
+    name = "deploy-mac-x86_64-zip",
+    artifact_group = "typedb-all-mac-x86_64",
+    artifact_name = "typedb-all-mac-x86_64-{version}.zip",
+    release = deployment["artifact"]["release"]["upload"],
+    snapshot = deployment["artifact"]["snapshot"]["upload"],
+    target = ":assemble-mac-x86_64-zip",
+)
+
+deploy_artifact(
+    name = "deploy-mac-arm64-zip",
+    artifact_group = "typedb-all-mac-arm64",
+    artifact_name = "typedb-all-mac-arm64-{version}.zip",
+    release = deployment["artifact"]["release"]["upload"],
+    snapshot = deployment["artifact"]["snapshot"]["upload"],
+    target = ":assemble-mac-arm64-zip",
+)
+
+deploy_artifact(
+    name = "deploy-linux-x86_64-targz",
+    artifact_group = "typedb-all-linux-x86_64",
+    artifact_name = "typedb-all-linux-x86_64-{version}.tar.gz",
+    release = deployment["artifact"]["release"]["upload"],
+    snapshot = deployment["artifact"]["snapshot"]["upload"],
+    target = ":assemble-linux-x86_64-targz",
+)
+
+deploy_artifact(
+    name = "deploy-linux-arm64-targz",
+    artifact_group = "typedb-all-linux-arm64",
+    artifact_name = "typedb-all-linux-arm64-{version}.tar.gz",
+    release = deployment["artifact"]["release"]["upload"],
+    snapshot = deployment["artifact"]["snapshot"]["upload"],
+    target = ":assemble-linux-arm64-targz",
+)
+
+# Convenience
+alias(
+    name = "assemble-typedb-server",
+    actual = select({
+        "@vaticle_bazel_distribution//platform:is_linux_arm64" : ":assemble-linux-arm64-targz",
+        "@vaticle_bazel_distribution//platform:is_linux_x86_64" : ":assemble-linux-x86_64-targz",
+        "@vaticle_bazel_distribution//platform:is_mac_arm64" : ":assemble-mac-arm64-zip",
+        "@vaticle_bazel_distribution//platform:is_mac_x86_64" : ":assemble-mac-x86_64-zip",
+#        "@vaticle_bazel_distribution//platform:is_windows_x86_64" : ":assemble-windows-x86_64-zip"
+    }),
+    visibility = ["//tests/assembly:__subpackages__"],
+)
+alias(
+    name = "deploy-typedb-server",
+    actual = select({
+        "@vaticle_bazel_distribution//platform:is_linux_arm64" : ":deploy-linux-arm64-targz",
+        "@vaticle_bazel_distribution//platform:is_linux_x86_64" : ":deploy-linux-x86_64-targz",
+        "@vaticle_bazel_distribution//platform:is_mac_arm64" : ":deploy-mac-arm64-zip",
+        "@vaticle_bazel_distribution//platform:is_mac_x86_64" : ":deploy-mac-x86_64-zip",
+#        "@vaticle_bazel_distribution//platform:is_windows_x86_64" : ":deploy-windows-x86_64-zip"
+    })
+)
+
+# docker
+docker_container_image(
+    name = "assemble-docker-x86_64",
+    operating_system = "linux",
+    architecture = "amd64",
+    base = "@ubuntu-22.04-arm64//image",
+    cmd = [
+        "/opt/typedb-all-linux-x86_64/typedb_server_bin"
+    ],
+    directory = "opt",
+    env = {
+        "LANG": "C.UTF-8",
+        "LC_ALL": "C.UTF-8",
+    },
+    ports = ["1729"],
+    tars = [":assemble-linux-x86_64-targz"],
+    visibility = ["//test:__subpackages__"],
+    volumes = ["/opt/typedb-all-linux-x86_64/server/data/"],
+    workdir = "/opt/typedb-all-linux-x86_64",
+    target_compatible_with = constraint_linux_x86_64,
+)
+
+docker_container_image(
+    name = "assemble-docker-arm64",
+    operating_system = "linux",
+    architecture = "arm64",
+    base = "@ubuntu-22.04-arm64//image",
+    cmd = [
+        "/opt/typedb-all-linux-arm64/typedb_server_bin"
+    ],
+    directory = "opt",
+    env = {
+        "LANG": "C.UTF-8",
+        "LC_ALL": "C.UTF-8",
+    },
+    ports = ["1729"],
+    tars = [":assemble-linux-arm64-targz"],
+    visibility = ["//test:__subpackages__"],
+    volumes = ["/opt/typedb-all-linux-arm64/server/data/"],
+    workdir = "/opt/typedb-all-linux-arm64",
+    target_compatible_with = constraint_linux_arm64,
+)
+
+docker_container_push(
+    name = "deploy-docker-release-x86_64",
+    format = "Docker",
+    image = ":assemble-docker-x86_64",
+    registry = deployment_docker["docker.index"],
+    repository = "{}/{}".format(
+        deployment_docker["docker.organisation"],
+        deployment_docker["docker.release.repository"],
+    ),
+    tag_file = "//docker:version-x86_64",
+    target_compatible_with = constraint_linux_x86_64,
+)
+
+docker_container_push(
+    name = "deploy-docker-release-arm64",
+    format = "Docker",
+    image = ":assemble-docker-arm64",
+    registry = deployment_docker["docker.index"],
+    repository = "{}/{}".format(
+        deployment_docker["docker.organisation"],
+        deployment_docker["docker.release.repository"],
+    ),
+    tag_file = "//docker:version-arm64",
+    target_compatible_with = constraint_linux_arm64,
+)
+
+# validation & tests
+release_validate_deps(
+    name = "release-validate-deps",
+    refs = "@vaticle_typedb_workspace_refs//:refs.json",
+    tagged_deps = [
+        "@vaticle_typeql",
+        "@vaticle_typedb_protocol",
+    ],
+    tags = ["manual"],  # in order for bazel test //... to not fail
+    version_file = "VERSION",
+)
 
 checkstyle_test(
     name = "checkstyle",

--- a/VERSION
+++ b/VERSION
@@ -1,1 +1,1 @@
-2.25.7
+dummy-for-safety

--- a/VERSION
+++ b/VERSION
@@ -1,1 +1,1 @@
-dummy-for-safety
+3.0.0-alpha-0

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -91,6 +91,12 @@ crate_repositories()
 load("//dependencies/vaticle:repositories.bzl", "vaticle_bazel_distribution")
 vaticle_bazel_distribution()
 
+# Load @vaticle_bazel_distribution_uploader
+load("@vaticle_bazel_distribution//common/uploader:deps.bzl", uploader_deps = "deps")
+uploader_deps()
+load("@vaticle_bazel_distribution_uploader//:requirements.bzl", install_uploader_deps = "install_deps")
+install_uploader_deps()
+
 # Load //common
 load("@vaticle_bazel_distribution//common:deps.bzl", "rules_pkg")
 rules_pkg()
@@ -104,37 +110,32 @@ github_deps()
 # Load //pip
 load("@vaticle_bazel_distribution//pip:deps.bzl", pip_deps = "deps")
 pip_deps()
-#
-####################################################
-## Load @vaticle_dependencies//distribution/docker #
-####################################################
-#
-## must be loaded after `vaticle_bazel_distribution` to ensure
-## `rules_pkg` is correctly patched (bazel-distribution #251)
-#
-## Load //distribution/docker
-#load("@vaticle_dependencies//distribution/docker:deps.bzl", docker_deps = "deps")
-#docker_deps()
-#
-#load("@io_bazel_rules_go//go:deps.bzl", "go_register_toolchains", "go_rules_dependencies")
-#load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies", "go_repository")
-#go_rules_dependencies()
-#go_register_toolchains(version = "1.18.3")
-#gazelle_dependencies()
-#
-#load("@io_bazel_rules_docker//repositories:repositories.bzl", bazel_rules_docker_repositories = "repositories")
-#bazel_rules_docker_repositories()
-#
-#load("@io_bazel_rules_docker//repositories:deps.bzl", bazel_rules_docker_container_deps = "deps")
-#bazel_rules_docker_container_deps()
-#
-#load("@io_bazel_rules_docker//container:container.bzl", "container_pull")
-#container_pull(
-#  name = "vaticle_ubuntu_image",
-#  registry = "index.docker.io",
-#  repository = "vaticle/ubuntu",
-#  tag = "4ee548cea883c716055566847c4736a7ef791c38"
-#)
+
+###################################################
+# Load @vaticle_dependencies//distribution/docker #
+###################################################
+
+# must be loaded after `vaticle_bazel_distribution` to ensure
+# `rules_pkg` is correctly patched (bazel-distribution #251)
+
+# Load //distribution/docker
+load("@vaticle_dependencies//distribution/docker:deps.bzl", docker_deps = "deps")
+docker_deps()
+
+load("@io_bazel_rules_go//go:deps.bzl", "go_register_toolchains", "go_rules_dependencies")
+load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies", "go_repository")
+go_rules_dependencies()
+go_register_toolchains(version = "1.18.3")
+gazelle_dependencies()
+
+load("@io_bazel_rules_docker//repositories:repositories.bzl", bazel_rules_docker_repositories = "repositories")
+bazel_rules_docker_repositories()
+
+load("@io_bazel_rules_docker//repositories:deps.bzl", bazel_rules_docker_container_deps = "deps")
+bazel_rules_docker_container_deps()
+
+load("//docker:images.bzl", docker_base_images = "base_images")
+docker_base_images()
 
 #####################################
 # Load @vaticle/typedb dependencies #

--- a/docker/BUILD
+++ b/docker/BUILD
@@ -1,0 +1,40 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+package(default_visibility = ["//visibility:public"])
+load("@vaticle_bazel_distribution//platform:constraints.bzl", "constraint_linux_arm64", "constraint_linux_x86_64")
+load("@vaticle_dependencies//tool/checkstyle:rules.bzl", "checkstyle_test")
+
+platform(
+    name = "linux-x86_64",
+    constraint_values = constraint_linux_x86_64,
+)
+
+platform(
+    name = "linux-arm64",
+    constraint_values = constraint_linux_arm64,
+)
+
+genrule(
+  name = "version-arm64",
+  srcs = ["//:VERSION"],
+  outs = ["version-arm64.txt"],
+  tools = [],
+  cmd = "cp $(location //:VERSION) $@; echo \"-arm64\" >> $@"
+)
+
+
+genrule(
+  name = "version-x86_64",
+  srcs = ["//:VERSION"],
+  outs = ["version-x86_64.txt"],
+  tools = [],
+  cmd = "cp $(location //:VERSION) $@; echo \"-x86_64\" >> $@"
+)
+
+checkstyle_test(
+    name = "checkstyle",
+    include = glob(["*",]),
+    license_type = "mpl-header",
+)

--- a/docker/images.bzl
+++ b/docker/images.bzl
@@ -1,0 +1,21 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+load("@io_bazel_rules_docker//container:pull.bzl", "container_pull")
+
+def base_images():
+    container_pull(
+        name = "ubuntu-22.04-x86_64",
+        architecture = "amd64",
+        registry = "index.docker.io",
+        repository = "amd64/ubuntu",
+        digest = "sha256:3d1556a8a18cf5307b121e0a98e93f1ddf1f3f8e092f1fddfd941254785b95d7",
+    )
+    container_pull(
+        name = "ubuntu-22.04-arm64",
+        architecture="arm64",
+        registry = "index.docker.io",
+        repository = "arm64v8/ubuntu",
+        digest = "sha256:7c75ab2b0567edbb9d4834a2c51e462ebd709740d1f2c40bcd23c56e974fe2a8",
+    )

--- a/resource/BUILD
+++ b/resource/BUILD
@@ -19,6 +19,11 @@ rust_library(
     ],
 )
 
+filegroup(
+    name = "logo",
+    srcs = ["typedb-ascii.txt"],
+)
+
 checkstyle_test(
     name = "checkstyle",
     include = glob(["*"]),

--- a/server/parameters/config.rs
+++ b/server/parameters/config.rs
@@ -18,9 +18,12 @@ pub struct Config {
 
 impl Config {
     pub fn new() -> Self {
+        let typedb_dir_or_current = std::env::current_exe()
+            .map(|path| path.parent().unwrap().to_path_buf())
+            .unwrap_or(std::env::current_dir().unwrap());
         Self {
             server: ServerConfig { address: SocketAddr::from_str("127.0.0.1:1729").unwrap() },
-            storage: StorageConfig { data: "runtimedata/server/data".into() },
+            storage: StorageConfig { data: typedb_dir_or_current.join(PathBuf::from_str("server/data").unwrap()) },
         }
     }
 

--- a/server/typedb.rs
+++ b/server/typedb.rs
@@ -5,7 +5,6 @@
  */
 
 use std::{error::Error, fmt, fs, io, path::PathBuf};
-
 use database::{database_manager::DatabaseManager, DatabaseOpenError};
 use resource::constants::server::GRPC_CONNECTION_KEEPALIVE;
 

--- a/tests/assembly/BUILD
+++ b/tests/assembly/BUILD
@@ -1,0 +1,31 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+load("@vaticle_dependencies//tool/checkstyle:rules.bzl", "checkstyle_test")
+load("@rules_rust//rust:defs.bzl", "rust_test")
+
+rust_test(
+    name = "test_assembly",
+    srcs = ["assembly.rs"],
+    deps = [
+        "@crates//:tokio",
+    ],
+    data = ["//:assemble-typedb-server"],
+    env = select({
+        "@vaticle_bazel_distribution//platform:is_linux_x86_64" : {"TYPEDB_ASSEMBLY_ARCHIVE": "typedb-all-linux-x86_64.tar.gz" },
+        "@vaticle_bazel_distribution//platform:is_linux_arm64" : {"TYPEDB_ASSEMBLY_ARCHIVE":"typedb-all-linux-arm64.tar.gz"},
+        "@vaticle_bazel_distribution//platform:is_mac_x86_64" : {"TYPEDB_ASSEMBLY_ARCHIVE": "typedb-all-mac-x86_64.zip"},
+        "@vaticle_bazel_distribution//platform:is_mac_arm64" : {"TYPEDB_ASSEMBLY_ARCHIVE":"typedb-all-mac-arm64.zip"},
+        # "@vaticle_bazel_distribution//platform:is_windows_x86_64" : ":assemble-windows-x86_64-zip"},
+    }),
+)
+
+checkstyle_test(
+    name = "checkstyle",
+    include = glob(["*"]),
+    exclude = glob([
+        "Cargo.*",
+    ]),
+    license_type = "mpl-header",
+)

--- a/tests/assembly/assembly.rs
+++ b/tests/assembly/assembly.rs
@@ -1,0 +1,61 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+use std::process::{Child, Command, Output};
+
+fn build_cmd(cmd_str: &str) -> Command {
+    let mut cmd = Command::new("sh");
+    cmd.arg("-c").arg(cmd_str);
+    cmd
+}
+
+fn kill_process(process: Child) -> std::io::Result<Output> {
+    let mut process = process;
+    match process.try_wait() {
+        Ok(Some(_)) => {}
+        _ => {
+            let output = build_cmd(format!("kill -s TERM {}", process.id()).as_str())
+                .output().expect("Failed to run kill command");
+            if !output.status.success() {
+                println!("kill-ing process failed: {:?}", output);
+            }
+        }
+    }
+    process.wait_with_output()
+}
+
+#[test]
+fn test_assembly() {
+    let archive_name = std::env::var("TYPEDB_ASSEMBLY_ARCHIVE").unwrap();
+    let extract_cmd = if archive_name.ends_with(".zip") {
+        let without_extension = archive_name.replace(".zip", "");
+        format!("unzip {archive_name} && mv {without_extension} typedb-extracted")
+    } else if archive_name.ends_with(".tar.gz") {
+        let without_extension = archive_name.replace(".tar.gz", "");
+        format!("tar -xf {archive_name} && mv {without_extension} typedb-extracted")
+    } else {
+        unreachable!("Expected .zip or .tar.gz");
+    };
+
+    let extract_output = build_cmd(extract_cmd.as_str())
+        .output().expect("Failed to run tar");
+    if !extract_output.status.success() {
+        panic!("{:?}", extract_output);
+    }
+    let server_process = build_cmd("typedb-extracted/typedb_server_bin").spawn().expect("Failed to spawn server process");
+    let test_result = run_test_against_server();
+    let server_process_output = kill_process(server_process);
+
+    if test_result.is_err() {
+        println!("Server process output:\n{:?}", server_process_output);
+        test_result.unwrap();
+    }
+}
+
+fn run_test_against_server() -> Result<(),()> {
+    // TODO
+    Ok(())
+}


### PR DESCRIPTION
## Release notes: product changes
Introduce deployment jobs for server 3.x on CircleCI

## Motivation
Introduce deployment jobs for server 3.x on CircleCI

## Implementation
Introduce deployment jobs for server 3.x on CircleCI
* raw artefacts deployed to cloudsmith for `{linux, mac}-{x86_64, arm64}`
* docker image for `amd64` & `arm64` + A circleci step for pushing the image referencing both.