### PR TITLE
3.0 Add query type to the query rows header. Implement connection/database bdd steps

### DIFF
--- a/database/database.rs
+++ b/database/database.rs
@@ -409,9 +409,10 @@ typedb_error!(
 
 typedb_error!(
     pub DatabaseDeleteError(component = "Database delete", prefix = "DBD") {
-        InUse(1, "Cannot delete database since it is in use."),
-        StorageDelete(2, "Error while deleting storage resources.", ( typedb_source: StorageDeleteError )),
-        DirectoryDelete(3, "Error deleting directory.", ( source: Arc<io::Error> )),
+        DoesNotExist(1, "Cannot delete database since it does not exist."),
+        InUse(2, "Cannot delete database since it is in use."),
+        StorageDelete(3, "Error while deleting storage resources.", ( typedb_source: StorageDeleteError )),
+        DirectoryDelete(4, "Error deleting directory.", ( source: Arc<io::Error> )),
     }
 );
 

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -33,23 +33,15 @@ def vaticle_typedb_common():
     )
 
 def vaticle_typedb_protocol():
-    native.local_repository(
+    git_repository(
         name = "vaticle_typedb_protocol",
-        path = "../typedb-protocol",
+        remote = "https://github.com/typedb/typedb-protocol",
+        commit = "47667a3d28bb30056c5e883b938aef58532df725",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_protocol
     )
-#    git_repository( # TODO: Update ref to the merged protocol!
-#        name = "vaticle_typedb_protocol",
-#        remote = "https://github.com/typedb/typedb-protocol",
-#        tag = "3.0.0-alpha-0",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_protocol
-#    )
 
 def vaticle_typedb_behaviour():
-    native.local_repository(
+    git_repository(
         name = "vaticle_typedb_behaviour",
-        path = "../typedb-behaviour",
+        remote = "https://github.com/typedb/typedb-behaviour",
+        commit = "5975dae103bbbeb59ce802c8c4e16ba6e997db3c", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_behaviour
     )
-#    git_repository(
-#        name = "vaticle_typedb_behaviour",
-#        remote = "https://github.com/typedb/typedb-behaviour",
-#        commit = "5975dae103bbbeb59ce802c8c4e16ba6e997db3c", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_behaviour
-#    )

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -33,15 +33,23 @@ def vaticle_typedb_common():
     )
 
 def vaticle_typedb_protocol():
-    git_repository(
+    native.local_repository(
         name = "vaticle_typedb_protocol",
-        remote = "https://github.com/typedb/typedb-protocol",
-        tag = "3.0.0-alpha-0",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_protocol
+        path = "../typedb-protocol",
     )
+#    git_repository( # TODO: Update ref to the merged protocol!
+#        name = "vaticle_typedb_protocol",
+#        remote = "https://github.com/typedb/typedb-protocol",
+#        tag = "3.0.0-alpha-0",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_protocol
+#    )
 
 def vaticle_typedb_behaviour():
-    git_repository(
+    native.local_repository(
         name = "vaticle_typedb_behaviour",
-        remote = "https://github.com/typedb/typedb-behaviour",
-        commit = "5975dae103bbbeb59ce802c8c4e16ba6e997db3c", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_behaviour
+        path = "../typedb-behaviour",
     )
+#    git_repository(
+#        name = "vaticle_typedb_behaviour",
+#        remote = "https://github.com/typedb/typedb-behaviour",
+#        commit = "5975dae103bbbeb59ce802c8c4e16ba6e997db3c", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_behaviour
+#    )

--- a/server/service/response_builders.rs
+++ b/server/service/response_builders.rs
@@ -111,9 +111,13 @@ pub(crate) mod transaction {
 
     pub(crate) fn query_res_ok_concept_row_stream(
         column_variable_names: Vec<String>,
+        query_type: typedb_protocol::query::Type,
     ) -> typedb_protocol::query::initial_res::ok::Ok {
         typedb_protocol::query::initial_res::ok::Ok::ConceptRowStream(
-            typedb_protocol::query::initial_res::ok::ConceptRowStream { column_variable_names },
+            typedb_protocol::query::initial_res::ok::ConceptRowStream {
+                column_variable_names,
+                query_type: query_type.into(),
+            },
         )
     }
 

--- a/server/service/typedb_service.rs
+++ b/server/service/typedb_service.rs
@@ -70,7 +70,12 @@ impl typedb_protocol::type_db_server::TypeDb for TypeDBService {
             event!(Level::TRACE, "Rejected connection_open: {:?}", &err);
             return Err(err.into_status());
         } else {
-            event!(Level::TRACE, "Successful connection_open from '{}' version '{}'", &message.driver_lang, &message.driver_version);
+            event!(
+                Level::TRACE,
+                "Successful connection_open from '{}' version '{}'",
+                &message.driver_lang,
+                &message.driver_version
+            );
             // generate a connection ID per 'connection_open' to be able to trace different connections by the same user
             Ok(Response::new(connection_open_res(
                 self.generate_connection_id(),

--- a/tests/behaviour/connection/database/BUILD
+++ b/tests/behaviour/connection/database/BUILD
@@ -4,7 +4,6 @@
 
 load("@vaticle_dependencies//tool/checkstyle:rules.bzl", "checkstyle_test")
 load("@rules_rust//rust:defs.bzl", "rust_test")
-# TODO: Add test_ prefix to target names
 
 rust_test(
     name = "test_database",

--- a/tests/behaviour/connection/transaction/BUILD
+++ b/tests/behaviour/connection/transaction/BUILD
@@ -4,7 +4,6 @@
 
 load("@vaticle_dependencies//tool/checkstyle:rules.bzl", "checkstyle_test")
 load("@rules_rust//rust:defs.bzl", "rust_test")
-# TODO: Add test_ prefix to target names
 
 rust_test(
     name = "test_transaction",

--- a/tests/behaviour/steps/connection/database.rs
+++ b/tests/behaviour/steps/connection/database.rs
@@ -9,36 +9,42 @@ use std::sync::Mutex;
 use cucumber::gherkin::Step;
 use futures::future::join_all;
 use macro_rules_attribute::apply;
-use server::typedb;
+use server::{typedb, typedb::Server};
 
 use crate::{generic_step, params, util, Context};
 
-pub async fn server_create_database(server: &'_ Mutex<typedb::Server>, name: String) {
-    server.lock().unwrap().database_manager().create_database(&name);
+async fn server_create_database(server: &'_ Server, name: String) {
+    server.database_manager().create_database(&name);
 }
 
-pub async fn server_delete_database(server: &'_ Mutex<typedb::Server>, name: String, may_error: params::MayError) {
-    may_error.check(server.lock().unwrap().database_manager().delete_database(&name));
+async fn server_delete_database(server: &'_ Server, name: String, may_error: params::MayError) {
+    may_error.check(server.database_manager().delete_database(&name));
 }
 
 #[apply(generic_step)]
 #[step(expr = "connection create database: {word}")]
 pub async fn connection_create_database(context: &mut Context, name: String) {
-    server_create_database(context.server().unwrap(), name).await
+    let server = context.server().unwrap().lock().unwrap();
+    server_create_database(&server, name).await;
+    drop(server)
 }
 
 #[apply(generic_step)]
 #[step(expr = "connection create database(s):")]
 pub async fn connection_create_databases(context: &mut Context, step: &Step) {
+    let server = context.server().unwrap().lock().unwrap();
     for name in util::iter_table(step) {
-        server_create_database(context.server().unwrap(), name.into()).await;
+        server_create_database(&server, name.into()).await;
     }
+    drop(server)
 }
 
 #[apply(generic_step)]
 #[step(expr = "connection create database(s) in parallel:")]
 pub async fn connection_create_databases_in_parallel(context: &mut Context, step: &Step) {
-    join_all(util::iter_table(step).map(|name| server_create_database(context.server().unwrap(), name.into()))).await;
+    let server = context.server().unwrap().lock().unwrap();
+    join_all(util::iter_table(step).map(|name| server_create_database(&server, name.into()))).await;
+    drop(server)
 }
 
 #[apply(generic_step)]
@@ -53,25 +59,28 @@ pub async fn connection_reset_database(context: &mut Context, name: String) {
 #[apply(generic_step)]
 #[step(expr = "connection delete database: {word}{may_error}")]
 pub async fn connection_delete_database(context: &mut Context, name: String, may_error: params::MayError) {
-    server_delete_database(context.server().unwrap(), name, may_error).await
+    let server = context.server().unwrap().lock().unwrap();
+    server_delete_database(&server, name, may_error).await;
+    drop(server)
 }
 
 #[apply(generic_step)]
 #[step(expr = "connection delete database(s):")]
 async fn connection_delete_databases(context: &mut Context, step: &Step) {
+    let server = context.server().unwrap().lock().unwrap();
     for name in util::iter_table(step) {
-        server_delete_database(context.server().unwrap(), name.into(), params::MayError::False).await;
+        server_delete_database(&server, name.into(), params::MayError::False).await;
     }
+    drop(server)
 }
 
 #[apply(generic_step)]
 #[step(expr = "connection delete database(s) in parallel:")]
 async fn connection_delete_databases_in_parallel(context: &mut Context, step: &Step) {
-    join_all(
-        util::iter_table(step)
-            .map(|name| server_delete_database(context.server().unwrap(), name.into(), params::MayError::False)),
-    )
-    .await;
+    let server = context.server().unwrap().lock().unwrap();
+    join_all(util::iter_table(step).map(|name| server_delete_database(&server, name.into(), params::MayError::False)))
+        .await;
+    drop(server)
 }
 
 #[apply(generic_step)]

--- a/tests/behaviour/steps/connection/mod.rs
+++ b/tests/behaviour/steps/connection/mod.rs
@@ -4,7 +4,11 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-use std::sync::{Arc, Mutex, OnceLock};
+use std::{
+    error::Error,
+    fmt,
+    sync::{Arc, Mutex, OnceLock},
+};
 
 use macro_rules_attribute::apply;
 use server::{parameters::config::Config, typedb};
@@ -39,4 +43,25 @@ pub async fn connection_ignore(_: &mut Context) {}
 #[step("connection does not have any database")]
 pub async fn connection_does_not_have_any_database(context: &mut Context) {
     assert!(context.server().unwrap().lock().unwrap().database_manager().database_names().is_empty())
+}
+
+#[derive(Debug, Clone)]
+pub enum BehaviourConnectionTestExecutionError {
+    CannotCommitReadTransaction,
+    CannotRollbackReadTransaction,
+}
+
+impl fmt::Display for BehaviourConnectionTestExecutionError {
+    fn fmt(&self, _f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        todo!()
+    }
+}
+
+impl Error for BehaviourConnectionTestExecutionError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match self {
+            Self::CannotCommitReadTransaction => None,
+            Self::CannotRollbackReadTransaction => None,
+        }
+    }
 }

--- a/tests/behaviour/steps/connection/transaction.rs
+++ b/tests/behaviour/steps/connection/transaction.rs
@@ -52,7 +52,7 @@ pub async fn transaction_has_type(context: &mut Context, tx_type: String) {
 #[step(expr = "transaction commits{may_error}")]
 pub async fn transaction_commits(context: &mut Context, may_error: MayError) {
     match context.take_transaction().unwrap() {
-        ActiveTransaction::Read(_) => (),
+        ActiveTransaction::Read(_) => panic!("Cannot commit read transaction"),
         ActiveTransaction::Write(tx) => {
             if let Some(error) = may_error.check(tx.commit()) {
                 if let DataCommitError::ConceptWriteErrors { source: errors, .. } = error {
@@ -79,6 +79,16 @@ pub async fn transaction_commits(context: &mut Context, may_error: MayError) {
 }
 
 #[apply(generic_step)]
+#[step(expr = "transaction rollbacks")]
+pub async fn transaction_rollbacks(context: &mut Context) {
+    match context.take_transaction().unwrap() {
+        ActiveTransaction::Read(_) => panic!("Cannot rollback read transaction"),
+        ActiveTransaction::Write(mut tx) => tx.rollback(),
+        ActiveTransaction::Schema(mut tx) => tx.rollback(),
+    }
+}
+
+#[apply(generic_step)]
 #[step(expr = "transaction closes")]
 pub async fn transaction_closes(context: &mut Context) {
     context.close_transaction()
@@ -92,7 +102,7 @@ pub async fn open_transactions_in_parallel(context: &mut Context) {
 
 #[apply(generic_step)]
 #[step(expr = "transactions in parallel are null: {boolean}")]
-pub async fn transations_in_parallel_are_null(context: &mut Context, are_null: Boolean) {
+pub async fn transactions_in_parallel_are_null(context: &mut Context, are_null: Boolean) {
     todo!()
 }
 

--- a/tests/behaviour/steps/lib.rs
+++ b/tests/behaviour/steps/lib.rs
@@ -9,7 +9,8 @@
 
 use std::{
     collections::HashMap,
-    iter, mem,
+    error::Error,
+    fmt, iter, mem,
     path::Path,
     sync::{Arc, Mutex},
 };
@@ -180,6 +181,27 @@ impl Context {
 
 fn is_ignore(tag: &str) -> bool {
     tag == "ignore" || tag == "ignore-typedb"
+}
+
+#[derive(Debug, Clone)]
+pub enum BehaviourTestExecutionError {
+    UseInvalidTransactionAsWrite,
+    UseInvalidTransactionAsSchema,
+}
+
+impl fmt::Display for BehaviourTestExecutionError {
+    fn fmt(&self, _f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        todo!()
+    }
+}
+
+impl Error for BehaviourTestExecutionError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match self {
+            Self::UseInvalidTransactionAsWrite => None,
+            Self::UseInvalidTransactionAsSchema => None,
+        }
+    }
 }
 
 #[macro_export]

--- a/tests/behaviour/steps/params.rs
+++ b/tests/behaviour/steps/params.rs
@@ -113,14 +113,14 @@ impl TypeQLMayError {
         self.as_may_error_logic().expects_error()
     }
 
-    fn as_may_error_parsing(&self) -> MayError {
+    pub fn as_may_error_parsing(&self) -> MayError {
         match self {
             TypeQLMayError::Parsing => MayError::True,
             | TypeQLMayError::False | TypeQLMayError::Logic => MayError::False,
         }
     }
 
-    fn as_may_error_logic(&self) -> MayError {
+    pub fn as_may_error_logic(&self) -> MayError {
         match self {
             TypeQLMayError::Logic => MayError::True,
             | TypeQLMayError::False | TypeQLMayError::Parsing => MayError::False,

--- a/tests/behaviour/steps/transaction_context.rs
+++ b/tests/behaviour/steps/transaction_context.rs
@@ -38,7 +38,9 @@ pub(crate) use with_read_tx;
 macro_rules! with_write_tx {
     ($context:ident, |$tx:ident| $expr:expr) => {
         match $context.active_transaction.as_mut().unwrap() {
-            $crate::transaction_context::ActiveTransaction::Read(_) => panic!("Using Read transaction as Write"),
+            $crate::transaction_context::ActiveTransaction::Read(_) => {
+                panic!("Using Read transaction as Write. You probably wanted to expect an error before")
+            }
             $crate::transaction_context::ActiveTransaction::Write($tx) => $expr,
             $crate::transaction_context::ActiveTransaction::Schema($tx) => $expr,
         }
@@ -49,8 +51,12 @@ pub(crate) use with_write_tx;
 macro_rules! with_schema_tx {
     ($context:ident, |$tx:ident| $expr:expr) => {
         match $context.active_transaction.as_mut().unwrap() {
-            $crate::transaction_context::ActiveTransaction::Read(_) => panic!("Using Read transaction as Schema"),
-            $crate::transaction_context::ActiveTransaction::Write(_) => panic!("Using Write transaction as Schema"),
+            $crate::transaction_context::ActiveTransaction::Read(_) => {
+                panic!("Using Read transaction as Schema. You probably wanted to expect an error before")
+            }
+            $crate::transaction_context::ActiveTransaction::Write(_) => {
+                panic!("Using Write transaction as Schema. You probably wanted to expect an error before")
+            }
             $crate::transaction_context::ActiveTransaction::Schema($tx) => $expr,
         }
     };
@@ -67,7 +73,9 @@ macro_rules! with_write_tx_deconstructed {
         $transaction_options:ident $(,)?
      | $expr:expr) => {
         match $context.take_transaction().unwrap() {
-            $crate::transaction_context::ActiveTransaction::Read(_) => panic!("Using Read transaction as Write"),
+            $crate::transaction_context::ActiveTransaction::Read(_) => {
+                panic!("Using Read transaction as Write. You probably wanted to expect an error before")
+            }
             $crate::transaction_context::ActiveTransaction::Write(::database::transaction::TransactionWrite {
                 snapshot: $snapshot,
                 type_manager: $type_manager,


### PR DESCRIPTION
## Release notes: product changes
We update the server to server the [updated protocol](https://github.com/typedb/typedb-protocol/pull/209) and return the type of the executed query as a part of the query row stream answer.

We also fix the server's database manipulation code and implement additional bdd steps to pass the `connection/database` bdd tests.
