### PR TITLE
Bump TypeQL to 2.28.6

### DIFF
--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -22,7 +22,7 @@ def vaticle_typeql():
     git_repository(
         name = "vaticle_typeql",
         remote = "https://github.com/vaticle/typeql",
-        commit = "4061e355cb3b52a0f82ab58cc2f4f599182ef7cb",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typeql
+        tag = "2.28.6",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typeql
     )
 
 def vaticle_typedb_protocol():


### PR DESCRIPTION
## Release notes: product changes
Bumps TypeQL to 2.28.6 for grammar fixes to error messages.

## Motivation
We need this to create an artifact that typedb-driver can use for tests, allowing me green tests on the release pipeline.

## Implementation
Bumps TypeQL to 2.28.6 for grammar fixes to error messages.