### PR TITLE
Fix greedy planner: variables are produced immediately

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -70,13 +70,13 @@ rust_register_toolchains(
         "x86_64-pc-windows-msvc",
         "x86_64-unknown-linux-gnu",
     ],
-    rust_analyzer_version = "1.80.1",
-    versions = ["1.80.1"],
+    rust_analyzer_version = "1.81.0",
+    versions = ["1.81.0"],
 )
 
 rust_analyzer_toolchain_tools_repository(
     name = "rust_analyzer_toolchain_tools",
-    version = "1.80.1"
+    version = "1.81.0"
 )
 
 load("@vaticle_dependencies//library/crates:crates.bzl", "fetch_crates")

--- a/compiler/match_/planner/vertex/mod.rs
+++ b/compiler/match_/planner/vertex/mod.rs
@@ -16,7 +16,7 @@ use ir::pattern::{
     constraint::{Comparison, Has, Links, SubKind},
     Vertex,
 };
-use itertools::Itertools;
+use itertools::{chain, Itertools};
 
 use crate::match_::inference::type_annotations::TypeAnnotations;
 
@@ -374,6 +374,13 @@ impl ThingPlanner {
 
 impl Costed for ThingPlanner {
     fn cost(&self, inputs: &[usize], elements: &[PlannerVertex]) -> VertexCost {
+        let bounds = chain!(&self.bound_value_equal, &self.bound_value_above, &self.bound_value_below).collect_vec();
+        for &i in inputs {
+            if !bounds.contains(&&Input::Variable(i)) {
+                return VertexCost::default();
+            }
+        }
+
         let per_input = OPEN_ITERATOR_RELATIVE_COST;
         let per_output = ADVANCE_ITERATOR_RELATIVE_COST;
         let mut branching_factor = self.expected_size;

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -21,8 +21,8 @@ def vaticle_dependencies():
 def vaticle_typeql():
     git_repository(
         name = "vaticle_typeql",
-        remote = "https://github.com/dmitrii-ubskii/typeql",
-        commit = "a96fd316c2bb0f4250426260097b0eae3d4bffff",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typeql
+        remote = "https://github.com/typedb/typeql",
+        commit = "97ee61b25f0f461018acaadbf55c488b1a92d291",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typeql
     )
 
 def vaticle_typedb_common():
@@ -42,6 +42,6 @@ def vaticle_typedb_protocol():
 def vaticle_typedb_behaviour():
     git_repository(
         name = "vaticle_typedb_behaviour",
-        remote = "https://github.com/dmitrii-ubskii/typedb-behaviour",
-        commit = "064ab4b39a53b9f084ca72fa935191c47fbaa858", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_behaviour
+        remote = "https://github.com/typedb/typedb-behaviour",
+        commit = "5975dae103bbbeb59ce802c8c4e16ba6e997db3c", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_behaviour
     )

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -21,8 +21,8 @@ def vaticle_dependencies():
 def vaticle_typeql():
     git_repository(
         name = "vaticle_typeql",
-        remote = "https://github.com/typedb/typeql",
-        commit = "29bb3df624de519f1d7d6695d2cfc99bdffa6a08",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typeql
+        remote = "https://github.com/dmitrii-ubskii/typeql",
+        commit = "a96fd316c2bb0f4250426260097b0eae3d4bffff",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typeql
     )
 
 def vaticle_typedb_common():
@@ -42,6 +42,6 @@ def vaticle_typedb_protocol():
 def vaticle_typedb_behaviour():
     git_repository(
         name = "vaticle_typedb_behaviour",
-        remote = "https://github.com/typedb/typedb-behaviour",
-        commit = "5d51697cb98b6426422d11c964a7fa0ffe3370d7", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_behaviour
+        remote = "https://github.com/dmitrii-ubskii/typedb-behaviour",
+        commit = "064ab4b39a53b9f084ca72fa935191c47fbaa858", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_behaviour
     )

--- a/encoding/graph/thing/edge.rs
+++ b/encoding/graph/thing/edge.rs
@@ -297,7 +297,7 @@ impl<'a> ThingEdgeHasReverse<'a> {
         Self::RANGE_PREFIX.end..Self::RANGE_PREFIX.end + self.from_length()
     }
 
-    #[allow(clippy::wrong_self_convention)] // `from` refers to the edge's source vertex
+    #[allow(clippy::wrong_self_convention, reason = "`from` refers to the edge's source vertex")]
     fn from_length(&self) -> usize {
         let byte = self.bytes.bytes()[Self::INDEX_FROM_PREFIX];
         let prefix = PrefixID::new([byte]);

--- a/executor/tests/compile_execute.rs
+++ b/executor/tests/compile_execute.rs
@@ -294,6 +294,14 @@ fn test_links_planning_traversal() {
     }
 }
 
+const USER_LABEL: Label = Label::new_static("user");
+const ORDER_LABEL: Label = Label::new_static("order");
+const PURCHASE_LABEL: Label = Label::new_static("purchase");
+const PURCHASE_BUYER_LABEL: Label = Label::new_static_scoped("buyer", "purchase", "purchase:buyer");
+const PURCHASE_ORDER_LABEL: Label = Label::new_static_scoped("order", "purchase", "purchase:order");
+const STATUS_LABEL: Label = Label::new_static("status");
+const TIMESTAMP_LABEL: Label = Label::new_static("timestamp");
+
 #[test]
 fn test_links_intersection() {
     let (_tmp_dir, mut storage) = create_core_storage();
@@ -305,57 +313,92 @@ fn test_links_intersection() {
     const CARDINALITY_ANY: AnnotationCardinality = AnnotationCardinality::new(0, None);
     const RELATES_CARDINALITY_ANY: RelatesAnnotation = RelatesAnnotation::Cardinality(CARDINALITY_ANY);
 
-    let person_type = type_manager.create_entity_type(&mut snapshot, &PERSON_LABEL).unwrap();
-    let membership_type = type_manager.create_relation_type(&mut snapshot, &MEMBERSHIP_LABEL).unwrap();
+    let user_type = type_manager.create_entity_type(&mut snapshot, &USER_LABEL).unwrap();
+    let order_type = type_manager.create_entity_type(&mut snapshot, &ORDER_LABEL).unwrap();
+    let purchase_type = type_manager.create_relation_type(&mut snapshot, &PURCHASE_LABEL).unwrap();
 
-    let relates_member = membership_type
+    let status_type = type_manager.create_attribute_type(&mut snapshot, &STATUS_LABEL).unwrap();
+    status_type.set_value_type(&mut snapshot, &type_manager, &thing_manager, ValueType::String).unwrap();
+    let timestamp_type = type_manager.create_attribute_type(&mut snapshot, &TIMESTAMP_LABEL).unwrap();
+    timestamp_type.set_value_type(&mut snapshot, &type_manager, &thing_manager, ValueType::DateTime).unwrap();
+
+    order_type
+        .set_owns(&mut snapshot, &type_manager, &thing_manager, status_type.clone(), Ordering::Unordered)
+        .unwrap();
+    order_type
+        .set_owns(&mut snapshot, &type_manager, &thing_manager, timestamp_type.clone(), Ordering::Unordered)
+        .unwrap();
+
+    let relates_buyer = purchase_type
         .create_relates(
             &mut snapshot,
             &type_manager,
             &thing_manager,
-            MEMBERSHIP_MEMBER_LABEL.name().as_str(),
+            PURCHASE_BUYER_LABEL.name().as_str(),
             Ordering::Unordered,
         )
         .unwrap();
-    relates_member.set_annotation(&mut snapshot, &type_manager, &thing_manager, RELATES_CARDINALITY_ANY).unwrap();
-    let membership_member_type = relates_member.role();
+    relates_buyer.set_annotation(&mut snapshot, &type_manager, &thing_manager, RELATES_CARDINALITY_ANY).unwrap();
+    let purchase_buyer_type = relates_buyer.role();
 
-    person_type.set_plays(&mut snapshot, &type_manager, &thing_manager, membership_member_type.clone()).unwrap();
+    user_type.set_plays(&mut snapshot, &type_manager, &thing_manager, purchase_buyer_type.clone()).unwrap();
 
-    let person = [
-        thing_manager.create_entity(&mut snapshot, person_type.clone()).unwrap(),
-        thing_manager.create_entity(&mut snapshot, person_type.clone()).unwrap(),
-        thing_manager.create_entity(&mut snapshot, person_type.clone()).unwrap(),
-    ];
-
-    let membership = [
-        thing_manager.create_relation(&mut snapshot, membership_type.clone()).unwrap(),
-        thing_manager.create_relation(&mut snapshot, membership_type.clone()).unwrap(),
-    ];
-
-    membership[0]
-        .add_player(
+    let relates_order = purchase_type
+        .create_relates(
             &mut snapshot,
+            &type_manager,
             &thing_manager,
-            membership_member_type.clone(),
-            person[0].clone().into_owned_object(),
+            PURCHASE_ORDER_LABEL.name().as_str(),
+            Ordering::Unordered,
         )
         .unwrap();
-    membership[0]
-        .add_player(
-            &mut snapshot,
-            &thing_manager,
-            membership_member_type.clone(),
-            person[1].clone().into_owned_object(),
-        )
+    relates_order.set_annotation(&mut snapshot, &type_manager, &thing_manager, RELATES_CARDINALITY_ANY).unwrap();
+    let purchase_order_type = relates_order.role();
+
+    order_type.set_plays(&mut snapshot, &type_manager, &thing_manager, purchase_order_type.clone()).unwrap();
+
+    // END SCHEMA
+
+    let user = [(); 3].map(|_| thing_manager.create_entity(&mut snapshot, user_type.clone()).unwrap());
+    let order = [(); 3].map(|_| thing_manager.create_entity(&mut snapshot, order_type.clone()).unwrap());
+
+    let status = ["canceled", "dispatched", "paid"]
+        .map(|s| thing_manager.create_attribute(&mut snapshot, status_type.clone(), Value::String(s.into())).unwrap());
+
+    let timestamp = [(); 3].map(|_| {
+        thing_manager
+            .create_attribute(&mut snapshot, timestamp_type.clone(), Value::DateTime(Default::default()))
+            .unwrap()
+    });
+
+    order[0].set_has_unordered(&mut snapshot, &thing_manager, status[0].clone()).unwrap();
+    order[1].set_has_unordered(&mut snapshot, &thing_manager, status[1].clone()).unwrap();
+    order[2].set_has_unordered(&mut snapshot, &thing_manager, status[2].clone()).unwrap();
+
+    order[0].set_has_unordered(&mut snapshot, &thing_manager, timestamp[0].clone()).unwrap();
+    order[1].set_has_unordered(&mut snapshot, &thing_manager, timestamp[1].clone()).unwrap();
+    order[2].set_has_unordered(&mut snapshot, &thing_manager, timestamp[2].clone()).unwrap();
+
+    let purchase = [(); 3].map(|_| thing_manager.create_relation(&mut snapshot, purchase_type.clone()).unwrap());
+
+    purchase[0]
+        .add_player(&mut snapshot, &thing_manager, purchase_buyer_type.clone(), user[0].clone().into_owned_object())
         .unwrap();
-    membership[1]
-        .add_player(
-            &mut snapshot,
-            &thing_manager,
-            membership_member_type.clone(),
-            person[2].clone().into_owned_object(),
-        )
+    purchase[1]
+        .add_player(&mut snapshot, &thing_manager, purchase_buyer_type.clone(), user[0].clone().into_owned_object())
+        .unwrap();
+    purchase[2]
+        .add_player(&mut snapshot, &thing_manager, purchase_buyer_type.clone(), user[1].clone().into_owned_object())
+        .unwrap();
+
+    purchase[0]
+        .add_player(&mut snapshot, &thing_manager, purchase_order_type.clone(), order[0].clone().into_owned_object())
+        .unwrap();
+    purchase[1]
+        .add_player(&mut snapshot, &thing_manager, purchase_order_type.clone(), order[0].clone().into_owned_object())
+        .unwrap();
+    purchase[2]
+        .add_player(&mut snapshot, &thing_manager, purchase_order_type.clone(), order[1].clone().into_owned_object())
         .unwrap();
 
     let finalise_result = thing_manager.finalise(&mut snapshot);
@@ -365,7 +408,12 @@ fn test_links_intersection() {
     let mut statistics = Statistics::new(SequenceNumber::new(0));
     statistics.may_synchronise(&storage).unwrap();
 
-    let query = "match $membership isa membership, links ($person1, $person2);";
+    // END DATA
+
+    let query = "match
+    $p isa purchase, links (order: $order, buyer: $buyer);
+    $order has status $status;
+    $order has timestamp $timestamp;";
     let match_ = typeql::parse_query(query).unwrap().into_pipeline().stages.remove(0).into_match();
 
     // IR
@@ -373,7 +421,7 @@ fn test_links_intersection() {
     let mut translation_context = TranslationContext::new();
     let builder = translate_match(&mut translation_context, &empty_function_index, &match_).unwrap();
     // builder.add_limit(3);
-    // builder.add_filter(vec!["person", "age"]).unwrap();
+    // builder.add_filter(vec!["user", "age"]).unwrap();
     let block = builder.finish();
 
     // Executor
@@ -409,7 +457,7 @@ fn test_links_intersection() {
         .try_collect::<_, Vec<_>, _>()
         .unwrap();
 
-    assert_eq!(rows.len(), 2);
+    assert_eq!(rows.len(), 3);
 
     for row in rows {
         for value in row {

--- a/ir/pattern/mod.rs
+++ b/ir/pattern/mod.rs
@@ -73,6 +73,14 @@ impl<ID: IrID> Vertex<ID> {
         }
     }
 
+    pub fn as_label(&self) -> Option<&Label<'static>> {
+        if let Self::Label(v) = self {
+            Some(v)
+        } else {
+            None
+        }
+    }
+
     pub fn as_parameter(&self) -> Option<ParameterID> {
         if let &Self::Parameter(v) = self {
             Some(v)

--- a/main.rs
+++ b/main.rs
@@ -7,7 +7,7 @@
 #![deny(unused_must_use)]
 #![deny(elided_lifetimes_in_paths)]
 
-use logger::{initialise_logging, initialise_logging_global};
+use logger::initialise_logging_global;
 use resource::constants::server::ASCII_LOGO;
 use server::parameters::config::Config;
 

--- a/server/service/transaction_service.rs
+++ b/server/service/transaction_service.rs
@@ -514,7 +514,7 @@ impl TransactionService {
         let _ = self.cancel_queued_write_queries().await;
 
         match self.transaction.take() {
-            None => {}
+            None => (),
             Some(Transaction::Read(transaction)) => transaction.close(),
             Some(Transaction::Write(transaction)) => transaction.close(),
             Some(Transaction::Schema(transaction)) => transaction.close(),

--- a/tests/behaviour/concept/thing/attribute.rs
+++ b/tests/behaviour/concept/thing/attribute.rs
@@ -4,6 +4,8 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
+#![expect(unexpected_cfgs, reason = "features defined in Bazel targets aren't currently communicated to Cargo")]
+
 use steps::Context;
 
 #[tokio::test]

--- a/tests/behaviour/concept/thing/entity.rs
+++ b/tests/behaviour/concept/thing/entity.rs
@@ -4,6 +4,8 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
+#![expect(unexpected_cfgs, reason = "features defined in Bazel targets aren't currently communicated to Cargo")]
+
 use steps::Context;
 
 #[tokio::test]

--- a/tests/behaviour/concept/thing/has.rs
+++ b/tests/behaviour/concept/thing/has.rs
@@ -4,6 +4,8 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
+#![expect(unexpected_cfgs, reason = "features defined in Bazel targets aren't currently communicated to Cargo")]
+
 use steps::Context;
 
 #[tokio::test]

--- a/tests/behaviour/concept/thing/relation.rs
+++ b/tests/behaviour/concept/thing/relation.rs
@@ -4,6 +4,8 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
+#![expect(unexpected_cfgs, reason = "features defined in Bazel targets aren't currently communicated to Cargo")]
+
 use steps::Context;
 
 #[tokio::test]

--- a/tests/behaviour/concept/thing/roleplayer.rs
+++ b/tests/behaviour/concept/thing/roleplayer.rs
@@ -4,6 +4,8 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
+#![expect(unexpected_cfgs, reason = "features defined in Bazel targets aren't currently communicated to Cargo")]
+
 use steps::Context;
 
 #[tokio::test]

--- a/tests/behaviour/concept/type/attribute_type.rs
+++ b/tests/behaviour/concept/type/attribute_type.rs
@@ -4,6 +4,8 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
+#![expect(unexpected_cfgs, reason = "features defined in Bazel targets aren't currently communicated to Cargo")]
+
 use steps::Context;
 
 #[tokio::test]

--- a/tests/behaviour/concept/type/entity_type.rs
+++ b/tests/behaviour/concept/type/entity_type.rs
@@ -4,6 +4,8 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
+#![expect(unexpected_cfgs, reason = "features defined in Bazel targets aren't currently communicated to Cargo")]
+
 use steps::Context;
 
 #[tokio::test]

--- a/tests/behaviour/concept/type/owns.rs
+++ b/tests/behaviour/concept/type/owns.rs
@@ -4,6 +4,8 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
+#![expect(unexpected_cfgs, reason = "features defined in Bazel targets aren't currently communicated to Cargo")]
+
 use steps::Context;
 
 #[tokio::test]

--- a/tests/behaviour/concept/type/owns_annotations.rs
+++ b/tests/behaviour/concept/type/owns_annotations.rs
@@ -4,6 +4,8 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
+#![expect(unexpected_cfgs, reason = "features defined in Bazel targets aren't currently communicated to Cargo")]
+
 use steps::Context;
 
 #[tokio::test]

--- a/tests/behaviour/concept/type/plays.rs
+++ b/tests/behaviour/concept/type/plays.rs
@@ -4,6 +4,8 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
+#![expect(unexpected_cfgs, reason = "features defined in Bazel targets aren't currently communicated to Cargo")]
+
 use steps::Context;
 
 #[tokio::test]

--- a/tests/behaviour/concept/type/relation_type.rs
+++ b/tests/behaviour/concept/type/relation_type.rs
@@ -4,6 +4,8 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
+#![expect(unexpected_cfgs, reason = "features defined in Bazel targets aren't currently communicated to Cargo")]
+
 use steps::Context;
 
 #[tokio::test]

--- a/tests/behaviour/connection/database/database.rs
+++ b/tests/behaviour/connection/database/database.rs
@@ -4,6 +4,8 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
+#![expect(unexpected_cfgs, reason = "features defined in Bazel targets aren't currently communicated to Cargo")]
+
 use steps::Context;
 
 #[tokio::test]

--- a/tests/behaviour/connection/transaction/transaction.rs
+++ b/tests/behaviour/connection/transaction/transaction.rs
@@ -4,6 +4,8 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
+#![expect(unexpected_cfgs, reason = "features defined in Bazel targets aren't currently communicated to Cargo")]
+
 use steps::Context;
 
 #[tokio::test]

--- a/tests/behaviour/query/language/define.rs
+++ b/tests/behaviour/query/language/define.rs
@@ -4,6 +4,8 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
+#![expect(unexpected_cfgs, reason = "features defined in Bazel targets aren't currently communicated to Cargo")]
+
 use steps::Context;
 
 #[tokio::test]

--- a/tests/behaviour/query/language/expressions.rs
+++ b/tests/behaviour/query/language/expressions.rs
@@ -4,6 +4,8 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
+#![expect(unexpected_cfgs, reason = "features defined in Bazel targets aren't currently communicated to Cargo")]
+
 use steps::Context;
 
 #[tokio::test]

--- a/tests/behaviour/query/language/insert.rs
+++ b/tests/behaviour/query/language/insert.rs
@@ -4,6 +4,8 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
+#![expect(unexpected_cfgs, reason = "features defined in Bazel targets aren't currently communicated to Cargo")]
+
 use steps::Context;
 
 #[tokio::test]

--- a/tests/behaviour/query/language/match.rs
+++ b/tests/behaviour/query/language/match.rs
@@ -4,6 +4,8 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
+#![expect(unexpected_cfgs, reason = "features defined in Bazel targets aren't currently communicated to Cargo")]
+
 use steps::Context;
 
 #[tokio::test]

--- a/tests/behaviour/query/language/pipelines.rs
+++ b/tests/behaviour/query/language/pipelines.rs
@@ -4,6 +4,8 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
+#![expect(unexpected_cfgs, reason = "features defined in Bazel targets aren't currently communicated to Cargo")]
+
 use steps::Context;
 
 #[tokio::test]

--- a/tests/behaviour/query/language/redefine.rs
+++ b/tests/behaviour/query/language/redefine.rs
@@ -4,6 +4,8 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
+#![expect(unexpected_cfgs, reason = "features defined in Bazel targets aren't currently communicated to Cargo")]
+
 use steps::Context;
 
 #[tokio::test]


### PR DESCRIPTION
## Release notes: product changes

Fixes a crash on a malformed intersection plan.

## Motivation

Previously the greedy planner could produce a double intersection. E.g., when the planner was given constraints `$x has $a`, `$x isa T`, `$a isa A`, could then attempt to lump all the constraints into a single intersection iterator producing `($x, $a)`.
The lowering of the plan to the executor, however, cannot support this intersection (there is no corresponding executor, nor is one possible in the current architecture), so it would e.g. intersect `$x has $a` and `$x isa T` to produce `$x` and `$a`, then traverse `$a isa A`. As `$a` was not registered as an input to the third constraint, it is unbound. The executor then attempts to produce what is essentially a cartesian product of `$a * $a`, encounters multiple values for `$a`, and crashes.
 
## Implementation

Mark variables as produced eagerly as the constraint is registered. This does mean that the greedy planner is currently incapable of producing intersections.