### PR TITLE
Add console script as assembly test

### DIFF
--- a/tests/assembly/BUILD
+++ b/tests/assembly/BUILD
@@ -11,7 +11,7 @@ rust_test(
     deps = [
         "@crates//:tokio",
     ],
-    data = ["//:assemble-typedb-all"],
+    data = ["//:assemble-typedb-all", ":script.tql"],
     env = select({
         "@vaticle_bazel_distribution//platform:is_linux_x86_64" : {"TYPEDB_ASSEMBLY_ARCHIVE": "typedb-all-linux-x86_64.tar.gz" },
         "@vaticle_bazel_distribution//platform:is_linux_arm64" : {"TYPEDB_ASSEMBLY_ARCHIVE":"typedb-all-linux-arm64.tar.gz"},

--- a/tests/assembly/assembly.rs
+++ b/tests/assembly/assembly.rs
@@ -45,18 +45,21 @@ fn test_assembly() {
     if !extract_output.status.success() {
         panic!("{:?}", extract_output);
     }
-    let server_process =
-        build_cmd("typedb-extracted/typedb_server_bin").spawn().expect("Failed to spawn server process");
-    let test_result = run_test_against_server();
+    let server_process = build_cmd("typedb-extracted/typedb server").spawn().expect("Failed to spawn server process");
+    let console_process_output = run_test_against_server();
     let server_process_output = kill_process(server_process);
 
-    if test_result.is_err() {
+    if !console_process_output.status.success() {
+        println!("Test failed:");
+        println!("Console process output:\n{:?}", console_process_output);
         println!("Server process output:\n{:?}", server_process_output);
-        test_result.unwrap();
+        assert!(false);
     }
 }
 
-fn run_test_against_server() -> Result<(), ()> {
-    // TODO
-    Ok(())
+fn run_test_against_server() -> Output {
+    let console_script_result = build_cmd("typedb-extracted/typedb console --script=tests/assembly/script.tql")
+        .output()
+        .expect("Failed to run console script");
+    console_script_result
 }

--- a/tests/assembly/script.tql
+++ b/tests/assembly/script.tql
@@ -1,3 +1,8 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+#
+
 database create foo
 database list
 database delete foo

--- a/tests/assembly/script.tql
+++ b/tests/assembly/script.tql
@@ -1,0 +1,3 @@
+database create foo
+database list
+database delete foo


### PR DESCRIPTION
## Release notes: product changes
Add assembly test

## Motivation
The test ensures the packaged console can run a simple typeql script against the packaged server.


## Implementation
Extends the assembly test to run a console script.