### PR TITLE
Update TypeDB Console version

### DIFF
--- a/dependencies/vaticle/artifacts.bzl
+++ b/dependencies/vaticle/artifacts.bzl
@@ -12,7 +12,7 @@ def vaticle_typedb_console_artifact():
         artifact_name = "typedb-console-{platform}-{version}.{ext}",
         tag_source = deployment["artifact"]["release"]["download"],
         commit_source = deployment["artifact"]["snapshot"]["download"],
-        commit = "f6db966139f26da5f10f2d4f298161ad25104daf",
+        commit = "060397dac5bca395b99b65a50e6424a45c87b353"
     )
 
 maven_artifacts = {

--- a/dependencies/vaticle/artifacts.bzl
+++ b/dependencies/vaticle/artifacts.bzl
@@ -12,7 +12,7 @@ def vaticle_typedb_console_artifact():
         artifact_name = "typedb-console-{platform}-{version}.{ext}",
         tag_source = deployment["artifact"]["release"]["download"],
         commit_source = deployment["artifact"]["snapshot"]["download"],
-        tag = "fef76105f953c8ccdd51f3f5aa357c7d5ea30d45",
+        commit = "49013950aab80c8da1bd05402ca1ee19d7b8a91a",
     )
 
 maven_artifacts = {

--- a/dependencies/vaticle/artifacts.bzl
+++ b/dependencies/vaticle/artifacts.bzl
@@ -12,7 +12,7 @@ def vaticle_typedb_console_artifact():
         artifact_name = "typedb-console-{platform}-{version}.{ext}",
         tag_source = deployment["artifact"]["release"]["download"],
         commit_source = deployment["artifact"]["snapshot"]["download"],
-        tag = "2.28.2-rc1",
+        tag = "fef76105f953c8ccdd51f3f5aa357c7d5ea30d45",
     )
 
 maven_artifacts = {

--- a/dependencies/vaticle/artifacts.bzl
+++ b/dependencies/vaticle/artifacts.bzl
@@ -12,7 +12,7 @@ def vaticle_typedb_console_artifact():
         artifact_name = "typedb-console-{platform}-{version}.{ext}",
         tag_source = deployment["artifact"]["release"]["download"],
         commit_source = deployment["artifact"]["snapshot"]["download"],
-        commit = "49013950aab80c8da1bd05402ca1ee19d7b8a91a",
+        commit = "f6db966139f26da5f10f2d4f298161ad25104daf",
     )
 
 maven_artifacts = {


### PR DESCRIPTION
## Release notes: product changes
Update TypeDB Console to a version with an updated `password-update` command which allows specifying the password directly.

## Motivation
Update TypeDB Console to a version with an updated `password-update` command which allows specifying the password directly.

## Implementation
- Update TypeDB Console version in `artifacts.bzl`