### PR TITLE
Update GitHub urls to reflect renaming the GitHub organisation

### DIFF
--- a/.factory/automation.yml
+++ b/.factory/automation.yml
@@ -13,7 +13,7 @@ config:
 build:
   quality:
     filter:
-      owner: vaticle
+      owner: typedb
       branch: [master, development]
     dependency-analysis:
       image: vaticle-ubuntu-22.04
@@ -107,7 +107,7 @@ build:
     test-benchmark-reasoner:
       image: vaticle-ubuntu-22.04
       filter:
-        owner: vaticle
+        owner: typedb
         branch: [master, development]
       dependencies: [build]
       command: |
@@ -121,7 +121,7 @@ build:
     test-assembly-linux-targz:
       image: vaticle-ubuntu-20.04
       filter:
-        owner: vaticle
+        owner: typedb
         branch: [master, development]
       dependencies: [build, build-dependency, test-unit, test-integration, test-behaviour-connection, test-behaviour-concept, test-behaviour-query-read, test-behaviour-query-write, test-behaviour-query-definable, test-behaviour-reasoner]
       command: |
@@ -130,7 +130,7 @@ build:
     test-assembly-docker:
       image: vaticle-ubuntu-22.04
       filter:
-        owner: vaticle
+        owner: typedb
         branch: [master, development]
       dependencies: [build, build-dependency, test-unit, test-integration, test-behaviour-connection, test-behaviour-concept, test-behaviour-query-read, test-behaviour-query-write, test-behaviour-query-definable, test-behaviour-reasoner]
       command: |
@@ -139,7 +139,7 @@ build:
     deploy-artifact-snapshot:
       image: vaticle-ubuntu-22.04
       filter:
-        owner: vaticle
+        owner: typedb
         branch: [master, development]
       dependencies: [test-assembly-linux-targz]
       command: |
@@ -159,7 +159,7 @@ build:
     deploy-apt-snapshot:
       image: vaticle-ubuntu-22.04
       filter:
-        owner: vaticle
+        owner: typedb
         branch: [master, development]
       dependencies: [test-assembly-linux-targz]
       command: |
@@ -171,7 +171,7 @@ build:
 #    deploy-brew-snapshot:
 #      image: vaticle-ubuntu-22.04
 #      filter:
-#        owner: vaticle
+#        owner: typedb
 #        branch: master
 #      command: |
 #        export DEPLOY_BREW_TOKEN=$REPO_GITHUB_TOKEN DEPLOY_BREW_USERNAME=$REPO_GITHUB_USERNAME DEPLOY_BREW_EMAIL=$REPO_GITHUB_EMAIL
@@ -179,7 +179,7 @@ build:
     test-deployment-apt-x86_64:
       image: vaticle-ubuntu-22.04 # use LTS for apt tests
       filter:
-        owner: vaticle
+        owner: typedb
         branch: [master, development]
       dependencies: [deploy-apt-snapshot]
       command: |
@@ -189,7 +189,7 @@ build:
     deploy-runner-maven-snapshot:
       image: vaticle-ubuntu-22.04
       filter:
-        owner: vaticle
+        owner: typedb
         branch: [master, development]
       dependencies: [build]
       command: |
@@ -200,7 +200,7 @@ build:
     sync-dependencies:
       image: vaticle-ubuntu-22.04
       filter:
-        owner: vaticle
+        owner: typedb
         branch: [master, development]
       dependencies:
         - build
@@ -225,7 +225,7 @@ build:
 
 release:
   filter:
-    owner: vaticle
+    owner: typedb
     branch: master
   validation:
     validate-dependencies:
@@ -240,7 +240,7 @@ release:
     deploy-github:
       image: vaticle-ubuntu-22.04
       filter:
-        owner: vaticle
+        owner: typedb
         branch: master
       command: |
         export DEPLOY_GITHUB_TOKEN=$REPO_GITHUB_TOKEN
@@ -250,7 +250,7 @@ release:
       image: vaticle-ubuntu-22.04
       dependencies: [deploy-github]
       filter:
-        owner: vaticle
+        owner: typedb
         branch: master
       command: |
         export DEPLOY_BREW_TOKEN=$REPO_GITHUB_TOKEN DEPLOY_BREW_USERNAME=$REPO_GITHUB_USERNAME DEPLOY_BREW_EMAIL=$REPO_GITHUB_EMAIL
@@ -258,7 +258,7 @@ release:
     deploy-apt-release:
       image: vaticle-ubuntu-22.04
       filter:
-        owner: vaticle
+        owner: typedb
         branch: master
       dependencies: [deploy-github]
       command: |
@@ -270,7 +270,7 @@ release:
     deploy-docker:
       image: vaticle-ubuntu-22.04
       filter:
-        owner: vaticle
+        owner: typedb
         branch: master
       dependencies: [deploy-github]
       command: |
@@ -281,7 +281,7 @@ release:
     deploy-artifact-release:
       image: vaticle-ubuntu-22.04
       filter:
-        owner: vaticle
+        owner: typedb
         branch: master
       dependencies: [deploy-github]
       command: |
@@ -300,7 +300,7 @@ release:
         bazel run --//server:config=release --define version=$(cat VERSION) //:deploy-windows-x86_64-zip -- release
     deploy-runner-maven-release:
       filter:
-        owner: vaticle
+        owner: typedb
         branch: master
       image: vaticle-ubuntu-22.04
       command: |
@@ -310,7 +310,7 @@ release:
     sync-dependencies-release:
       image: vaticle-ubuntu-22.04
       filter:
-        owner: vaticle
+        owner: typedb
         branch: [master, development]
       dependencies:
         - deploy-github

--- a/common/diagnostics/Diagnostics.java
+++ b/common/diagnostics/Diagnostics.java
@@ -152,7 +152,7 @@ public abstract class Diagnostics {
             user.setUsername(serverID);
             Sentry.setUser(user);
 
-            // FIXME temporary heartbeat every 24 hours (https://github.com/vaticle/typedb/pull/7045)
+            // FIXME temporary heartbeat every 24 hours (https://github.com/typedb/typedb/pull/7045)
             if (sentryEnabled) {
                 scheduled.schedule(() -> {
                     Sentry.startTransaction(new TransactionContext("server", "bootup")).finish(SpanStatus.OK);

--- a/config/brew/typedb.rb
+++ b/config/brew/typedb.rb
@@ -8,12 +8,12 @@ class Typedb < Formula
   homepage "https://typedb.com"
 
   on_arm do
-    url "https://github.com/vaticle/typedb/releases/download/{version}/typedb-all-mac-arm64-{version}.zip"
+    url "https://github.com/typedb/typedb/releases/download/{version}/typedb-all-mac-arm64-{version}.zip"
     sha256 "{sha256-arm64}"
   end
 
   on_intel do
-    url "https://github.com/vaticle/typedb/releases/download/{version}/typedb-all-mac-x86_64-{version}.zip"
+    url "https://github.com/typedb/typedb/releases/download/{version}/typedb-all-mac-x86_64-{version}.zip"
     sha256 "{sha256-x86_64}"
   end
 

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -7,34 +7,34 @@ load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 def vaticle_bazel_distribution():
     git_repository(
         name = "vaticle_bazel_distribution",
-        remote = "https://github.com/vaticle/bazel-distribution",
+        remote = "https://github.com/typedb/bazel-distribution",
         commit = "0040e492db47eb83681a62ddf8491a7218633164", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_bazel_distribution
     )
 
 def vaticle_dependencies():
     git_repository(
         name = "vaticle_dependencies",
-        remote = "https://github.com/vaticle/dependencies",
+        remote = "https://github.com/typedb/dependencies",
         commit = "294ef724c3853c9851e1e0c6bc04e0470c724e10", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
     )
 
 def vaticle_typeql():
     git_repository(
         name = "vaticle_typeql",
-        remote = "https://github.com/vaticle/typeql",
+        remote = "https://github.com/typedb/typeql",
         tag = "2.28.6",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typeql
     )
 
 def vaticle_typedb_protocol():
     git_repository(
         name = "vaticle_typedb_protocol",
-        remote = "https://github.com/vaticle/typedb-protocol",
+        remote = "https://github.com/typedb/typedb-protocol",
         commit = "aea498d852d763c20d9ecc7d11423d7506964b95",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_protocol
     )
 
 def vaticle_typedb_behaviour():
     git_repository(
         name = "vaticle_typedb_behaviour",
-        remote = "https://github.com/vaticle/typedb-behaviour",
+        remote = "https://github.com/typedb/typedb-behaviour",
         commit = "8353423079b33f885ed3716bade90b0e05e49f2d",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_behaviour
     )

--- a/pattern/Conjunction.java
+++ b/pattern/Conjunction.java
@@ -238,7 +238,7 @@ public class Conjunction implements Pattern, Cloneable {
         Conjunction that = (Conjunction) obj;
         // TODO: This doesn't work! It doesn't compare constraints
         // TODO: negations should be a set not list
-        // TODO: both are corrected with https://github.com/vaticle/typedb/issues/6115
+        // TODO: both are corrected with https://github.com/typedb/typedb/issues/6115
         return (this.variableSet.equals(that.variables()) &&
                 this.negations.equals(that.negations()));
     }

--- a/pattern/Disjunction.java
+++ b/pattern/Disjunction.java
@@ -101,7 +101,7 @@ public class Disjunction implements Pattern, Cloneable {
 
         Disjunction that = (Disjunction) o;
         // TODO: should use a set-comparison
-        // TODO: corrected with https://github.com/vaticle/typedb/issues/6115
+        // TODO: corrected with https://github.com/typedb/typedb/issues/6115
         return this.conjunctions.equals(that.conjunctions);
     }
 


### PR DESCRIPTION
## Usage and product changes
Updates usages of GitHub urls to reflect the vaticle organisation being renamed to TypeDB

## Implementation
Updates `github.com/vaticle/*` repository urls to `github.com/typedb/*` in 
* factory's `automation.yml`
* the brew config
* comments in java files 
The links in the readme remain untouched