### PR TITLE
Update function type inference for pipelines

### DIFF
--- a/compiler/annotation/function.rs
+++ b/compiler/annotation/function.rs
@@ -4,18 +4,27 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-use std::collections::BTreeSet;
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    sync::Arc,
+};
 
-use answer::Type;
+use answer::{variable::Variable, Type};
 use concept::type_::type_manager::TypeManager;
 use encoding::{graph::definition::definition_key::DefinitionKey, value::value_type::ValueType};
-use ir::pipeline::{
-    function::{AnonymousFunction, Function},
-    function_signature::FunctionIDAPI,
+use ir::{
+    pattern::Vertex,
+    pipeline::{
+        function::{AnonymousFunction, Function, FunctionBody, ReturnOperation},
+        function_signature::FunctionIDAPI,
+    },
 };
 use storage::snapshot::ReadableSnapshot;
 
-use crate::annotation::{pipeline::AnnotatedStage, FunctionTypeInferenceError};
+use crate::annotation::{
+    pipeline::{annotate_pipeline, annotate_pipeline_stages, AnnotatedStage},
+    FunctionTypeInferenceError,
+};
 
 #[derive(Debug, Clone)]
 pub enum FunctionParameterAnnotation {
@@ -26,13 +35,13 @@ pub enum FunctionParameterAnnotation {
 #[derive(Debug, Clone)]
 pub struct AnnotatedFunction {
     stages: Vec<AnnotatedStage>,
-    return_annotations: Vec<BTreeSet<FunctionParameterAnnotation>>,
+    return_annotations: Vec<FunctionParameterAnnotation>,
 }
 
 #[derive(Debug, Clone)]
 pub struct AnnotatedAnonymousFunction {
     stages: Vec<AnnotatedStage>,
-    return_annotations: Vec<BTreeSet<FunctionParameterAnnotation>>,
+    return_annotations: Vec<FunctionParameterAnnotation>,
 }
 
 /// Indexed by Function ID
@@ -104,69 +113,108 @@ impl AnnotatedFunctions for AnnotatedUnindexedFunctions {
 }
 
 pub fn annotate_functions(
-    functions: Vec<Function>,
+    mut functions: Vec<Function>,
     snapshot: &impl ReadableSnapshot,
     type_manager: &TypeManager,
     indexed_annotated_functions: &IndexedAnnotatedFunctions,
 ) -> Result<AnnotatedUnindexedFunctions, FunctionTypeInferenceError> {
-    // // In the preliminary annotations, functions are annotated based only on the variable categories of the called function.
-    // let preliminary_annotations_res: Result<Vec<FunctionAnnotations>, FunctionTypeInferenceError> = functions
-    //     .iter()
-    //     .map(|function| annotate_function(function, snapshot, type_manager, indexed_annotated_functions, None))
-    //     .collect();
-    // let preliminary_annotations =
-    //     AnnotatedUnindexedFunctions::new(functions.into_boxed_slice(), preliminary_annotations_res?.into_boxed_slice());
-    //
-    // // In the second round, finer annotations are available at the function calls so the annotations in function bodies can be refined.
-    // let annotations_res = preliminary_annotations
-    //     .iter_functions()
-    //     .map(|function| {
-    //         annotate_function(
-    //             function,
-    //             snapshot,
-    //             type_manager,
-    //             indexed_annotated_functions,
-    //             Some(&preliminary_annotations),
-    //         )
-    //     })
-    //     .collect::<Result<Vec<FunctionAnnotations>, FunctionTypeInferenceError>>()?;
-    //
-    // // TODO: ^Optimise. There's no reason to do all of type inference again. We can re-use the graphs, and restart at the source of any SCC.
-    // // TODO: We don't propagate annotations until convergence, so we don't always detect unsatisfiable queries
-    // // Further, In a chain of three functions where the first two bodies have no function calls
-    // // but rely on the third function to infer annotations, the annotations will not reach the first function.
-    // let (ir, _) = preliminary_annotations.into_parts();
-    // let annotated = AnnotatedUnindexedFunctions::new(ir, annotations_res.into_boxed_slice());
-    // Ok(annotated)
+    // In the preliminary annotations, functions are annotated based only on the variable categories of the called function.
+    let preliminary_annotated_functions = functions
+        .iter_mut()
+        .map(|function| annotate_function(function, snapshot, type_manager, indexed_annotated_functions, None))
+        .collect::<Result<Vec<AnnotatedFunction>, FunctionTypeInferenceError>>()?;
+    let preliminary_annotations = AnnotatedUnindexedFunctions::new(preliminary_annotated_functions);
 
-    // TODO: implement
-    Ok(AnnotatedUnindexedFunctions::empty())
+    // In the second round, finer annotations are available at the function calls so the annotations in function bodies can be refined.
+    let annotated_functions = functions
+        .iter_mut()
+        .map(|function| {
+            annotate_function(
+                function,
+                snapshot,
+                type_manager,
+                indexed_annotated_functions,
+                Some(&preliminary_annotations),
+            )
+        })
+        .collect::<Result<Vec<AnnotatedFunction>, FunctionTypeInferenceError>>()?;
+
+    // TODO: ^Optimise. There's no reason to do all of type inference again. We can re-use the graphs, and restart at the source of any SCC.
+    // TODO: We don't propagate annotations until convergence, so we don't always detect unsatisfiable queries
+    // Further, In a chain of three functions where the first two bodies have no function calls
+    // but rely on the third function to infer annotations, the annotations will not reach the first function.
+    Ok(AnnotatedUnindexedFunctions::new(annotated_functions))
 }
 
 pub fn annotate_function(
-    function: &Function,
+    function: &mut Function,
     snapshot: &impl ReadableSnapshot,
     type_manager: &TypeManager,
     indexed_annotated_functions: &IndexedAnnotatedFunctions,
     local_functions: Option<&AnnotatedUnindexedFunctions>,
 ) -> Result<AnnotatedFunction, FunctionTypeInferenceError> {
-    // let root_graph = infer_types(
-    //     snapshot,
-    //     function.block(),
-    //     function.variable_registry(),
-    //     type_manager,
-    //     &BTreeMap::new(),
-    //     indexed_annotated_functions,
-    //     local_functions,
-    // )
-    // .map_err(|err| FunctionTypeInferenceError::TypeInference {
-    //     name: function.name().to_string(),
-    //     typedb_source: err,
-    // })?;
-    // let body_annotations = TypeAnnotations::build(root_graph);
-    // let return_types = function.return_operation().return_types(body_annotations.vertex_annotations());
-    // Ok(FunctionAnnotations { return_annotations: return_types, block_annotations: body_annotations })
-    todo!("We need to allow a function to contain an entire pipeline, instead of just a match block")
+    let Function { name, context, function_body: FunctionBody { stages, return_operation }, arguments } = function;
+    // TODO: Work the argument in.
+    let (stages, running_variable_types, running_value_types) = annotate_pipeline_stages(
+        snapshot,
+        type_manager,
+        indexed_annotated_functions,
+        &mut context.variable_registry,
+        &context.parameters,
+        local_functions,
+        stages.clone(),
+    )
+    .map_err(|err| FunctionTypeInferenceError::TypeInference {
+        name: name.to_string(),
+        typedb_source: Box::new(err),
+    })?;
+    let return_annotations =
+        extract_return_type_annotations(return_operation, &running_variable_types, &running_value_types);
+    Ok(AnnotatedFunction { return_annotations, stages })
+}
+
+pub fn extract_return_type_annotations(
+    return_operation: &ReturnOperation,
+    body_variable_annotations: &BTreeMap<Variable, Arc<BTreeSet<Type>>>,
+    body_variable_value_types: &BTreeMap<Variable, ValueType>,
+) -> Vec<FunctionParameterAnnotation> {
+    match return_operation {
+        ReturnOperation::Stream(vars) => {
+            vars.iter()
+                .map(|var| {
+                    get_function_parameter(var, body_variable_annotations, body_variable_value_types)
+                    // TODO: body_variable_value_types
+                })
+                .collect()
+        }
+        ReturnOperation::Single(_, vars) => vars
+            .iter()
+            .map(|var| get_function_parameter(var, body_variable_annotations, body_variable_value_types))
+            .collect(),
+        ReturnOperation::ReduceReducer(reducers) => {
+            // aggregates return value types?
+            todo!()
+        }
+        ReturnOperation::ReduceCheck() => {
+            // aggregates return value types?
+            todo!()
+        }
+    }
+}
+
+fn get_function_parameter(
+    variable: &Variable,
+    body_variable_annotations: &BTreeMap<Variable, Arc<BTreeSet<Type>>>,
+    body_variable_value_types: &BTreeMap<Variable, ValueType>,
+) -> FunctionParameterAnnotation {
+    if let Some(arced_types) = body_variable_annotations.get(variable) {
+        let types: &BTreeSet<Type> = &arced_types;
+        FunctionParameterAnnotation::Concept(types.clone())
+    } else if let Some(value_type) = body_variable_value_types.get(variable) {
+        FunctionParameterAnnotation::Value(value_type.clone())
+    } else {
+        unreachable!()
+    }
 }
 
 pub fn annotate_anonymous_function(

--- a/compiler/annotation/function.rs
+++ b/compiler/annotation/function.rs
@@ -38,6 +38,16 @@ pub struct AnnotatedFunction {
     return_annotations: Vec<FunctionParameterAnnotation>,
 }
 
+impl AnnotatedFunction {
+    pub fn pipeline_annotations(&self) -> &Vec<AnnotatedStage> {
+        &self.stages
+    }
+
+    pub fn return_annotations(&self) -> &Vec<FunctionParameterAnnotation> {
+        &self.return_annotations
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct AnnotatedAnonymousFunction {
     stages: Vec<AnnotatedStage>,

--- a/compiler/annotation/mod.rs
+++ b/compiler/annotation/mod.rs
@@ -33,7 +33,7 @@ typedb_error!(
 
 typedb_error!(
     pub FunctionTypeInferenceError(component = "Function type inference", prefix = "FIN") {
-        TypeInference(0, "Type inference error while type checking function '{name}'.", name: String, ( typedb_source : TypeInferenceError )),
+        TypeInference(0, "Type inference error while type checking function '{name}'.", name: String, ( typedb_source : Box<AnnotationError> )),
     }
 );
 

--- a/compiler/annotation/type_inference.rs
+++ b/compiler/annotation/type_inference.rs
@@ -219,7 +219,6 @@ pub mod tests {
     //
     #[test]
     fn test_functions() {
-        // todo!()
         let (_tmp_dir, storage) = setup_storage();
         let (type_manager, thing_manager) = managers();
 

--- a/function/function_manager.rs
+++ b/function/function_manager.rs
@@ -78,9 +78,9 @@ impl FunctionManager {
         // Prepare ir
         let function_index =
             HashMapFunctionSignatureIndex::build(functions.iter().map(|f| (f.function_id.clone().into(), &f.parsed)));
-        let ir = Self::translate_functions(snapshot, &functions, &function_index)?;
+        let translated = Self::translate_functions(snapshot, &functions, &function_index)?;
         // Run type-inference
-        annotate_functions(ir, snapshot, type_manager, &IndexedAnnotatedFunctions::empty())
+        annotate_functions(translated, snapshot, type_manager, &IndexedAnnotatedFunctions::empty())
             .map_err(|source| FunctionError::AllFunctionsTypeCheckFailure { typedb_source: source })?;
         Ok(())
     }

--- a/ir/pipeline/function.rs
+++ b/ir/pipeline/function.rs
@@ -39,6 +39,10 @@ impl Function {
         &self.arguments
     }
 
+    pub fn translation_context(&self) -> &TranslationContext {
+        &self.context
+    }
+
     pub fn translation_context_mut(&mut self) -> &mut TranslationContext {
         &mut self.context
     }

--- a/ir/pipeline/function.rs
+++ b/ir/pipeline/function.rs
@@ -13,20 +13,17 @@ use answer::{variable::Variable, Type};
 use typeql::schema::definable::function::SingleSelector;
 
 use crate::{
-    pattern::Vertex,
     pipeline::reduce::Reducer,
     translation::{pipeline::TranslatedStage, TranslationContext},
 };
 
-pub type PlaceholderTypeQLReturnOperation = String;
-
 #[derive(Debug, Clone)]
 pub struct Function {
-    context: TranslationContext,
-    name: String,
-    function_body: FunctionBody,
+    pub context: TranslationContext,
+    pub name: String,
+    pub function_body: FunctionBody,
     // Variable categories for args & return can be read from the block's context.
-    arguments: Vec<Variable>,
+    pub arguments: Vec<Variable>,
 }
 
 impl Function {
@@ -42,8 +39,8 @@ impl Function {
         &self.arguments
     }
 
-    pub fn translation_context(&self) -> &TranslationContext {
-        &self.context
+    pub fn translation_context_mut(&mut self) -> &mut TranslationContext {
+        &mut self.context
     }
 
     pub fn body(&self) -> &FunctionBody {
@@ -65,8 +62,8 @@ impl AnonymousFunction {
 
 #[derive(Debug, Clone)]
 pub struct FunctionBody {
-    stages: Vec<TranslatedStage>,
-    return_operation: ReturnOperation,
+    pub stages: Vec<TranslatedStage>,
+    pub return_operation: ReturnOperation,
 }
 
 impl FunctionBody {
@@ -89,32 +86,6 @@ pub enum ReturnOperation {
     Single(SingleSelector, Vec<Variable>),
     ReduceCheck(),
     ReduceReducer(Vec<Reducer>),
-}
-
-impl ReturnOperation {
-    pub fn return_types(
-        &self,
-        function_variable_annotations: &BTreeMap<Vertex<Variable>, Arc<BTreeSet<Type>>>,
-    ) -> Vec<BTreeSet<Type>> {
-        match self {
-            ReturnOperation::Stream(vars) => {
-                let inputs = vars.iter().map(|&var| function_variable_annotations.get(&Vertex::Variable(var)).unwrap());
-                inputs.map(|types| BTreeSet::from_iter(types.iter().cloned())).collect()
-            }
-            ReturnOperation::Single(_, vars) => {
-                let inputs = vars.iter().map(|&var| function_variable_annotations.get(&Vertex::Variable(var)).unwrap());
-                inputs.map(|types| BTreeSet::from_iter(types.iter().cloned())).collect()
-            }
-            ReturnOperation::ReduceReducer(reducers) => {
-                // aggregates return value types?
-                todo!()
-            }
-            ReturnOperation::ReduceCheck() => {
-                // aggregates return value types?
-                todo!()
-            }
-        }
-    }
 }
 
 impl ReturnOperation {

--- a/ir/pipeline/function.rs
+++ b/ir/pipeline/function.rs
@@ -43,10 +43,6 @@ impl Function {
         &self.context
     }
 
-    pub fn translation_context_mut(&mut self) -> &mut TranslationContext {
-        &mut self.context
-    }
-
     pub fn body(&self) -> &FunctionBody {
         &self.function_body
     }

--- a/main.rs
+++ b/main.rs
@@ -9,6 +9,7 @@
 
 use logger::initialise_logging_global;
 use server::parameters::config::Config;
+use resource::constants::server::ASCII_LOGO;
 
 #[tokio::main]
 async fn main() {


### PR DESCRIPTION
## Release notes: product changes
Update function type inference for pipelines

## Motivation
Function type-inference was commented out and not updated as part of a recent refactor. This PR restores it.

## Implementation
Update function type inference for pipelines