### PR TITLE
Enable connection BDDs in CI

### DIFF
--- a/.factory/automation.yml
+++ b/.factory/automation.yml
@@ -58,12 +58,12 @@ build:
 #        bazel test //ir/tests/... --test_output=streamed
 #        bazel test //query/tests/... --test_output=streamed
 #        bazel test //storage/tests/... --test_output=streamed
-#    test-behaviour-connection:
-#      image: vaticle-ubuntu-22.04
-#      dependencies: [build]
-#      command: |
-#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-#        bazel test //test/behaviour/connection/... --test_output=streamed
+    test-behaviour-connection:
+      image: vaticle-ubuntu-22.04
+      dependencies: [build]
+      command: |
+        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+        bazel test //tests/behaviour/connection/... --test_output=streamed
 #    test-behaviour-concept:
 #      image: vaticle-ubuntu-22.04
 #      dependencies: [build]

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -43,5 +43,5 @@ def vaticle_typedb_behaviour():
     git_repository(
         name = "vaticle_typedb_behaviour",
         remote = "https://github.com/typedb/typedb-behaviour",
-        commit = "c777b2e2c8afe18445634e30a9a3428ef33df129",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_behaviour
+        commit = "323131ad0a84cbab2418b9de58f16b8f00f7d23e",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_behaviour
     )

--- a/tests/behaviour/steps/connection/mod.rs
+++ b/tests/behaviour/steps/connection/mod.rs
@@ -36,13 +36,15 @@ pub async fn typedb_starts(context: &mut Context) {
 
 #[apply(generic_step)]
 #[step("connection opens with default authentication")]
-#[step("connection has been opened")]
+#[step("connection closes")]
+#[step("connection is open: true")]
+#[step("connection is open: false")]
 pub async fn connection_ignore(_: &mut Context) {}
 
 #[apply(generic_step)]
-#[step("connection does not have any database")]
-pub async fn connection_does_not_have_any_database(context: &mut Context) {
-    assert!(context.server().unwrap().lock().unwrap().database_manager().database_names().is_empty())
+#[step(expr = r"connection has {int} database(s)")]
+pub async fn connection_has_count_databases(context: &mut Context, count: usize) {
+    assert_eq!(context.server().unwrap().lock().unwrap().database_manager().database_names().len(), count)
 }
 
 #[derive(Debug, Clone)]

--- a/tests/behaviour/steps/connection/transaction.rs
+++ b/tests/behaviour/steps/connection/transaction.rs
@@ -104,11 +104,11 @@ pub async fn transaction_has_type(context: &mut Context, tx_type: String) {
 #[apply(generic_step)]
 #[step(expr = "transactions( in parallel) have type:")]
 pub async fn transactions_in_parallel_have_type(context: &mut Context, step: &Step) {
-    // let mut active_transaction_iter = context.get_concurrent_transactions().iter();
-    // for tx_type in util::iter_table(step) {
-    //     transaction_type_matches(active_transaction_iter.next().unwrap(), &tx_type)
-    // }
-    // assert!(active_transaction_iter.next().is_none(), "Opened more transactions than tested!")
+    let mut active_transaction_iter = context.get_concurrent_transactions().iter();
+    for tx_type in util::iter_table(step) {
+        transaction_type_matches(active_transaction_iter.next().unwrap(), &tx_type)
+    }
+    assert!(active_transaction_iter.next().is_none(), "Opened more transactions than tested!")
 }
 
 #[apply(generic_step)]


### PR DESCRIPTION
## Release notes: product changes
We update some of the steps for BDDs to match the [updated definitions](https://github.com/typedb/typedb-behaviour/pull/303).
Additionally, we add connection BDDs to the factory CI to make sure that this piece of the system is safe and stable.
