### PR TITLE
Include console in 3.0 distribution

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -192,7 +192,7 @@ docker_container_image(
     architecture = "amd64",
     base = "@ubuntu-22.04-x86_64//image",
     cmd = [
-        "/opt/typedb-all-linux-x86_64/typedb_server_bin"
+        "/opt/typedb-all-linux-x86_64/typedb server"
     ],
     directory = "opt",
     env = {
@@ -213,7 +213,7 @@ docker_container_image(
     architecture = "arm64",
     base = "@ubuntu-22.04-arm64//image",
     cmd = [
-        "/opt/typedb-all-linux-arm64/typedb_server_bin"
+        "/opt/typedb-all-linux-arm64/typedb server"
     ],
     directory = "opt",
     env = {

--- a/BUILD
+++ b/BUILD
@@ -191,9 +191,7 @@ docker_container_image(
     operating_system = "linux",
     architecture = "amd64",
     base = "@ubuntu-22.04-x86_64//image",
-    cmd = [
-        "/opt/typedb-all-linux-x86_64/typedb server"
-    ],
+    cmd = ["/opt/typedb-all-linux-x86_64/typedb", "server"],
     directory = "opt",
     env = {
         "LANG": "C.UTF-8",
@@ -212,9 +210,7 @@ docker_container_image(
     operating_system = "linux",
     architecture = "arm64",
     base = "@ubuntu-22.04-arm64//image",
-    cmd = [
-        "/opt/typedb-all-linux-arm64/typedb server"
-    ],
+    cmd = ["/opt/typedb-all-linux-arm64/typedb", "server"],
     directory = "opt",
     env = {
         "LANG": "C.UTF-8",

--- a/BUILD
+++ b/BUILD
@@ -16,7 +16,7 @@ load("@vaticle_bazel_distribution//platform:constraints.bzl", "constraint_linux_
 load("@io_bazel_rules_docker//container:image.bzl", docker_container_image = "container_image")
 load("@io_bazel_rules_docker//container:container.bzl", docker_container_push = "container_push")
 
-load("@rules_pkg//:mappings.bzl", "pkg_files")
+load("@rules_pkg//:mappings.bzl", "pkg_files", "pkg_attributes")
 load("@rules_pkg//:pkg.bzl", "pkg_tar")
 load("@rules_rust//rust:defs.bzl", "rust_binary")
 
@@ -47,12 +47,8 @@ empty_directories = [
     "server/data",
 ]
 
-permissions = {
-    "server/conf/config.yml": "0755",
-    "server/data": "0755",
-    "server/typedb_server_bin": "0755",
-    "typedb":  "0755",
-}
+binary_permissions = pkg_attributes(mode = "0744")
+other_permissions = {} # These don't seem to work.
 
 alias(
     name = "typedb_console_artifact",
@@ -65,7 +61,7 @@ alias(
     })
 )
 
-
+# The directory structure for distribution
 artifact_repackage(
     name = "console-repackaged",
     srcs = [":typedb_console_artifact"],
@@ -75,7 +71,8 @@ artifact_repackage(
 pkg_files(
     name = "package-server-and-entry",
     srcs = ["//:typedb_server_bin", "//binary:typedb"],
-    renames = {"//:typedb_server_bin" : "server/typedb_server_bin"}
+    renames = {"//:typedb_server_bin" : "server/typedb_server_bin"},
+    attributes = binary_permissions,
 )
 
 pkg_tar(
@@ -84,12 +81,13 @@ pkg_tar(
     deps = [":console-repackaged"],
 )
 
+
 assemble_zip(
     name = "assemble-mac-x86_64-zip",
     additional_files = assemble_files,
     empty_directories = empty_directories,
     output_filename = "typedb-all-mac-x86_64",
-    permissions = permissions,
+    permissions = other_permissions,
     targets = ["//:package-typedb"],
     visibility = ["//tests/assembly:__subpackages__"],
     target_compatible_with = constraint_mac_x86_64,
@@ -100,7 +98,7 @@ assemble_zip(
     additional_files = assemble_files,
     empty_directories = empty_directories,
     output_filename = "typedb-all-mac-arm64",
-    permissions = permissions,
+    permissions = other_permissions,
     targets = ["//:package-typedb"],
     visibility = ["//tests/assembly:__subpackages__"],
     target_compatible_with = constraint_mac_arm64,
@@ -111,7 +109,7 @@ assemble_targz(
     additional_files = assemble_files,
     empty_directories = empty_directories,
     output_filename = "typedb-all-linux-x86_64",
-    permissions = permissions,
+    permissions = other_permissions,
     targets = ["//:package-typedb"],
     visibility = ["//tests/assembly:__subpackages__"],
     target_compatible_with = constraint_linux_x86_64,
@@ -122,7 +120,7 @@ assemble_targz(
     additional_files = assemble_files,
     empty_directories = empty_directories,
     output_filename = "typedb-all-linux-arm64",
-    permissions = permissions,
+    permissions = other_permissions,
     targets = ["//:package-typedb"],
     visibility = ["//tests/assembly:__subpackages__"],
     target_compatible_with = constraint_linux_arm64,

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -152,8 +152,8 @@ vaticle_typeql()
 
 vaticle_typedb_protocol()
 
-#load("//dependencies/vaticle:artifacts.bzl", "vaticle_typedb_console_artifact")
-#vaticle_typedb_console_artifact()
+load("//dependencies/vaticle:artifacts.bzl", "vaticle_typedb_console_artifact")
+vaticle_typedb_console_artifact()
 
 ############################
 # Load @maven dependencies #

--- a/binary/BUILD
+++ b/binary/BUILD
@@ -1,0 +1,16 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+#
+
+load("@vaticle_bazel_distribution//apt:rules.bzl", "assemble_apt", "deploy_apt")
+load("@vaticle_bazel_distribution//common:rules.bzl", "assemble_targz")
+load("@vaticle_dependencies//distribution:deployment.bzl", "deployment")
+load("@vaticle_dependencies//tool/checkstyle:rules.bzl", "checkstyle_test")
+
+exports_files(["typedb"])
+checkstyle_test(
+    name = "checkstyle",
+    include = glob(["*"]),
+    license_type = "mpl-header",
+)

--- a/binary/typedb
+++ b/binary/typedb
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+# TypeDB global variables
+JAVA_BIN=java
+if [[ ! -z "$JAVA_HOME" ]]; then
+    JAVA_BIN="$JAVA_HOME/bin/java"
+fi
+[[ $(readlink $0) ]] && path=$(readlink $0) || path=$0
+TYPEDB_HOME=$(cd "$(dirname "${path}")" && pwd -P)
+
+TYPEDB_SERVER_DIR="${TYPEDB_HOME}/server"
+
+# ================================================
+# common helper functions
+# ================================================
+exit_if_java_not_found() {
+    which "${JAVA_BIN}" > /dev/null
+    exit_code=$?
+
+    if [[ $exit_code -ne 0 ]]; then
+        echo "Java is not installed on this machine. TypeDB needs Java 11+ in order to run."
+        exit 1
+    fi
+}
+
+print_usage() {
+    # TODO: Add [--help] back to server
+    echo "  Server:          typedb server"
+    echo "  Console:         typedb console [--help]"
+}
+
+# =============================================
+# main routine
+# =============================================
+
+
+case "$1" in
+    console)
+        exit_if_java_not_found
+        SERVICE_LIB_CP="console/lib/*"
+        CLASSPATH="${TYPEDB_HOME}/${SERVICE_LIB_CP}:${TYPEDB_HOME}/console/conf/"
+        # exec replaces current shell process with java so no commands after this one will ever get executed
+        exec ${JAVA_BIN} ${JAVAOPTS} -cp "${CLASSPATH}" -Dtypedb.dir="${TYPEDB_HOME}" com.vaticle.typedb.console.TypeDBConsole "${@:2}"
+        ;;
+
+    server)
+        # exec replaces current shell process with java so no commands after these ones will ever get executed
+        TYPEDB_SERVER_BIN="${TYPEDB_HOME}/server/typedb_server_bin"
+        exec ${TYPEDB_SERVER_BIN} "${@:2}"
+        ;;
+
+    "")
+        echo "Missing argument. Possible commands are:"
+        print_usage
+        exit 1
+        ;;
+    *)
+        echo "Invalid argument: $1. Possible commands are: "
+        print_usage
+        exit 1
+        ;;
+    esac
+fi

--- a/dependencies/vaticle/artifacts.bzl
+++ b/dependencies/vaticle/artifacts.bzl
@@ -12,5 +12,5 @@ def vaticle_typedb_console_artifact():
         artifact_name = "typedb-console-{platform}-{version}.{ext}",
         tag_source = deployment["artifact"]["release"]["download"],
         commit_source = deployment["artifact"]["snapshot"]["download"],
-        tag = "2.28.4",
+        commit = "2a1765b19af65628ca23077db024e9f5f030a51f",
     )

--- a/dependencies/vaticle/artifacts.bzl
+++ b/dependencies/vaticle/artifacts.bzl
@@ -5,12 +5,12 @@
 load("@vaticle_dependencies//distribution/artifact:rules.bzl", "native_artifact_files")
 load("@vaticle_dependencies//distribution:deployment.bzl", "deployment")
 
-#def vaticle_typedb_console_artifact():
-#    native_artifact_files(
-#        name = "vaticle_typedb_console_artifact",
-#        group_name = "vaticle_typedb_console",
-#        artifact_name = "typedb-console-{platform}-{version}.{ext}",
-#        tag_source = deployment["artifact"]["release"]["download"],
-#        commit_source = deployment["artifact"]["snapshot"]["download"],
-#        commit = "0cee03cc2146f2fc042e338f83eadcb044051581",
-#    )
+def vaticle_typedb_console_artifact():
+    native_artifact_files(
+        name = "vaticle_typedb_console_artifact",
+        group_name = "typedb-console-{platform}",
+        artifact_name = "typedb-console-{platform}-{version}.{ext}",
+        tag_source = deployment["artifact"]["release"]["download"],
+        commit_source = deployment["artifact"]["snapshot"]["download"],
+        tag = "2.28.4",
+    )

--- a/docker/BUILD
+++ b/docker/BUILD
@@ -21,7 +21,7 @@ genrule(
   srcs = ["//:VERSION"],
   outs = ["version-arm64.txt"],
   tools = [],
-  cmd = "cp $(location //:VERSION) $@; echo \"-arm64\" >> $@"
+  cmd = "VERSION=$$(cat $(location //:VERSION)); echo \"$$VERSION-arm64\" > $@"
 )
 
 
@@ -30,7 +30,7 @@ genrule(
   srcs = ["//:VERSION"],
   outs = ["version-x86_64.txt"],
   tools = [],
-  cmd = "cp $(location //:VERSION) $@; echo \"-x86_64\" >> $@"
+  cmd = "VERSION=$$(cat $(location //:VERSION)); echo \"$$VERSION-x86_64\" > $@"
 )
 
 checkstyle_test(


### PR DESCRIPTION
## Release notes: product changes
Includes console in 3.0 distribution

## Motivation
We used to do it + It's nice to have an interface to run queries without writing code.

## Implementation
Re-introduces existing workflow to consume the `typedb-console-*` artifact and package it into the `typedb-all-*` artefact.