### PR TITLE
Add BDD test for pipeline modifiers

### DIFF
--- a/compiler/BUILD
+++ b/compiler/BUILD
@@ -49,6 +49,7 @@ checkstyle_test(
         "insert/**/*.rs",
         "delete/**/*.rs",
         "expression/**/*.rs",
+        "fetch/*.rs",
     ]),
     exclude = glob([
         "Cargo.*",

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -43,5 +43,5 @@ def vaticle_typedb_behaviour():
     git_repository(
         name = "vaticle_typedb_behaviour",
         remote = "https://github.com/typedb/typedb-behaviour",
-        commit = "edc7d682edfb0e0ca476bb9ee7cfb2f1c4203c06",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_behaviour
+        commit = "c777b2e2c8afe18445634e30a9a3428ef33df129",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_behaviour
     )

--- a/ir/program/modifier.rs
+++ b/ir/program/modifier.rs
@@ -53,6 +53,15 @@ pub enum SortVariable {
     Descending(Variable),
 }
 
+impl SortVariable {
+    pub fn variable(&self) -> Variable {
+        match self {
+            SortVariable::Ascending(var) => var.clone(),
+            SortVariable::Descending(var) => var.clone(),
+        }
+    }
+}
+
 #[derive(Debug, Copy, Clone)]
 pub struct Offset {
     offset: u64,

--- a/query/error.rs
+++ b/query/error.rs
@@ -37,5 +37,6 @@ typedb_error!(
         CouldNotDetermineValueTypeForReducerInput(15, "The value-type for the reducer input variable '{variable}' could not be determined.", variable: String),
         ReducerInputVariableDidNotHaveSingleValueType(16, "The reducer input variable '{variable}' had multiple value-types.", variable: String),
         UnsupportedValueTypeForReducer(17, "The input variable to the reducer'{reducer}({variable})' reducer had an unsupported value-type: '{value_type}'", reducer: String, variable: String, value_type: ValueTypeCategory),
+        UncomparableValueTypesForSortVariable(18, "The sort variable '{variable}' could return uncomparable value-types '{category1}' & '{category2}'.", variable: String, category1: ValueTypeCategory, category2: ValueTypeCategory),
     }
 );

--- a/tests/behaviour/query/language/BUILD
+++ b/tests/behaviour/query/language/BUILD
@@ -62,6 +62,17 @@ rust_test(
 )
 
 rust_test(
+    name = "test_modifiers",
+    srcs = ["modifiers.rs"],
+    deps = [
+        "//tests/behaviour/steps:steps",
+        "@crates//:tokio",
+    ],
+    data = ["@vaticle_typedb_behaviour//query/language:modifiers.feature"],
+    crate_features = ["bazel"],
+)
+
+rust_test(
     name = "test_reduce",
     srcs = ["reduce.rs"],
     deps = [

--- a/tests/behaviour/query/language/modifiers.rs
+++ b/tests/behaviour/query/language/modifiers.rs
@@ -1,0 +1,21 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+use steps::Context;
+
+#[tokio::test]
+async fn test() {
+    // Bazel specific path: when running the test in bazel, the external data from
+    // @vaticle_typedb_behaviour is stored in a directory that is a sibling to
+    // the working directory.
+    #[cfg(feature = "bazel")]
+    let path = "../vaticle_typedb_behaviour/query/language/modifiers.feature";
+
+    #[cfg(not(feature = "bazel"))]
+    let path = "bazel-typedb/external/vaticle_typedb_behaviour/query/language/modifiers.feature";
+
+    assert!(Context::test(path, false).await);
+}

--- a/tests/behaviour/steps/query/typeql.rs
+++ b/tests/behaviour/steps/query/typeql.rs
@@ -380,3 +380,21 @@ fn does_type_match(context: &Context, var_value: &VariableValue<'_>, expected: &
 async fn answer_size_is(context: &mut Context, answer_size: i32) {
     assert_eq!(context.answers.len(), answer_size as usize)
 }
+
+#[apply(generic_step)]
+#[step(expr = r"order of answer concepts is")]
+async fn order_of_answers_is(context: &mut Context, step: &Step) {
+    let num_specs = step.table().unwrap().rows.len() - 1;
+    let num_answers = context.answers.len();
+    assert_eq!(
+        num_specs, num_answers,
+        "expected the number of identifier entries to match the number of answers, found {} entries and {} answers",
+        num_specs, num_answers
+    );
+    for (spec_row, answer_row) in iter_table_map(step).zip(&context.answers) {
+        assert!(
+            spec_row.iter().all(|(&var, &spec)| does_var_in_row_match_spec(context, answer_row, var, spec)),
+            "The answer found did not match the specified row {spec_row:?}"
+        );
+    }
+}


### PR DESCRIPTION
## Release notes: product changes
Add BDD test for pipeline modifiers; Fixes some bugs uncovered in the process.

## Motivation
Ports the modifiers (`select, sort, offset, limit`) BDD test to 3.0 syntax.

## Implementation
Ports the modifiers (`select, sort, offset, limit`) BDD test to 3.0 syntax, introduces a test for it.