### PR TITLE
Fix within-transaction query concurrency

### DIFF
--- a/executor/error.rs
+++ b/executor/error.rs
@@ -10,7 +10,7 @@ use crate::InterruptType;
 
 typedb_error!(
     pub ReadExecutionError(component = "Read execution", prefix = "REX") {
-        Interrupted(1, "Execution interrupted, cause: '{interrupt}'.", interrupt: InterruptType),
+        Interrupted(1, "Execution interrupted by to a concurrent {interrupt}.", interrupt: InterruptType),
         ConceptRead(2, "Concept read error.", ( source: ConceptReadError )),
         CreatingIterator(3, "Error creating iterator from {instruction_name} instruction.", instruction_name: String, ( source: ConceptReadError )),
         AdvancingIteratorTo(4, "Error moving iterator (by steps or seek) to target value.", ( source: ConceptReadError )),

--- a/executor/error.rs
+++ b/executor/error.rs
@@ -6,10 +6,11 @@
 
 use concept::error::ConceptReadError;
 use error::typedb_error;
+use crate::InterruptType;
 
 typedb_error!(
     pub ReadExecutionError(component = "Read execution", prefix = "REX") {
-        Interrupted(1, "Execution was interrupted."),
+        Interrupted(1, "Execution interrupted, cause: '{interrupt}'.", interrupt: InterruptType),
         ConceptRead(2, "Concept read error.", ( source: ConceptReadError )),
         CreatingIterator(3, "Error creating iterator from {instruction_name} instruction.", instruction_name: String, ( source: ConceptReadError )),
         AdvancingIteratorTo(4, "Error moving iterator (by steps or seek) to target value.", ( source: ConceptReadError )),

--- a/executor/lib.rs
+++ b/executor/lib.rs
@@ -53,6 +53,7 @@ pub enum InterruptType {
     TransactionCommitted,
     TransactionRolledback,
     WriteQueryExecution,
+    SchemaQueryExecution,
 }
 
 impl Display for InterruptType {
@@ -62,6 +63,7 @@ impl Display for InterruptType {
             InterruptType::TransactionCommitted => write!(f, "transaction committed"),
             InterruptType::TransactionRolledback => write!(f, "transaction rolled back"),
             InterruptType::WriteQueryExecution => write!(f, "write query executed."),
+            InterruptType::SchemaQueryExecution => write!(f, "schema query executed."),
         }
     }
 }

--- a/executor/lib.rs
+++ b/executor/lib.rs
@@ -59,11 +59,11 @@ pub enum InterruptType {
 impl Display for InterruptType {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
-            InterruptType::TransactionClosed => write!(f, "transaction closed"),
-            InterruptType::TransactionCommitted => write!(f, "transaction committed"),
-            InterruptType::TransactionRolledback => write!(f, "transaction rolled back"),
-            InterruptType::WriteQueryExecution => write!(f, "write query executed."),
-            InterruptType::SchemaQueryExecution => write!(f, "schema query executed."),
+            InterruptType::TransactionClosed => write!(f, "transaction close"),
+            InterruptType::TransactionCommitted => write!(f, "transaction commit"),
+            InterruptType::TransactionRolledback => write!(f, "transaction rollback"),
+            InterruptType::WriteQueryExecution => write!(f, "write query"),
+            InterruptType::SchemaQueryExecution => write!(f, "schema query"),
         }
     }
 }

--- a/executor/lib.rs
+++ b/executor/lib.rs
@@ -46,13 +46,21 @@ impl<'a> IntoIterator for &'a SelectedPositions {
     }
 }
 
+#[derive(Debug, Copy, Clone)]
+pub enum InterruptType {
+    TransactionClosed,
+    TransactionCommitted,
+    TransactionRolledback,
+    WriteQueryExecution,
+}
+
 #[derive(Debug)]
 pub struct ExecutionInterrupt {
-    signal: Option<tokio::sync::broadcast::Receiver<()>>,
+    signal: Option<tokio::sync::broadcast::Receiver<InterruptType>>,
 }
 
 impl ExecutionInterrupt {
-    pub fn new(signal: tokio::sync::broadcast::Receiver<()>) -> Self {
+    pub fn new(signal: tokio::sync::broadcast::Receiver<T>) -> Self {
         Self { signal: Some(signal) }
     }
 
@@ -61,6 +69,9 @@ impl ExecutionInterrupt {
     }
 
     pub fn check(&mut self) -> bool {
+        // TODO: return Optional<InterruptType>
+
+
         // TODO: if this becomes expensive to check frequently (try_recv may acquire locks), we could
         //       optimise it by caching the last time it was checked, and only actually check
         //       the signal once T micros/millis are elapsed... if this is really really cheap we can

--- a/executor/pattern_executor.rs
+++ b/executor/pattern_executor.rs
@@ -98,8 +98,8 @@ impl PatternExecutor {
 
         loop {
             // TODO: inject interrupt into Checkers that could filter out many rows without ending as well.
-            if interrupt.check() {
-                return Err(ReadExecutionError::Interrupted {});
+            if let Some(interrupt) = interrupt.check() {
+                return Err(ReadExecutionError::Interrupted { interrupt });
             }
 
             match direction {

--- a/executor/pipeline/delete.rs
+++ b/executor/pipeline/delete.rs
@@ -64,8 +64,10 @@ where
                 return Err((PipelineExecutionError::WriteError { typedb_source: err }, context));
             }
 
-            if index % 100 == 0 && interrupt.check() {
-                return Err((PipelineExecutionError::Interrupted {}, context));
+            if index % 100 == 0 {
+                if let Some(interrupt) = interrupt.check() {
+                    return Err((PipelineExecutionError::Interrupted { interrupt }, context));
+                }
             }
         }
 

--- a/executor/pipeline/insert.rs
+++ b/executor/pipeline/insert.rs
@@ -71,8 +71,10 @@ where
                 return Err((PipelineExecutionError::WriteError { typedb_source: err }, context));
             }
 
-            if index % 100 == 0 && interrupt.check() {
-                return Err((PipelineExecutionError::Interrupted {}, context));
+            if index % 100 == 0 {
+                if let Some(interrupt) = interrupt.check() {
+                    return Err((PipelineExecutionError::Interrupted { interrupt }, context));
+                }
             }
         }
         Ok((WrittenRowsIterator::new(batch), context))

--- a/executor/pipeline/mod.rs
+++ b/executor/pipeline/mod.rs
@@ -21,7 +21,7 @@ pub mod stage;
 typedb_error!(
     pub PipelineExecutionError(component = "Pipeline execution", prefix = "PEX") {
         // TODO: migrate to `typedb_error` once they are typedb errors
-        Interrupted(1, "Execution interrupted. Cause: '{interrupt}'.", interrupt: InterruptType),
+        Interrupted(1, "Execution interrupted by to a concurrent {interrupt}.", interrupt: InterruptType),
         ConceptRead(2, "Error reading concept.", ( source: ConceptReadError )),
         InitialisingMatchIterator(3, "Error initialising Match clause iterator.", ( source: ConceptReadError )),
         WriteError(4, "Error executing write operation.", ( typedb_source: WriteError )),

--- a/executor/pipeline/mod.rs
+++ b/executor/pipeline/mod.rs
@@ -8,9 +8,7 @@ use concept::error::ConceptReadError;
 use error::typedb_error;
 use lending_iterator::LendingIterator;
 
-use crate::{
-    batch::Batch, error::ReadExecutionError, pipeline::stage::StageIterator, row::MaybeOwnedRow, write::WriteError,
-};
+use crate::{batch::Batch, error::ReadExecutionError, InterruptType, pipeline::stage::StageIterator, row::MaybeOwnedRow, write::WriteError};
 
 pub mod delete;
 pub mod initial;
@@ -23,7 +21,7 @@ pub mod stage;
 typedb_error!(
     pub PipelineExecutionError(component = "Pipeline execution", prefix = "PEX") {
         // TODO: migrate to `typedb_error` once they are typedb errors
-        Interrupted(1, "Query was interrupted."),
+        Interrupted(1, "Execution interrupted. Cause: '{interrupt}'.", interrupt: InterruptType),
         ConceptRead(2, "Error reading concept.", ( source: ConceptReadError )),
         InitialisingMatchIterator(3, "Error initialising Match clause iterator.", ( source: ConceptReadError )),
         WriteError(4, "Error executing write operation.", ( typedb_source: WriteError )),

--- a/server/service/error.rs
+++ b/server/service/error.rs
@@ -29,6 +29,7 @@ pub(crate) enum ProtocolError {
         driver_lang: String,
         driver_version: String,
     },
+    FailedQueryResponse {}
 }
 
 impl IntoGRPCStatus for ProtocolError {
@@ -66,7 +67,7 @@ impl IntoGRPCStatus for ProtocolError {
                     "#
                 ))
             }
-            ProtocolError::UnrecognisedTransactionType { enum_variant, .. } => Status::with_error_details(
+            Self::UnrecognisedTransactionType { enum_variant, .. } => Status::with_error_details(
                 Code::InvalidArgument,
                 "Bad request",
                 ErrorDetails::with_bad_request_violation(
@@ -76,6 +77,7 @@ impl IntoGRPCStatus for ProtocolError {
                     ),
                 ),
             ),
+            Self::FailedQueryResponse {} => Status::internal("Failed to send response"),
         }
     }
 }


### PR DESCRIPTION
## Release notes: product changes

We update the in-transaction query behaviour to result in a predictable and well-defined behaviour. In any applicable transaction, the following rules hold:

1. Read queries are able to run concurrency and lazily, without limitation
2. Write queries always execute eagerly, but answers are sent back lazily
3. Schema queries and write queries interrupt all running read queries and finished write queries that are lazily sending answers

As a user, we see the following - reads after writes or schema queries are just fine:
```
let transaction = transaction(...);
let writes_iter = transaction.query("insert $x isa person;").await.unwrap().into_rows();
let reads_iter = transaction.query("match $x isa person;").await.unwrap().into_rows();

// both are readable:
writes_iter.next().await.unwrap();
reads_iter.next().await.unwrap();
```
In the other order, we will get an interrupt:
```
let transaction = transaction(...);
let reads_iter = transaction.query("match $x isa person;").await.unwrap().into_rows();
let writes_iter = transaction.query("insert $x isa person;").await.unwrap().into_rows();

// only writes are still available
writes_iter.next().await.unwrap();
assert!(reads_iter.next().await.is_err());
```