### PR TITLE
Update docker image to have both x86_64 and arm64 versions

### DIFF
--- a/.factory/automation.yml
+++ b/.factory/automation.yml
@@ -20,225 +20,208 @@ build:
       command: |
         bazel run @vaticle_dependencies//factory/analysis:dependency-analysis
   correctness:
-#    build:
-#      image: vaticle-ubuntu-22.04
-#      command: |
-#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-#        bazel build //...
-#        bazel run @vaticle_dependencies//tool/checkstyle:test-coverage
-#        bazel test $(bazel query 'kind(checkstyle_test, //...)') --test_output=streamed
-#    build-dependency:
-#      image: vaticle-ubuntu-22.04
-#      command: |
-#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-#        dependencies/maven/update.sh
-#        git diff --exit-code dependencies/maven/artifacts.snapshot
-#        bazel run @vaticle_dependencies//tool/unuseddeps:unused-deps -- list
-#    test-unit:
-#      image: vaticle-ubuntu-22.04
-#      dependencies: [build]
-#      command: |
-#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-#        bazel test //common/... --test_output=streamed
-#        bazel test //pattern/... --test_output=streamed
-#        bazel test //logic/... --test_output=streamed
-#        bazel test //reasoner/... --test_output=streamed
-#        bazel test //server/... --test_output=streamed
-#    test-integration:
-#      image: vaticle-ubuntu-22.04
-#      dependencies: [build]
-#      command: |
-#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-#        bazel test //test/integration/... --test_output=streamed
-#    test-behaviour-connection:
-#      image: vaticle-ubuntu-22.04
-#      dependencies: [build]
-#      command: |
-#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-#        bazel test //test/behaviour/connection/... --test_output=streamed
-#    test-behaviour-concept:
-#      image: vaticle-ubuntu-22.04
-#      dependencies: [build]
-#      command: |
-#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-#        bazel test //test/behaviour/concept/... --test_output=streamed
-#    test-behaviour-query-read:
-#      image: vaticle-ubuntu-22.04
-#      dependencies: [build]
-#      command: |
-#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-#        bazel test //test/behaviour/query/language/match/... --test_output=streamed
-#        bazel test //test/behaviour/query/language/expression/... --test_output=streamed
-#        bazel test //test/behaviour/query/language/modifiers/... --test_output=streamed
-#        bazel test //test/behaviour/query/language/get/... --test_output=streamed
-#        bazel test //test/behaviour/query/language/fetch/... --test_output=streamed
-#    test-behaviour-query-write:
-#      image: vaticle-ubuntu-22.04
-#      dependencies: [build]
-#      command: |
-#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-#        bazel test //test/behaviour/query/language/insert/... --test_output=streamed
-#        bazel test //test/behaviour/query/language/delete/... --test_output=streamed
-#        bazel test //test/behaviour/query/language/update/... --test_output=streamed
-#    test-behaviour-query-definable:
-#      image: vaticle-ubuntu-22.04
-#      dependencies: [build]
-#      command: |
-#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-#        bazel test //test/behaviour/query/language/define/... --test_output=streamed
-#        bazel test //test/behaviour/query/language/undefine/... --test_output=streamed
-#        bazel test //test/behaviour/query/language/rule_validation/... --test_output=streamed
-#    test-behaviour-reasoner:
-#      image: vaticle-ubuntu-22.04
-#      dependencies: [build]
-#      command: |
-#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-#        bazel test //test/behaviour/reasoner/tests/attribute_attachment:test --test_output=streamed
-#        bazel test //test/behaviour/reasoner/tests/compound_queries:test --test_output=streamed
-#        bazel test //test/behaviour/reasoner/tests/concept_inequality:test --test_output=streamed
-#        bazel test //test/behaviour/reasoner/tests/negation:test --test_output=streamed
-#        bazel test //test/behaviour/reasoner/tests/recursion:test --test_output=streamed
-#        bazel test //test/behaviour/reasoner/tests/relation_inference:test --test_output=streamed
-#        bazel test //test/behaviour/reasoner/tests/rule_interaction:test --test_output=streamed
-#        bazel test //test/behaviour/reasoner/tests/schema_queries:test --test_output=streamed
-#        bazel test //test/behaviour/reasoner/tests/type_hierarchy:test --test_output=streamed
-#        bazel test //test/behaviour/reasoner/tests/value_predicate:test --test_output=streamed
-#        bazel test //test/behaviour/reasoner/tests/variable_roles:test --test_output=streamed
-#    test-benchmark-reasoner:
-#      image: vaticle-ubuntu-22.04
-#      filter:
-#        owner: typedb
-#        branch: [master, development]
-#      dependencies: [build]
-#      command: |
-#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-#        bazel test //test/benchmark/reasoner/iam/basic:test-basic --test_output=streamed
-#        bazel test //test/benchmark/reasoner/iam/complex:test-conjunction-structure --test_output=streamed
-#        bazel test //test/benchmark/reasoner/iam/complex:test-complex-rule-graph --test_output=streamed
-#        bazel test //test/benchmark/reasoner/iam/complex:test-language-features --test_output=streamed
-#        bazel test //test/benchmark/reasoner/iam/complex:test-large-data --test_output=streamed
-#        bazel test //test/benchmark/reasoner/iam/complex:test-real-queries --test_output=streamed
-#    test-assembly-linux-targz:
-#      image: vaticle-ubuntu-20.04
-#      filter:
-#        owner: typedb
-#        branch: [master, development]
-#      dependencies: [build, build-dependency, test-unit, test-integration, test-behaviour-connection, test-behaviour-concept, test-behaviour-query-read, test-behaviour-query-write, test-behaviour-query-definable, test-behaviour-reasoner]
-#      command: |
-#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-#        bazel test //test/assembly:assembly --test_output=streamed
-#    test-assembly-docker:
-#      image: vaticle-ubuntu-22.04
-#      filter:
-#        owner: typedb
-#        branch: [master, development]
-#      dependencies: [build, build-dependency, test-unit, test-integration, test-behaviour-connection, test-behaviour-concept, test-behaviour-query-read, test-behaviour-query-write, test-behaviour-query-definable, test-behaviour-reasoner]
-#      command: |
-#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-#        bazel test //test/assembly:docker --test_output=streamed
-#    deploy-artifact-snapshot:
-#      image: vaticle-ubuntu-22.04
-#      filter:
-#        owner: typedb
-#        branch: [master, development]
-#      dependencies: [test-assembly-linux-targz]
-#      command: |
-#        export DEPLOY_ARTIFACT_USERNAME=$REPO_TYPEDB_USERNAME
-#        export DEPLOY_ARTIFACT_PASSWORD=$REPO_TYPEDB_PASSWORD
-#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-#        bazel run --define version=$(git rev-parse HEAD) //server:deploy-linux-arm64-targz -- snapshot
-#        bazel run --define version=$(git rev-parse HEAD) //server:deploy-linux-x86_64-targz -- snapshot
-#        bazel run --define version=$(git rev-parse HEAD) //server:deploy-mac-arm64-zip -- snapshot
-#        bazel run --define version=$(git rev-parse HEAD) //server:deploy-mac-x86_64-zip -- snapshot
-#        bazel run --define version=$(git rev-parse HEAD) //server:deploy-windows-x86_64-zip -- snapshot
-#        bazel run --define version=$(git rev-parse HEAD) //:deploy-linux-arm64-targz -- snapshot
-#        bazel run --define version=$(git rev-parse HEAD) //:deploy-linux-x86_64-targz -- snapshot
-#        bazel run --define version=$(git rev-parse HEAD) //:deploy-mac-arm64-zip -- snapshot
-#        bazel run --define version=$(git rev-parse HEAD) //:deploy-mac-x86_64-zip -- snapshot
-#        bazel run --define version=$(git rev-parse HEAD) //:deploy-windows-x86_64-zip -- snapshot
-#    deploy-apt-snapshot:
-#      image: vaticle-ubuntu-22.04
-#      filter:
-#        owner: typedb
-#        branch: [master, development]
-#      dependencies: [test-assembly-linux-targz]
-#      command: |
-#        export DEPLOY_APT_USERNAME=$REPO_TYPEDB_USERNAME
-#        export DEPLOY_APT_PASSWORD=$REPO_TYPEDB_PASSWORD
-#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-#        bazel run --define version=$(git rev-parse HEAD) //:deploy-apt-x86_64 -- snapshot
-#        bazel run --define version=$(git rev-parse HEAD) //:deploy-apt-arm64 -- snapshot
-##    deploy-brew-snapshot:
-##      image: vaticle-ubuntu-22.04
-##      filter:
-##        owner: typedb
-##        branch: master
-##      command: |
-##        export DEPLOY_BREW_TOKEN=$REPO_GITHUB_TOKEN DEPLOY_BREW_USERNAME=$REPO_GITHUB_USERNAME DEPLOY_BREW_EMAIL=$REPO_GITHUB_EMAIL
-##        bazel run --define version=$(cat VERSION) //:deploy-brew -- snapshot
-#    test-deployment-apt-x86_64:
-#      image: vaticle-ubuntu-22.04 # use LTS for apt tests
-#      filter:
-#        owner: typedb
-#        branch: [master, development]
-#      dependencies: [deploy-apt-snapshot]
-#      command: |
-#        export TEST_DEPLOYMENT_APT_COMMIT=$FACTORY_COMMIT
-#        bazel test //test/deployment:apt --action_env=TEST_DEPLOYMENT_APT_COMMIT --test_output=streamed
-#
-#    deploy-runner-maven-snapshot:
-#      image: vaticle-ubuntu-22.04
-#      filter:
-#        owner: typedb
-#        branch: [master, development]
-#      dependencies: [build]
-#      command: |
-#        export DEPLOY_MAVEN_USERNAME=$REPO_TYPEDB_USERNAME
-#        export DEPLOY_MAVEN_PASSWORD=$REPO_TYPEDB_PASSWORD
-#        bazel run --define version=$(git rev-parse HEAD) //tool/runner:deploy-maven -- snapshot
-#
-#    sync-dependencies:
-#      image: vaticle-ubuntu-22.04
-#      filter:
-#        owner: typedb
-#        branch: [master, development]
-#      dependencies:
-#        - build
-#        - build-dependency
-#        - test-unit
-#        - test-integration
-#        - test-behaviour-connection
-#        - test-behaviour-concept
-#        - test-behaviour-query-read
-#        - test-behaviour-query-write
-#        - test-behaviour-query-definable
-#        - test-behaviour-reasoner
-#        - test-benchmark-reasoner
-#        - test-assembly-linux-targz
-#        - test-assembly-docker
-#        - deploy-artifact-snapshot
-#        - deploy-apt-snapshot
-#        - test-deployment-apt-x86_64
-#      command: |
-#          export SYNC_DEPENDENCIES_TOKEN=$REPO_GITHUB_TOKEN
-#          bazel run @vaticle_dependencies//tool/sync:dependencies -- --source ${FACTORY_REPO}@${FACTORY_COMMIT}
-
-    deploy-docker-test:
+    build:
+      image: vaticle-ubuntu-22.04
+      command: |
+        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+        bazel build //...
+        bazel run @vaticle_dependencies//tool/checkstyle:test-coverage
+        bazel test $(bazel query 'kind(checkstyle_test, //...)') --test_output=streamed
+    build-dependency:
+      image: vaticle-ubuntu-22.04
+      command: |
+        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+        dependencies/maven/update.sh
+        git diff --exit-code dependencies/maven/artifacts.snapshot
+        bazel run @vaticle_dependencies//tool/unuseddeps:unused-deps -- list
+    test-unit:
+      image: vaticle-ubuntu-22.04
+      dependencies: [build]
+      command: |
+        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+        bazel test //common/... --test_output=streamed
+        bazel test //pattern/... --test_output=streamed
+        bazel test //logic/... --test_output=streamed
+        bazel test //reasoner/... --test_output=streamed
+        bazel test //server/... --test_output=streamed
+    test-integration:
+      image: vaticle-ubuntu-22.04
+      dependencies: [build]
+      command: |
+        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+        bazel test //test/integration/... --test_output=streamed
+    test-behaviour-connection:
+      image: vaticle-ubuntu-22.04
+      dependencies: [build]
+      command: |
+        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+        bazel test //test/behaviour/connection/... --test_output=streamed
+    test-behaviour-concept:
+      image: vaticle-ubuntu-22.04
+      dependencies: [build]
+      command: |
+        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+        bazel test //test/behaviour/concept/... --test_output=streamed
+    test-behaviour-query-read:
+      image: vaticle-ubuntu-22.04
+      dependencies: [build]
+      command: |
+        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+        bazel test //test/behaviour/query/language/match/... --test_output=streamed
+        bazel test //test/behaviour/query/language/expression/... --test_output=streamed
+        bazel test //test/behaviour/query/language/modifiers/... --test_output=streamed
+        bazel test //test/behaviour/query/language/get/... --test_output=streamed
+        bazel test //test/behaviour/query/language/fetch/... --test_output=streamed
+    test-behaviour-query-write:
+      image: vaticle-ubuntu-22.04
+      dependencies: [build]
+      command: |
+        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+        bazel test //test/behaviour/query/language/insert/... --test_output=streamed
+        bazel test //test/behaviour/query/language/delete/... --test_output=streamed
+        bazel test //test/behaviour/query/language/update/... --test_output=streamed
+    test-behaviour-query-definable:
+      image: vaticle-ubuntu-22.04
+      dependencies: [build]
+      command: |
+        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+        bazel test //test/behaviour/query/language/define/... --test_output=streamed
+        bazel test //test/behaviour/query/language/undefine/... --test_output=streamed
+        bazel test //test/behaviour/query/language/rule_validation/... --test_output=streamed
+    test-behaviour-reasoner:
+      image: vaticle-ubuntu-22.04
+      dependencies: [build]
+      command: |
+        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+        bazel test //test/behaviour/reasoner/tests/attribute_attachment:test --test_output=streamed
+        bazel test //test/behaviour/reasoner/tests/compound_queries:test --test_output=streamed
+        bazel test //test/behaviour/reasoner/tests/concept_inequality:test --test_output=streamed
+        bazel test //test/behaviour/reasoner/tests/negation:test --test_output=streamed
+        bazel test //test/behaviour/reasoner/tests/recursion:test --test_output=streamed
+        bazel test //test/behaviour/reasoner/tests/relation_inference:test --test_output=streamed
+        bazel test //test/behaviour/reasoner/tests/rule_interaction:test --test_output=streamed
+        bazel test //test/behaviour/reasoner/tests/schema_queries:test --test_output=streamed
+        bazel test //test/behaviour/reasoner/tests/type_hierarchy:test --test_output=streamed
+        bazel test //test/behaviour/reasoner/tests/value_predicate:test --test_output=streamed
+        bazel test //test/behaviour/reasoner/tests/variable_roles:test --test_output=streamed
+    test-benchmark-reasoner:
       image: vaticle-ubuntu-22.04
       filter:
-        owner: [typedb]
-        branch: [docker-arm64-for-2.x]
+        owner: typedb
+        branch: [master, development]
+      dependencies: [build]
       command: |
-        export VERSION=$(cat VERSION)
-        docker login -u $REPO_DOCKER_USERNAME -p $REPO_DOCKER_PASSWORD
         bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-        bazel run --@io_bazel_rules_docker//transitions:enable=false --//server:config=release //:deploy-docker-release-x86_64
-        bazel run --@io_bazel_rules_docker//transitions:enable=false --//server:config=release //:deploy-docker-release-arm64
-        export DOCKER_REPO="typedb-snapshot"
-        docker manifest create vaticle/$DOCKER_REPO:$VERSION --amend vaticle/$DOCKER_REPO:$VERSION-x86_64 --amend vaticle/$DOCKER_REPO:$VERSION-arm64
-        docker manifest push vaticle/$DOCKER_REPO:$VERSION
-        docker manifest create vaticle/$DOCKER_REPO:latest --amend vaticle/$DOCKER_REPO:$VERSION-x86_64 --amend vaticle/$DOCKER_REPO:$VERSION-arm64
-        docker manifest push vaticle/$DOCKER_REPO:latest
+        bazel test //test/benchmark/reasoner/iam/basic:test-basic --test_output=streamed
+        bazel test //test/benchmark/reasoner/iam/complex:test-conjunction-structure --test_output=streamed
+        bazel test //test/benchmark/reasoner/iam/complex:test-complex-rule-graph --test_output=streamed
+        bazel test //test/benchmark/reasoner/iam/complex:test-language-features --test_output=streamed
+        bazel test //test/benchmark/reasoner/iam/complex:test-large-data --test_output=streamed
+        bazel test //test/benchmark/reasoner/iam/complex:test-real-queries --test_output=streamed
+    test-assembly-linux-targz:
+      image: vaticle-ubuntu-20.04
+      filter:
+        owner: typedb
+        branch: [master, development]
+      dependencies: [build, build-dependency, test-unit, test-integration, test-behaviour-connection, test-behaviour-concept, test-behaviour-query-read, test-behaviour-query-write, test-behaviour-query-definable, test-behaviour-reasoner]
+      command: |
+        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+        bazel test //test/assembly:assembly --test_output=streamed
+    test-assembly-docker:
+      image: vaticle-ubuntu-22.04
+      filter:
+        owner: typedb
+        branch: [master, development]
+      dependencies: [build, build-dependency, test-unit, test-integration, test-behaviour-connection, test-behaviour-concept, test-behaviour-query-read, test-behaviour-query-write, test-behaviour-query-definable, test-behaviour-reasoner]
+      command: |
+        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+        bazel test //test/assembly:docker --test_output=streamed
+    deploy-artifact-snapshot:
+      image: vaticle-ubuntu-22.04
+      filter:
+        owner: typedb
+        branch: [master, development]
+      dependencies: [test-assembly-linux-targz]
+      command: |
+        export DEPLOY_ARTIFACT_USERNAME=$REPO_TYPEDB_USERNAME
+        export DEPLOY_ARTIFACT_PASSWORD=$REPO_TYPEDB_PASSWORD
+        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+        bazel run --define version=$(git rev-parse HEAD) //server:deploy-linux-arm64-targz -- snapshot
+        bazel run --define version=$(git rev-parse HEAD) //server:deploy-linux-x86_64-targz -- snapshot
+        bazel run --define version=$(git rev-parse HEAD) //server:deploy-mac-arm64-zip -- snapshot
+        bazel run --define version=$(git rev-parse HEAD) //server:deploy-mac-x86_64-zip -- snapshot
+        bazel run --define version=$(git rev-parse HEAD) //server:deploy-windows-x86_64-zip -- snapshot
+        bazel run --define version=$(git rev-parse HEAD) //:deploy-linux-arm64-targz -- snapshot
+        bazel run --define version=$(git rev-parse HEAD) //:deploy-linux-x86_64-targz -- snapshot
+        bazel run --define version=$(git rev-parse HEAD) //:deploy-mac-arm64-zip -- snapshot
+        bazel run --define version=$(git rev-parse HEAD) //:deploy-mac-x86_64-zip -- snapshot
+        bazel run --define version=$(git rev-parse HEAD) //:deploy-windows-x86_64-zip -- snapshot
+    deploy-apt-snapshot:
+      image: vaticle-ubuntu-22.04
+      filter:
+        owner: typedb
+        branch: [master, development]
+      dependencies: [test-assembly-linux-targz]
+      command: |
+        export DEPLOY_APT_USERNAME=$REPO_TYPEDB_USERNAME
+        export DEPLOY_APT_PASSWORD=$REPO_TYPEDB_PASSWORD
+        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+        bazel run --define version=$(git rev-parse HEAD) //:deploy-apt-x86_64 -- snapshot
+        bazel run --define version=$(git rev-parse HEAD) //:deploy-apt-arm64 -- snapshot
+#    deploy-brew-snapshot:
+#      image: vaticle-ubuntu-22.04
+#      filter:
+#        owner: typedb
+#        branch: master
+#      command: |
+#        export DEPLOY_BREW_TOKEN=$REPO_GITHUB_TOKEN DEPLOY_BREW_USERNAME=$REPO_GITHUB_USERNAME DEPLOY_BREW_EMAIL=$REPO_GITHUB_EMAIL
+#        bazel run --define version=$(cat VERSION) //:deploy-brew -- snapshot
+    test-deployment-apt-x86_64:
+      image: vaticle-ubuntu-22.04 # use LTS for apt tests
+      filter:
+        owner: typedb
+        branch: [master, development]
+      dependencies: [deploy-apt-snapshot]
+      command: |
+        export TEST_DEPLOYMENT_APT_COMMIT=$FACTORY_COMMIT
+        bazel test //test/deployment:apt --action_env=TEST_DEPLOYMENT_APT_COMMIT --test_output=streamed
+
+    deploy-runner-maven-snapshot:
+      image: vaticle-ubuntu-22.04
+      filter:
+        owner: typedb
+        branch: [master, development]
+      dependencies: [build]
+      command: |
+        export DEPLOY_MAVEN_USERNAME=$REPO_TYPEDB_USERNAME
+        export DEPLOY_MAVEN_PASSWORD=$REPO_TYPEDB_PASSWORD
+        bazel run --define version=$(git rev-parse HEAD) //tool/runner:deploy-maven -- snapshot
+
+    sync-dependencies:
+      image: vaticle-ubuntu-22.04
+      filter:
+        owner: typedb
+        branch: [master, development]
+      dependencies:
+        - build
+        - build-dependency
+        - test-unit
+        - test-integration
+        - test-behaviour-connection
+        - test-behaviour-concept
+        - test-behaviour-query-read
+        - test-behaviour-query-write
+        - test-behaviour-query-definable
+        - test-behaviour-reasoner
+        - test-benchmark-reasoner
+        - test-assembly-linux-targz
+        - test-assembly-docker
+        - deploy-artifact-snapshot
+        - deploy-apt-snapshot
+        - test-deployment-apt-x86_64
+      command: |
+          export SYNC_DEPENDENCIES_TOKEN=$REPO_GITHUB_TOKEN
+          bazel run @vaticle_dependencies//tool/sync:dependencies -- --source ${FACTORY_REPO}@${FACTORY_COMMIT}
 
 release:
   filter:
@@ -296,7 +279,7 @@ release:
         bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
         bazel run --@io_bazel_rules_docker//transitions:enable=false --//server:config=release //:deploy-docker-release-x86_64
         bazel run --@io_bazel_rules_docker//transitions:enable=false --//server:config=release //:deploy-docker-release-arm64
-        export DOCKER_REPO="typedb" 
+        export DOCKER_REPO="typedb"
         docker manifest create vaticle/$DOCKER_REPO:$VERSION --amend vaticle/$DOCKER_REPO:$VERSION-x86_64 --amend vaticle/$DOCKER_REPO:$VERSION-arm64
         docker manifest push vaticle/$DOCKER_REPO:$VERSION
         docker manifest create vaticle/$DOCKER_REPO:latest --amend vaticle/$DOCKER_REPO:$VERSION-x86_64 --amend vaticle/$DOCKER_REPO:$VERSION-arm64

--- a/.factory/automation.yml
+++ b/.factory/automation.yml
@@ -20,208 +20,224 @@ build:
       command: |
         bazel run @vaticle_dependencies//factory/analysis:dependency-analysis
   correctness:
-    build:
-      image: vaticle-ubuntu-22.04
-      command: |
-        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-        bazel build //...
-        bazel run @vaticle_dependencies//tool/checkstyle:test-coverage
-        bazel test $(bazel query 'kind(checkstyle_test, //...)') --test_output=streamed
-    build-dependency:
-      image: vaticle-ubuntu-22.04
-      command: |
-        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-        dependencies/maven/update.sh
-        git diff --exit-code dependencies/maven/artifacts.snapshot
-        bazel run @vaticle_dependencies//tool/unuseddeps:unused-deps -- list
-    test-unit:
-      image: vaticle-ubuntu-22.04
-      dependencies: [build]
-      command: |
-        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-        bazel test //common/... --test_output=streamed
-        bazel test //pattern/... --test_output=streamed
-        bazel test //logic/... --test_output=streamed
-        bazel test //reasoner/... --test_output=streamed
-        bazel test //server/... --test_output=streamed
-    test-integration:
-      image: vaticle-ubuntu-22.04
-      dependencies: [build]
-      command: |
-        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-        bazel test //test/integration/... --test_output=streamed
-    test-behaviour-connection:
-      image: vaticle-ubuntu-22.04
-      dependencies: [build]
-      command: |
-        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-        bazel test //test/behaviour/connection/... --test_output=streamed
-    test-behaviour-concept:
-      image: vaticle-ubuntu-22.04
-      dependencies: [build]
-      command: |
-        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-        bazel test //test/behaviour/concept/... --test_output=streamed
-    test-behaviour-query-read:
-      image: vaticle-ubuntu-22.04
-      dependencies: [build]
-      command: |
-        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-        bazel test //test/behaviour/query/language/match/... --test_output=streamed
-        bazel test //test/behaviour/query/language/expression/... --test_output=streamed
-        bazel test //test/behaviour/query/language/modifiers/... --test_output=streamed
-        bazel test //test/behaviour/query/language/get/... --test_output=streamed
-        bazel test //test/behaviour/query/language/fetch/... --test_output=streamed
-    test-behaviour-query-write:
-      image: vaticle-ubuntu-22.04
-      dependencies: [build]
-      command: |
-        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-        bazel test //test/behaviour/query/language/insert/... --test_output=streamed
-        bazel test //test/behaviour/query/language/delete/... --test_output=streamed
-        bazel test //test/behaviour/query/language/update/... --test_output=streamed
-    test-behaviour-query-definable:
-      image: vaticle-ubuntu-22.04
-      dependencies: [build]
-      command: |
-        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-        bazel test //test/behaviour/query/language/define/... --test_output=streamed
-        bazel test //test/behaviour/query/language/undefine/... --test_output=streamed
-        bazel test //test/behaviour/query/language/rule_validation/... --test_output=streamed
-    test-behaviour-reasoner:
-      image: vaticle-ubuntu-22.04
-      dependencies: [build]
-      command: |
-        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-        bazel test //test/behaviour/reasoner/tests/attribute_attachment:test --test_output=streamed
-        bazel test //test/behaviour/reasoner/tests/compound_queries:test --test_output=streamed
-        bazel test //test/behaviour/reasoner/tests/concept_inequality:test --test_output=streamed
-        bazel test //test/behaviour/reasoner/tests/negation:test --test_output=streamed
-        bazel test //test/behaviour/reasoner/tests/recursion:test --test_output=streamed
-        bazel test //test/behaviour/reasoner/tests/relation_inference:test --test_output=streamed
-        bazel test //test/behaviour/reasoner/tests/rule_interaction:test --test_output=streamed
-        bazel test //test/behaviour/reasoner/tests/schema_queries:test --test_output=streamed
-        bazel test //test/behaviour/reasoner/tests/type_hierarchy:test --test_output=streamed
-        bazel test //test/behaviour/reasoner/tests/value_predicate:test --test_output=streamed
-        bazel test //test/behaviour/reasoner/tests/variable_roles:test --test_output=streamed
-    test-benchmark-reasoner:
-      image: vaticle-ubuntu-22.04
-      filter:
-        owner: typedb
-        branch: [master, development]
-      dependencies: [build]
-      command: |
-        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-        bazel test //test/benchmark/reasoner/iam/basic:test-basic --test_output=streamed
-        bazel test //test/benchmark/reasoner/iam/complex:test-conjunction-structure --test_output=streamed
-        bazel test //test/benchmark/reasoner/iam/complex:test-complex-rule-graph --test_output=streamed
-        bazel test //test/benchmark/reasoner/iam/complex:test-language-features --test_output=streamed
-        bazel test //test/benchmark/reasoner/iam/complex:test-large-data --test_output=streamed
-        bazel test //test/benchmark/reasoner/iam/complex:test-real-queries --test_output=streamed
-    test-assembly-linux-targz:
-      image: vaticle-ubuntu-20.04
-      filter:
-        owner: typedb
-        branch: [master, development]
-      dependencies: [build, build-dependency, test-unit, test-integration, test-behaviour-connection, test-behaviour-concept, test-behaviour-query-read, test-behaviour-query-write, test-behaviour-query-definable, test-behaviour-reasoner]
-      command: |
-        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-        bazel test //test/assembly:assembly --test_output=streamed
-    test-assembly-docker:
-      image: vaticle-ubuntu-22.04
-      filter:
-        owner: typedb
-        branch: [master, development]
-      dependencies: [build, build-dependency, test-unit, test-integration, test-behaviour-connection, test-behaviour-concept, test-behaviour-query-read, test-behaviour-query-write, test-behaviour-query-definable, test-behaviour-reasoner]
-      command: |
-        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-        bazel test //test/assembly:docker --test_output=streamed
-    deploy-artifact-snapshot:
-      image: vaticle-ubuntu-22.04
-      filter:
-        owner: typedb
-        branch: [master, development]
-      dependencies: [test-assembly-linux-targz]
-      command: |
-        export DEPLOY_ARTIFACT_USERNAME=$REPO_TYPEDB_USERNAME
-        export DEPLOY_ARTIFACT_PASSWORD=$REPO_TYPEDB_PASSWORD
-        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-        bazel run --define version=$(git rev-parse HEAD) //server:deploy-linux-arm64-targz -- snapshot
-        bazel run --define version=$(git rev-parse HEAD) //server:deploy-linux-x86_64-targz -- snapshot
-        bazel run --define version=$(git rev-parse HEAD) //server:deploy-mac-arm64-zip -- snapshot
-        bazel run --define version=$(git rev-parse HEAD) //server:deploy-mac-x86_64-zip -- snapshot
-        bazel run --define version=$(git rev-parse HEAD) //server:deploy-windows-x86_64-zip -- snapshot
-        bazel run --define version=$(git rev-parse HEAD) //:deploy-linux-arm64-targz -- snapshot
-        bazel run --define version=$(git rev-parse HEAD) //:deploy-linux-x86_64-targz -- snapshot
-        bazel run --define version=$(git rev-parse HEAD) //:deploy-mac-arm64-zip -- snapshot
-        bazel run --define version=$(git rev-parse HEAD) //:deploy-mac-x86_64-zip -- snapshot
-        bazel run --define version=$(git rev-parse HEAD) //:deploy-windows-x86_64-zip -- snapshot
-    deploy-apt-snapshot:
-      image: vaticle-ubuntu-22.04
-      filter:
-        owner: typedb
-        branch: [master, development]
-      dependencies: [test-assembly-linux-targz]
-      command: |
-        export DEPLOY_APT_USERNAME=$REPO_TYPEDB_USERNAME
-        export DEPLOY_APT_PASSWORD=$REPO_TYPEDB_PASSWORD
-        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-        bazel run --define version=$(git rev-parse HEAD) //:deploy-apt-x86_64 -- snapshot
-        bazel run --define version=$(git rev-parse HEAD) //:deploy-apt-arm64 -- snapshot
-#    deploy-brew-snapshot:
+#    build:
+#      image: vaticle-ubuntu-22.04
+#      command: |
+#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+#        bazel build //...
+#        bazel run @vaticle_dependencies//tool/checkstyle:test-coverage
+#        bazel test $(bazel query 'kind(checkstyle_test, //...)') --test_output=streamed
+#    build-dependency:
+#      image: vaticle-ubuntu-22.04
+#      command: |
+#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+#        dependencies/maven/update.sh
+#        git diff --exit-code dependencies/maven/artifacts.snapshot
+#        bazel run @vaticle_dependencies//tool/unuseddeps:unused-deps -- list
+#    test-unit:
+#      image: vaticle-ubuntu-22.04
+#      dependencies: [build]
+#      command: |
+#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+#        bazel test //common/... --test_output=streamed
+#        bazel test //pattern/... --test_output=streamed
+#        bazel test //logic/... --test_output=streamed
+#        bazel test //reasoner/... --test_output=streamed
+#        bazel test //server/... --test_output=streamed
+#    test-integration:
+#      image: vaticle-ubuntu-22.04
+#      dependencies: [build]
+#      command: |
+#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+#        bazel test //test/integration/... --test_output=streamed
+#    test-behaviour-connection:
+#      image: vaticle-ubuntu-22.04
+#      dependencies: [build]
+#      command: |
+#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+#        bazel test //test/behaviour/connection/... --test_output=streamed
+#    test-behaviour-concept:
+#      image: vaticle-ubuntu-22.04
+#      dependencies: [build]
+#      command: |
+#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+#        bazel test //test/behaviour/concept/... --test_output=streamed
+#    test-behaviour-query-read:
+#      image: vaticle-ubuntu-22.04
+#      dependencies: [build]
+#      command: |
+#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+#        bazel test //test/behaviour/query/language/match/... --test_output=streamed
+#        bazel test //test/behaviour/query/language/expression/... --test_output=streamed
+#        bazel test //test/behaviour/query/language/modifiers/... --test_output=streamed
+#        bazel test //test/behaviour/query/language/get/... --test_output=streamed
+#        bazel test //test/behaviour/query/language/fetch/... --test_output=streamed
+#    test-behaviour-query-write:
+#      image: vaticle-ubuntu-22.04
+#      dependencies: [build]
+#      command: |
+#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+#        bazel test //test/behaviour/query/language/insert/... --test_output=streamed
+#        bazel test //test/behaviour/query/language/delete/... --test_output=streamed
+#        bazel test //test/behaviour/query/language/update/... --test_output=streamed
+#    test-behaviour-query-definable:
+#      image: vaticle-ubuntu-22.04
+#      dependencies: [build]
+#      command: |
+#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+#        bazel test //test/behaviour/query/language/define/... --test_output=streamed
+#        bazel test //test/behaviour/query/language/undefine/... --test_output=streamed
+#        bazel test //test/behaviour/query/language/rule_validation/... --test_output=streamed
+#    test-behaviour-reasoner:
+#      image: vaticle-ubuntu-22.04
+#      dependencies: [build]
+#      command: |
+#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+#        bazel test //test/behaviour/reasoner/tests/attribute_attachment:test --test_output=streamed
+#        bazel test //test/behaviour/reasoner/tests/compound_queries:test --test_output=streamed
+#        bazel test //test/behaviour/reasoner/tests/concept_inequality:test --test_output=streamed
+#        bazel test //test/behaviour/reasoner/tests/negation:test --test_output=streamed
+#        bazel test //test/behaviour/reasoner/tests/recursion:test --test_output=streamed
+#        bazel test //test/behaviour/reasoner/tests/relation_inference:test --test_output=streamed
+#        bazel test //test/behaviour/reasoner/tests/rule_interaction:test --test_output=streamed
+#        bazel test //test/behaviour/reasoner/tests/schema_queries:test --test_output=streamed
+#        bazel test //test/behaviour/reasoner/tests/type_hierarchy:test --test_output=streamed
+#        bazel test //test/behaviour/reasoner/tests/value_predicate:test --test_output=streamed
+#        bazel test //test/behaviour/reasoner/tests/variable_roles:test --test_output=streamed
+#    test-benchmark-reasoner:
 #      image: vaticle-ubuntu-22.04
 #      filter:
 #        owner: typedb
-#        branch: master
+#        branch: [master, development]
+#      dependencies: [build]
 #      command: |
-#        export DEPLOY_BREW_TOKEN=$REPO_GITHUB_TOKEN DEPLOY_BREW_USERNAME=$REPO_GITHUB_USERNAME DEPLOY_BREW_EMAIL=$REPO_GITHUB_EMAIL
-#        bazel run --define version=$(cat VERSION) //:deploy-brew -- snapshot
-    test-deployment-apt-x86_64:
-      image: vaticle-ubuntu-22.04 # use LTS for apt tests
-      filter:
-        owner: typedb
-        branch: [master, development]
-      dependencies: [deploy-apt-snapshot]
-      command: |
-        export TEST_DEPLOYMENT_APT_COMMIT=$FACTORY_COMMIT
-        bazel test //test/deployment:apt --action_env=TEST_DEPLOYMENT_APT_COMMIT --test_output=streamed
+#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+#        bazel test //test/benchmark/reasoner/iam/basic:test-basic --test_output=streamed
+#        bazel test //test/benchmark/reasoner/iam/complex:test-conjunction-structure --test_output=streamed
+#        bazel test //test/benchmark/reasoner/iam/complex:test-complex-rule-graph --test_output=streamed
+#        bazel test //test/benchmark/reasoner/iam/complex:test-language-features --test_output=streamed
+#        bazel test //test/benchmark/reasoner/iam/complex:test-large-data --test_output=streamed
+#        bazel test //test/benchmark/reasoner/iam/complex:test-real-queries --test_output=streamed
+#    test-assembly-linux-targz:
+#      image: vaticle-ubuntu-20.04
+#      filter:
+#        owner: typedb
+#        branch: [master, development]
+#      dependencies: [build, build-dependency, test-unit, test-integration, test-behaviour-connection, test-behaviour-concept, test-behaviour-query-read, test-behaviour-query-write, test-behaviour-query-definable, test-behaviour-reasoner]
+#      command: |
+#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+#        bazel test //test/assembly:assembly --test_output=streamed
+#    test-assembly-docker:
+#      image: vaticle-ubuntu-22.04
+#      filter:
+#        owner: typedb
+#        branch: [master, development]
+#      dependencies: [build, build-dependency, test-unit, test-integration, test-behaviour-connection, test-behaviour-concept, test-behaviour-query-read, test-behaviour-query-write, test-behaviour-query-definable, test-behaviour-reasoner]
+#      command: |
+#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+#        bazel test //test/assembly:docker --test_output=streamed
+#    deploy-artifact-snapshot:
+#      image: vaticle-ubuntu-22.04
+#      filter:
+#        owner: typedb
+#        branch: [master, development]
+#      dependencies: [test-assembly-linux-targz]
+#      command: |
+#        export DEPLOY_ARTIFACT_USERNAME=$REPO_TYPEDB_USERNAME
+#        export DEPLOY_ARTIFACT_PASSWORD=$REPO_TYPEDB_PASSWORD
+#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+#        bazel run --define version=$(git rev-parse HEAD) //server:deploy-linux-arm64-targz -- snapshot
+#        bazel run --define version=$(git rev-parse HEAD) //server:deploy-linux-x86_64-targz -- snapshot
+#        bazel run --define version=$(git rev-parse HEAD) //server:deploy-mac-arm64-zip -- snapshot
+#        bazel run --define version=$(git rev-parse HEAD) //server:deploy-mac-x86_64-zip -- snapshot
+#        bazel run --define version=$(git rev-parse HEAD) //server:deploy-windows-x86_64-zip -- snapshot
+#        bazel run --define version=$(git rev-parse HEAD) //:deploy-linux-arm64-targz -- snapshot
+#        bazel run --define version=$(git rev-parse HEAD) //:deploy-linux-x86_64-targz -- snapshot
+#        bazel run --define version=$(git rev-parse HEAD) //:deploy-mac-arm64-zip -- snapshot
+#        bazel run --define version=$(git rev-parse HEAD) //:deploy-mac-x86_64-zip -- snapshot
+#        bazel run --define version=$(git rev-parse HEAD) //:deploy-windows-x86_64-zip -- snapshot
+#    deploy-apt-snapshot:
+#      image: vaticle-ubuntu-22.04
+#      filter:
+#        owner: typedb
+#        branch: [master, development]
+#      dependencies: [test-assembly-linux-targz]
+#      command: |
+#        export DEPLOY_APT_USERNAME=$REPO_TYPEDB_USERNAME
+#        export DEPLOY_APT_PASSWORD=$REPO_TYPEDB_PASSWORD
+#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+#        bazel run --define version=$(git rev-parse HEAD) //:deploy-apt-x86_64 -- snapshot
+#        bazel run --define version=$(git rev-parse HEAD) //:deploy-apt-arm64 -- snapshot
+##    deploy-brew-snapshot:
+##      image: vaticle-ubuntu-22.04
+##      filter:
+##        owner: typedb
+##        branch: master
+##      command: |
+##        export DEPLOY_BREW_TOKEN=$REPO_GITHUB_TOKEN DEPLOY_BREW_USERNAME=$REPO_GITHUB_USERNAME DEPLOY_BREW_EMAIL=$REPO_GITHUB_EMAIL
+##        bazel run --define version=$(cat VERSION) //:deploy-brew -- snapshot
+#    test-deployment-apt-x86_64:
+#      image: vaticle-ubuntu-22.04 # use LTS for apt tests
+#      filter:
+#        owner: typedb
+#        branch: [master, development]
+#      dependencies: [deploy-apt-snapshot]
+#      command: |
+#        export TEST_DEPLOYMENT_APT_COMMIT=$FACTORY_COMMIT
+#        bazel test //test/deployment:apt --action_env=TEST_DEPLOYMENT_APT_COMMIT --test_output=streamed
+#
+#    deploy-runner-maven-snapshot:
+#      image: vaticle-ubuntu-22.04
+#      filter:
+#        owner: typedb
+#        branch: [master, development]
+#      dependencies: [build]
+#      command: |
+#        export DEPLOY_MAVEN_USERNAME=$REPO_TYPEDB_USERNAME
+#        export DEPLOY_MAVEN_PASSWORD=$REPO_TYPEDB_PASSWORD
+#        bazel run --define version=$(git rev-parse HEAD) //tool/runner:deploy-maven -- snapshot
+#
+#    sync-dependencies:
+#      image: vaticle-ubuntu-22.04
+#      filter:
+#        owner: typedb
+#        branch: [master, development]
+#      dependencies:
+#        - build
+#        - build-dependency
+#        - test-unit
+#        - test-integration
+#        - test-behaviour-connection
+#        - test-behaviour-concept
+#        - test-behaviour-query-read
+#        - test-behaviour-query-write
+#        - test-behaviour-query-definable
+#        - test-behaviour-reasoner
+#        - test-benchmark-reasoner
+#        - test-assembly-linux-targz
+#        - test-assembly-docker
+#        - deploy-artifact-snapshot
+#        - deploy-apt-snapshot
+#        - test-deployment-apt-x86_64
+#      command: |
+#          export SYNC_DEPENDENCIES_TOKEN=$REPO_GITHUB_TOKEN
+#          bazel run @vaticle_dependencies//tool/sync:dependencies -- --source ${FACTORY_REPO}@${FACTORY_COMMIT}
 
-    deploy-runner-maven-snapshot:
+    deploy-docker-test:
       image: vaticle-ubuntu-22.04
       filter:
-        owner: typedb
-        branch: [master, development]
-      dependencies: [build]
+        owner: [typedb]
+        branch: [docker-arm64-for-2.x]
       command: |
-        export DEPLOY_MAVEN_USERNAME=$REPO_TYPEDB_USERNAME
-        export DEPLOY_MAVEN_PASSWORD=$REPO_TYPEDB_PASSWORD
-        bazel run --define version=$(git rev-parse HEAD) //tool/runner:deploy-maven -- snapshot
-
-    sync-dependencies:
-      image: vaticle-ubuntu-22.04
-      filter:
-        owner: typedb
-        branch: [master, development]
-      dependencies:
-        - build
-        - build-dependency
-        - test-unit
-        - test-integration
-        - test-behaviour-connection
-        - test-behaviour-concept
-        - test-behaviour-query-read
-        - test-behaviour-query-write
-        - test-behaviour-query-definable
-        - test-behaviour-reasoner
-        - test-benchmark-reasoner
-        - test-assembly-linux-targz
-        - test-assembly-docker
-        - deploy-artifact-snapshot
-        - deploy-apt-snapshot
-        - test-deployment-apt-x86_64
-      command: |
-          export SYNC_DEPENDENCIES_TOKEN=$REPO_GITHUB_TOKEN
-          bazel run @vaticle_dependencies//tool/sync:dependencies -- --source ${FACTORY_REPO}@${FACTORY_COMMIT}
+        docker login -u $REPO_DOCKER_USERNAME -p $REPO_DOCKER_PASSWORD
+        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+        bazel run --@io_bazel_rules_docker//transitions:enable=false --//server:config=release //:deploy-docker-release-x86_64
+        bazel run --@io_bazel_rules_docker//transitions:enable=false --//server:config=release //:deploy-docker-release-arm64
+        export DOCKER_REPO="typedb"
+        docker manifest create vaticle/$DOCKER_REPO:$VERSION --amend vaticle/$DOCKER_REPO:$VERSION-x86_64 --amend vaticle/$DOCKER_REPO:$VERSION-arm64
+        docker manifest push vaticle/$DOCKER_REPO:$VERSION
+        docker manifest create vaticle/$DOCKER_REPO:latest --amend vaticle/$DOCKER_REPO:$VERSION-x86_64 --amend vaticle/$DOCKER_REPO:$VERSION-arm64
+        docker manifest push vaticle/$DOCKER_REPO:latest
 
 release:
   filter:
@@ -278,7 +294,6 @@ release:
         bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
         bazel run --@io_bazel_rules_docker//transitions:enable=false --//server:config=release //:deploy-docker-release-x86_64
         bazel run --@io_bazel_rules_docker//transitions:enable=false --//server:config=release //:deploy-docker-release-arm64
-#        bazel run --//server:config=release //:deploy-docker-release-overwrite-latest-tag
         export DOCKER_REPO="typedb" 
         docker manifest create vaticle/$DOCKER_REPO:$VERSION --amend vaticle/$DOCKER_REPO:$VERSION-x86_64 --amend vaticle/$DOCKER_REPO:$VERSION-arm64
         docker manifest push vaticle/$DOCKER_REPO:$VERSION

--- a/.factory/automation.yml
+++ b/.factory/automation.yml
@@ -276,8 +276,15 @@ release:
       command: |
         docker login -u $REPO_DOCKER_USERNAME -p $REPO_DOCKER_PASSWORD
         bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-        bazel run --//server:config=release //:deploy-docker-release
-        bazel run --//server:config=release //:deploy-docker-release-overwrite-latest-tag
+        bazel run --@io_bazel_rules_docker//transitions:enable=false --//server:config=release //:deploy-docker-release-x86_64
+        bazel run --@io_bazel_rules_docker//transitions:enable=false --//server:config=release //:deploy-docker-release-arm64
+#        bazel run --//server:config=release //:deploy-docker-release-overwrite-latest-tag
+        export DOCKER_REPO="typedb" 
+        docker manifest create vaticle/$DOCKER_REPO:$VERSION --amend vaticle/$DOCKER_REPO:$VERSION-x86_64 --amend vaticle/$DOCKER_REPO:$VERSION-arm64
+        docker manifest push vaticle/$DOCKER_REPO:$VERSION
+        docker manifest create vaticle/$DOCKER_REPO:latest --amend vaticle/$DOCKER_REPO:$VERSION-x86_64 --amend vaticle/$DOCKER_REPO:$VERSION-arm64
+        docker manifest push vaticle/$DOCKER_REPO:latest
+
     deploy-artifact-release:
       image: vaticle-ubuntu-22.04
       filter:

--- a/.factory/automation.yml
+++ b/.factory/automation.yml
@@ -229,6 +229,7 @@ build:
         owner: [typedb]
         branch: [docker-arm64-for-2.x]
       command: |
+        export VERSION=$(cat VERSION)
         docker login -u $REPO_DOCKER_USERNAME -p $REPO_DOCKER_PASSWORD
         bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
         bazel run --@io_bazel_rules_docker//transitions:enable=false --//server:config=release //:deploy-docker-release-x86_64
@@ -290,6 +291,7 @@ release:
         branch: master
       dependencies: [deploy-github]
       command: |
+        export VERSION=$(cat VERSION)
         docker login -u $REPO_DOCKER_USERNAME -p $REPO_DOCKER_PASSWORD
         bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
         bazel run --@io_bazel_rules_docker//transitions:enable=false --//server:config=release //:deploy-docker-release-x86_64

--- a/.factory/automation.yml
+++ b/.factory/automation.yml
@@ -233,7 +233,7 @@ build:
         bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
         bazel run --@io_bazel_rules_docker//transitions:enable=false --//server:config=release //:deploy-docker-release-x86_64
         bazel run --@io_bazel_rules_docker//transitions:enable=false --//server:config=release //:deploy-docker-release-arm64
-        export DOCKER_REPO="typedb"
+        export DOCKER_REPO="typedb-snapshot"
         docker manifest create vaticle/$DOCKER_REPO:$VERSION --amend vaticle/$DOCKER_REPO:$VERSION-x86_64 --amend vaticle/$DOCKER_REPO:$VERSION-arm64
         docker manifest push vaticle/$DOCKER_REPO:$VERSION
         docker manifest create vaticle/$DOCKER_REPO:latest --amend vaticle/$DOCKER_REPO:$VERSION-x86_64 --amend vaticle/$DOCKER_REPO:$VERSION-arm64

--- a/BUILD
+++ b/BUILD
@@ -415,18 +415,18 @@ docker_container_push(
     ),
     tag_file = "//docker:version-arm64",
 )
-
-docker_container_push(
-    name = "deploy-docker-release-overwrite-latest-tag",
-    format = "Docker",
-    image = ":assemble-docker",
-    registry = deployment_docker["docker.index"],
-    repository = "{}/{}".format(
-        deployment_docker["docker.organisation"],
-        deployment_docker["docker.release.repository"],
-    ),
-    tag = "latest",
-)
+#
+#docker_container_push(
+#    name = "deploy-docker-release-overwrite-latest-tag",
+#    format = "Docker",
+#    image = ":assemble-docker",
+#    registry = deployment_docker["docker.index"],
+#    repository = "{}/{}".format(
+#        deployment_docker["docker.organisation"],
+#        deployment_docker["docker.release.repository"],
+#    ),
+#    tag = "latest",
+#)
 
 checkstyle_test(
     name = "checkstyle",

--- a/BUILD
+++ b/BUILD
@@ -9,8 +9,6 @@ load("@vaticle_bazel_distribution//brew:rules.bzl", "deploy_brew")
 load("@vaticle_bazel_distribution//common:rules.bzl", "assemble_targz", "assemble_versioned", "assemble_zip", "checksum")
 load("@vaticle_bazel_distribution//github:rules.bzl", "deploy_github")
 load("@vaticle_bazel_distribution//common/targz:rules.bzl", "targz_edit")
-load("@vaticle_bazel_distribution//platform:constraints.bzl", "constraint_linux_arm64", "constraint_linux_x86_64",
-     "constraint_mac_arm64", "constraint_mac_x86_64", "constraint_win_x86_64")
 load("@vaticle_dependencies//builder/java:rules.bzl", "native_java_libraries")
 load("@vaticle_dependencies//distribution:deployment.bzl", "deployment")
 load("@vaticle_dependencies//distribution/artifact:rules.bzl", "artifact_repackage")
@@ -415,18 +413,6 @@ docker_container_push(
     ),
     tag_file = "//docker:version-arm64",
 )
-#
-#docker_container_push(
-#    name = "deploy-docker-release-overwrite-latest-tag",
-#    format = "Docker",
-#    image = ":assemble-docker",
-#    registry = deployment_docker["docker.index"],
-#    repository = "{}/{}".format(
-#        deployment_docker["docker.organisation"],
-#        deployment_docker["docker.release.repository"],
-#    ),
-#    tag = "latest",
-#)
 
 checkstyle_test(
     name = "checkstyle",

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -123,13 +123,8 @@ bazel_rules_docker_repositories()
 load("@io_bazel_rules_docker//repositories:deps.bzl", bazel_rules_docker_container_deps = "deps")
 bazel_rules_docker_container_deps()
 
-load("@io_bazel_rules_docker//container:container.bzl", "container_pull")
-container_pull(
-  name = "vaticle_ubuntu_image",
-  registry = "index.docker.io",
-  repository = "vaticle/ubuntu",
-  tag = "4ee548cea883c716055566847c4736a7ef791c38"
-)
+load("//docker:images.bzl", docker_base_images = "base_images")
+docker_base_images()
 
 #####################################
 # Load @vaticle/typedb dependencies #

--- a/deployment.bzl
+++ b/deployment.bzl
@@ -5,7 +5,7 @@
 deployment = {
   'docker.index': 'index.docker.io',
   'docker.organisation': 'vaticle',
-  'docker.release.repository': 'typedb-snapshot',
+  'docker.release.repository': 'typedb',
   'github.organisation': 'typedb',
   'github.repository': 'typedb'
 }

--- a/deployment.bzl
+++ b/deployment.bzl
@@ -5,7 +5,7 @@
 deployment = {
   'docker.index': 'index.docker.io',
   'docker.organisation': 'vaticle',
-  'docker.release.repository': 'typedb',
+  'docker.release.repository': 'typedb-snapshot',
   'github.organisation': 'typedb',
   'github.repository': 'typedb'
 }

--- a/docker/BUILD
+++ b/docker/BUILD
@@ -1,0 +1,40 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+package(default_visibility = ["//visibility:public"])
+load("@vaticle_bazel_distribution//platform:constraints.bzl", "constraint_linux_arm64", "constraint_linux_x86_64")
+load("@vaticle_dependencies//tool/checkstyle:rules.bzl", "checkstyle_test")
+
+platform(
+    name = "linux-x86_64",
+    constraint_values = constraint_linux_x86_64,
+)
+
+platform(
+    name = "linux-arm64",
+    constraint_values = constraint_linux_arm64,
+)
+
+genrule(
+  name = "version-arm64",
+  srcs = ["//:VERSION"],
+  outs = ["version-arm64.txt"],
+  tools = [],
+  cmd = "VERSION=$$(cat $(location //:VERSION)); echo \"$$VERSION-arm64\" > $@"
+)
+
+
+genrule(
+  name = "version-x86_64",
+  srcs = ["//:VERSION"],
+  outs = ["version-x86_64.txt"],
+  tools = [],
+  cmd = "VERSION=$$(cat $(location //:VERSION)); echo \"$$VERSION-x86_64\" > $@"
+)
+
+checkstyle_test(
+    name = "checkstyle",
+    include = glob(["*",]),
+    license_type = "mpl-header",
+)

--- a/docker/images.bzl
+++ b/docker/images.bzl
@@ -5,17 +5,22 @@
 load("@io_bazel_rules_docker//container:pull.bzl", "container_pull")
 
 def base_images():
+    # FROM amd64/ubuntu:22.04
+    # RUN apt-get -y update && apt-get install -y openjdk-11-jre-headless && rm -rf /var/lib/apt/lists
     container_pull(
         name = "ubuntu-22.04-x86_64",
         architecture = "amd64",
         registry = "index.docker.io",
-        repository = "amd64/ubuntu",
-        digest = "sha256:3d1556a8a18cf5307b121e0a98e93f1ddf1f3f8e092f1fddfd941254785b95d7",
+        repository = "vaticle/ubuntu",
+        digest = "sha256:2c45c92258ee82c28b5e2ab32cabe21e24116aa2a248fb510a4c4d625073217b",
     )
+
+    # FROM arm64v8/ubuntu:22.04
+    # RUN apt-get -y update && apt-get install -y openjdk-11-jre-headless && rm -rf /var/lib/apt/lists
     container_pull(
         name = "ubuntu-22.04-arm64",
         architecture="arm64",
         registry = "index.docker.io",
-        repository = "arm64v8/ubuntu",
-        digest = "sha256:7c75ab2b0567edbb9d4834a2c51e462ebd709740d1f2c40bcd23c56e974fe2a8",
+        repository = "vaticle/ubuntu",
+        digest = "sha256:927ed8f99876bceff89856447719273e1b434d32b112a6b5528054334c82fb6d",
     )

--- a/docker/images.bzl
+++ b/docker/images.bzl
@@ -1,0 +1,21 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+load("@io_bazel_rules_docker//container:pull.bzl", "container_pull")
+
+def base_images():
+    container_pull(
+        name = "ubuntu-22.04-x86_64",
+        architecture = "amd64",
+        registry = "index.docker.io",
+        repository = "amd64/ubuntu",
+        digest = "sha256:3d1556a8a18cf5307b121e0a98e93f1ddf1f3f8e092f1fddfd941254785b95d7",
+    )
+    container_pull(
+        name = "ubuntu-22.04-arm64",
+        architecture="arm64",
+        registry = "index.docker.io",
+        repository = "arm64v8/ubuntu",
+        digest = "sha256:7c75ab2b0567edbb9d4834a2c51e462ebd709740d1f2c40bcd23c56e974fe2a8",
+    )

--- a/test/assembly/BUILD
+++ b/test/assembly/BUILD
@@ -57,7 +57,7 @@ typedb_java_test(
         "@vaticle_bazel_distribution//platform:is_windows_x86_64": "@vaticle_typedb_console_artifact_windows-x86_64//file",
     },
     data = [
-        "//:assemble-docker.tar"
+        "//:assemble-docker-x86_64"
     ]
 )
 


### PR DESCRIPTION
## Release notes: product changes
Publish arm64 docker images. Previously, docker would fall-back to running the x86_64 images, which sometimes resulted in a JVM crash loop.

## Motivation
Support docker on arm64 platforms

## Implementation
Uses the approach similar to 3.0:  
1. We import two ubuntu base images, one for x86_64 and one for arm64
2. We unpack the typedb-linux-all-{x86_64, arm64} on top of the corresponding base image.
3. We push each to `vaticle/typedb:<VERSION>-<ARCH>`
4. We use docker cli to create the multi-arch `vaticle/typedb:<VERSION>` manifest from these and push it.
5. We repeat 4, but for the 'latest' tag