### PR TITLE
Fetch iii

### DIFF
--- a/compiler/annotation/expression/block_compiler.rs
+++ b/compiler/annotation/expression/block_compiler.rs
@@ -136,7 +136,7 @@ fn compile_expressions_recursive<'a, Snapshot: ReadableSnapshot>(
     }
     let compiled =
         ExpressionCompilationContext::compile(expression, &context.variable_value_types, &context.parameters)?;
-    context.variable_value_types.insert(assigned_variable, compiled.return_type);
+    context.variable_value_types.insert(assigned_variable, compiled.return_type.clone());
     context.compiled_expressions.insert(assigned_variable, compiled);
     Ok(())
 }
@@ -154,7 +154,7 @@ fn resolve_type_for_variable<'a, Snapshot: ReadableSnapshot>(
                 compile_expressions_recursive(context, variable, expression_assignments)?;
                 context
                     .variable_value_types
-                    .insert(variable, context.compiled_expressions.get(&variable).unwrap().return_type);
+                    .insert(variable, context.compiled_expressions.get(&variable).unwrap().return_type.clone());
                 Ok(())
             }
         } else {
@@ -173,12 +173,12 @@ fn resolve_type_for_variable<'a, Snapshot: ReadableSnapshot>(
             match variable_category {
                 VariableCategory::Attribute | VariableCategory::Thing => {
                     debug_assert!(types.iter().all(|t| matches!(t, answer::Type::Attribute(_))));
-                    context.variable_value_types.insert(variable, ExpressionValueType::Single(value_type.category()));
+                    context.variable_value_types.insert(variable, ExpressionValueType::Single(value_type.clone()));
                     Ok(())
                 }
                 VariableCategory::AttributeList | VariableCategory::ThingList => {
                     debug_assert!(types.iter().all(|t| matches!(t, answer::Type::Attribute(_))));
-                    context.variable_value_types.insert(variable, ExpressionValueType::List(value_type.category()));
+                    context.variable_value_types.insert(variable, ExpressionValueType::List(value_type.clone()));
                     Ok(())
                 }
                 _ => Err(ExpressionCompileError::VariableMustBeValueOrAttribute {

--- a/compiler/annotation/expression/block_compiler.rs
+++ b/compiler/annotation/expression/block_compiler.rs
@@ -23,7 +23,7 @@ use storage::snapshot::ReadableSnapshot;
 
 use crate::annotation::{
     expression::{
-        compiled_expression::{CompiledExpression, ExpressionValueType},
+        compiled_expression::{ExecutableExpression, ExpressionValueType},
         expression_compiler::ExpressionCompilationContext,
         ExpressionCompileError,
     },
@@ -40,7 +40,7 @@ struct BlockExpressionsCompilationContext<'block, Snapshot: ReadableSnapshot> {
     type_manager: &'block TypeManager,
     type_annotations: &'block TypeAnnotations,
 
-    compiled_expressions: HashMap<Variable, CompiledExpression>,
+    compiled_expressions: HashMap<Variable, ExecutableExpression>,
     variable_value_types: HashMap<Variable, ExpressionValueType>,
     visited_expressions: HashSet<Variable>,
 }
@@ -52,7 +52,7 @@ pub fn compile_expressions<'block, Snapshot: ReadableSnapshot>(
     variable_registry: &'block mut VariableRegistry,
     parameters: &'block ParameterRegistry,
     type_annotations: &'block TypeAnnotations,
-) -> Result<HashMap<Variable, CompiledExpression>, ExpressionCompileError> {
+) -> Result<HashMap<Variable, ExecutableExpression>, ExpressionCompileError> {
     let mut expression_index = HashMap::new();
     index_expressions(block.conjunction(), &mut expression_index)?;
     let assigned_variables = expression_index.keys().cloned().collect_vec();

--- a/compiler/annotation/expression/compiled_expression.rs
+++ b/compiler/annotation/expression/compiled_expression.rs
@@ -11,14 +11,14 @@ use ir::pattern::ParameterID;
 use crate::annotation::expression::instructions::op_codes::ExpressionOpCode;
 
 #[derive(Debug, Clone)]
-pub struct CompiledExpression {
+pub struct ExecutableExpression {
     pub(crate) instructions: Vec<ExpressionOpCode>,
     pub(crate) variables: Vec<Variable>,
     pub(crate) constants: Vec<ParameterID>,
     pub(crate) return_type: ExpressionValueType,
 }
 
-impl CompiledExpression {
+impl ExecutableExpression {
     pub fn instructions(&self) -> &[ExpressionOpCode] {
         &self.instructions
     }

--- a/compiler/annotation/expression/compiled_expression.rs
+++ b/compiler/annotation/expression/compiled_expression.rs
@@ -5,7 +5,7 @@
  */
 
 use answer::variable::Variable;
-use encoding::value::value_type::ValueTypeCategory;
+use encoding::value::value_type::{ValueType, ValueTypeCategory};
 use ir::pattern::ParameterID;
 
 use crate::annotation::expression::instructions::op_codes::ExpressionOpCode;
@@ -31,24 +31,24 @@ impl ExecutableExpression {
         self.constants.as_slice()
     }
 
-    pub fn return_type(&self) -> ExpressionValueType {
-        self.return_type
+    pub fn return_type(&self) -> &ExpressionValueType {
+        &self.return_type
     }
 }
 
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Clone)]
 pub enum ExpressionValueType {
     // TODO: we haven't implemented ConceptList, only ValueList right now.
     // TODO: this should hold an actual ValueType, not a Category!
-    Single(ValueTypeCategory),
-    List(ValueTypeCategory),
+    Single(ValueType),
+    List(ValueType),
 }
 
 impl ExpressionValueType {
-    pub fn value_type(&self) -> ValueTypeCategory {
+    pub fn value_type(&self) -> &ValueType {
         match self {
-            ExpressionValueType::Single(category) => *category,
-            ExpressionValueType::List(category) => *category,
+            ExpressionValueType::Single(value_type) => value_type,
+            ExpressionValueType::List(value_type) => value_type,
         }
     }
 }

--- a/compiler/annotation/expression/expression_compiler.rs
+++ b/compiler/annotation/expression/expression_compiler.rs
@@ -20,7 +20,7 @@ use ir::{
 };
 
 use crate::annotation::expression::{
-    compiled_expression::{CompiledExpression, ExpressionValueType},
+    compiled_expression::{ExecutableExpression, ExpressionValueType},
     instructions::{
         list_operations,
         load_cast::{CastLeftLongToDouble, CastRightLongToDouble, LoadConstant, LoadVariable},
@@ -64,13 +64,13 @@ impl<'this> ExpressionCompilationContext<'this> {
         expression_tree: &ExpressionTree<Variable>,
         variable_value_categories: &HashMap<Variable, ExpressionValueType>,
         parameters: &ParameterRegistry,
-    ) -> Result<CompiledExpression, ExpressionCompileError> {
+    ) -> Result<ExecutableExpression, ExpressionCompileError> {
         debug_assert!(expression_tree.variables().all(|var| variable_value_categories.contains_key(&var)));
         let mut builder = ExpressionCompilationContext::empty(expression_tree, variable_value_categories, parameters);
         builder.compile_recursive(expression_tree.get_root())?;
         let return_type = builder.pop_type()?;
         let ExpressionCompilationContext { instructions, variable_stack, constant_stack, .. } = builder;
-        Ok(CompiledExpression { instructions, variables: variable_stack, constants: constant_stack, return_type })
+        Ok(ExecutableExpression { instructions, variables: variable_stack, constants: constant_stack, return_type })
     }
 
     fn compile_recursive(&mut self, expression: &Expression<Variable>) -> Result<(), ExpressionCompileError> {

--- a/compiler/annotation/expression/instructions/binary.rs
+++ b/compiler/annotation/expression/instructions/binary.rs
@@ -52,12 +52,12 @@ where
     }
 
     fn validate_and_append(builder: &mut ExpressionCompilationContext<'_>) -> Result<(), ExpressionCompileError> {
-        let a2 = builder.pop_type_single()?;
-        let a1 = builder.pop_type_single()?;
+        let a2 = builder.pop_type_single()?.category();
+        let a1 = builder.pop_type_single()?.category();
         if (a1, a2) != (T1::VALUE_TYPE_CATEGORY, T2::VALUE_TYPE_CATEGORY) {
             Err(ExpressionCompileError::InternalUnexpectedValueType)?;
         }
-        builder.push_type_single(R::VALUE_TYPE_CATEGORY);
+        builder.push_type_single(R::VALUE_TYPE_CATEGORY.try_into_value_type().unwrap());
         builder.append_instruction(Self::OP_CODE);
         Ok(())
     }

--- a/compiler/annotation/expression/instructions/load_cast.rs
+++ b/compiler/annotation/expression/instructions/load_cast.rs
@@ -64,11 +64,11 @@ impl<From: NativeValueConvertible, To: ImplicitCast<From>> CompilableExpression 
     }
 
     fn validate_and_append(builder: &mut ExpressionCompilationContext<'_>) -> Result<(), ExpressionCompileError> {
-        let value_before = builder.pop_type_single()?;
+        let value_before = builder.pop_type_single()?.category();
         if value_before != From::VALUE_TYPE_CATEGORY {
             Err(ExpressionCompileError::InternalUnexpectedValueType)?;
         }
-        builder.push_type_single(To::VALUE_TYPE_CATEGORY);
+        builder.push_type_single(To::VALUE_TYPE_CATEGORY.try_into_value_type().unwrap());
 
         builder.append_instruction(Self::OP_CODE);
         Ok(())
@@ -86,11 +86,11 @@ impl<From: NativeValueConvertible, To: ImplicitCast<From>> CompilableExpression 
 
     fn validate_and_append(builder: &mut ExpressionCompilationContext<'_>) -> Result<(), ExpressionCompileError> {
         let right = builder.pop_type_single()?;
-        let left_before = builder.pop_type_single()?;
+        let left_before = builder.pop_type_single()?.category();
         if left_before != From::VALUE_TYPE_CATEGORY {
             Err(ExpressionCompileError::InternalUnexpectedValueType)?;
         }
-        builder.push_type_single(To::VALUE_TYPE_CATEGORY);
+        builder.push_type_single(To::VALUE_TYPE_CATEGORY.try_into_value_type().unwrap());
         builder.push_type_single(right);
 
         builder.append_instruction(Self::OP_CODE);
@@ -108,11 +108,11 @@ impl<From: NativeValueConvertible, To: ImplicitCast<From>> CompilableExpression 
     }
 
     fn validate_and_append(builder: &mut ExpressionCompilationContext<'_>) -> Result<(), ExpressionCompileError> {
-        let right_before = builder.pop_type_single()?;
+        let right_before = builder.pop_type_single()?.category();
         if right_before != From::VALUE_TYPE_CATEGORY {
             Err(ExpressionCompileError::InternalUnexpectedValueType)?;
         }
-        builder.push_type_single(To::VALUE_TYPE_CATEGORY);
+        builder.push_type_single(To::VALUE_TYPE_CATEGORY.try_into_value_type().unwrap());
 
         builder.append_instruction(Self::OP_CODE);
         Ok(())

--- a/compiler/annotation/expression/instructions/unary.rs
+++ b/compiler/annotation/expression/instructions/unary.rs
@@ -50,11 +50,11 @@ where
     }
 
     fn validate_and_append(builder: &mut ExpressionCompilationContext<'_>) -> Result<(), ExpressionCompileError> {
-        let a1 = builder.pop_type_single()?;
+        let a1 = builder.pop_type_single()?.category();
         if a1 != T1::VALUE_TYPE_CATEGORY {
             Err(ExpressionCompileError::InternalUnexpectedValueType)?;
         }
-        builder.push_type_single(R::VALUE_TYPE_CATEGORY);
+        builder.push_type_single(R::VALUE_TYPE_CATEGORY.try_into_value_type().unwrap());
         builder.append_instruction(Self::OP_CODE);
         Ok(())
     }

--- a/compiler/annotation/fetch.rs
+++ b/compiler/annotation/fetch.rs
@@ -10,20 +10,28 @@ use std::{
 };
 
 use answer::{variable::Variable, Type};
+use concept::type_::type_manager::TypeManager;
 use encoding::value::value_type::ValueType;
 use ir::{
-    pattern::{ParameterID, Vertex},
+    pattern::ParameterID,
     pipeline::fetch::{
-        FetchListAttributeAsList, FetchListAttributeFromList, FetchObjectAttributes, FetchSingleAttribute,
-        FetchSingleVar,
+        FetchListAttributeAsList, FetchListAttributeFromList, FetchListSubFetch, FetchObject, FetchObjectAttributes,
+        FetchObjectEntries, FetchSingleAttribute, FetchSingleVar, FetchSome,
     },
 };
+use storage::snapshot::ReadableSnapshot;
 
-use crate::annotation::{function::AnnotatedAnonymousFunction, pipeline::AnnotatedStage};
+use crate::annotation::{
+    function::{
+        annotate_anonymous_function, AnnotatedAnonymousFunction, AnnotatedUnindexedFunctions, IndexedAnnotatedFunctions,
+    },
+    pipeline::AnnotatedStage,
+    AnnotationError,
+};
 
 #[derive(Debug, Clone)]
 pub struct AnnotatedFetch {
-    input_type_annotations: BTreeMap<Vertex<Variable>, Arc<BTreeSet<Type>>>,
+    input_type_annotations: BTreeMap<Variable, Arc<BTreeSet<Type>>>,
     input_value_annotations: BTreeMap<Variable, ValueType>,
 
     object: AnnotatedFetchObject,
@@ -57,4 +65,102 @@ pub struct AnnotatedFetchObjectEntries {
 #[derive(Debug, Clone)]
 pub struct AnnotatedFetchListSubFetch {
     stages: Vec<AnnotatedStage>,
+}
+
+pub(crate) fn annotate_fetch(
+    fetch: FetchObject,
+    input_type_annotations: BTreeMap<Variable, Arc<BTreeSet<Type>>>,
+    input_value_annotations: BTreeMap<Variable, ValueType>,
+    snapshot: &impl ReadableSnapshot,
+    type_manager: &TypeManager,
+    indexed_annotated_functions: &IndexedAnnotatedFunctions,
+    local_functions: Option<&AnnotatedUnindexedFunctions>,
+) -> Result<AnnotatedFetch, AnnotationError> {
+    let object = annotate_object(fetch, snapshot, type_manager, indexed_annotated_functions, local_functions)?;
+    Ok(AnnotatedFetch { input_type_annotations, input_value_annotations, object })
+}
+
+fn annotate_object(
+    object: FetchObject,
+    snapshot: &impl ReadableSnapshot,
+    type_manager: &TypeManager,
+    indexed_annotated_functions: &IndexedAnnotatedFunctions,
+    local_functions: Option<&AnnotatedUnindexedFunctions>,
+) -> Result<AnnotatedFetchObject, AnnotationError> {
+    match object {
+        FetchObject::Entries(entries) => {
+            let annotated_entries = annotated_object_entries(
+                entries,
+                snapshot,
+                type_manager,
+                indexed_annotated_functions,
+                local_functions,
+            )?;
+            Ok(AnnotatedFetchObject::Entries(annotated_entries))
+        }
+        FetchObject::Attributes(attributes) => Ok(AnnotatedFetchObject::Attributes(attributes)),
+    }
+}
+
+fn annotated_object_entries(
+    entries: FetchObjectEntries,
+    snapshot: &impl ReadableSnapshot,
+    type_manager: &TypeManager,
+    indexed_annotated_functions: &IndexedAnnotatedFunctions,
+    local_functions: Option<&AnnotatedUnindexedFunctions>,
+) -> Result<AnnotatedFetchObjectEntries, AnnotationError> {
+    let mut annotated_entries = HashMap::new();
+    for (key, value) in entries.entries.into_iter() {
+        let annotated_value =
+            annotate_some(value, snapshot, type_manager, indexed_annotated_functions, local_functions)?;
+        annotated_entries.insert(key, annotated_value);
+    }
+    Ok(AnnotatedFetchObjectEntries { entries: annotated_entries })
+}
+
+fn annotate_some(
+    some: FetchSome,
+    snapshot: &impl ReadableSnapshot,
+    type_manager: &TypeManager,
+    indexed_annotated_functions: &IndexedAnnotatedFunctions,
+    local_functions: Option<&AnnotatedUnindexedFunctions>,
+) -> Result<AnnotatedFetchSome, AnnotationError> {
+    match some {
+        FetchSome::SingleVar(var) => Ok(AnnotatedFetchSome::SingleVar(var)),
+        FetchSome::SingleAttribute(attr) => Ok(AnnotatedFetchSome::SingleAttribute(attr)),
+        FetchSome::SingleFunction(function) => {
+            let annotated_function = annotate_anonymous_function(
+                &function,
+                snapshot,
+                type_manager,
+                indexed_annotated_functions,
+                local_functions,
+            )
+            .map_err(|err| AnnotationError::FetchBlockFunctionInferenceError { typedb_source: err })?;
+            Ok(AnnotatedFetchSome::SingleFunction(annotated_function))
+        }
+        FetchSome::Object(object) => {
+            let object =
+                annotate_object(*object, snapshot, type_manager, indexed_annotated_functions, local_functions)?;
+            Ok(AnnotatedFetchSome::Object(Box::new(object)))
+        }
+        FetchSome::ListFunction(function) => {
+            let annotated_function = annotate_anonymous_function(
+                &function,
+                snapshot,
+                type_manager,
+                indexed_annotated_functions,
+                local_functions,
+            )
+            .map_err(|err| AnnotationError::FetchBlockFunctionInferenceError { typedb_source: err })?;
+            Ok(AnnotatedFetchSome::ListFunction(annotated_function))
+        }
+        FetchSome::ListSubFetch(sub_fetch) => Ok(AnnotatedFetchSome::ListSubFetch(annotate_sub_fetch(sub_fetch))),
+        FetchSome::ListAttributesAsList(fetch) => Ok(AnnotatedFetchSome::ListAttributesAsList(fetch)),
+        FetchSome::ListAttributesFromList(fetch) => Ok(AnnotatedFetchSome::ListAttributesFromList(fetch)),
+    }
+}
+
+fn annotate_sub_fetch(sub_fetch: FetchListSubFetch) -> AnnotatedFetchListSubFetch {
+    todo!()
 }

--- a/compiler/annotation/function.rs
+++ b/compiler/annotation/function.rs
@@ -9,7 +9,10 @@ use std::collections::BTreeSet;
 use answer::Type;
 use concept::type_::type_manager::TypeManager;
 use encoding::{graph::definition::definition_key::DefinitionKey, value::value_type::ValueType};
-use ir::pipeline::{function::Function, function_signature::FunctionIDAPI};
+use ir::pipeline::{
+    function::{AnonymousFunction, Function},
+    function_signature::FunctionIDAPI,
+};
 use storage::snapshot::ReadableSnapshot;
 
 use crate::annotation::{pipeline::AnnotatedStage, FunctionTypeInferenceError};
@@ -147,6 +150,32 @@ pub fn annotate_function(
     indexed_annotated_functions: &IndexedAnnotatedFunctions,
     local_functions: Option<&AnnotatedUnindexedFunctions>,
 ) -> Result<AnnotatedFunction, FunctionTypeInferenceError> {
+    // let root_graph = infer_types(
+    //     snapshot,
+    //     function.block(),
+    //     function.variable_registry(),
+    //     type_manager,
+    //     &BTreeMap::new(),
+    //     indexed_annotated_functions,
+    //     local_functions,
+    // )
+    // .map_err(|err| FunctionTypeInferenceError::TypeInference {
+    //     name: function.name().to_string(),
+    //     typedb_source: err,
+    // })?;
+    // let body_annotations = TypeAnnotations::build(root_graph);
+    // let return_types = function.return_operation().return_types(body_annotations.vertex_annotations());
+    // Ok(FunctionAnnotations { return_annotations: return_types, block_annotations: body_annotations })
+    todo!("We need to allow a function to contain an entire pipeline, instead of just a match block")
+}
+
+pub fn annotate_anonymous_function(
+    function: &AnonymousFunction,
+    snapshot: &impl ReadableSnapshot,
+    type_manager: &TypeManager,
+    indexed_annotated_functions: &IndexedAnnotatedFunctions,
+    local_functions: Option<&AnnotatedUnindexedFunctions>,
+) -> Result<AnnotatedAnonymousFunction, FunctionTypeInferenceError> {
     // let root_graph = infer_types(
     //     snapshot,
     //     function.block(),

--- a/compiler/annotation/mod.rs
+++ b/compiler/annotation/mod.rs
@@ -23,6 +23,7 @@ typedb_error!(
         TypeInference(0, "Type inference error while compiling query annotations.", ( typedb_source : TypeInferenceError )),
         PreambleTypeInference(1, "Type inference error while compiling query premable functions.", ( typedb_source : FunctionTypeInferenceError )),
         ExpressionCompilation(2, "Error inferring correct expression types.", ( source : ExpressionCompileError )),
+        FetchBlockFunctionInferenceError(3, "Error during type inference for fetch sub-query.", (typedb_source : FunctionTypeInferenceError )),
         CouldNotDetermineValueTypeForReducerInput(10, "The value-type for the reducer input variable '{variable}' could not be determined.", variable: String),
         ReducerInputVariableDidNotHaveSingleValueType(11, "The reducer input variable '{variable}' had multiple value-types.", variable: String),
         UnsupportedValueTypeForReducer(12, "The input variable to the reducer'{reducer}({variable})' reducer had an unsupported value-type: '{value_type}'", reducer: String, variable: String, value_type: ValueTypeCategory),

--- a/compiler/annotation/pipeline.rs
+++ b/compiler/annotation/pipeline.rs
@@ -26,6 +26,7 @@ use ir::{
     },
     translation::pipeline::TranslatedStage,
 };
+use ir::pipeline::fetch::FetchObject;
 use storage::snapshot::ReadableSnapshot;
 
 use crate::{
@@ -44,6 +45,7 @@ use crate::{
 pub struct AnnotatedPipeline {
     pub annotated_preamble: AnnotatedUnindexedFunctions,
     pub annotated_stages: Vec<AnnotatedStage>,
+    pub annotated_fetch: Option<AnnotatedFetch>,
 }
 
 #[derive(Debug, Clone)]
@@ -63,9 +65,6 @@ pub enum AnnotatedStage {
         deleted_variables: Vec<Variable>,
         annotations: TypeAnnotations,
     },
-    Fetch {
-        annotated_fetch: AnnotatedFetch,
-    },
     // ...
     Select(Select),
     Sort(Sort),
@@ -82,6 +81,7 @@ pub fn annotate_pipeline(
     variable_registry: &mut VariableRegistry,
     parameters: &ParameterRegistry,
     translated_preamble: Vec<Function>,
+    translated_fetch: Option<FetchObject>,
     translated_stages: Vec<TranslatedStage>,
 ) -> Result<AnnotatedPipeline, AnnotationError> {
     let annotated_preamble =
@@ -120,7 +120,8 @@ pub fn annotate_pipeline(
         }
         annotated_stages.push(annotated_stage);
     }
-    Ok(AnnotatedPipeline { annotated_stages, annotated_preamble })
+    let annotated_fetch = translated_fetch.map(|fetch| annotate_fetch(fetch));
+    Ok(AnnotatedPipeline { annotated_stages, annotated_fetch, annotated_preamble })
 }
 
 fn annotate_stage(
@@ -252,10 +253,11 @@ fn annotate_stage(
             }
             Ok(AnnotatedStage::Reduce(reduce, reduce_instructions))
         }
-        TranslatedStage::Fetch { fetch_object } => {
-            todo!()
-        }
     }
+}
+
+fn annotate_fetch(fetch: FetchObject) -> AnnotatedFetch {
+    todo!()
 }
 
 pub fn validate_sort_variables_comparable(

--- a/compiler/annotation/pipeline.rs
+++ b/compiler/annotation/pipeline.rs
@@ -30,7 +30,7 @@ use storage::snapshot::ReadableSnapshot;
 
 use crate::{
     annotation::{
-        expression::{block_compiler::compile_expressions, compiled_expression::CompiledExpression},
+        expression::{block_compiler::compile_expressions, compiled_expression::ExecutableExpression},
         fetch::AnnotatedFetch,
         function::{annotate_functions, AnnotatedUnindexedFunctions, IndexedAnnotatedFunctions},
         match_inference::infer_types,
@@ -51,7 +51,8 @@ pub enum AnnotatedStage {
     Match {
         block: Block,
         block_annotations: TypeAnnotations,
-        compiled_expressions: HashMap<Variable, CompiledExpression>,
+        // expressions skip annotation and go straight to executable, breaking the abstraction a bit...
+        executable_expressions: HashMap<Variable, ExecutableExpression>,
     },
     Insert {
         block: Block,
@@ -157,7 +158,7 @@ fn annotate_stage(
             compiled_expressions.iter().for_each(|(&variable, expr)| {
                 running_value_variable_assigned_types.insert(variable, expr.return_type().value_type());
             });
-            Ok(AnnotatedStage::Match { block, block_annotations, compiled_expressions })
+            Ok(AnnotatedStage::Match { block, block_annotations, executable_expressions: compiled_expressions })
         }
 
         TranslatedStage::Insert { block } => {

--- a/compiler/executable/fetch/executable.rs
+++ b/compiler/executable/fetch/executable.rs
@@ -4,8 +4,6 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-pub struct FetchExecutable {
-
-}
+pub struct FetchExecutable {}
 
 pub fn compile() {}

--- a/compiler/executable/fetch/executable.rs
+++ b/compiler/executable/fetch/executable.rs
@@ -4,4 +4,8 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
+pub struct FetchExecutable {
+
+}
+
 pub fn compile() {}

--- a/compiler/executable/fetch/mod.rs
+++ b/compiler/executable/fetch/mod.rs
@@ -4,4 +4,4 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-mod executable;
+pub mod executable;

--- a/compiler/executable/function.rs
+++ b/compiler/executable/function.rs
@@ -4,16 +4,17 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
+use std::{collections::HashMap, sync::Arc};
 
-use std::collections::HashMap;
-use std::sync::Arc;
 use answer::variable::Variable;
 use concept::thing::statistics::Statistics;
 use ir::pipeline::VariableRegistry;
-use crate::annotation::function::AnnotatedFunction;
-use crate::executable::ExecutableError;
-use crate::executable::pipeline::ExecutablePipeline;
-use crate::VariablePosition;
+
+use crate::{
+    annotation::function::AnnotatedFunction,
+    executable::{pipeline::ExecutablePipeline, ExecutableCompilationError},
+    VariablePosition,
+};
 
 pub struct ExecutableFunction {
     executable: ExecutablePipeline,
@@ -24,6 +25,6 @@ pub(crate) fn compile_function(
     statistics: &Statistics,
     variable_registry: Arc<VariableRegistry>,
     function: &AnnotatedFunction,
-) -> Result<ExecutableFunction, ExecutableError> {
+) -> Result<ExecutableFunction, ExecutableCompilationError> {
     todo!()
 }

--- a/compiler/executable/function.rs
+++ b/compiler/executable/function.rs
@@ -1,0 +1,29 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use answer::variable::Variable;
+use concept::thing::statistics::Statistics;
+use ir::pipeline::VariableRegistry;
+use crate::annotation::function::AnnotatedFunction;
+use crate::executable::ExecutableError;
+use crate::executable::pipeline::ExecutablePipeline;
+use crate::VariablePosition;
+
+pub struct ExecutableFunction {
+    executable: ExecutablePipeline,
+    returns: HashMap<Variable, VariablePosition>,
+}
+
+pub(crate) fn compile_function(
+    statistics: &Statistics,
+    variable_registry: Arc<VariableRegistry>,
+    function: &AnnotatedFunction,
+) -> Result<ExecutableFunction, ExecutableError> {
+    todo!()
+}

--- a/compiler/executable/match_/planner/mod.rs
+++ b/compiler/executable/match_/planner/mod.rs
@@ -15,7 +15,7 @@ use ir::pipeline::{block::Block, VariableRegistry};
 use itertools::Itertools;
 
 use crate::{
-    annotation::{expression::compiled_expression::CompiledExpression, type_annotations::TypeAnnotations},
+    annotation::{expression::compiled_expression::ExecutableExpression, type_annotations::TypeAnnotations},
     executable::match_::{
         instructions::{CheckInstruction, ConstraintInstruction},
         planner::{
@@ -36,7 +36,7 @@ pub fn compile(
     input_variables: &HashMap<Variable, VariablePosition>,
     type_annotations: &TypeAnnotations,
     variable_registry: Arc<VariableRegistry>,
-    expressions: &HashMap<Variable, CompiledExpression>,
+    expressions: &HashMap<Variable, ExecutableExpression>,
     statistics: &Statistics,
 ) -> MatchExecutable {
     let conjunction = block.conjunction();

--- a/compiler/executable/match_/planner/plan.rs
+++ b/compiler/executable/match_/planner/plan.rs
@@ -26,7 +26,7 @@ use ir::{
 use itertools::Itertools;
 
 use crate::{
-    annotation::{expression::compiled_expression::CompiledExpression, type_annotations::TypeAnnotations},
+    annotation::{expression::compiled_expression::ExecutableExpression, type_annotations::TypeAnnotations},
     executable::match_::{
         instructions::{
             thing::{
@@ -58,7 +58,7 @@ pub(crate) fn plan_conjunction<'a>(
     input_variables: &HashMap<Variable, VariablePosition>,
     type_annotations: &'a TypeAnnotations,
     variable_registry: &VariableRegistry,
-    _expressions: &HashMap<Variable, CompiledExpression>,
+    _expressions: &HashMap<Variable, ExecutableExpression>,
     statistics: &'a Statistics,
 ) -> ConjunctionPlan<'a> {
     let subplans = conjunction

--- a/compiler/executable/mod.rs
+++ b/compiler/executable/mod.rs
@@ -5,20 +5,20 @@
  */
 
 use error::typedb_error;
+
 use crate::executable::insert::WriteCompilationError;
 
 pub mod delete;
 pub mod fetch;
+pub mod function;
 pub mod insert;
 pub mod match_;
 pub mod modifiers;
-pub mod reduce;
 pub mod pipeline;
-pub mod function;
-
+pub mod reduce;
 
 typedb_error!(
-    pub ExecutableError(component = "Query executable", prefix = "QEE") {
+    pub ExecutableCompilationError(component = "Query executable", prefix = "QEE") {
         InsertExecutableCompilation(1, "Error compiling insert stage into executable.", (source : WriteCompilationError)),
         DeleteExecutableCompilation(2, "Error compiling delete stage into executable.", (source : WriteCompilationError)),
     }

--- a/compiler/executable/mod.rs
+++ b/compiler/executable/mod.rs
@@ -4,9 +4,22 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
+use error::typedb_error;
+use crate::executable::insert::WriteCompilationError;
+
 pub mod delete;
 pub mod fetch;
 pub mod insert;
 pub mod match_;
 pub mod modifiers;
 pub mod reduce;
+pub mod pipeline;
+pub mod function;
+
+
+typedb_error!(
+    pub ExecutableError(component = "Query executable", prefix = "QEE") {
+        InsertExecutableCompilation(1, "Error compiling insert stage into executable.", (source : WriteCompilationError)),
+        DeleteExecutableCompilation(2, "Error compiling delete stage into executable.", (source : WriteCompilationError)),
+    }
+);

--- a/compiler/executable/reduce.rs
+++ b/compiler/executable/reduce.rs
@@ -7,7 +7,6 @@
 use std::collections::HashMap;
 
 use answer::variable::Variable;
-use encoding::value::value_type::ValueTypeCategory;
 use ir::pattern::IrID;
 
 use crate::VariablePosition;
@@ -37,22 +36,22 @@ pub enum ReduceInstruction<ID: IrID> {
 }
 
 impl<ID: IrID> ReduceInstruction<ID> {
-    pub fn output_type(&self) -> ValueTypeCategory {
+    pub fn output_type(&self) -> ValueType {
         match self {
-            Self::Count => ValueTypeCategory::Long,
-            Self::CountVar(_) => ValueTypeCategory::Long,
-            Self::SumLong(_) => ValueTypeCategory::Long,
-            Self::SumDouble(_) => ValueTypeCategory::Double,
-            Self::MaxLong(_) => ValueTypeCategory::Long,
-            Self::MaxDouble(_) => ValueTypeCategory::Double,
-            Self::MinLong(_) => ValueTypeCategory::Long,
-            Self::MinDouble(_) => ValueTypeCategory::Double,
-            Self::MeanLong(_) => ValueTypeCategory::Double,
-            Self::MeanDouble(_) => ValueTypeCategory::Double,
-            Self::MedianLong(_) => ValueTypeCategory::Double,
-            Self::MedianDouble(_) => ValueTypeCategory::Double,
-            Self::StdLong(_) => ValueTypeCategory::Double,
-            Self::StdDouble(_) => ValueTypeCategory::Double,
+            Self::Count => ValueType::Long,
+            Self::CountVar(_) => ValueType::Long,
+            Self::SumLong(_) => ValueType::Long,
+            Self::SumDouble(_) => ValueType::Double,
+            Self::MaxLong(_) => ValueType::Long,
+            Self::MaxDouble(_) => ValueType::Double,
+            Self::MinLong(_) => ValueType::Long,
+            Self::MinDouble(_) => ValueType::Double,
+            Self::MeanLong(_) => ValueType::Double,
+            Self::MeanDouble(_) => ValueType::Double,
+            Self::MedianLong(_) => ValueType::Double,
+            Self::MedianDouble(_) => ValueType::Double,
+            Self::StdLong(_) => ValueType::Double,
+            Self::StdDouble(_) => ValueType::Double,
         }
     }
 }

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -22,7 +22,7 @@ def vaticle_typeql():
     git_repository(
         name = "vaticle_typeql",
         remote = "https://github.com/typedb/typeql",
-        commit = "1174632991b67b9d089df407f778023de6aa3233",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typeql
+        commit = "e8f6d1cef1cf9e3f89f6dbcd590f29541b59544e",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typeql
     )
 
 def vaticle_typedb_common():

--- a/executor/expression_executor.rs
+++ b/executor/expression_executor.rs
@@ -8,7 +8,7 @@ use std::collections::HashMap;
 
 use answer::variable::Variable;
 use compiler::annotation::expression::{
-    compiled_expression::CompiledExpression,
+    compiled_expression::ExecutableExpression,
     instructions::{
         binary::{Binary, BinaryExpression, MathRemainderLong},
         list_operations::{ListConstructor, ListIndex, ListIndexRange},
@@ -95,7 +95,7 @@ pub struct ExpressionExecutor {}
 
 impl ExpressionExecutor {
     pub fn evaluate(
-        compiled: CompiledExpression,
+        compiled: ExecutableExpression,
         input: HashMap<Variable, ExpressionValue>,
         parameters: &ParameterRegistry,
     ) -> Result<ExpressionValue, ExpressionEvaluationError> {

--- a/executor/tests/execute_expression.rs
+++ b/executor/tests/execute_expression.rs
@@ -111,8 +111,8 @@ fn test_basic() {
         let (vars, expr, params) = compile_expression_via_match(
             "$a + $b",
             HashMap::from([
-                ("a", ExpressionValueType::Single(ValueTypeCategory::Long)),
-                ("b", ExpressionValueType::Single(ValueTypeCategory::Long)),
+                ("a", ExpressionValueType::Single(ValueTypeCategory::Long.try_into_value_type().unwrap())),
+                ("b", ExpressionValueType::Single(ValueTypeCategory::Long.try_into_value_type().unwrap())),
             ]),
         )
         .unwrap();
@@ -262,7 +262,7 @@ fn list_ops() {
     {
         let (vars, expr, params) = compile_expression_via_match(
             "$y[1]",
-            HashMap::from([("y", ExpressionValueType::List(ValueTypeCategory::Long))]),
+            HashMap::from([("y", ExpressionValueType::List(ValueTypeCategory::Long.try_into_value_type().unwrap()))]),
         )
         .unwrap();
         let y = ["y"].into_iter().map(|name| *vars.get(name).unwrap()).exactly_one().unwrap();
@@ -276,7 +276,7 @@ fn list_ops() {
     {
         let (vars, expr, params) = compile_expression_via_match(
             "$y[1..3]",
-            HashMap::from([("y", ExpressionValueType::List(ValueTypeCategory::Long))]),
+            HashMap::from([("y", ExpressionValueType::List(ValueTypeCategory::Long.try_into_value_type().unwrap()))]),
         )
         .unwrap();
         let y = ["y"].into_iter().map(|name| *vars.get(name).unwrap()).exactly_one().unwrap();

--- a/executor/tests/execute_expression.rs
+++ b/executor/tests/execute_expression.rs
@@ -8,7 +8,7 @@ use std::collections::HashMap;
 
 use answer::variable::Variable;
 use compiler::annotation::expression::{
-    compiled_expression::{CompiledExpression, ExpressionValueType},
+    compiled_expression::{ExecutableExpression, ExpressionValueType},
     expression_compiler::ExpressionCompilationContext,
     ExpressionCompileError,
 };
@@ -44,7 +44,7 @@ impl From<ExpressionCompileError> for PatternDefitionOrExpressionCompileError {
 fn compile_expression_via_match(
     s: &str,
     variable_types: HashMap<&str, ExpressionValueType>,
-) -> Result<(HashMap<String, Variable>, CompiledExpression, ParameterRegistry), PatternDefitionOrExpressionCompileError>
+) -> Result<(HashMap<String, Variable>, ExecutableExpression, ParameterRegistry), PatternDefitionOrExpressionCompileError>
 {
     let query = format!("match $x = {}; select $x;", s);
     let mut translation_context = TranslationContext::new();

--- a/ir/pipeline/fetch.rs
+++ b/ir/pipeline/fetch.rs
@@ -47,7 +47,7 @@ pub enum FetchObject {
 
 #[derive(Debug, Clone)]
 pub struct FetchObjectEntries {
-    pub(crate) entries: HashMap<ParameterID, FetchSome>,
+    pub entries: HashMap<ParameterID, FetchSome>,
 }
 
 #[derive(Debug, Clone)]

--- a/ir/pipeline/mod.rs
+++ b/ir/pipeline/mod.rs
@@ -85,6 +85,11 @@ typedb_error!(
             declaration: ReturnReduction,
             ( typedb_source : Box<RepresentationError>)
         ),
+        IllegalFetch(
+            6,
+            "Fetch clauses cannot be used inside of functions or function blocks that terminate in a 'return' statement.\nSource:\n{declaration}",
+            declaration: FunctionBlock
+        ),
     }
 );
 

--- a/ir/translation/function.rs
+++ b/ir/translation/function.rs
@@ -52,13 +52,15 @@ pub(crate) fn translate_function_block(
     context: &mut TranslationContext,
     function_block: &FunctionBlock,
 ) -> Result<FunctionBody, FunctionRepresentationError> {
-    let stages =
-        translate_pipeline_stages(snapshot, function_index, context, &function_block.stages).map_err(|err| {
-            FunctionRepresentationError::BlockDefinition {
-                declaration: function_block.clone(),
-                typedb_source: Box::new(err),
-            }
+    let (stages, fetch) = translate_pipeline_stages(snapshot, function_index, context, &function_block.stages)
+        .map_err(|err| FunctionRepresentationError::BlockDefinition {
+            declaration: function_block.clone(),
+            typedb_source: Box::new(err),
         })?;
+
+    if fetch.is_some() {
+        return Err(FunctionRepresentationError::IllegalFetch { declaration: function_block.clone() });
+    }
 
     let return_operation = match &function_block.return_stmt {
         ReturnStatement::Stream(stream) => build_return_stream(&context, stream),

--- a/ir/translation/pipeline.rs
+++ b/ir/translation/pipeline.rs
@@ -4,9 +4,11 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-use answer::variable::Variable;
-use storage::snapshot::ReadableSnapshot;
 use typeql::query::stage::{Operator as TypeQLOperator, Stage as TypeQLStage, Stage};
+
+use answer::variable::Variable;
+use primitive::either::Either;
+use storage::snapshot::ReadableSnapshot;
 
 use crate::{
     pipeline::{
@@ -15,25 +17,26 @@ use crate::{
         function::Function,
         function_signature::FunctionSignatureIndex,
         modifier::{Limit, Offset, Require, Select, Sort},
-        reduce::Reduce,
-        ParameterRegistry, VariableRegistry,
+        ParameterRegistry,
+        reduce::Reduce, VariableRegistry,
     },
+    RepresentationError,
     translation::{
         fetch::translate_fetch,
         function::translate_function,
         match_::translate_match,
         modifiers::{translate_limit, translate_offset, translate_require, translate_select, translate_sort},
         reduce::translate_reduce,
-        writes::{translate_delete, translate_insert},
         TranslationContext,
+        writes::{translate_delete, translate_insert},
     },
-    RepresentationError,
 };
 
 #[derive(Debug, Clone)]
 pub struct TranslatedPipeline {
     pub translated_preamble: Vec<Function>,
     pub translated_stages: Vec<TranslatedStage>,
+    pub translated_fetch: Option<FetchObject>,
     pub variable_registry: VariableRegistry,
     pub value_parameters: ParameterRegistry,
 }
@@ -42,11 +45,13 @@ impl TranslatedPipeline {
     pub(crate) fn new(
         translation_context: TranslationContext,
         translated_preamble: Vec<Function>,
+        translated_fetch: Option<FetchObject>,
         translated_stages: Vec<TranslatedStage>,
     ) -> Self {
         TranslatedPipeline {
             translated_preamble,
             translated_stages,
+            translated_fetch,
             variable_registry: translation_context.variable_registry,
             value_parameters: translation_context.parameters,
         }
@@ -58,8 +63,6 @@ pub enum TranslatedStage {
     Match { block: Block },
     Insert { block: Block },
     Delete { block: Block, deleted_variables: Vec<Variable> },
-
-    Fetch { fetch_object: FetchObject },
 
     // ...
     Select(Select),
@@ -84,12 +87,13 @@ pub fn translate_pipeline(
         .map_err(|source| RepresentationError::FunctionRepresentation { typedb_source: source })?;
 
     let mut translation_context = TranslationContext::new();
-    let translated_stages =
+    let (translated_stages, translated_fetch) =
         translate_pipeline_stages(snapshot, all_function_signatures, &mut translation_context, &query.stages)?;
 
     Ok(TranslatedPipeline {
         translated_preamble,
         translated_stages,
+        translated_fetch,
         variable_registry: translation_context.variable_registry,
         value_parameters: translation_context.parameters,
     })
@@ -100,16 +104,22 @@ pub(crate) fn translate_pipeline_stages(
     all_function_signatures: &impl FunctionSignatureIndex,
     translation_context: &mut TranslationContext,
     stages: &[Stage],
-) -> Result<Vec<TranslatedStage>, RepresentationError> {
+) -> Result<(Vec<TranslatedStage>, Option<FetchObject>), RepresentationError> {
     let mut translated_stages: Vec<TranslatedStage> = Vec::with_capacity(stages.len());
     for (i, stage) in stages.iter().enumerate() {
         let translated = translate_stage(snapshot, translation_context, all_function_signatures, stage)?;
-        if matches!(translated, TranslatedStage::Fetch { .. }) && i != stages.len() - 1 {
-            return Err(RepresentationError::NonTerminalFetch { declaration: stage.clone() });
+        match translated {
+            Either::First(stage) => translated_stages.push(stage),
+            Either::Second(fetch) => {
+                if i != stages.len() - 1 {
+                    return Err(RepresentationError::NonTerminalFetch { declaration: stage.clone() });
+                } else {
+                    return Ok((translated_stages, Some(fetch)));
+                }
+            }
         }
-        translated_stages.push(translated);
     }
-    Ok(translated_stages)
+    Ok((translated_stages, None))
 }
 
 fn translate_stage(
@@ -117,36 +127,41 @@ fn translate_stage(
     translation_context: &mut TranslationContext,
     all_function_signatures: &impl FunctionSignatureIndex,
     typeql_stage: &TypeQLStage,
-) -> Result<TranslatedStage, RepresentationError> {
+) -> Result<Either<TranslatedStage, FetchObject>, RepresentationError> {
     match typeql_stage {
         TypeQLStage::Match(match_) => translate_match(translation_context, all_function_signatures, match_)
-            .map(|builder| TranslatedStage::Match { block: builder.finish() }),
+            .map(|builder| Either::First(TranslatedStage::Match { block: builder.finish() })),
         TypeQLStage::Insert(insert) => {
-            translate_insert(translation_context, insert).map(|block| TranslatedStage::Insert { block })
+            translate_insert(translation_context, insert).map(|block| Either::First(TranslatedStage::Insert { block }))
         }
         TypeQLStage::Delete(delete) => translate_delete(translation_context, delete)
-            .map(|(block, deleted_variables)| TranslatedStage::Delete { block, deleted_variables }),
+            .map(|(block, deleted_variables)| Either::First(TranslatedStage::Delete { block, deleted_variables })),
         TypeQLStage::Fetch(fetch) => translate_fetch(snapshot, translation_context, all_function_signatures, fetch)
-            .map(|translated| TranslatedStage::Fetch { fetch_object: translated })
+            .map(|translated| Either::Second(translated))
             .map_err(|err| RepresentationError::FetchRepresentation { typedb_source: err }),
         TypeQLStage::Operator(modifier) => match modifier {
             TypeQLOperator::Select(select) => {
-                translate_select(translation_context, select).map(|filter| TranslatedStage::Select(filter))
+                translate_select(translation_context, select)
+                    .map(|filter| Either::First(TranslatedStage::Select(filter)))
             }
             TypeQLOperator::Sort(sort) => {
-                translate_sort(translation_context, sort).map(|sort| TranslatedStage::Sort(sort))
+                translate_sort(translation_context, sort).map(|sort| Either::First(TranslatedStage::Sort(sort)))
             }
             TypeQLOperator::Offset(offset) => {
-                translate_offset(translation_context, offset).map(|offset| TranslatedStage::Offset(offset))
+                translate_offset(translation_context, offset)
+                    .map(|offset| Either::First(TranslatedStage::Offset(offset)))
             }
             TypeQLOperator::Limit(limit) => {
-                translate_limit(translation_context, limit).map(|limit| TranslatedStage::Limit(limit))
+                translate_limit(translation_context, limit)
+                    .map(|limit| Either::First(TranslatedStage::Limit(limit)))
             }
             TypeQLOperator::Reduce(reduce) => {
-                translate_reduce(translation_context, reduce).map(|reduce| TranslatedStage::Reduce(reduce))
+                translate_reduce(translation_context, reduce)
+                    .map(|reduce| Either::First(TranslatedStage::Reduce(reduce)))
             }
             TypeQLOperator::Require(require) => {
-                translate_require(translation_context, require).map(|require| TranslatedStage::Require(require))
+                translate_require(translation_context, require)
+                    .map(|require| Either::First(TranslatedStage::Require(require)))
             }
         },
         _ => Err(RepresentationError::UnrecognisedClause { declaration: typeql_stage.clone() }),

--- a/ir/translation/pipeline.rs
+++ b/ir/translation/pipeline.rs
@@ -4,11 +4,10 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-use typeql::query::stage::{Operator as TypeQLOperator, Stage as TypeQLStage, Stage};
-
 use answer::variable::Variable;
 use primitive::either::Either;
 use storage::snapshot::ReadableSnapshot;
+use typeql::query::stage::{Operator as TypeQLOperator, Stage as TypeQLStage, Stage};
 
 use crate::{
     pipeline::{
@@ -17,19 +16,19 @@ use crate::{
         function::Function,
         function_signature::FunctionSignatureIndex,
         modifier::{Limit, Offset, Require, Select, Sort},
-        ParameterRegistry,
-        reduce::Reduce, VariableRegistry,
+        reduce::Reduce,
+        ParameterRegistry, VariableRegistry,
     },
-    RepresentationError,
     translation::{
         fetch::translate_fetch,
         function::translate_function,
         match_::translate_match,
         modifiers::{translate_limit, translate_offset, translate_require, translate_select, translate_sort},
         reduce::translate_reduce,
-        TranslationContext,
         writes::{translate_delete, translate_insert},
+        TranslationContext,
     },
+    RepresentationError,
 };
 
 #[derive(Debug, Clone)]
@@ -140,29 +139,20 @@ fn translate_stage(
             .map(|translated| Either::Second(translated))
             .map_err(|err| RepresentationError::FetchRepresentation { typedb_source: err }),
         TypeQLStage::Operator(modifier) => match modifier {
-            TypeQLOperator::Select(select) => {
-                translate_select(translation_context, select)
-                    .map(|filter| Either::First(TranslatedStage::Select(filter)))
-            }
+            TypeQLOperator::Select(select) => translate_select(translation_context, select)
+                .map(|filter| Either::First(TranslatedStage::Select(filter))),
             TypeQLOperator::Sort(sort) => {
                 translate_sort(translation_context, sort).map(|sort| Either::First(TranslatedStage::Sort(sort)))
             }
-            TypeQLOperator::Offset(offset) => {
-                translate_offset(translation_context, offset)
-                    .map(|offset| Either::First(TranslatedStage::Offset(offset)))
-            }
+            TypeQLOperator::Offset(offset) => translate_offset(translation_context, offset)
+                .map(|offset| Either::First(TranslatedStage::Offset(offset))),
             TypeQLOperator::Limit(limit) => {
-                translate_limit(translation_context, limit)
-                    .map(|limit| Either::First(TranslatedStage::Limit(limit)))
+                translate_limit(translation_context, limit).map(|limit| Either::First(TranslatedStage::Limit(limit)))
             }
-            TypeQLOperator::Reduce(reduce) => {
-                translate_reduce(translation_context, reduce)
-                    .map(|reduce| Either::First(TranslatedStage::Reduce(reduce)))
-            }
-            TypeQLOperator::Require(require) => {
-                translate_require(translation_context, require)
-                    .map(|require| Either::First(TranslatedStage::Require(require)))
-            }
+            TypeQLOperator::Reduce(reduce) => translate_reduce(translation_context, reduce)
+                .map(|reduce| Either::First(TranslatedStage::Reduce(reduce))),
+            TypeQLOperator::Require(require) => translate_require(translation_context, require)
+                .map(|require| Either::First(TranslatedStage::Require(require))),
         },
         _ => Err(RepresentationError::UnrecognisedClause { declaration: typeql_stage.clone() }),
     }

--- a/main.rs
+++ b/main.rs
@@ -8,7 +8,6 @@
 #![deny(elided_lifetimes_in_paths)]
 
 use logger::initialise_logging_global;
-use resource::constants::server::ASCII_LOGO;
 use server::parameters::config::Config;
 
 #[tokio::main]

--- a/query/error.rs
+++ b/query/error.rs
@@ -6,7 +6,7 @@
 
 use compiler::{
     annotation::{expression::ExpressionCompileError, AnnotationError},
-    executable::insert::WriteCompilationError,
+    executable::{insert::WriteCompilationError, ExecutableCompilationError},
 };
 use error::typedb_error;
 use executor::pipeline::PipelineExecutionError;
@@ -25,7 +25,8 @@ typedb_error!(
         FunctionDefinition(5, "Error in provided function. ", ( typedb_source: FunctionRepresentationError )),
         FunctionRetrieval(6, "Failed to retrieve function. ",  ( typedb_source: FunctionError )),
         Representation(7, "Error in provided query. ", ( typedb_source: RepresentationError )),
-        Annotation(8, "Error in provided query. ", ( typedb_source: AnnotationError )),
+        Annotation(8, "Error analysing query. ", ( typedb_source: AnnotationError )),
+        ExecutableCompilation(9, "Error compiling query. ", ( typedb_source: ExecutableCompilationError )),
         WriteCompilation(10, "Error while compiling write query.", ( source: WriteCompilationError )),
         ExpressionCompilation(11, "Error while compiling expression.", ( source: ExpressionCompileError )),
         WritePipelineExecutionError(12, "Error while execution write pipeline.", ( typedb_source: PipelineExecutionError )),

--- a/query/lib.rs
+++ b/query/lib.rs
@@ -3,7 +3,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
-mod compilation;
 mod definable_resolution;
 mod definable_status;
 mod define;


### PR DESCRIPTION
## Release notes: product changes

We implement further refactoring, which pull Fetch into Annotations and Executables, without implementing any sub-methods yet.