### PR TITLE
Disjunction support

### DIFF
--- a/answer/variable_value.rs
+++ b/answer/variable_value.rs
@@ -28,14 +28,14 @@ impl<'a> VariableValue<'a> {
     pub fn as_type(&self) -> &Type {
         match self {
             Self::Type(type_) => type_,
-            _ => panic!("VariableValue is not a Type"),
+            _ => panic!("VariableValue is not a Type: {self:?}"),
         }
     }
 
     pub fn as_thing(&self) -> &Thing<'a> {
         match self {
             VariableValue::Thing(thing) => thing,
-            _ => panic!("VariableValue is not a Thing"),
+            _ => panic!("VariableValue is not a Thing: {self:?}"),
         }
     }
 

--- a/compiler/annotation/match_inference.rs
+++ b/compiler/annotation/match_inference.rs
@@ -98,9 +98,9 @@ where
     }
 }
 
-pub fn infer_types<'graph>(
+pub fn infer_types(
     snapshot: &impl ReadableSnapshot,
-    block: &'graph Block,
+    block: &Block,
     variable_registry: &VariableRegistry,
     type_manager: &TypeManager,
     previous_stage_variable_annotations: &BTreeMap<Variable, Arc<BTreeSet<TypeAnnotation>>>,

--- a/compiler/annotation/pipeline.rs
+++ b/compiler/annotation/pipeline.rs
@@ -264,11 +264,11 @@ fn annotate_stage(
                 }
                 Constraint::RoleName(role_name) => {
                     running_variable_annotations.insert(
-                        role_name.left().as_variable().unwrap(),
-                        insert_annotations.vertex_annotations_of(role_name.left()).unwrap().clone(),
+                        role_name.type_().as_variable().unwrap(),
+                        insert_annotations.vertex_annotations_of(role_name.type_()).unwrap().clone(),
                     );
                 }
-                _ => {}
+                _ => (),
             });
             check_annotations(
                 snapshot,

--- a/compiler/annotation/type_seeder.rs
+++ b/compiler/annotation/type_seeder.rs
@@ -633,7 +633,7 @@ impl UnaryConstraint for Label<Variable> {
         )
         .map_err(|source| TypeInferenceError::ConceptRead { source })?;
         if let Some(annotation) = annotation_opt {
-            graph_vertices.add_or_intersect(self.left(), Cow::Owned(BTreeSet::from([annotation])));
+            graph_vertices.add_or_intersect(self.type_(), Cow::Owned(BTreeSet::from([annotation])));
             Ok(())
         } else {
             Err(TypeInferenceError::LabelNotResolved { name: self.type_label().to_string() })
@@ -660,7 +660,7 @@ impl UnaryConstraint for RoleName<Variable> {
                     .map_err(|source| TypeInferenceError::ConceptRead { source })?;
                 annotations.extend(subtypes.into_iter().map(|subtype| TypeAnnotation::RoleType(subtype.clone())));
             }
-            graph_vertices.add_or_intersect(self.left(), Cow::Owned(annotations));
+            graph_vertices.add_or_intersect(self.type_(), Cow::Owned(annotations));
             Ok(())
         } else {
             Err(TypeInferenceError::RoleNameNotResolved { name: self.name().to_string() })

--- a/compiler/annotation/type_seeder.rs
+++ b/compiler/annotation/type_seeder.rs
@@ -115,7 +115,7 @@ impl<'this, Snapshot: ReadableSnapshot> TypeGraphSeedingContext<'this, Snapshot>
 
         // Seed vertices in root & disjunctions
         self.seed_vertex_annotations_from_type_and_function_return(graph)?;
-        self.annotate_fixed_vertices(graph)?;
+
         let mut some_vertex_was_directly_annotated = true;
         while some_vertex_was_directly_annotated {
             let mut changed = true;
@@ -205,6 +205,7 @@ impl<'this, Snapshot: ReadableSnapshot> TypeGraphSeedingContext<'this, Snapshot>
         &self,
         graph: &mut TypeInferenceGraph<'_>,
     ) -> Result<(), TypeInferenceError> {
+        self.annotate_fixed_vertices(graph)?;
         // Get vertex annotations from Type & Function returns
         let TypeInferenceGraph { vertices, .. } = graph;
         for constraint in graph.conjunction.constraints() {

--- a/compiler/executable/fetch/executable.rs
+++ b/compiler/executable/fetch/executable.rs
@@ -9,7 +9,7 @@ use std::{collections::HashMap, sync::Arc};
 use answer::variable::Variable;
 use concept::{thing::statistics::Statistics, type_::attribute_type::AttributeType};
 use error::typedb_error;
-use ir::pattern::ParameterID;
+use ir::{pattern::ParameterID, pipeline::VariableRegistry};
 
 use crate::{
     annotation::fetch::{AnnotatedFetch, AnnotatedFetchListSubFetch, AnnotatedFetchObject, AnnotatedFetchSome},

--- a/compiler/executable/fetch/executable.rs
+++ b/compiler/executable/fetch/executable.rs
@@ -9,7 +9,7 @@ use std::{collections::HashMap, sync::Arc};
 use answer::variable::Variable;
 use concept::{thing::statistics::Statistics, type_::attribute_type::AttributeType};
 use error::typedb_error;
-use ir::{pattern::ParameterID, pipeline::VariableRegistry};
+use ir::pattern::ParameterID;
 
 use crate::{
     annotation::fetch::{AnnotatedFetch, AnnotatedFetchListSubFetch, AnnotatedFetchObject, AnnotatedFetchSome},

--- a/compiler/executable/insert/executable.rs
+++ b/compiler/executable/insert/executable.rs
@@ -250,18 +250,18 @@ fn collect_type_bindings(
 
     filter_variants!(Constraint::Label : constraints)
         .map(|label| {
-            let annotations = type_annotations.vertex_annotations_of(label.left()).unwrap();
+            let annotations = type_annotations.vertex_annotations_of(label.type_()).unwrap();
             #[cfg(debug_assertions)]
             debug_assert!(annotations.len() == 1);
             let type_ = annotations.first().unwrap();
 
             #[cfg(debug_assertions)]
             {
-                debug_assert!(!seen.contains(label.left()));
-                seen.insert(label.left());
+                debug_assert!(!seen.contains(label.type_()));
+                seen.insert(label.type_());
             }
 
-            Ok((label.left().clone(), type_.clone()))
+            Ok((label.type_().clone(), type_.clone()))
         })
         .chain(constraints.iter().flat_map(|con| con.vertices().filter(|v| v.is_label())).map(|label| {
             let type_ = type_annotations.vertex_annotations_of(label).unwrap().iter().exactly_one().unwrap();
@@ -279,8 +279,8 @@ pub(crate) fn collect_role_type_bindings(
 
     filter_variants!(Constraint::RoleName : constraints)
         .map(|role_name| {
-            let annotations = type_annotations.vertex_annotations_of(role_name.left()).unwrap();
-            let variable = role_name.left().as_variable().unwrap();
+            let annotations = type_annotations.vertex_annotations_of(role_name.type_()).unwrap();
+            let variable = role_name.type_().as_variable().unwrap();
             let type_ = if annotations.len() == 1 {
                 annotations.iter().find(|_| true).unwrap()
             } else {

--- a/compiler/executable/match_/instructions/mod.rs
+++ b/compiler/executable/match_/instructions/mod.rs
@@ -270,7 +270,7 @@ impl<ID: IrID> ConstraintInstruction<ID> {
 
     pub(crate) fn add_check(&mut self, check: CheckInstruction<ID>) {
         match self {
-            Self::TypeList(_) => unreachable!("free-standing type variable can't have checks"),
+            Self::TypeList(_) => unreachable!("free-standing type variable can't have checks"), // TODO this is untrue
             Self::Sub(inner) => inner.add_check(check),
             Self::SubReverse(inner) => inner.add_check(check),
             Self::Owns(inner) => inner.add_check(check),

--- a/compiler/executable/match_/instructions/mod.rs
+++ b/compiler/executable/match_/instructions/mod.rs
@@ -20,7 +20,7 @@ use itertools::Itertools;
 
 use crate::{
     annotation::type_annotations::TypeAnnotations, executable::match_::planner::match_executable::InstructionAPI,
-    VariablePosition,
+    ExecutorVariable, VariablePosition,
 };
 
 pub mod thing;
@@ -50,7 +50,7 @@ impl VariableMode {
 
 #[derive(Clone, Debug)]
 pub struct VariableModes {
-    modes: HashMap<VariablePosition, VariableMode>,
+    modes: HashMap<ExecutorVariable, VariableMode>,
 }
 
 impl VariableModes {
@@ -59,26 +59,32 @@ impl VariableModes {
     }
 
     pub(crate) fn new_for(
-        instruction: &ConstraintInstruction<VariablePosition>,
+        instruction: &ConstraintInstruction<ExecutorVariable>,
         selected: &[VariablePosition],
-        named: &HashSet<VariablePosition>,
+        named: &HashSet<ExecutorVariable>,
     ) -> Self {
         let mut modes = Self::new();
-        instruction.ids_foreach(|id| {
-            let var_mode =
-                VariableMode::new(instruction.is_input_variable(id), selected.contains(&id), named.contains(&id));
-            modes.insert(id, var_mode)
+        instruction.ids_foreach(|var| {
+            let var_mode = match var {
+                ExecutorVariable::Internal(_) => {
+                    VariableMode::new(instruction.is_input_variable(var), false, named.contains(&var))
+                }
+                ExecutorVariable::RowPosition(pos) => {
+                    VariableMode::new(instruction.is_input_variable(var), selected.contains(&pos), named.contains(&var))
+                }
+            };
+            modes.insert(var, var_mode);
         });
         modes
     }
 
-    fn insert(&mut self, variable_position: VariablePosition, mode: VariableMode) {
+    fn insert(&mut self, variable_position: ExecutorVariable, mode: VariableMode) {
         let existing = self.modes.insert(variable_position, mode);
         debug_assert!(existing.is_none())
     }
 
-    pub fn get(&self, variable_position: VariablePosition) -> Option<&VariableMode> {
-        self.modes.get(&variable_position)
+    pub fn get(&self, variable_position: ExecutorVariable) -> Option<VariableMode> {
+        self.modes.get(&variable_position).copied()
     }
 
     pub fn all_inputs(&self) -> bool {
@@ -347,8 +353,8 @@ pub enum CheckVertex<ID> {
     Parameter(ParameterID),
 }
 
-impl CheckVertex<VariablePosition> {
-    pub(crate) fn resolve(vertex: Vertex<VariablePosition>, type_annotations: &TypeAnnotations) -> Self {
+impl CheckVertex<ExecutorVariable> {
+    pub(crate) fn resolve(vertex: Vertex<ExecutorVariable>, type_annotations: &TypeAnnotations) -> Self {
         match vertex {
             Vertex::Variable(var) => Self::Variable(var),
             Vertex::Parameter(param) => Self::Parameter(param),

--- a/compiler/executable/match_/instructions/mod.rs
+++ b/compiler/executable/match_/instructions/mod.rs
@@ -270,7 +270,7 @@ impl<ID: IrID> ConstraintInstruction<ID> {
 
     pub(crate) fn add_check(&mut self, check: CheckInstruction<ID>) {
         match self {
-            Self::TypeList(_) => unreachable!("free-standing type variable can't have checks"), // TODO this is untrue
+            Self::TypeList(inner) => inner.add_check(check),
             Self::Sub(inner) => inner.add_check(check),
             Self::SubReverse(inner) => inner.add_check(check),
             Self::Owns(inner) => inner.add_check(check),

--- a/compiler/executable/match_/planner/match_executable.rs
+++ b/compiler/executable/match_/planner/match_executable.rs
@@ -101,7 +101,7 @@ impl ExecutionStep {
             ExecutionStep::UnsortedJoin(step) => step.output_width(),
             ExecutionStep::Assignment(step) => step.output_width(),
             ExecutionStep::Check(_) => 0, // FIXME is this correct?
-            ExecutionStep::Disjunction(_) => todo!(),
+            ExecutionStep::Disjunction(step) => step.output_width(),
             ExecutionStep::Negation(_) => 0,
             ExecutionStep::Optional(_) => todo!(),
         }
@@ -243,7 +243,14 @@ impl CheckStep {
 
 #[derive(Clone, Debug)]
 pub struct DisjunctionStep {
-    pub disjunction: Vec<MatchExecutable>,
+    pub branches: Vec<MatchExecutable>,
+    pub output_width: u32,
+}
+
+impl DisjunctionStep {
+    pub fn output_width(&self) -> u32 {
+        self.output_width
+    }
 }
 
 #[derive(Clone, Debug)]

--- a/compiler/executable/match_/planner/match_executable.rs
+++ b/compiler/executable/match_/planner/match_executable.rs
@@ -26,8 +26,6 @@ use crate::{
 #[derive(Clone, Debug)]
 pub struct MatchExecutable {
     pub(crate) steps: Vec<ExecutionStep>,
-    pub(crate) variable_registry: Arc<VariableRegistry>, // TODO: Maybe we never need this?
-
     variable_positions: HashMap<Variable, VariablePosition>,
     variable_positions_index: Vec<Variable>,
 }
@@ -35,11 +33,10 @@ pub struct MatchExecutable {
 impl MatchExecutable {
     pub fn new(
         steps: Vec<ExecutionStep>,
-        variable_registry: Arc<VariableRegistry>,
         variable_positions: HashMap<Variable, VariablePosition>,
         variable_positions_index: Vec<Variable>,
     ) -> Self {
-        Self { steps, variable_registry, variable_positions, variable_positions_index }
+        Self { steps, variable_positions, variable_positions_index }
     }
 
     pub fn steps(&self) -> &[ExecutionStep] {

--- a/compiler/executable/match_/planner/mod.rs
+++ b/compiler/executable/match_/planner/mod.rs
@@ -53,7 +53,7 @@ pub fn compile(
         expressions,
         statistics,
     )
-    .lower(input_variables, variable_registry)
+    .lower(input_variables.keys().copied(), input_variables, variable_registry)
 }
 
 #[derive(Debug, Default)]
@@ -167,7 +167,7 @@ struct MatchExecutableBuilder {
 }
 
 impl MatchExecutableBuilder {
-    fn with_inputs(input_variables: &HashMap<Variable, VariablePosition>) -> Self {
+    fn with_assigned_positions(input_variables: &HashMap<Variable, VariablePosition>) -> Self {
         let index = input_variables.clone();
         let outputs = index.iter().map(|(&var, &pos)| (pos, var)).collect();
         let next_position = input_variables.values().max().map(|&pos| pos.position + 1).unwrap_or_default();

--- a/compiler/executable/match_/planner/mod.rs
+++ b/compiler/executable/match_/planner/mod.rs
@@ -54,7 +54,7 @@ pub fn compile(
         statistics,
     )
     .lower(
-        &block.scope_context().get_variable_scopes().map(|(var, _)| var).collect_vec(),
+        &block.block_context().get_variable_scopes().map(|(var, _)| var).collect_vec(),
         input_variables,
         variable_registry,
     )

--- a/compiler/executable/match_/planner/mod.rs
+++ b/compiler/executable/match_/planner/mod.rs
@@ -132,7 +132,7 @@ impl StepBuilder {
                 ExecutionStep::Intersection(IntersectionStep::new(
                     sort_variable,
                     instructions,
-                    selected_variables.into_iter().map(|var| index[&var]).collect(),
+                    selected_variables.into_iter().filter_map(|var| index.get(&var).copied()).collect(),
                     named_variables,
                     output_width.unwrap(),
                 ))
@@ -140,21 +140,24 @@ impl StepBuilder {
             Self::Check(CheckBuilder { instructions, selected_variables, output_width }) => {
                 ExecutionStep::Check(CheckStep::new(
                     instructions,
-                    selected_variables.into_iter().map(|var| index[&var]).collect(),
+                    selected_variables.into_iter().filter_map(|var| index.get(&var).copied()).collect(),
                     output_width.unwrap(),
                 ))
             }
             Self::Negation(NegationBuilder { negation, selected_variables, output_width }) => {
                 ExecutionStep::Negation(NegationStep::new(
                     negation,
-                    selected_variables.into_iter().map(|var| index[&var]).collect(),
+                    selected_variables.into_iter().filter_map(|var| index.get(&var).copied()).collect(),
                     output_width.unwrap(),
                 ))
             }
             Self::Disjunction(DisjunctionBuilder { branches, selected_variables, output_width }) => {
                 ExecutionStep::Disjunction(DisjunctionStep {
                     branches,
-                    selected_variables: selected_variables.into_iter().map(|var| index[&var]).collect(),
+                    selected_variables: selected_variables
+                        .into_iter()
+                        .filter_map(|var| index.get(&var).copied())
+                        .collect(),
                     output_width: output_width.unwrap(),
                 })
             }

--- a/compiler/executable/match_/planner/mod.rs
+++ b/compiler/executable/match_/planner/mod.rs
@@ -25,7 +25,7 @@ use crate::{
             plan::plan_conjunction,
         },
     },
-    VariablePosition,
+    ExecutorVariable, VariablePosition,
 };
 
 pub mod function_plan;
@@ -44,126 +44,72 @@ pub fn compile(
     let conjunction = block.conjunction();
     let block_context = block.block_context();
     debug_assert!(conjunction.captured_variables(block_context).all(|var| input_variables.contains_key(&var)));
+
+    let assigned_identities =
+        input_variables.iter().map(|(&var, &position)| (var, ExecutorVariable::RowPosition(position))).collect();
+
     plan_conjunction(
         conjunction,
         block_context,
-        input_variables,
+        &input_variables,
         type_annotations,
         &variable_registry,
         expressions,
         statistics,
     )
-    .lower(
-        &block.block_context().get_variable_scopes().map(|(var, _)| var).collect_vec(),
-        input_variables,
-        variable_registry,
-    )
+    .lower(variable_registry.variable_names().keys().copied(), &assigned_identities, &variable_registry)
+    .finish(variable_registry)
 }
 
 #[derive(Debug)]
 struct IntersectionBuilder {
     sort_variable: Option<Variable>,
-    instructions: Vec<ConstraintInstruction<VariablePosition>>,
-    selected_variables: Vec<Variable>,
-    output_width: Option<u32>,
+    instructions: Vec<ConstraintInstruction<ExecutorVariable>>,
 }
 
 impl IntersectionBuilder {
-    fn new(selected_variables: Vec<Variable>) -> Self {
-        Self { sort_variable: None, instructions: Vec::new(), selected_variables, output_width: None }
+    fn new() -> Self {
+        Self { sort_variable: None, instructions: Vec::new() }
     }
 }
 
 #[derive(Debug, Default)]
 struct CheckBuilder {
-    instructions: Vec<CheckInstruction<VariablePosition>>,
-    selected_variables: Vec<Variable>,
-    output_width: Option<u32>,
+    instructions: Vec<CheckInstruction<ExecutorVariable>>,
 }
 
 #[derive(Debug)]
 struct NegationBuilder {
-    negation: MatchExecutable,
-    selected_variables: Vec<Variable>,
-    output_width: Option<u32>,
+    negation: MatchExecutableBuilder,
 }
 
 impl NegationBuilder {
-    fn new(negation: MatchExecutable, selected_variables: Vec<Variable>) -> Self {
-        Self { negation, selected_variables, output_width: None }
+    fn new(negation: MatchExecutableBuilder) -> Self {
+        Self { negation }
     }
 }
 
 #[derive(Debug)]
 struct DisjunctionBuilder {
-    branches: Vec<MatchExecutable>,
-    selected_variables: Vec<Variable>,
-    output_width: Option<u32>,
+    branches: Vec<MatchExecutableBuilder>,
 }
 
 impl DisjunctionBuilder {
-    fn new(branches: Vec<MatchExecutable>, selected_variables: Vec<Variable>) -> Self {
-        Self { branches, selected_variables, output_width: None }
+    fn new(branches: Vec<MatchExecutableBuilder>) -> Self {
+        Self { branches }
     }
 }
 
 #[derive(Debug)]
-enum StepBuilder {
+// TODO rename
+enum StepInstructionsBuilder {
     Intersection(IntersectionBuilder),
     Check(CheckBuilder),
     Negation(NegationBuilder),
     Disjunction(DisjunctionBuilder),
 }
 
-impl StepBuilder {
-    fn finish(
-        self,
-        index: &HashMap<Variable, VariablePosition>,
-        named_variables: &HashSet<VariablePosition>,
-    ) -> ExecutionStep {
-        match self {
-            Self::Intersection(IntersectionBuilder {
-                sort_variable,
-                selected_variables,
-                instructions,
-                output_width,
-            }) => {
-                let sort_variable = sort_variable.map(|var| index[&var]).unwrap();
-                ExecutionStep::Intersection(IntersectionStep::new(
-                    sort_variable,
-                    instructions,
-                    selected_variables.into_iter().filter_map(|var| index.get(&var).copied()).collect(),
-                    named_variables,
-                    output_width.unwrap(),
-                ))
-            }
-            Self::Check(CheckBuilder { instructions, selected_variables, output_width }) => {
-                ExecutionStep::Check(CheckStep::new(
-                    instructions,
-                    selected_variables.into_iter().filter_map(|var| index.get(&var).copied()).collect(),
-                    output_width.unwrap(),
-                ))
-            }
-            Self::Negation(NegationBuilder { negation, selected_variables, output_width }) => {
-                ExecutionStep::Negation(NegationStep::new(
-                    negation,
-                    selected_variables.into_iter().filter_map(|var| index.get(&var).copied()).collect(),
-                    output_width.unwrap(),
-                ))
-            }
-            Self::Disjunction(DisjunctionBuilder { branches, selected_variables, output_width }) => {
-                ExecutionStep::Disjunction(DisjunctionStep {
-                    branches,
-                    selected_variables: selected_variables
-                        .into_iter()
-                        .filter_map(|var| index.get(&var).copied())
-                        .collect(),
-                    output_width: output_width.unwrap(),
-                })
-            }
-        }
-    }
-
+impl StepInstructionsBuilder {
     fn as_intersection(&self) -> Option<&IntersectionBuilder> {
         match self {
             Self::Intersection(v) => Some(v),
@@ -200,106 +146,159 @@ impl StepBuilder {
     fn is_check(&self) -> bool {
         matches!(self, Self::Check(..))
     }
+}
 
-    fn set_output_width(&mut self, position: u32) {
-        match self {
-            | StepBuilder::Intersection(IntersectionBuilder { output_width, .. })
-            | StepBuilder::Disjunction(DisjunctionBuilder { output_width, .. })
-            | StepBuilder::Check(CheckBuilder { output_width, .. })
-            | StepBuilder::Negation(NegationBuilder { output_width, .. }) => *output_width = Some(position),
+impl From<StepInstructionsBuilder> for StepBuilder {
+    fn from(instructions_builder: StepInstructionsBuilder) -> Self {
+        StepBuilder { selected_variables: Vec::new(), builder: instructions_builder }
+    }
+}
+
+#[derive(Debug)]
+struct StepBuilder {
+    selected_variables: Vec<Variable>,
+    builder: StepInstructionsBuilder,
+}
+
+impl StepBuilder {
+    fn finish(
+        self,
+        index: &HashMap<Variable, ExecutorVariable>,
+        named_variables: &HashSet<ExecutorVariable>,
+        variable_registry: Arc<VariableRegistry>,
+    ) -> ExecutionStep {
+        let selected_variables = self
+            .selected_variables
+            .into_iter()
+            .filter_map(|var| index.get(&var).and_then(ExecutorVariable::as_position))
+            .collect_vec();
+        let output_width = selected_variables.iter().map(|position| position.as_usize() as u32 + 1).max().unwrap_or(0);
+
+        match self.builder {
+            StepInstructionsBuilder::Intersection(IntersectionBuilder { sort_variable, instructions }) => {
+                let sort_variable = index[&sort_variable.unwrap()];
+                ExecutionStep::Intersection(IntersectionStep::new(
+                    sort_variable,
+                    instructions,
+                    selected_variables,
+                    named_variables,
+                    output_width,
+                ))
+            }
+            StepInstructionsBuilder::Check(CheckBuilder { instructions }) => {
+                ExecutionStep::Check(CheckStep::new(instructions, selected_variables, output_width))
+            }
+            StepInstructionsBuilder::Negation(NegationBuilder { negation }) => ExecutionStep::Negation(
+                NegationStep::new(negation.finish(variable_registry), selected_variables, output_width),
+            ),
+            StepInstructionsBuilder::Disjunction(DisjunctionBuilder { branches }) => {
+                ExecutionStep::Disjunction(DisjunctionStep::new(
+                    branches.into_iter().map(|builder| builder.finish(variable_registry.clone())).collect(),
+                    selected_variables,
+                    output_width,
+                ))
+            }
         }
     }
 }
 
+#[derive(Debug)]
 struct MatchExecutableBuilder {
-    steps: Vec<StepBuilder>,
-    current: Option<StepBuilder>,
-    outputs: HashMap<VariablePosition, Variable>,
-    producers: HashMap<Variable, (usize, usize)>,
     selected_variables: Vec<Variable>,
-    index: HashMap<Variable, VariablePosition>,
+    current_outputs: Vec<Variable>,
+    produced_so_far: HashSet<Variable>,
+
+    steps: Vec<StepBuilder>,
+    current: Option<Box<StepBuilder>>,
+
+    outputs: HashMap<ExecutorVariable, Variable>,
+    index: HashMap<Variable, ExecutorVariable>,
     next_output: VariablePosition,
 }
 
 impl MatchExecutableBuilder {
-    fn new(input_variables: &HashMap<Variable, VariablePosition>, selected_variables: Vec<Variable>) -> Self {
-        let index = input_variables.clone();
+    fn new(assigned_positions: &HashMap<Variable, ExecutorVariable>, selected_variables: Vec<Variable>) -> Self {
+        let index = assigned_positions.clone();
+        let current_outputs = index.keys().copied().collect();
         let outputs = index.iter().map(|(&var, &pos)| (pos, var)).collect();
-        let next_position = input_variables.values().max().map(|&pos| pos.position + 1).unwrap_or_default();
+        let next_position = assigned_positions
+            .values()
+            .filter_map(ExecutorVariable::as_position)
+            .max()
+            .map(|pos| pos.position + 1)
+            .unwrap_or(0);
         let next_output = VariablePosition::new(next_position);
         Self {
+            selected_variables,
+            current_outputs,
+            produced_so_far: HashSet::new(),
             steps: Vec::new(),
             current: None,
             outputs,
-            producers: HashMap::new(),
-            selected_variables,
             index,
             next_output,
         }
     }
 
-    fn get_step_mut(&mut self, step: usize) -> Option<&mut StepBuilder> {
-        self.steps.get_mut(step).or(self.current.as_mut())
-    }
-
-    fn push_instruction(
-        &mut self,
-        sort_variable: Variable,
-        instruction: ConstraintInstruction<Variable>,
-        outputs: impl IntoIterator<Item = Variable>,
-    ) {
-        if let Some(StepBuilder::Intersection(intersection_builder)) = &self.current {
+    fn push_instruction(&mut self, sort_variable: Variable, instruction: ConstraintInstruction<Variable>) {
+        if let Some(StepBuilder { builder: StepInstructionsBuilder::Intersection(intersection_builder), .. }) =
+            self.current.as_deref()
+        {
             if let Some(current_sort) = intersection_builder.sort_variable {
                 if current_sort != sort_variable || instruction.is_input_variable(current_sort) {
                     self.finish_one();
                 }
             }
         }
-        if self.current.as_ref().is_some_and(|builder| !builder.is_intersection()) {
+
+        if self.current.as_ref().is_some_and(|builder| !builder.builder.is_intersection()) {
             self.finish_one();
         }
 
         if self.current.is_none() {
-            self.current = Some(StepBuilder::Intersection(IntersectionBuilder::new(self.selected_variables.clone())))
+            self.current = Some(Box::new(StepBuilder {
+                selected_variables: self.current_outputs.clone(),
+                builder: StepInstructionsBuilder::Intersection(IntersectionBuilder::new()),
+            }));
         }
 
-        let current = self.current.as_ref().unwrap().as_intersection().unwrap();
+        instruction.new_variables_foreach(|variable| {
+            self.produced_so_far.insert(variable);
+        });
 
-        let producer_index = (self.steps.len(), current.instructions.len());
-        for var in outputs {
-            self.register_output(var);
-            self.producers.entry(var).or_insert(producer_index);
-        }
-
-        let current = self.current.as_mut().unwrap().as_intersection_mut().unwrap();
+        let current = self.current.as_mut().unwrap().builder.as_intersection_mut().unwrap();
         current.sort_variable = Some(sort_variable);
         current.instructions.push(instruction.map(&self.index));
     }
 
-    fn push_check(&mut self, variables: &[Variable], check: CheckInstruction<VariablePosition>) {
-        let producer = variables.iter().map(|var| self.producers.get(var)).max().unwrap_or(None);
-        if let Some(&(program, instruction)) = producer {
-            let Some(intersection) = self.get_step_mut(program).and_then(|step| step.as_intersection_mut()) else {
-                todo!("expected an intersection to be the producer")
-            };
-            intersection.instructions[instruction].add_check(check);
-        } else {
-            // all variables are inputs
-            if self.current.as_ref().is_some_and(|builder| !builder.is_check()) {
-                self.finish_one();
+    fn push_check(&mut self, variables: &[Variable], check: CheckInstruction<ExecutorVariable>) {
+        if let Some(intersection) = self.current.as_mut().and_then(|b| b.builder.as_intersection_mut()) {
+            for instruction in intersection.instructions.iter_mut().rev() {
+                let mut is_producer = false;
+                instruction.new_variables_foreach(|var| is_producer |= variables.contains(&self.outputs[&var]));
+                if is_producer {
+                    instruction.add_check(check);
+                    self.current.as_mut().unwrap().selected_variables = self.current_outputs.clone();
+                    return;
+                }
             }
-            if self.current.is_none() {
-                self.current = Some(StepBuilder::Check(CheckBuilder::default()))
-            }
-            let current = self.current.as_mut().unwrap().as_check_mut().unwrap();
-            current.instructions.push(check);
-        };
-    }
-
-    fn push_step(&mut self, variable_positions: &HashMap<Variable, VariablePosition>, mut step: StepBuilder) {
-        if self.current.is_some() {
+        }
+        // all variables are inputs
+        if self.current.as_ref().is_some_and(|builder| !builder.builder.is_check()) {
             self.finish_one();
         }
+        if self.current.is_none() {
+            self.current = Some(Box::new(StepBuilder {
+                selected_variables: self.current_outputs.clone(),
+                builder: StepInstructionsBuilder::Check(CheckBuilder::default()),
+            }))
+        }
+        let current = self.current.as_mut().unwrap().builder.as_check_mut().unwrap();
+        current.instructions.push(check);
+    }
+
+    fn push_step(&mut self, variable_positions: &HashMap<Variable, ExecutorVariable>, mut step: StepBuilder) {
+        self.finish_one();
         for (&var, &pos) in variable_positions {
             if !self.position_mapping().contains_key(&var) {
                 self.index.insert(var, pos);
@@ -307,30 +306,39 @@ impl MatchExecutableBuilder {
                 self.next_output.position += 1;
             }
         }
-        step.set_output_width(self.next_output.position);
+        self.produced_so_far.extend(self.current_outputs.iter().copied());
+        step.selected_variables = self.current_outputs.clone();
+
         self.steps.push(step);
     }
 
-    fn position_mapping(&self) -> &HashMap<Variable, VariablePosition> {
+    fn position_mapping(&self) -> &HashMap<Variable, ExecutorVariable> {
         &self.index
     }
 
-    fn position(&self, var: Variable) -> VariablePosition {
+    fn position(&self, var: Variable) -> ExecutorVariable {
         self.index[&var]
     }
 
     fn register_output(&mut self, var: Variable) {
         if let hash_map::Entry::Vacant(entry) = self.index.entry(var) {
-            entry.insert(self.next_output);
-            self.outputs.insert(self.next_output, var);
+            entry.insert(ExecutorVariable::RowPosition(self.next_output));
+            self.outputs.insert(ExecutorVariable::RowPosition(self.next_output), var);
+            self.current_outputs.push(var);
             self.next_output.position += 1;
+        }
+    }
+
+    fn remove_output(&mut self, var: Variable) {
+        if !self.selected_variables.contains(&var) {
+            self.current_outputs.retain(|v| v != &var);
         }
     }
 
     fn finish_one(&mut self) {
         if let Some(mut current) = self.current.take() {
-            current.set_output_width(self.next_output.position);
-            self.steps.push(current);
+            current.selected_variables = self.current_outputs.clone();
+            self.steps.push(*current);
         }
     }
 
@@ -341,9 +349,16 @@ impl MatchExecutableBuilder {
             .iter()
             .filter_map(|(var, &pos)| variable_registry.variable_names().get(var).and(Some(pos)))
             .collect();
-        let steps = self.steps.into_iter().map(|builder| builder.finish(&self.index, &named_variables)).collect();
-        let variable_positions_index =
-            self.outputs.iter().sorted_by_key(|(k, _)| k.as_usize()).map(|(_, &v)| v).collect();
-        MatchExecutable::new(steps, self.index.clone(), variable_positions_index)
+        let steps = self
+            .steps
+            .into_iter()
+            .map(|builder| builder.finish(&self.index, &named_variables, variable_registry.clone()))
+            .collect();
+        let variable_positions_index = self.outputs.iter().sorted_by_key(|(&k, _)| k).map(|(_, &v)| v).collect();
+        MatchExecutable::new(
+            steps,
+            self.index.into_iter().filter_map(|(var, id)| Some((var, id.as_position()?))).collect(),
+            variable_positions_index,
+        )
     }
 }

--- a/compiler/executable/match_/planner/mod.rs
+++ b/compiler/executable/match_/planner/mod.rs
@@ -269,11 +269,11 @@ impl MatchExecutableBuilder {
         let named_variables = self
             .index
             .iter()
-            .filter_map(|(var, pos)| variable_registry.variable_names().get(var).map(|_| pos.clone()))
+            .filter_map(|(var, &pos)| variable_registry.variable_names().get(var).and(Some(pos)))
             .collect();
         let steps = self.steps.into_iter().map(|builder| builder.finish(&self.index, &named_variables)).collect();
         let variable_positions_index =
             self.outputs.iter().sorted_by_key(|(k, _)| k.as_usize()).map(|(_, &v)| v).collect();
-        MatchExecutable::new(steps, variable_registry, self.index.clone(), variable_positions_index)
+        MatchExecutable::new(steps, self.index.clone(), variable_positions_index)
     }
 }

--- a/compiler/executable/match_/planner/plan.rs
+++ b/compiler/executable/match_/planner/plan.rs
@@ -102,7 +102,7 @@ fn make_builder<'a>(
                         make_builder(
                             conj,
                             block_context,
-                            input_variables,
+                            variable_positions,
                             type_annotations,
                             variable_registry,
                             _expressions,
@@ -130,7 +130,7 @@ fn make_builder<'a>(
 
     let mut plan_builder = ConjunctionPlanBuilder::new(type_annotations, statistics);
     plan_builder.register_variables(
-        input_variables.keys().copied(),
+        variable_positions.keys().copied(),
         conjunction.captured_variables(block_context),
         conjunction.declared_variables(block_context),
         variable_registry,
@@ -1044,7 +1044,10 @@ pub(super) struct Graph<'a> {
 
 impl fmt::Debug for Graph<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("Graph").field("variable_index", &self.variable_index).field("elements", &self.elements).finish()
+        f.debug_struct(type_name_of_val(self))
+            .field("variable_index", &self.variable_index)
+            .field("elements", &self.elements)
+            .finish()
     }
 }
 

--- a/compiler/executable/match_/planner/plan.rs
+++ b/compiler/executable/match_/planner/plan.rs
@@ -262,6 +262,9 @@ impl<'a> ConjunctionPlanBuilder<'a> {
         }
 
         for variable in shared_variables {
+            if self.graph.variable_index.contains_key(&variable) {
+                continue;
+            }
             self.shared_variables.push(variable);
             let category = variable_registry.get_variable_category(variable).unwrap();
             match category {
@@ -284,6 +287,9 @@ impl<'a> ConjunctionPlanBuilder<'a> {
         }
 
         for variable in local_variables {
+            if self.graph.variable_index.contains_key(&variable) {
+                continue;
+            }
             let category = variable_registry.get_variable_category(variable).unwrap();
             match category {
                 | VariableCategory::Type
@@ -620,11 +626,14 @@ impl ConjunctionPlan<'_> {
                         let has_consumers = || self.consumers_of_var(output).next().is_some();
                         if is_selected() || has_consumers() {
                             match_builder.register_output(self.graph.index_to_variable[&output]);
+                        } else {
+                            match_builder.register_internal(self.graph.index_to_variable[&output]);
                         }
                     }
                     if self.outputs_of_pattern(pattern).next().is_none() {
-                        self.may_make_check_step(&mut match_builder, pattern, &variable_registry);
+                        self.may_make_check_step(&mut match_builder, pattern, variable_registry);
                     }
+                    match_builder.finish_one()
                 }
             }
         }

--- a/compiler/executable/match_/planner/plan.rs
+++ b/compiler/executable/match_/planner/plan.rs
@@ -486,7 +486,7 @@ impl<'a> PlanBuilder<'a> {
             .iter()
             .enumerate()
             .map(|(i, idx)| self.graph.elements[idx].cost(&ordering[..i], &self.graph))
-            .fold(ElementCost::default(), |acc, e| acc.chain(e));
+            .fold(ElementCost::FREE, |acc, e| acc.chain(e));
 
         let Self { shared_variables, graph, type_annotations, statistics: _ } = self;
 

--- a/compiler/executable/match_/planner/vertex/constraint.rs
+++ b/compiler/executable/match_/planner/vertex/constraint.rs
@@ -1,0 +1,431 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+use std::collections::{HashMap, HashSet};
+
+use answer::variable::Variable;
+use concept::thing::statistics::Statistics;
+use ir::pattern::constraint::{Has, Links, SubKind};
+use itertools::Itertools;
+
+use crate::match_::{
+    inference::type_annotations::TypeAnnotations,
+    planner::vertex::{
+        Costed, Direction, ElementCost, Input, PlannerVertex, ADVANCE_ITERATOR_RELATIVE_COST,
+        OPEN_ITERATOR_RELATIVE_COST,
+    },
+};
+
+#[derive(Debug)]
+pub(crate) enum ConstraintVertex {
+    Isa(IsaPlanner),
+    Has(HasPlanner),
+    Links(LinksPlanner),
+
+    Sub(SubPlanner),
+    Owns(OwnsPlanner),
+    Relates(RelatesPlanner),
+    Plays(PlaysPlanner),
+}
+
+impl ConstraintVertex {
+    pub(crate) fn is_valid(&self, _: usize, _: &[usize], _: &HashMap<usize, HashSet<usize>>) -> bool {
+        true // always valid: iterators
+    }
+
+    pub(crate) fn unbound_direction(&self) -> Direction {
+        match self {
+            Self::Isa(inner) => inner.unbound_direction,
+            Self::Has(inner) => inner.unbound_direction,
+            Self::Links(inner) => inner.unbound_direction,
+            Self::Sub(inner) => inner.unbound_direction,
+            Self::Owns(inner) => inner.unbound_direction,
+            Self::Relates(inner) => inner.unbound_direction,
+            Self::Plays(inner) => inner.unbound_direction,
+        }
+    }
+
+    pub(crate) fn variables(&self) -> Box<dyn Iterator<Item = usize> + '_> {
+        match self {
+            Self::Isa(inner) => Box::new(inner.variables()),
+            Self::Has(inner) => Box::new(inner.variables()),
+            Self::Links(inner) => Box::new(inner.variables()),
+
+            Self::Sub(inner) => Box::new(inner.variables()),
+            Self::Owns(inner) => Box::new(inner.variables()),
+            Self::Relates(inner) => Box::new(inner.variables()),
+            Self::Plays(inner) => Box::new(inner.variables()),
+        }
+    }
+}
+
+impl Costed for ConstraintVertex {
+    fn cost(&self, inputs: &[usize], elements: &[PlannerVertex<'_>]) -> ElementCost {
+        match self {
+            Self::Isa(inner) => inner.cost(inputs, elements),
+            Self::Has(inner) => inner.cost(inputs, elements),
+            Self::Links(inner) => inner.cost(inputs, elements),
+
+            Self::Sub(inner) => inner.cost(inputs, elements),
+            Self::Owns(inner) => inner.cost(inputs, elements),
+            Self::Relates(inner) => inner.cost(inputs, elements),
+            Self::Plays(inner) => inner.cost(inputs, elements),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub(crate) struct IsaPlanner {
+    thing: usize,
+    type_: Input,
+    unbound_direction: Direction,
+}
+
+impl IsaPlanner {
+    pub(crate) fn from_constraint(
+        isa: &ir::pattern::constraint::Isa<Variable>,
+        variable_index: &HashMap<Variable, usize>,
+        _type_annotations: &TypeAnnotations,
+        _statistics: &Statistics,
+    ) -> Self {
+        let thing = variable_index[&isa.thing().as_variable().unwrap()];
+        let type_ = Input::from_vertex(isa.type_(), variable_index);
+        Self { thing, type_, unbound_direction: Direction::Reverse }
+    }
+
+    fn variables(&self) -> impl Iterator<Item = usize> {
+        [Some(self.thing), self.type_.as_variable()].into_iter().flatten()
+    }
+}
+
+impl Costed for IsaPlanner {
+    fn cost(&self, inputs: &[usize], elements: &[PlannerVertex<'_>]) -> ElementCost {
+        elements[self.thing].cost(inputs, elements)
+    }
+}
+
+#[derive(Debug)]
+pub(crate) struct HasPlanner {
+    pub owner: usize,
+    pub attribute: usize,
+    expected_size: f64,
+    expected_unbound_size: f64,
+    unbound_direction: Direction,
+}
+
+impl HasPlanner {
+    pub(crate) fn from_constraint(
+        constraint: &Has<Variable>,
+        variable_index: &HashMap<Variable, usize>,
+        type_annotations: &TypeAnnotations,
+        statistics: &Statistics,
+    ) -> Self {
+        let owner = constraint.owner();
+        let attribute = constraint.attribute();
+
+        let owner_types = &**type_annotations.vertex_annotations_of(owner).unwrap();
+        let attribute_types = &**type_annotations.vertex_annotations_of(attribute).unwrap();
+
+        let expected_size = itertools::iproduct!(owner_types, attribute_types)
+            .filter_map(|(owner, attribute)| {
+                statistics.has_attribute_counts.get(&owner.as_object_type())?.get(&attribute.as_attribute_type())
+            })
+            .sum::<u64>() as f64;
+
+        let unbound_forward_size = owner_types
+            .iter()
+            .filter_map(|owner| statistics.has_attribute_counts.get(&owner.as_object_type()))
+            .flat_map(|counts| counts.values())
+            .sum::<u64>() as f64;
+
+        let unbound_backward_size = attribute_types
+            .iter()
+            .filter_map(|attribute| statistics.attribute_owner_counts.get(&attribute.as_attribute_type()))
+            .flat_map(|counts| counts.values())
+            .sum::<u64>() as f64;
+
+        let expected_unbound_size = f64::min(unbound_forward_size, unbound_backward_size);
+        let unbound_direction =
+            if unbound_forward_size <= unbound_backward_size { Direction::Canonical } else { Direction::Reverse };
+
+        Self {
+            owner: variable_index[&owner.as_variable().unwrap()],
+            attribute: variable_index[&attribute.as_variable().unwrap()],
+            expected_size,
+            expected_unbound_size,
+            unbound_direction,
+        }
+    }
+
+    fn variables(&self) -> impl Iterator<Item = usize> {
+        [self.owner, self.attribute].into_iter()
+    }
+}
+
+impl Costed for HasPlanner {
+    fn cost(&self, inputs: &[usize], elements: &[PlannerVertex<'_>]) -> ElementCost {
+        let is_owner_bound = inputs.contains(&self.owner);
+        let is_attribute_bound = inputs.contains(&self.attribute);
+
+        let per_input = OPEN_ITERATOR_RELATIVE_COST;
+
+        let per_output = match (is_owner_bound, is_attribute_bound) {
+            (true, true) => 0.0,
+            (false, false) => ADVANCE_ITERATOR_RELATIVE_COST * self.expected_unbound_size / self.expected_size,
+            (true, false) | (false, true) => ADVANCE_ITERATOR_RELATIVE_COST,
+        };
+
+        let owner_size = elements[self.owner].as_variable().unwrap().expected_size();
+        let attribute_size = elements[self.attribute].as_variable().unwrap().expected_size();
+
+        let branching_factor = match (is_owner_bound, is_attribute_bound) {
+            (true, true) => self.expected_size / owner_size / attribute_size,
+            (true, false) => self.expected_size / owner_size,
+            (false, true) => self.expected_size / attribute_size,
+            (false, false) => self.expected_size,
+        };
+
+        ElementCost { per_input, per_output, branching_factor }
+    }
+}
+
+#[derive(Debug)]
+pub(crate) struct LinksPlanner {
+    pub relation: usize,
+    pub player: usize,
+    pub role: usize,
+    expected_size: f64,
+    expected_unbound_size: f64,
+    unbound_direction: Direction,
+}
+
+impl LinksPlanner {
+    pub(crate) fn from_constraint(
+        links: &Links<Variable>,
+        variable_index: &HashMap<Variable, usize>,
+        type_annotations: &TypeAnnotations,
+        statistics: &Statistics,
+    ) -> Self {
+        let relation = links.relation();
+        let player = links.player();
+        let role = links.role_type();
+
+        let relation_types = &**type_annotations.vertex_annotations_of(relation).unwrap();
+        let player_types = &**type_annotations.vertex_annotations_of(player).unwrap();
+
+        let constraint_types =
+            type_annotations.constraint_annotations_of(links.clone().into()).unwrap().as_left_right_filtered();
+
+        let expected_size = constraint_types
+            .filters_on_left()
+            .iter()
+            .flat_map(|(relation, roles)| {
+                roles.iter().cartesian_product(player_types).flat_map(|(role, player)| {
+                    statistics
+                        .relation_role_player_counts
+                        .get(&relation.as_relation_type())?
+                        .get(&role.as_role_type())?
+                        .get(&player.as_object_type())
+                })
+            })
+            .sum::<u64>() as f64;
+
+        let unbound_forward_size = relation_types
+            .iter()
+            .filter_map(|relation| {
+                Some(statistics.relation_role_player_counts.get(&relation.as_relation_type())?.values().flat_map(
+                    |player_to_count| {
+                        player_types.iter().filter_map(|player| player_to_count.get(&player.as_object_type()))
+                    },
+                ))
+            })
+            .flatten()
+            .sum::<u64>() as f64;
+
+        let unbound_backward_size = player_types
+            .iter()
+            .filter_map(|player| {
+                Some(statistics.player_role_relation_counts.get(&player.as_object_type())?.values().flat_map(
+                    |relation_to_count| {
+                        relation_types.iter().filter_map(|relation| relation_to_count.get(&relation.as_relation_type()))
+                    },
+                ))
+            })
+            .flatten()
+            .sum::<u64>() as f64;
+
+        let expected_unbound_size = f64::min(unbound_forward_size, unbound_backward_size);
+        let unbound_direction =
+            if unbound_forward_size <= unbound_backward_size { Direction::Canonical } else { Direction::Reverse };
+
+        let relation = relation.as_variable().unwrap();
+        let player = player.as_variable().unwrap();
+        let role = role.as_variable().unwrap();
+
+        Self {
+            relation: variable_index[&relation],
+            player: variable_index[&player],
+            role: variable_index[&role],
+            expected_size,
+            expected_unbound_size,
+            unbound_direction,
+        }
+    }
+
+    fn variables(&self) -> impl Iterator<Item = usize> {
+        [self.relation, self.player, self.role].into_iter()
+    }
+}
+
+impl Costed for LinksPlanner {
+    fn cost(&self, inputs: &[usize], elements: &[PlannerVertex<'_>]) -> ElementCost {
+        let is_relation_bound = inputs.contains(&self.relation);
+        let is_player_bound = inputs.contains(&self.player);
+
+        let per_input = OPEN_ITERATOR_RELATIVE_COST;
+
+        let per_output = match (is_relation_bound, is_player_bound) {
+            (true, true) => 0.0,
+            (false, false) => ADVANCE_ITERATOR_RELATIVE_COST * self.expected_unbound_size / self.expected_size,
+            (true, false) | (false, true) => ADVANCE_ITERATOR_RELATIVE_COST,
+        };
+
+        let relation_size = elements[self.relation].as_variable().unwrap().expected_size();
+        let player_size = elements[self.player].as_variable().unwrap().expected_size();
+
+        let branching_factor = match (is_relation_bound, is_player_bound) {
+            (true, true) => self.expected_size / relation_size / player_size,
+            (true, false) => self.expected_size / relation_size,
+            (false, true) => self.expected_size / player_size,
+            (false, false) => self.expected_size,
+        };
+
+        ElementCost { per_input, per_output, branching_factor }
+    }
+}
+
+#[derive(Debug)]
+pub(crate) struct SubPlanner {
+    type_: Input,
+    supertype: Input,
+    kind: SubKind,
+    unbound_direction: Direction,
+}
+
+impl SubPlanner {
+    pub(crate) fn from_constraint(
+        sub: &ir::pattern::constraint::Sub<Variable>,
+        variable_index: &HashMap<Variable, usize>,
+        _type_annotations: &TypeAnnotations,
+    ) -> Self {
+        Self {
+            type_: Input::from_vertex(sub.subtype(), variable_index),
+            supertype: Input::from_vertex(sub.supertype(), variable_index),
+            kind: sub.sub_kind(),
+            unbound_direction: Direction::Reverse,
+        }
+    }
+
+    fn variables(&self) -> impl Iterator<Item = usize> {
+        [self.type_.as_variable(), self.supertype.as_variable()].into_iter().flatten()
+    }
+}
+
+impl Costed for SubPlanner {
+    fn cost(&self, _inputs: &[usize], _elements: &[PlannerVertex<'_>]) -> ElementCost {
+        ElementCost { per_input: 0.0, per_output: 0.0, branching_factor: 1.0 }
+    }
+}
+
+#[derive(Debug)]
+pub(crate) struct OwnsPlanner {
+    owner: Input,
+    attribute: Input,
+    unbound_direction: Direction,
+}
+
+impl OwnsPlanner {
+    pub(crate) fn from_constraint(
+        owns: &ir::pattern::constraint::Owns<Variable>,
+        variable_index: &HashMap<Variable, usize>,
+        _type_annotations: &TypeAnnotations,
+        _statistics: &Statistics,
+    ) -> OwnsPlanner {
+        let owner = Input::from_vertex(owns.owner(), variable_index);
+        let attribute = Input::from_vertex(owns.attribute(), variable_index);
+        Self { owner, attribute, unbound_direction: Direction::Canonical }
+    }
+
+    fn variables(&self) -> impl Iterator<Item = usize> {
+        [self.owner.as_variable(), self.attribute.as_variable()].into_iter().flatten()
+    }
+}
+
+impl Costed for OwnsPlanner {
+    fn cost(&self, _inputs: &[usize], _elements: &[PlannerVertex<'_>]) -> ElementCost {
+        ElementCost { per_input: 0.0, per_output: 0.0, branching_factor: 1.0 }
+    }
+}
+
+#[derive(Debug)]
+pub(crate) struct RelatesPlanner {
+    relation: Input,
+    role_type: Input,
+    unbound_direction: Direction,
+}
+
+impl RelatesPlanner {
+    pub(crate) fn from_constraint(
+        relates: &ir::pattern::constraint::Relates<Variable>,
+        variable_index: &HashMap<Variable, usize>,
+        _type_annotations: &TypeAnnotations,
+        _statistics: &Statistics,
+    ) -> RelatesPlanner {
+        let relation = Input::from_vertex(relates.relation(), variable_index);
+        let role_type = Input::from_vertex(relates.role_type(), variable_index);
+        Self { relation, role_type, unbound_direction: Direction::Canonical }
+    }
+
+    fn variables(&self) -> impl Iterator<Item = usize> {
+        [self.relation.as_variable(), self.role_type.as_variable()].into_iter().flatten()
+    }
+}
+
+impl Costed for RelatesPlanner {
+    fn cost(&self, _inputs: &[usize], _elements: &[PlannerVertex<'_>]) -> ElementCost {
+        ElementCost { per_input: 0.0, per_output: 0.0, branching_factor: 1.0 }
+    }
+}
+
+#[derive(Debug)]
+pub(crate) struct PlaysPlanner {
+    player: Input,
+    role_type: Input,
+    unbound_direction: Direction,
+}
+
+impl PlaysPlanner {
+    pub(crate) fn from_constraint(
+        plays: &ir::pattern::constraint::Plays<Variable>,
+        variable_index: &HashMap<Variable, usize>,
+        _type_annotations: &TypeAnnotations,
+        _statistics: &Statistics,
+    ) -> PlaysPlanner {
+        let player = Input::from_vertex(plays.player(), variable_index);
+        let role_type = Input::from_vertex(plays.role_type(), variable_index);
+        Self { player, role_type, unbound_direction: Direction::Canonical }
+    }
+
+    fn variables(&self) -> impl Iterator<Item = usize> {
+        [self.player.as_variable(), self.role_type.as_variable()].into_iter().flatten()
+    }
+}
+
+impl Costed for PlaysPlanner {
+    fn cost(&self, _inputs: &[usize], _elements: &[PlannerVertex<'_>]) -> ElementCost {
+        ElementCost { per_input: 0.0, per_output: 0.0, branching_factor: 1.0 }
+    }
+}

--- a/compiler/executable/match_/planner/vertex/constraint.rs
+++ b/compiler/executable/match_/planner/vertex/constraint.rs
@@ -4,7 +4,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-use std::{collections::HashMap, iter};
+use std::{collections::HashMap, fmt, iter};
 
 use answer::variable::Variable;
 use concept::thing::statistics::Statistics;
@@ -91,11 +91,17 @@ pub(crate) enum TypeListConstraint<'a> {
     Kind(&'a Kind<Variable>),
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone)]
 pub(crate) struct TypeListPlanner<'a> {
     constraint: TypeListConstraint<'a>,
     var: VariableVertexId,
     num_types: f64,
+}
+
+impl<'a> fmt::Debug for TypeListPlanner<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("TypeListPlanner").field("constraint", &self.constraint).finish()
+    }
 }
 
 impl<'a> TypeListPlanner<'a> {
@@ -153,12 +159,18 @@ impl Costed for TypeListPlanner<'_> {
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone)]
 pub(crate) struct IsaPlanner<'a> {
     isa: &'a Isa<Variable>,
     thing: VariableVertexId,
     type_: Input,
     unbound_direction: Direction,
+}
+
+impl<'a> fmt::Debug for IsaPlanner<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("IsaPlanner").field("isa", self.isa).finish()
+    }
 }
 
 impl<'a> IsaPlanner<'a> {
@@ -188,7 +200,7 @@ impl Costed for IsaPlanner<'_> {
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone)]
 pub(crate) struct HasPlanner<'a> {
     has: &'a Has<Variable>,
     pub owner: VariableVertexId,
@@ -196,6 +208,12 @@ pub(crate) struct HasPlanner<'a> {
     expected_size: f64,
     expected_unbound_size: f64,
     unbound_direction: Direction,
+}
+
+impl<'a> fmt::Debug for HasPlanner<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("HasPlanner").field("has", &self.has).finish()
+    }
 }
 
 impl<'a> HasPlanner<'a> {
@@ -282,7 +300,7 @@ impl Costed for HasPlanner<'_> {
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone)]
 pub(crate) struct LinksPlanner<'a> {
     links: &'a Links<Variable>,
     pub relation: VariableVertexId,
@@ -291,6 +309,12 @@ pub(crate) struct LinksPlanner<'a> {
     expected_size: f64,
     expected_unbound_size: f64,
     unbound_direction: Direction,
+}
+
+impl<'a> fmt::Debug for LinksPlanner<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("LinksPlanner").field("links", &self.links).finish()
+    }
 }
 
 impl<'a> LinksPlanner<'a> {

--- a/compiler/executable/match_/planner/vertex/constraint.rs
+++ b/compiler/executable/match_/planner/vertex/constraint.rs
@@ -19,7 +19,7 @@ use crate::{
     },
 };
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub(crate) enum ConstraintVertex<'a> {
     TypeList(TypeListPlanner<'a>),
 
@@ -84,14 +84,14 @@ impl Costed for ConstraintVertex<'_> {
     }
 }
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub(crate) enum TypeListConstraint<'a> {
     Label(&'a Label<Variable>),
     RoleName(&'a RoleName<Variable>),
     Kind(&'a Kind<Variable>),
 }
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub(crate) struct TypeListPlanner<'a> {
     constraint: TypeListConstraint<'a>,
     var: VariableVertexId,
@@ -153,7 +153,7 @@ impl Costed for TypeListPlanner<'_> {
     }
 }
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub(crate) struct IsaPlanner<'a> {
     isa: &'a Isa<Variable>,
     thing: VariableVertexId,
@@ -188,7 +188,7 @@ impl Costed for IsaPlanner<'_> {
     }
 }
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub(crate) struct HasPlanner<'a> {
     has: &'a Has<Variable>,
     pub owner: VariableVertexId,
@@ -282,7 +282,7 @@ impl Costed for HasPlanner<'_> {
     }
 }
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub(crate) struct LinksPlanner<'a> {
     links: &'a Links<Variable>,
     pub relation: VariableVertexId,
@@ -410,7 +410,7 @@ impl Costed for LinksPlanner<'_> {
     }
 }
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub(crate) struct SubPlanner<'a> {
     sub: &'a Sub<Variable>,
     type_: Input,
@@ -449,7 +449,7 @@ impl Costed for SubPlanner<'_> {
     }
 }
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub(crate) struct OwnsPlanner<'a> {
     owns: &'a Owns<Variable>,
     owner: Input,
@@ -484,7 +484,7 @@ impl Costed for OwnsPlanner<'_> {
     }
 }
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub(crate) struct RelatesPlanner<'a> {
     relates: &'a Relates<Variable>,
     relation: Input,
@@ -519,7 +519,7 @@ impl Costed for RelatesPlanner<'_> {
     }
 }
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub(crate) struct PlaysPlanner<'a> {
     plays: &'a Plays<Variable>,
     player: Input,

--- a/compiler/executable/match_/planner/vertex/mod.rs
+++ b/compiler/executable/match_/planner/vertex/mod.rs
@@ -6,75 +6,57 @@
 
 use std::{
     collections::{HashMap, HashSet},
-    fmt, iter,
+    iter,
 };
 
 use answer::variable::Variable;
 use concept::thing::statistics::Statistics;
-use ir::pattern::{
-    constraint::{Comparison, Has, Links, SubKind},
-    Vertex,
-};
-use itertools::{chain, Itertools};
+use ir::pattern::{constraint::Comparison, Vertex};
+use itertools::chain;
 
-use crate::annotation::type_annotations::TypeAnnotations;
+use crate::{
+    annotation::type_annotations::TypeAnnotations,
+    match_::planner::{
+        plan::PlanBuilder,
+        vertex::{constraint::ConstraintVertex, variable::VariableVertex},
+    },
+};
+
+pub(super) mod constraint;
+pub(super) mod variable;
 
 const OPEN_ITERATOR_RELATIVE_COST: f64 = 5.0;
 const ADVANCE_ITERATOR_RELATIVE_COST: f64 = 1.0;
 
-const REGEX_EXPECTED_CHECKS_PER_MATCH: f64 = 2.0;
-const CONTAINS_EXPECTED_CHECKS_PER_MATCH: f64 = 2.0;
-
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub enum Direction {
-    Canonical,
-    Reverse,
-}
+const _REGEX_EXPECTED_CHECKS_PER_MATCH: f64 = 2.0;
+const _CONTAINS_EXPECTED_CHECKS_PER_MATCH: f64 = 2.0;
 
 // FIXME name
 #[derive(Debug)]
-pub(crate) enum PlannerVertex {
-    Constant,
-    Label(LabelPlanner),
+pub(super) enum PlannerVertex<'a> {
+    Fixed(FixedVertex),
+    Variable(VariableVertex),
+    Constraint(ConstraintVertex),
 
-    Input(InputPlanner),
-
-    Type(TypePlanner),
-    Thing(ThingPlanner),
-    Value(ValuePlanner),
-
-    Isa(IsaPlanner),
-    Has(HasPlanner),
-    Links(LinksPlanner),
-    Expression(()),
     Comparison(ComparisonPlanner),
-
-    Sub(SubPlanner),
-    Owns(OwnsPlanner),
-    Relates(RelatesPlanner),
-    Plays(PlaysPlanner),
+    Expression(()),
 
     FunctionCall(FunctionCallPlanner),
-
-    NestedPattern(NestedPatternPlanner),
+    Negation(NegationPlanner),
+    Disjunction(DisjunctionPlanner<'a>),
 }
 
-impl PlannerVertex {
-    pub(crate) fn is_valid(&self, index: usize, ordered: &[usize], adjacency: &HashMap<usize, HashSet<usize>>) -> bool {
+impl PlannerVertex<'_> {
+    pub(super) fn is_valid(&self, index: usize, ordered: &[usize], adjacency: &HashMap<usize, HashSet<usize>>) -> bool {
         match self {
-            Self::Constant | Self::Label(_) => true, // always valid: comes from query
+            Self::Fixed(_) => true, // always valid: comes from query
+            Self::Variable(inner) => inner.is_valid(index, ordered, adjacency),
+            Self::Constraint(inner) => inner.is_valid(index, ordered, adjacency),
 
-            Self::Input(_) => true, // always valid: comes from the enclosing scope
-
-            Self::Type(_) | Self::Thing(_) | Self::Value(_) => {
-                let adjacent = &adjacency[&index];
-                ordered.iter().any(|x| adjacent.contains(x))
-            } // may be invalid: must be produced
-
-            Self::Expression(_) => todo!("validate expression"), // may be invalid: inputs must be bound
             Self::FunctionCall(FunctionCallPlanner { arguments, .. }) => {
                 arguments.iter().all(|arg| ordered.contains(arg))
             }
+
             Self::Comparison(ComparisonPlanner { lhs, rhs }) => {
                 if let Input::Variable(lhs) = lhs {
                     if !ordered.contains(lhs) {
@@ -89,126 +71,25 @@ impl PlannerVertex {
                 true
             }
 
-            | Self::Isa(_)
-            | Self::Has(_)
-            | Self::Links(_)
-            | Self::Sub(_)
-            | Self::Owns(_)
-            | Self::Relates(_)
-            | Self::Plays(_) => true, // always valid: iterators
+            Self::Expression(_) => todo!("validate expression"), // may be invalid: inputs must be bound
 
-            Self::NestedPattern(inner) => inner.is_valid(index, ordered, adjacency),
-        }
-    }
-
-    fn as_thing(&self) -> Option<&ThingPlanner> {
-        match self {
-            Self::Thing(v) => Some(v),
-            _ => None,
-        }
-    }
-
-    pub(crate) fn unbound_direction(&self) -> Direction {
-        match self {
-            Self::Constant => todo!(),
-            Self::Label(_) => todo!(),
-            Self::Input(_) => unreachable!(),
-            Self::Type(_) => unreachable!(),
-            Self::Thing(_) => unreachable!(),
-            Self::Value(_) => unreachable!(),
-            Self::Isa(inner) => inner.unbound_direction,
-            Self::Has(inner) => inner.unbound_direction,
-            Self::Links(inner) => inner.unbound_direction,
-            Self::Expression(_) => todo!(),
             Self::FunctionCall(_) => todo!(),
-            Self::Comparison(_) => Direction::Canonical,
-            Self::Sub(inner) => inner.unbound_direction,
-            Self::Owns(inner) => inner.unbound_direction,
-            Self::Relates(inner) => inner.unbound_direction,
-            Self::Plays(inner) => inner.unbound_direction,
-            Self::NestedPattern(_) => unreachable!(),
+            Self::Negation(inner) => inner.is_valid(index, ordered, adjacency),
+            Self::Disjunction(inner) => inner.is_valid(index, ordered, adjacency),
         }
     }
 
     pub(crate) fn variables(&self) -> Box<dyn Iterator<Item = usize> + '_> {
         match self {
-            Self::Constant => Box::new(iter::empty()),
-            Self::Label(inner) => Box::new(inner.variables()),
-
-            Self::Input(_inner) => Box::new(iter::empty()),
-            Self::Type(_) | Self::Thing(_) | Self::Value(_) => Box::new(iter::empty()),
-
-            Self::Isa(inner) => Box::new(inner.variables()),
-            Self::Has(inner) => Box::new(inner.variables()),
-            Self::Links(inner) => Box::new(inner.variables()),
-            Self::Expression(_inner) => todo!(),
+            Self::Fixed(inner) => inner.variables(),
+            Self::Variable(_) => Box::new(iter::empty()),
+            Self::Constraint(inner) => inner.variables(),
             Self::FunctionCall(inner) => Box::new(inner.variables()),
             Self::Comparison(inner) => Box::new(inner.variables()),
-
-            Self::Sub(inner) => Box::new(inner.variables()),
-            Self::Owns(inner) => Box::new(inner.variables()),
-            Self::Relates(inner) => Box::new(inner.variables()),
-            Self::Plays(inner) => Box::new(inner.variables()),
-
-            Self::NestedPattern(inner) => Box::new(inner.variables()),
-        }
-    }
-
-    pub(crate) fn add_is(&mut self, other: usize) {
-        match self {
-            Self::Constant => todo!(),
-            Self::Label(_) => todo!(),
-
-            Self::Input(_inner) => todo!(),
-            Self::Type(_inner) => todo!(),
-            Self::Thing(inner) => inner.add_is(other),
-            Self::Value(_inner) => todo!(),
-
-            Self::Isa(_inner) => todo!(),
-            Self::Has(_inner) => todo!(),
-            Self::Links(_inner) => todo!(),
-            Self::FunctionCall(_inner) => todo!(),
             Self::Expression(_inner) => todo!(),
-            Self::Comparison(_inner) => todo!(),
-
-            Self::Sub(_inner) => todo!(),
-            Self::Owns(_inner) => todo!(),
-            Self::Relates(_inner) => todo!(),
-            Self::Plays(_inner) => todo!(),
-
-            Self::NestedPattern(_inner) => unreachable!(),
+            Self::Negation(inner) => Box::new(inner.variables()),
+            Self::Disjunction(inner) => Box::new(inner.variables()),
         }
-    }
-
-    pub(crate) fn add_equal(&mut self, other: Input) {
-        match self {
-            Self::Constant | Self::Input(_) => (),
-            Self::Value(_) => todo!(),
-            Self::Thing(inner) => inner.add_equal(other),
-            _ => todo!(),
-        }
-    }
-
-    pub(crate) fn add_lower_bound(&mut self, other: Input) {
-        match self {
-            Self::Constant | Self::Input(_) => (),
-            Self::Value(_inner) => todo!(),
-            Self::Thing(inner) => inner.add_lower_bound(other),
-            _ => todo!(),
-        }
-    }
-
-    pub(crate) fn add_upper_bound(&mut self, other: Input) {
-        match self {
-            Self::Constant | Self::Input(_) => (),
-            Self::Value(_inner) => todo!(),
-            Self::Thing(inner) => inner.add_upper_bound(other),
-            _ => todo!(),
-        }
-    }
-
-    pub(crate) fn is_variable(&self) -> bool {
-        matches!(self, Self::Thing(_) | Self::Type(_) | Self::Value(_))
     }
 
     /// Returns `true` if the planner vertex is [`Value`].
@@ -216,7 +97,7 @@ impl PlannerVertex {
     /// [`Value`]: PlannerVertex::Value
     #[must_use]
     pub(crate) fn is_value(&self) -> bool {
-        matches!(self, Self::Value(..))
+        self.as_variable().is_some_and(VariableVertex::is_value)
     }
 
     /// Returns `true` if the planner vertex is [`Input`].
@@ -224,7 +105,32 @@ impl PlannerVertex {
     /// [`Input`]: PlannerVertex::Input
     #[must_use]
     pub(crate) fn is_input(&self) -> bool {
-        matches!(self, Self::Input(..))
+        self.as_variable().is_some_and(VariableVertex::is_input)
+    }
+
+    pub(super) fn is_variable(&self) -> bool {
+        matches!(self, Self::Variable(_))
+    }
+
+    pub(super) fn as_variable(&self) -> Option<&VariableVertex> {
+        match self {
+            Self::Variable(v) => Some(v),
+            _ => None,
+        }
+    }
+
+    pub(super) fn as_variable_mut(&mut self) -> Option<&mut VariableVertex> {
+        match self {
+            Self::Variable(v) => Some(v),
+            _ => None,
+        }
+    }
+
+    pub(super) fn as_constraint(&self) -> Option<&ConstraintVertex> {
+        match self {
+            Self::Constraint(v) => Some(v),
+            _ => None,
+        }
     }
 }
 
@@ -255,44 +161,64 @@ impl Default for ElementCost {
     }
 }
 
-pub(crate) trait Costed {
-    fn cost(&self, inputs: &[usize], elements: &[PlannerVertex]) -> ElementCost;
+pub(super) trait Costed {
+    fn cost(&self, inputs: &[usize], elements: &[PlannerVertex<'_>]) -> ElementCost;
 }
 
-impl Costed for PlannerVertex {
-    fn cost(&self, inputs: &[usize], elements: &[PlannerVertex]) -> ElementCost {
+impl Costed for PlannerVertex<'_> {
+    fn cost(&self, inputs: &[usize], elements: &[PlannerVertex<'_>]) -> ElementCost {
         match self {
-            Self::Constant => ElementCost::default(),
-            Self::Label(_) => ElementCost::default(),
-            Self::Input(inner) => inner.cost(inputs, elements),
+            Self::Fixed(inner) => inner.cost(inputs, elements),
+            Self::Variable(inner) => inner.cost(inputs, elements),
+            Self::Constraint(inner) => inner.cost(inputs, elements),
 
-            Self::Type(inner) => inner.cost(inputs, elements),
-            Self::Thing(inner) => inner.cost(inputs, elements),
-            Self::Value(inner) => inner.cost(inputs, elements),
-
-            Self::Isa(inner) => inner.cost(inputs, elements),
-            Self::Has(inner) => inner.cost(inputs, elements),
-            Self::Links(inner) => inner.cost(inputs, elements),
-            Self::Expression(_) => todo!("expression cost"),
             Self::FunctionCall(inner) => inner.cost(inputs, elements),
             Self::Comparison(inner) => inner.cost(inputs, elements),
+            Self::Expression(_) => todo!("expression cost"),
 
-            Self::Sub(inner) => inner.cost(inputs, elements),
-            Self::Owns(inner) => inner.cost(inputs, elements),
-            Self::Relates(inner) => inner.cost(inputs, elements),
-            Self::Plays(inner) => inner.cost(inputs, elements),
+            Self::Negation(inner) => inner.cost(inputs, elements),
+            Self::Disjunction(inner) => inner.cost(inputs, elements),
+        }
+    }
+}
 
-            Self::NestedPattern(inner) => inner.cost(inputs, elements),
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Direction {
+    Canonical,
+    Reverse,
+}
+
+#[derive(Debug)]
+pub(super) enum FixedVertex {
+    Constant,
+    TypeList(TypeListPlanner),
+}
+
+impl FixedVertex {
+    fn variables(&self) -> Box<dyn Iterator<Item = usize>> {
+        match self {
+            FixedVertex::Constant => Box::new(iter::empty()),
+            FixedVertex::TypeList(inner) => Box::new(inner.variables()),
+        }
+    }
+}
+
+impl Costed for FixedVertex {
+    fn cost(&self, inputs: &[usize], elements: &[PlannerVertex<'_>]) -> ElementCost {
+        match self {
+            FixedVertex::Constant => ElementCost::default(),
+            FixedVertex::TypeList(inner) => inner.cost(inputs, elements),
         }
     }
 }
 
 #[derive(Debug)]
-pub(crate) struct LabelPlanner {
+pub(super) struct TypeListPlanner {
     var: usize,
+    num_types: f64,
 }
 
-impl LabelPlanner {
+impl TypeListPlanner {
     fn variables(&self) -> impl Iterator<Item = usize> {
         iter::once(self.var)
     }
@@ -300,214 +226,34 @@ impl LabelPlanner {
     pub(crate) fn from_label_constraint(
         label: &ir::pattern::constraint::Label<Variable>,
         variable_index: &HashMap<Variable, usize>,
-        _type_annotations: &TypeAnnotations,
-    ) -> LabelPlanner {
-        Self { var: variable_index[&label.left().as_variable().unwrap()] }
+        type_annotations: &TypeAnnotations,
+    ) -> TypeListPlanner {
+        let num_types = type_annotations.vertex_annotations_of(label.type_()).map(|annos| annos.len()).unwrap_or(0);
+        Self { var: variable_index[&label.type_().as_variable().unwrap()], num_types: num_types as f64 }
     }
 
     pub(crate) fn from_role_name_constraint(
         role_name: &ir::pattern::constraint::RoleName<Variable>,
         variable_index: &HashMap<Variable, usize>,
-        _type_annotations: &TypeAnnotations,
-    ) -> LabelPlanner {
-        Self { var: variable_index[&role_name.left().as_variable().unwrap()] }
+        type_annotations: &TypeAnnotations,
+    ) -> TypeListPlanner {
+        let num_types = type_annotations.vertex_annotations_of(role_name.type_()).map(|annos| annos.len()).unwrap_or(0);
+        Self { var: variable_index[&role_name.type_().as_variable().unwrap()], num_types: num_types as f64 }
     }
 
     pub(crate) fn from_kind_constraint(
         kind: &ir::pattern::constraint::Kind<Variable>,
         variable_index: &HashMap<Variable, usize>,
-        _type_annotations: &TypeAnnotations,
-    ) -> LabelPlanner {
-        Self { var: variable_index[&kind.type_().as_variable().unwrap()] }
-    }
-}
-
-#[derive(Debug)]
-pub(crate) struct InputPlanner;
-
-impl InputPlanner {
-    pub(crate) fn from_variable(_: Variable, _: &TypeAnnotations) -> Self {
-        Self
-    }
-}
-
-impl Costed for InputPlanner {
-    fn cost(&self, _inputs: &[usize], _elements: &[PlannerVertex]) -> ElementCost {
-        ElementCost::default()
-    }
-}
-
-#[derive(Debug)]
-pub(crate) struct TypePlanner {
-    branching_factor: f64,
-}
-
-impl TypePlanner {
-    pub(crate) fn from_variable(variable: Variable, type_annotations: &TypeAnnotations) -> Self {
-        let num_types = type_annotations.vertex_annotations_of(&Vertex::Variable(variable)).unwrap().len();
-        Self { branching_factor: num_types as f64 }
-    }
-}
-
-impl Costed for TypePlanner {
-    fn cost(&self, _inputs: &[usize], _elements: &[PlannerVertex]) -> ElementCost {
-        ElementCost::free_with_branching(self.branching_factor)
-    }
-}
-
-#[derive(Default)]
-pub(crate) struct ThingPlanner {
-    expected_size: f64,
-
-    bound_exact: HashSet<usize>, // IID or exact Type + Value
-
-    bound_value_equal: HashSet<Input>,
-    bound_value_below: HashSet<Input>,
-    bound_value_above: HashSet<Input>,
-}
-
-impl fmt::Debug for ThingPlanner {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("ThingPlanner").finish()
-    }
-}
-
-impl ThingPlanner {
-    pub(crate) fn from_variable(
-        variable: Variable,
         type_annotations: &TypeAnnotations,
-        statistics: &Statistics,
-    ) -> Self {
-        let expected_size = type_annotations
-            .vertex_annotations_of(&Vertex::Variable(variable))
-            .expect("expected thing variable to have been annotated with types")
-            .iter()
-            .filter_map(|type_| match type_ {
-                answer::Type::Entity(type_) => statistics.entity_counts.get(type_),
-                answer::Type::Relation(type_) => statistics.relation_counts.get(type_),
-                answer::Type::Attribute(type_) => statistics.attribute_counts.get(type_),
-                answer::Type::RoleType(type_) => {
-                    panic!("Found a Thing variable `{variable}` with a Role Type annotation: {type_}")
-                }
-            })
-            .sum::<u64>() as f64;
-        Self { expected_size, ..Default::default() }
-    }
-
-    pub(crate) fn add_is(&mut self, other: usize) {
-        self.bound_exact.insert(other);
-    }
-
-    pub(crate) fn add_equal(&mut self, other: Input) {
-        self.bound_value_equal.insert(other);
-    }
-
-    pub(crate) fn add_lower_bound(&mut self, other: Input) {
-        self.bound_value_below.insert(other);
-    }
-
-    pub(crate) fn add_upper_bound(&mut self, other: Input) {
-        self.bound_value_above.insert(other);
+    ) -> TypeListPlanner {
+        let num_types = type_annotations.vertex_annotations_of(kind.type_()).map(|annos| annos.len()).unwrap_or(0);
+        Self { var: variable_index[&kind.type_().as_variable().unwrap()], num_types: num_types as f64 }
     }
 }
 
-impl Costed for ThingPlanner {
-    fn cost(&self, inputs: &[usize], elements: &[PlannerVertex]) -> ElementCost {
-        let bounds = chain!(&self.bound_value_equal, &self.bound_value_above, &self.bound_value_below).collect_vec();
-        for &i in inputs {
-            if !bounds.contains(&&Input::Variable(i)) {
-                return ElementCost::default();
-            }
-        }
-
-        if self.bound_exact.iter().any(|bound| inputs.contains(bound)) {
-            return ElementCost::default();
-        }
-
-        let per_input = OPEN_ITERATOR_RELATIVE_COST;
-        let per_output = ADVANCE_ITERATOR_RELATIVE_COST;
-        let mut branching_factor = self.expected_size;
-
-        for bound in &self.bound_value_equal {
-            if bound == &Input::Fixed {
-                branching_factor /= self.expected_size;
-            } else if matches!(bound, Input::Variable(var) if inputs.contains(var)) {
-                let b = match &elements[bound.as_variable().unwrap()] {
-                    PlannerVertex::Constant => 1.0,
-                    PlannerVertex::Value(value) => 1.0 / value.expected_size(inputs),
-                    PlannerVertex::Thing(thing) => 1.0 / thing.expected_size,
-                    _ => unreachable!("equality with an edge"),
-                };
-                branching_factor = f64::min(branching_factor, b);
-            }
-        }
-
-        /* TODO
-        let mut is_bounded_below = false;
-        let mut is_bounded_above = false;
-
-        for &input in inputs {
-            if self.bound_exact.contains(&input) {
-                if matches!(elements[input], PlannerVertex::Constant) {
-                } else {
-                    // comes from a previous step, must be in the DB?
-                    // TODO verify this assumption
-                    per_input = 0.0;
-                    per_output = 0.0;
-                    branching_factor /= self.expected_size;
-                }
-            }
-
-            if self.bound_value_equal.contains(&input) {
-                let b = match &elements[input] {
-                    PlannerVertex::Constant => 1.0,
-                    PlannerVertex::Value(value) => 1.0 / value.expected_size(inputs),
-                    PlannerVertex::Thing(thing) => 1.0 / thing.expected_size,
-                    _ => unreachable!("equality with an edge"),
-                };
-                branching_factor = f64::min(branching_factor, b);
-            }
-
-            if self.bound_value_below.contains(&input) {
-                is_bounded_below = true;
-            }
-
-            if self.bound_value_above.contains(&input) {
-                is_bounded_above = true;
-            }
-        }
-
-        if is_bounded_below ^ is_bounded_above {
-            branching_factor /= 2.0
-        } else if is_bounded_below && is_bounded_above {
-            branching_factor /= 3.0
-        }
-        */
-
-        ElementCost { per_input, per_output, branching_factor }
-    }
-}
-
-#[derive(Debug)]
-pub(crate) struct ValuePlanner;
-
-impl ValuePlanner {
-    pub(crate) fn from_variable(_: Variable) -> Self {
-        Self
-    }
-
-    fn expected_size(&self, _inputs: &[usize]) -> f64 {
-        todo!("value planner expected size")
-    }
-}
-
-impl Costed for ValuePlanner {
-    fn cost(&self, inputs: &[usize], _elements: &[PlannerVertex]) -> ElementCost {
-        if inputs.is_empty() {
-            ElementCost { per_input: 0.0, per_output: 0.0, branching_factor: 1.0 }
-        } else {
-            ElementCost { per_input: f64::INFINITY, per_output: 0.0, branching_factor: f64::INFINITY }
-        }
+impl Costed for TypeListPlanner {
+    fn cost(&self, _: &[usize], _: &[PlannerVertex<'_>]) -> ElementCost {
+        ElementCost::free_with_branching(self.num_types)
     }
 }
 
@@ -531,238 +277,6 @@ impl Input {
         } else {
             None
         }
-    }
-}
-
-#[derive(Debug)]
-pub(crate) struct IsaPlanner {
-    thing: usize,
-    type_: Input,
-    unbound_direction: Direction,
-}
-
-impl IsaPlanner {
-    pub(crate) fn from_constraint(
-        isa: &ir::pattern::constraint::Isa<Variable>,
-        variable_index: &HashMap<Variable, usize>,
-        _type_annotations: &TypeAnnotations,
-        _statistics: &Statistics,
-    ) -> Self {
-        let thing = variable_index[&isa.thing().as_variable().unwrap()];
-        let type_ = Input::from_vertex(isa.type_(), variable_index);
-        Self { thing, type_, unbound_direction: Direction::Reverse }
-    }
-
-    fn variables(&self) -> impl Iterator<Item = usize> {
-        [Some(self.thing), self.type_.as_variable()].into_iter().flatten()
-    }
-}
-
-impl Costed for IsaPlanner {
-    fn cost(&self, inputs: &[usize], elements: &[PlannerVertex]) -> ElementCost {
-        elements[self.thing].cost(inputs, elements)
-    }
-}
-
-#[derive(Debug)]
-pub(crate) struct HasPlanner {
-    pub owner: usize,
-    pub attribute: usize,
-    expected_size: f64,
-    expected_unbound_size: f64,
-    unbound_direction: Direction,
-}
-
-impl HasPlanner {
-    pub(crate) fn from_constraint(
-        constraint: &Has<Variable>,
-        variable_index: &HashMap<Variable, usize>,
-        type_annotations: &TypeAnnotations,
-        statistics: &Statistics,
-    ) -> Self {
-        let owner = constraint.owner();
-        let attribute = constraint.attribute();
-
-        let owner_types = &**type_annotations.vertex_annotations_of(owner).unwrap();
-        let attribute_types = &**type_annotations.vertex_annotations_of(attribute).unwrap();
-
-        let expected_size = itertools::iproduct!(owner_types, attribute_types)
-            .filter_map(|(owner, attribute)| {
-                statistics.has_attribute_counts.get(&owner.as_object_type())?.get(&attribute.as_attribute_type())
-            })
-            .sum::<u64>() as f64;
-
-        let unbound_forward_size = owner_types
-            .iter()
-            .filter_map(|owner| statistics.has_attribute_counts.get(&owner.as_object_type()))
-            .flat_map(|counts| counts.values())
-            .sum::<u64>() as f64;
-
-        let unbound_backward_size = attribute_types
-            .iter()
-            .filter_map(|attribute| statistics.attribute_owner_counts.get(&attribute.as_attribute_type()))
-            .flat_map(|counts| counts.values())
-            .sum::<u64>() as f64;
-
-        let expected_unbound_size = f64::min(unbound_forward_size, unbound_backward_size);
-        let unbound_direction =
-            if unbound_forward_size <= unbound_backward_size { Direction::Canonical } else { Direction::Reverse };
-
-        Self {
-            owner: variable_index[&owner.as_variable().unwrap()],
-            attribute: variable_index[&attribute.as_variable().unwrap()],
-            expected_size,
-            expected_unbound_size,
-            unbound_direction,
-        }
-    }
-
-    fn variables(&self) -> impl Iterator<Item = usize> {
-        [self.owner, self.attribute].into_iter()
-    }
-}
-
-impl Costed for HasPlanner {
-    fn cost(&self, inputs: &[usize], elements: &[PlannerVertex]) -> ElementCost {
-        let is_owner_bound = inputs.contains(&self.owner);
-        let is_attribute_bound = inputs.contains(&self.attribute);
-
-        let per_input = OPEN_ITERATOR_RELATIVE_COST;
-
-        let per_output = match (is_owner_bound, is_attribute_bound) {
-            (true, true) => 0.0,
-            (false, false) => ADVANCE_ITERATOR_RELATIVE_COST * self.expected_unbound_size / self.expected_size,
-            (true, false) | (false, true) => ADVANCE_ITERATOR_RELATIVE_COST,
-        };
-
-        let owner_size = if let Some(owner) = elements[self.owner].as_thing() { owner.expected_size } else { 1.0 };
-        let attribute_size =
-            if let Some(attribute) = elements[self.attribute].as_thing() { attribute.expected_size } else { 1.0 };
-
-        let branching_factor = match (is_owner_bound, is_attribute_bound) {
-            (true, true) => self.expected_size / owner_size / attribute_size,
-            (true, false) => self.expected_size / owner_size,
-            (false, true) => self.expected_size / attribute_size,
-            (false, false) => self.expected_size,
-        };
-
-        ElementCost { per_input, per_output, branching_factor }
-    }
-}
-
-#[derive(Debug)]
-pub(crate) struct LinksPlanner {
-    pub relation: usize,
-    pub player: usize,
-    pub role: usize,
-    expected_size: f64,
-    expected_unbound_size: f64,
-    unbound_direction: Direction,
-}
-
-impl LinksPlanner {
-    pub(crate) fn from_constraint(
-        links: &Links<Variable>,
-        variable_index: &HashMap<Variable, usize>,
-        type_annotations: &TypeAnnotations,
-        statistics: &Statistics,
-    ) -> Self {
-        let relation = links.relation();
-        let player = links.player();
-        let role = links.role_type();
-
-        let relation_types = &**type_annotations.vertex_annotations_of(relation).unwrap();
-        let player_types = &**type_annotations.vertex_annotations_of(player).unwrap();
-
-        let constraint_types =
-            type_annotations.constraint_annotations_of(links.clone().into()).unwrap().as_left_right_filtered();
-
-        let expected_size = constraint_types
-            .filters_on_left()
-            .iter()
-            .flat_map(|(relation, roles)| {
-                roles.iter().cartesian_product(player_types).flat_map(|(role, player)| {
-                    statistics
-                        .relation_role_player_counts
-                        .get(&relation.as_relation_type())?
-                        .get(&role.as_role_type())?
-                        .get(&player.as_object_type())
-                })
-            })
-            .sum::<u64>() as f64;
-
-        let unbound_forward_size = relation_types
-            .iter()
-            .filter_map(|relation| {
-                Some(statistics.relation_role_player_counts.get(&relation.as_relation_type())?.values().flat_map(
-                    |player_to_count| {
-                        player_types.iter().filter_map(|player| player_to_count.get(&player.as_object_type()))
-                    },
-                ))
-            })
-            .flatten()
-            .sum::<u64>() as f64;
-
-        let unbound_backward_size = player_types
-            .iter()
-            .filter_map(|player| {
-                Some(statistics.player_role_relation_counts.get(&player.as_object_type())?.values().flat_map(
-                    |relation_to_count| {
-                        relation_types.iter().filter_map(|relation| relation_to_count.get(&relation.as_relation_type()))
-                    },
-                ))
-            })
-            .flatten()
-            .sum::<u64>() as f64;
-
-        let expected_unbound_size = f64::min(unbound_forward_size, unbound_backward_size);
-        let unbound_direction =
-            if unbound_forward_size <= unbound_backward_size { Direction::Canonical } else { Direction::Reverse };
-
-        let relation = relation.as_variable().unwrap();
-        let player = player.as_variable().unwrap();
-        let role = role.as_variable().unwrap();
-
-        Self {
-            relation: variable_index[&relation],
-            player: variable_index[&player],
-            role: variable_index[&role],
-            expected_size,
-            expected_unbound_size,
-            unbound_direction,
-        }
-    }
-
-    fn variables(&self) -> impl Iterator<Item = usize> {
-        [self.relation, self.player, self.role].into_iter()
-    }
-}
-
-impl Costed for LinksPlanner {
-    fn cost(&self, inputs: &[usize], elements: &[PlannerVertex]) -> ElementCost {
-        let is_relation_bound = inputs.contains(&self.relation);
-        let is_player_bound = inputs.contains(&self.player);
-
-        let per_input = OPEN_ITERATOR_RELATIVE_COST;
-
-        let per_output = match (is_relation_bound, is_player_bound) {
-            (true, true) => 0.0,
-            (false, false) => ADVANCE_ITERATOR_RELATIVE_COST * self.expected_unbound_size / self.expected_size,
-            (true, false) | (false, true) => ADVANCE_ITERATOR_RELATIVE_COST,
-        };
-
-        let relation_size =
-            if let Some(relation) = elements[self.relation].as_thing() { relation.expected_size } else { 1.0 };
-        let player_size = if let Some(player) = elements[self.player].as_thing() { player.expected_size } else { 1.0 };
-
-        let branching_factor = match (is_relation_bound, is_player_bound) {
-            (true, true) => self.expected_size / relation_size / player_size,
-            (true, false) => self.expected_size / relation_size,
-            (false, true) => self.expected_size / player_size,
-            (false, false) => self.expected_size,
-        };
-
-        ElementCost { per_input, per_output, branching_factor }
     }
 }
 
@@ -814,142 +328,19 @@ impl ComparisonPlanner {
 }
 
 impl Costed for ComparisonPlanner {
-    fn cost(&self, _: &[usize], _: &[PlannerVertex]) -> ElementCost {
+    fn cost(&self, _: &[usize], _: &[PlannerVertex<'_>]) -> ElementCost {
         ElementCost::default()
     }
 }
 
 #[derive(Debug)]
-pub(crate) struct SubPlanner {
-    type_: Input,
-    supertype: Input,
-    kind: SubKind,
-    unbound_direction: Direction,
-}
-
-impl SubPlanner {
-    pub(crate) fn from_constraint(
-        sub: &ir::pattern::constraint::Sub<Variable>,
-        variable_index: &HashMap<Variable, usize>,
-        _type_annotations: &TypeAnnotations,
-    ) -> Self {
-        Self {
-            type_: Input::from_vertex(sub.subtype(), variable_index),
-            supertype: Input::from_vertex(sub.supertype(), variable_index),
-            kind: sub.sub_kind(),
-            unbound_direction: Direction::Reverse,
-        }
-    }
-
-    fn variables(&self) -> impl Iterator<Item = usize> {
-        [self.type_.as_variable(), self.supertype.as_variable()].into_iter().flatten()
-    }
-}
-
-impl Costed for SubPlanner {
-    fn cost(&self, _inputs: &[usize], _elements: &[PlannerVertex]) -> ElementCost {
-        ElementCost { per_input: 0.0, per_output: 0.0, branching_factor: 1.0 }
-    }
-}
-
-#[derive(Debug)]
-pub(crate) struct OwnsPlanner {
-    owner: Input,
-    attribute: Input,
-    unbound_direction: Direction,
-}
-
-impl OwnsPlanner {
-    pub(crate) fn from_constraint(
-        owns: &ir::pattern::constraint::Owns<Variable>,
-        variable_index: &HashMap<Variable, usize>,
-        _type_annotations: &TypeAnnotations,
-        _statistics: &Statistics,
-    ) -> OwnsPlanner {
-        let owner = Input::from_vertex(owns.owner(), variable_index);
-        let attribute = Input::from_vertex(owns.attribute(), variable_index);
-        Self { owner, attribute, unbound_direction: Direction::Canonical }
-    }
-
-    fn variables(&self) -> impl Iterator<Item = usize> {
-        [self.owner.as_variable(), self.attribute.as_variable()].into_iter().flatten()
-    }
-}
-
-impl Costed for OwnsPlanner {
-    fn cost(&self, _inputs: &[usize], _elements: &[PlannerVertex]) -> ElementCost {
-        ElementCost { per_input: 0.0, per_output: 0.0, branching_factor: 1.0 }
-    }
-}
-
-#[derive(Debug)]
-pub(crate) struct RelatesPlanner {
-    relation: Input,
-    role_type: Input,
-    unbound_direction: Direction,
-}
-
-impl RelatesPlanner {
-    pub(crate) fn from_constraint(
-        relates: &ir::pattern::constraint::Relates<Variable>,
-        variable_index: &HashMap<Variable, usize>,
-        _type_annotations: &TypeAnnotations,
-        _statistics: &Statistics,
-    ) -> RelatesPlanner {
-        let relation = Input::from_vertex(relates.relation(), variable_index);
-        let role_type = Input::from_vertex(relates.role_type(), variable_index);
-        Self { relation, role_type, unbound_direction: Direction::Canonical }
-    }
-
-    fn variables(&self) -> impl Iterator<Item = usize> {
-        [self.relation.as_variable(), self.role_type.as_variable()].into_iter().flatten()
-    }
-}
-
-impl Costed for RelatesPlanner {
-    fn cost(&self, _inputs: &[usize], _elements: &[PlannerVertex]) -> ElementCost {
-        ElementCost { per_input: 0.0, per_output: 0.0, branching_factor: 1.0 }
-    }
-}
-
-#[derive(Debug)]
-pub(crate) struct PlaysPlanner {
-    player: Input,
-    role_type: Input,
-    unbound_direction: Direction,
-}
-
-impl PlaysPlanner {
-    pub(crate) fn from_constraint(
-        plays: &ir::pattern::constraint::Plays<Variable>,
-        variable_index: &HashMap<Variable, usize>,
-        _type_annotations: &TypeAnnotations,
-        _statistics: &Statistics,
-    ) -> PlaysPlanner {
-        let player = Input::from_vertex(plays.player(), variable_index);
-        let role_type = Input::from_vertex(plays.role_type(), variable_index);
-        Self { player, role_type, unbound_direction: Direction::Canonical }
-    }
-
-    fn variables(&self) -> impl Iterator<Item = usize> {
-        [self.player.as_variable(), self.role_type.as_variable()].into_iter().flatten()
-    }
-}
-
-impl Costed for PlaysPlanner {
-    fn cost(&self, _inputs: &[usize], _elements: &[PlannerVertex]) -> ElementCost {
-        ElementCost { per_input: 0.0, per_output: 0.0, branching_factor: 1.0 }
-    }
-}
-
-#[derive(Debug)]
-pub(crate) struct NestedPatternPlanner {
+pub(super) struct NegationPlanner {
     variables: Vec<usize>,
     cost: ElementCost,
 }
 
-impl NestedPatternPlanner {
-    pub(crate) fn new(variables: Vec<usize>, cost: ElementCost) -> Self {
+impl NegationPlanner {
+    pub(super) fn new(variables: Vec<usize>, cost: ElementCost) -> Self {
         Self { variables, cost }
     }
 
@@ -962,9 +353,36 @@ impl NestedPatternPlanner {
     }
 }
 
-impl Costed for NestedPatternPlanner {
-    fn cost(&self, _inputs: &[usize], _elements: &[PlannerVertex]) -> ElementCost {
+impl Costed for NegationPlanner {
+    fn cost(&self, _inputs: &[usize], _elements: &[PlannerVertex<'_>]) -> ElementCost {
         // TODO cost can be adjusted for disjunctions
         self.cost
+    }
+}
+
+#[derive(Debug)]
+pub(super) struct DisjunctionPlanner<'a> {
+    input_variables: Vec<usize>,
+    shared_variables: Vec<usize>,
+    branch_builders: Vec<PlanBuilder<'a>>,
+}
+
+impl<'a> DisjunctionPlanner<'a> {
+    pub(super) fn from_builders(branch_builders: Vec<PlanBuilder<'a>>) -> Self {
+        Self { input_variables: Vec::new(), shared_variables: Vec::new(), branch_builders }
+    }
+
+    fn is_valid(&self, _index: usize, ordered: &[usize], _adjacency: &HashMap<usize, HashSet<usize>>) -> bool {
+        self.variables().all(|var| ordered.contains(&var))
+    }
+
+    fn variables(&self) -> impl Iterator<Item = usize> + '_ {
+        chain!(&self.input_variables, &self.shared_variables).copied()
+    }
+}
+
+impl Costed for DisjunctionPlanner<'_> {
+    fn cost(&self, _inputs: &[usize], _elements: &[PlannerVertex<'_>]) -> ElementCost {
+        todo!()
     }
 }

--- a/compiler/executable/match_/planner/vertex/mod.rs
+++ b/compiler/executable/match_/planner/vertex/mod.rs
@@ -87,14 +87,6 @@ impl PlannerVertex<'_> {
         }
     }
 
-    /// Returns `true` if the planner vertex is [`Value`].
-    ///
-    /// [`Value`]: PlannerVertex::Value
-    #[must_use]
-    pub(crate) fn is_value(&self) -> bool {
-        self.as_variable().is_some_and(VariableVertex::is_value)
-    }
-
     /// Returns `true` if the planner vertex is [`Input`].
     ///
     /// [`Input`]: PlannerVertex::Input
@@ -117,13 +109,6 @@ impl PlannerVertex<'_> {
     pub(super) fn as_variable_mut(&mut self) -> Option<&mut VariableVertex> {
         match self {
             Self::Variable(v) => Some(v),
-            _ => None,
-        }
-    }
-
-    pub(super) fn as_constraint(&self) -> Option<&ConstraintVertex<'_>> {
-        match self {
-            Self::Constraint(v) => Some(v),
             _ => None,
         }
     }

--- a/compiler/executable/match_/planner/vertex/variable.rs
+++ b/compiler/executable/match_/planner/vertex/variable.rs
@@ -148,7 +148,7 @@ impl InputPlanner {
 
 impl Costed for InputPlanner {
     fn cost(&self, _: &[VertexId], _: &Graph<'_>) -> ElementCost {
-        ElementCost::default()
+        ElementCost::FREE
     }
 }
 
@@ -165,7 +165,7 @@ impl SharedPlanner {
 
 impl Costed for SharedPlanner {
     fn cost(&self, _: &[VertexId], _: &Graph<'_>) -> ElementCost {
-        ElementCost::default()
+        ElementCost::FREE
     }
 }
 
@@ -258,12 +258,12 @@ impl Costed for ThingPlanner {
         for &i in inputs {
             let VertexId::Variable(i) = i else { continue };
             if !bounds.contains(&&Input::Variable(i)) {
-                return ElementCost::default();
+                return ElementCost::FREE;
             }
         }
 
         if self.bound_exact.iter().any(|&bound| inputs.contains(&VertexId::Variable(bound))) {
-            return ElementCost::default();
+            return ElementCost::FREE;
         }
 
         let per_input = OPEN_ITERATOR_RELATIVE_COST;

--- a/compiler/executable/match_/planner/vertex/variable.rs
+++ b/compiler/executable/match_/planner/vertex/variable.rs
@@ -1,0 +1,329 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+use std::{
+    collections::{HashMap, HashSet},
+    fmt,
+};
+
+use answer::variable::Variable;
+use concept::thing::statistics::Statistics;
+use ir::pattern::Vertex;
+use itertools::{chain, Itertools};
+
+use crate::match_::{
+    inference::type_annotations::TypeAnnotations,
+    planner::vertex::{
+        Costed, ElementCost, Input, PlannerVertex, ADVANCE_ITERATOR_RELATIVE_COST, OPEN_ITERATOR_RELATIVE_COST,
+    },
+};
+
+#[derive(Debug)]
+pub(crate) enum VariableVertex {
+    Input(InputPlanner),
+    Shared(SharedPlanner),
+
+    Type(TypePlanner),
+    Thing(ThingPlanner),
+    Value(ValuePlanner),
+}
+
+impl VariableVertex {
+    pub(super) fn is_valid(&self, index: usize, ordered: &[usize], adjacency: &HashMap<usize, HashSet<usize>>) -> bool {
+        match self {
+            Self::Input(_) => true, // always valid: comes from the enclosing scope
+            Self::Shared(_) => todo!(),
+
+            Self::Type(_) | Self::Thing(_) | Self::Value(_) => {
+                let adjacent = &adjacency[&index];
+                ordered.iter().any(|x| adjacent.contains(x))
+            } // may be invalid: must be produced
+        }
+    }
+
+    pub(crate) fn expected_size(&self) -> f64 {
+        match self {
+            Self::Input(_) => 1.0,
+            Self::Shared(_) => todo!(),
+            Self::Type(inner) => inner.expected_size,
+            Self::Thing(inner) => inner.expected_size,
+            Self::Value(_) => 1.0,
+        }
+    }
+
+    pub(crate) fn add_is(&mut self, other: usize) {
+        match self {
+            Self::Input(_inner) => todo!(),
+            Self::Shared(_) => todo!(),
+            Self::Type(_inner) => todo!(),
+            Self::Thing(inner) => inner.add_is(other),
+            Self::Value(_inner) => todo!(),
+        }
+    }
+
+    pub(crate) fn add_equal(&mut self, other: Input) {
+        match self {
+            Self::Input(_) => (),
+            Self::Shared(_) => todo!(),
+            Self::Value(_) => todo!(),
+            Self::Thing(inner) => inner.add_equal(other),
+            Self::Type(_) => unreachable!(),
+        }
+    }
+
+    pub(crate) fn add_lower_bound(&mut self, other: Input) {
+        match self {
+            Self::Input(_) => (),
+            Self::Shared(_) => todo!(),
+            Self::Value(_inner) => todo!(),
+            Self::Thing(inner) => inner.add_lower_bound(other),
+            Self::Type(_) => unreachable!(),
+        }
+    }
+
+    pub(crate) fn add_upper_bound(&mut self, other: Input) {
+        match self {
+            Self::Input(_) => (),
+            Self::Shared(_) => todo!(),
+            Self::Value(_inner) => todo!(),
+            Self::Thing(inner) => inner.add_upper_bound(other),
+            Self::Type(_) => unreachable!(),
+        }
+    }
+
+    /// Returns `true` if the variable vertex is [`Input`].
+    ///
+    /// [`Input`]: VariableVertex::Input
+    #[must_use]
+    pub(crate) fn is_input(&self) -> bool {
+        matches!(self, Self::Input(..))
+    }
+
+    /// Returns `true` if the variable vertex is [`Value`].
+    ///
+    /// [`Value`]: VariableVertex::Value
+    #[must_use]
+    pub(crate) fn is_value(&self) -> bool {
+        matches!(self, Self::Value(..))
+    }
+}
+
+impl Costed for VariableVertex {
+    fn cost(&self, inputs: &[usize], elements: &[PlannerVertex<'_>]) -> ElementCost {
+        match self {
+            Self::Input(inner) => inner.cost(inputs, elements),
+            Self::Shared(inner) => inner.cost(inputs, elements),
+
+            Self::Type(inner) => inner.cost(inputs, elements),
+            Self::Thing(inner) => inner.cost(inputs, elements),
+            Self::Value(inner) => inner.cost(inputs, elements),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub(crate) struct InputPlanner;
+
+impl InputPlanner {
+    pub(crate) fn from_variable(_: Variable, _: &TypeAnnotations) -> Self {
+        Self
+    }
+}
+
+impl Costed for InputPlanner {
+    fn cost(&self, _inputs: &[usize], _elements: &[PlannerVertex<'_>]) -> ElementCost {
+        ElementCost::default()
+    }
+}
+
+#[derive(Debug)]
+pub(crate) struct SharedPlanner;
+
+impl SharedPlanner {
+    pub(crate) fn from_variable(_: Variable, _: &TypeAnnotations) -> Self {
+        todo!()
+    }
+}
+
+impl Costed for SharedPlanner {
+    fn cost(&self, _inputs: &[usize], _elements: &[PlannerVertex<'_>]) -> ElementCost {
+        ElementCost::default()
+    }
+}
+
+#[derive(Debug)]
+pub(crate) struct TypePlanner {
+    expected_size: f64,
+}
+
+impl TypePlanner {
+    pub(crate) fn from_variable(variable: Variable, type_annotations: &TypeAnnotations) -> Self {
+        let num_types = type_annotations.vertex_annotations_of(&Vertex::Variable(variable)).unwrap().len();
+        Self { expected_size: num_types as f64 }
+    }
+}
+
+impl Costed for TypePlanner {
+    fn cost(&self, _inputs: &[usize], _elements: &[PlannerVertex<'_>]) -> ElementCost {
+        ElementCost::free_with_branching(self.expected_size)
+    }
+}
+
+#[derive(Default)]
+pub(crate) struct ThingPlanner {
+    expected_size: f64,
+
+    bound_exact: HashSet<usize>, // IID or exact Type + Value
+
+    bound_value_equal: HashSet<Input>,
+    bound_value_below: HashSet<Input>,
+    bound_value_above: HashSet<Input>,
+}
+
+impl fmt::Debug for ThingPlanner {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ThingPlanner").finish()
+    }
+}
+
+impl ThingPlanner {
+    pub(crate) fn from_variable(
+        variable: Variable,
+        type_annotations: &TypeAnnotations,
+        statistics: &Statistics,
+    ) -> Self {
+        let expected_size = type_annotations
+            .vertex_annotations_of(&Vertex::Variable(variable))
+            .expect("expected thing variable to have been annotated with types")
+            .iter()
+            .filter_map(|type_| match type_ {
+                answer::Type::Entity(type_) => statistics.entity_counts.get(type_),
+                answer::Type::Relation(type_) => statistics.relation_counts.get(type_),
+                answer::Type::Attribute(type_) => statistics.attribute_counts.get(type_),
+                answer::Type::RoleType(type_) => {
+                    panic!("Found a Thing variable `{variable}` with a Role Type annotation: {type_}")
+                }
+            })
+            .sum::<u64>() as f64;
+        Self { expected_size, ..Default::default() }
+    }
+
+    pub(crate) fn add_is(&mut self, other: usize) {
+        self.bound_exact.insert(other);
+    }
+
+    pub(crate) fn add_equal(&mut self, other: Input) {
+        self.bound_value_equal.insert(other);
+    }
+
+    pub(crate) fn add_lower_bound(&mut self, other: Input) {
+        self.bound_value_below.insert(other);
+    }
+
+    pub(crate) fn add_upper_bound(&mut self, other: Input) {
+        self.bound_value_above.insert(other);
+    }
+}
+
+impl Costed for ThingPlanner {
+    fn cost(&self, inputs: &[usize], elements: &[PlannerVertex<'_>]) -> ElementCost {
+        let bounds = chain!(&self.bound_value_equal, &self.bound_value_above, &self.bound_value_below).collect_vec();
+        for &i in inputs {
+            if !bounds.contains(&&Input::Variable(i)) {
+                return ElementCost::default();
+            }
+        }
+
+        if self.bound_exact.iter().any(|bound| inputs.contains(bound)) {
+            return ElementCost::default();
+        }
+
+        let per_input = OPEN_ITERATOR_RELATIVE_COST;
+        let per_output = ADVANCE_ITERATOR_RELATIVE_COST;
+        let mut branching_factor = self.expected_size;
+
+        for bound in &self.bound_value_equal {
+            if bound == &Input::Fixed {
+                branching_factor /= self.expected_size;
+            } else if matches!(bound, Input::Variable(var) if inputs.contains(var)) {
+                let b = match &elements[bound.as_variable().unwrap()] {
+                    PlannerVertex::Fixed(_) => 1.0,
+                    PlannerVertex::Variable(VariableVertex::Value(value)) => 1.0 / value.expected_size(inputs),
+                    PlannerVertex::Variable(VariableVertex::Thing(thing)) => 1.0 / thing.expected_size,
+                    _ => unreachable!("equality with an edge"),
+                };
+                branching_factor = f64::min(branching_factor, b);
+            }
+        }
+
+        /* TODO
+        let mut is_bounded_below = false;
+        let mut is_bounded_above = false;
+
+        for &input in inputs {
+            if self.bound_exact.contains(&input) {
+                if matches!(elements[input], PlannerVertex::Constant) {
+                } else {
+                    // comes from a previous step, must be in the DB?
+                    // TODO verify this assumption
+                    per_input = 0.0;
+                    per_output = 0.0;
+                    branching_factor /= self.expected_size;
+                }
+            }
+
+            if self.bound_value_equal.contains(&input) {
+                let b = match &elements[input] {
+                    PlannerVertex::Constant => 1.0,
+                    PlannerVertex::Value(value) => 1.0 / value.expected_size(inputs),
+                    PlannerVertex::Thing(thing) => 1.0 / thing.expected_size,
+                    _ => unreachable!("equality with an edge"),
+                };
+                branching_factor = f64::min(branching_factor, b);
+            }
+
+            if self.bound_value_below.contains(&input) {
+                is_bounded_below = true;
+            }
+
+            if self.bound_value_above.contains(&input) {
+                is_bounded_above = true;
+            }
+        }
+
+        if is_bounded_below ^ is_bounded_above {
+            branching_factor /= 2.0
+        } else if is_bounded_below && is_bounded_above {
+            branching_factor /= 3.0
+        }
+        */
+
+        ElementCost { per_input, per_output, branching_factor }
+    }
+}
+
+#[derive(Debug)]
+pub(crate) struct ValuePlanner;
+
+impl ValuePlanner {
+    pub(crate) fn from_variable(_: Variable) -> Self {
+        Self
+    }
+
+    fn expected_size(&self, _inputs: &[usize]) -> f64 {
+        todo!("value planner expected size")
+    }
+}
+
+impl Costed for ValuePlanner {
+    fn cost(&self, inputs: &[usize], _elements: &[PlannerVertex<'_>]) -> ElementCost {
+        if inputs.is_empty() {
+            ElementCost { per_input: 0.0, per_output: 0.0, branching_factor: 1.0 }
+        } else {
+            ElementCost { per_input: f64::INFINITY, per_output: 0.0, branching_factor: f64::INFINITY }
+        }
+    }
+}

--- a/compiler/executable/pipeline.rs
+++ b/compiler/executable/pipeline.rs
@@ -158,10 +158,9 @@ pub(crate) fn compile_pipeline_stages(
 ) -> Result<(HashMap<Variable, VariablePosition>, Vec<ExecutableStage>), ExecutableCompilationError> {
     let mut executable_stages = Vec::with_capacity(annotated_stages.len());
     let input_variable_positions =
-        input_variables.enumerate().map(|(i, var)| (var, VariablePosition { position: i as u32 })).collect();
+        input_variables.enumerate().map(|(i, var)| (var, VariablePosition::new(i as u32))).collect();
     for stage in annotated_stages {
-        let executable_stage = match executable_stages.last().map(|stage: &ExecutableStage| stage.output_row_mapping())
-        {
+        let executable_stage = match executable_stages.last().map(|stage| stage.output_row_mapping()) {
             Some(row_mapping) => compile_stage(statistics, variable_registry.clone(), functions, &row_mapping, stage)?,
             None => compile_stage(statistics, variable_registry.clone(), functions, &input_variable_positions, stage)?,
         };
@@ -263,7 +262,7 @@ fn compile_stage(
                 reductions.push(reducer_on_position);
             }
             Ok(ExecutableStage::Reduce(Arc::new(ReduceExecutable {
-                reductions: reductions,
+                reductions,
                 input_group_positions,
                 output_row_mapping,
             })))

--- a/compiler/executable/pipeline.rs
+++ b/compiler/executable/pipeline.rs
@@ -156,7 +156,7 @@ pub(crate) fn compile_pipeline_stages(
     annotated_stages: Vec<AnnotatedStage>,
     input_variables: impl Iterator<Item = Variable>,
 ) -> Result<(HashMap<Variable, VariablePosition>, Vec<ExecutableStage>), ExecutableCompilationError> {
-    let mut executable_stages = Vec::with_capacity(annotated_stages.len());
+    let mut executable_stages: Vec<ExecutableStage> = Vec::with_capacity(annotated_stages.len());
     let input_variable_positions =
         input_variables.enumerate().map(|(i, var)| (var, VariablePosition::new(i as u32))).collect();
     for stage in annotated_stages {

--- a/compiler/executable/reduce.rs
+++ b/compiler/executable/reduce.rs
@@ -8,7 +8,7 @@ use std::collections::HashMap;
 
 use answer::variable::Variable;
 use encoding::value::value_type::ValueType;
-use ir::pattern::{IrID, Vertex};
+use ir::pattern::IrID;
 
 use crate::VariablePosition;
 

--- a/compiler/lib.rs
+++ b/compiler/lib.rs
@@ -9,7 +9,7 @@
 
 use std::fmt;
 
-use answer::variable::{self, Variable};
+use answer::variable::Variable;
 use ir::pattern::IrID;
 
 pub mod annotation;

--- a/compiler/lib.rs
+++ b/compiler/lib.rs
@@ -7,8 +7,9 @@
 #![deny(elided_lifetimes_in_paths)]
 #![allow(clippy::result_large_err)]
 
-use std::fmt::{Display, Formatter};
+use std::fmt;
 
+use answer::variable::{self, Variable};
 use ir::pattern::IrID;
 
 pub mod annotation;
@@ -22,7 +23,61 @@ macro_rules! filter_variants {
 }
 pub(crate) use filter_variants;
 
-#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash, Ord, PartialOrd)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash, PartialOrd, Ord)]
+pub enum ExecutorVariable {
+    RowPosition(VariablePosition),
+    Internal(Variable),
+}
+
+impl ExecutorVariable {
+    pub fn new_position(position: u32) -> Self {
+        Self::RowPosition(VariablePosition { position })
+    }
+
+    pub fn new_internal(variable: Variable) -> Self {
+        Self::Internal(variable)
+    }
+
+    /// Returns `true` if the executor variable is [`Output`].
+    ///
+    /// [`Output`]: ExecutorVariable::Output
+    #[must_use]
+    pub fn is_output(&self) -> bool {
+        matches!(self, Self::RowPosition(..))
+    }
+
+    /// Returns `true` if the executor variable is [`Internal`].
+    ///
+    /// [`Internal`]: ExecutorVariable::Internal
+    #[must_use]
+    pub fn is_internal(&self) -> bool {
+        matches!(self, Self::Internal(..))
+    }
+
+    pub fn as_position(&self) -> Option<VariablePosition> {
+        match *self {
+            Self::RowPosition(v) => Some(v),
+            _ => None,
+        }
+    }
+
+    pub fn as_internal(&self) -> Option<Variable> {
+        match *self {
+            Self::Internal(v) => Some(v),
+            _ => None,
+        }
+    }
+}
+
+impl fmt::Display for ExecutorVariable {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Debug::fmt(self, f)
+    }
+}
+
+impl IrID for ExecutorVariable {}
+
+#[derive(Copy, Clone, Eq, PartialEq, Hash, Ord, PartialOrd)]
 pub struct VariablePosition {
     position: u32,
 }
@@ -37,9 +92,15 @@ impl VariablePosition {
     }
 }
 
-impl Display for VariablePosition {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+impl fmt::Debug for VariablePosition {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "P_{}", self.position)
+    }
+}
+
+impl fmt::Display for VariablePosition {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Debug::fmt(self, f)
     }
 }
 

--- a/concept/thing/statistics.rs
+++ b/concept/thing/statistics.rs
@@ -6,7 +6,6 @@
 
 use std::{
     collections::{BTreeMap, HashMap},
-    error::Error,
     ops::Bound,
 };
 

--- a/concept/thing/thing_manager/validation/mod.rs
+++ b/concept/thing/thing_manager/validation/mod.rs
@@ -4,8 +4,6 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-use std::error::Error;
-
 use bytes::util::HexBytesFormatter;
 use encoding::value::{label::Label, value::Value, value_type::ValueType};
 use error::typedb_error;

--- a/concept/thing/thing_manager/validation/operation_time_validation.rs
+++ b/concept/thing/thing_manager/validation/operation_time_validation.rs
@@ -7,7 +7,7 @@
 use std::collections::{BTreeMap, HashMap, HashSet};
 
 use bytes::util::HexBytesFormatter;
-use encoding::value::{value::Value, value_type::ValueType, ValueEncodable};
+use encoding::value::{value::Value, value_type::ValueType};
 use lending_iterator::LendingIterator;
 use storage::snapshot::ReadableSnapshot;
 
@@ -28,7 +28,7 @@ use crate::{
     },
     type_::{
         attribute_type::AttributeType, constraint::Constraint, entity_type::EntityType, object_type::ObjectType,
-        relation_type::RelationType, role_type::RoleType, Capability, ObjectTypeAPI, OwnerAPI, PlayerAPI, TypeAPI,
+        relation_type::RelationType, role_type::RoleType, ObjectTypeAPI, OwnerAPI, PlayerAPI, TypeAPI,
     },
 };
 

--- a/concept/type_/type_manager.rs
+++ b/concept/type_/type_manager.rs
@@ -19,7 +19,6 @@ use encoding::{
     },
     value::{label::Label, value_type::ValueType},
 };
-use itertools::Itertools;
 use primitive::maybe_owns::MaybeOwns;
 use resource::constants::encoding::StructFieldIDUInt;
 use storage::snapshot::{ReadableSnapshot, WritableSnapshot};

--- a/concept/type_/type_manager/validation/mod.rs
+++ b/concept/type_/type_manager/validation/mod.rs
@@ -4,8 +4,6 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-use std::error::Error;
-
 use encoding::{
     graph::type_::{CapabilityKind, Kind},
     value::{label::Label, value_type::ValueType},

--- a/concept/type_/type_manager/validation/operation_time_validation.rs
+++ b/concept/type_/type_manager/validation/operation_time_validation.rs
@@ -4,17 +4,14 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-use std::{
-    collections::{HashMap, HashSet, VecDeque},
-    hash::Hash,
-};
+use std::collections::{HashMap, HashSet, VecDeque};
 
 use encoding::{
     graph::{
         definition::definition_key::DefinitionKey,
         type_::{CapabilityKind, Kind},
     },
-    value::{label::Label, value_type::ValueType, ValueEncodable},
+    value::{label::Label, value_type::ValueType},
 };
 use itertools::Itertools;
 use lending_iterator::LendingIterator;

--- a/encoding/value/timezone.rs
+++ b/encoding/value/timezone.rs
@@ -41,12 +41,6 @@ pub enum TimeZone {
     Fixed(FixedOffset),
 }
 
-impl Default for TimeZone {
-    fn default() -> Self {
-        Self::IANA(Tz::default())
-    }
-}
-
 impl TimeZone {
     pub(crate) fn encode(self) -> [u8; 4] {
         match self {

--- a/executor/batch.rs
+++ b/executor/batch.rs
@@ -48,6 +48,10 @@ impl FixedBatch {
         self.entries
     }
 
+    pub(crate) fn is_empty(&self) -> bool {
+        self.multiplicities[..self.entries as usize].iter().all(|&mul| mul == 0)
+    }
+
     pub(crate) fn is_full(&self) -> bool {
         (self.entries * self.width) as usize == self.data.len()
     }

--- a/executor/instruction/constant_executor.rs
+++ b/executor/instruction/constant_executor.rs
@@ -5,7 +5,7 @@
  */
 
 use answer::variable_value::VariableValue;
-use compiler::executable::match_::instructions::thing::ConstantInstruction;
+use compiler::{executable::match_::instructions::thing::ConstantInstruction, ExecutorVariable};
 use concept::error::ConceptReadError;
 use storage::snapshot::ReadableSnapshot;
 
@@ -17,7 +17,6 @@ use crate::{
     },
     pipeline::stage::ExecutionContext,
     row::MaybeOwnedRow,
-    VariablePosition,
 };
 
 pub(crate) struct ConstantExecutor {
@@ -30,9 +29,9 @@ pub(crate) type ConstantValueIterator = lending_iterator::Once<TupleResult<'stat
 
 impl ConstantExecutor {
     pub(crate) fn new(
-        constant: ConstantInstruction<VariablePosition>,
+        constant: ConstantInstruction<ExecutorVariable>,
         variable_modes: VariableModes,
-        _sort_by: Option<VariablePosition>,
+        _sort_by: Option<ExecutorVariable>,
     ) -> Self {
         debug_assert!(!variable_modes.all_inputs());
         let ConstantInstruction { var, value, .. } = constant;

--- a/executor/instruction/function_call_binding_executor.rs
+++ b/executor/instruction/function_call_binding_executor.rs
@@ -4,10 +4,9 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
+use compiler::ExecutorVariable;
 use ir::pattern::constraint::FunctionCallBinding;
 
-use crate::VariablePosition;
-
 pub(crate) struct FunctionCallBindingIteratorExecutor {
-    function_call_binding: FunctionCallBinding<VariablePosition>,
+    function_call_binding: FunctionCallBinding<ExecutorVariable>,
 }

--- a/executor/instruction/owns_executor.rs
+++ b/executor/instruction/owns_executor.rs
@@ -7,13 +7,12 @@
 use std::{
     collections::{BTreeMap, BTreeSet, HashSet},
     iter,
-    marker::PhantomData,
     sync::Arc,
     vec,
 };
 
 use answer::{variable_value::VariableValue, Type};
-use compiler::executable::match_::instructions::type_::OwnsInstruction;
+use compiler::{executable::match_::instructions::type_::OwnsInstruction, ExecutorVariable};
 use concept::{
     error::ConceptReadError,
     type_::{owns::Owns, OwnerAPI},
@@ -33,11 +32,10 @@ use crate::{
     },
     pipeline::stage::ExecutionContext,
     row::MaybeOwnedRow,
-    VariablePosition,
 };
 
 pub(crate) struct OwnsExecutor {
-    owns: ir::pattern::constraint::Owns<VariablePosition>,
+    owns: ir::pattern::constraint::Owns<ExecutorVariable>,
     iterate_mode: BinaryIterateMode,
     variable_modes: VariableModes,
     tuple_positions: TuplePositions,
@@ -76,9 +74,9 @@ pub(super) const EXTRACT_ATTRIBUTE: OwnsVariableValueExtractor =
 
 impl OwnsExecutor {
     pub(crate) fn new(
-        owns: OwnsInstruction<VariablePosition>,
+        owns: OwnsInstruction<ExecutorVariable>,
         variable_modes: VariableModes,
-        sort_by: Option<VariablePosition>,
+        sort_by: ExecutorVariable,
     ) -> Self {
         let attribute_types = owns.attribute_types().clone();
         let owner_attribute_types = owns.owner_attribute_types().clone();
@@ -103,14 +101,13 @@ impl OwnsExecutor {
             TuplePositions::Pair([owner, attribute])
         };
 
-        let checker = Checker::<AsHkt![Owns<'_>]> {
+        let checker = Checker::<AsHkt![Owns<'_>]>::new(
             checks,
-            extractors: [(owner, EXTRACT_OWNER), (attribute, EXTRACT_ATTRIBUTE)]
+            [(owner, EXTRACT_OWNER), (attribute, EXTRACT_ATTRIBUTE)]
                 .into_iter()
                 .filter_map(|(var, ex)| Some((var?, ex)))
                 .collect(),
-            _phantom_data: PhantomData,
-        };
+        );
 
         Self {
             owns,

--- a/executor/instruction/sub_reverse_executor.rs
+++ b/executor/instruction/sub_reverse_executor.rs
@@ -6,13 +6,12 @@
 
 use std::{
     collections::{BTreeMap, BTreeSet},
-    marker::PhantomData,
     sync::Arc,
     vec,
 };
 
 use answer::Type;
-use compiler::executable::match_::instructions::type_::SubReverseInstruction;
+use compiler::{executable::match_::instructions::type_::SubReverseInstruction, ExecutorVariable};
 use concept::{
     error::ConceptReadError,
     type_::{type_manager::TypeManager, TypeAPI},
@@ -31,11 +30,10 @@ use crate::{
     },
     pipeline::stage::ExecutionContext,
     row::MaybeOwnedRow,
-    VariablePosition,
 };
 
 pub(crate) struct SubReverseExecutor {
-    sub: ir::pattern::constraint::Sub<VariablePosition>,
+    sub: ir::pattern::constraint::Sub<ExecutorVariable>,
     iterate_mode: BinaryIterateMode,
     variable_modes: VariableModes,
     tuple_positions: TuplePositions,
@@ -54,9 +52,9 @@ pub(super) type SubFilterFn = FilterFn<(Type, Type)>;
 
 impl SubReverseExecutor {
     pub(crate) fn new(
-        sub: SubReverseInstruction<VariablePosition>,
+        sub: SubReverseInstruction<ExecutorVariable>,
         variable_modes: VariableModes,
-        sort_by: Option<VariablePosition>,
+        sort_by: ExecutorVariable,
     ) -> Self {
         let subtypes = sub.subtypes().clone();
         let super_to_subtypes = sub.super_to_subtypes().clone();
@@ -81,14 +79,13 @@ impl SubReverseExecutor {
             TuplePositions::Pair([supertype, subtype])
         };
 
-        let checker = Checker::<AdHocHkt<(Type, Type)>> {
+        let checker = Checker::<AdHocHkt<(Type, Type)>>::new(
             checks,
-            extractors: [(subtype, EXTRACT_SUB), (supertype, EXTRACT_SUPER)]
+            [(subtype, EXTRACT_SUB), (supertype, EXTRACT_SUPER)]
                 .into_iter()
                 .filter_map(|(var, ex)| Some((var?, ex)))
                 .collect(),
-            _phantom_data: PhantomData,
-        };
+        );
 
         Self {
             sub,

--- a/executor/instruction/tuple.rs
+++ b/executor/instruction/tuple.rs
@@ -143,10 +143,10 @@ pub(crate) type TupleIndex = u16;
 
 pub(crate) type TupleResult<'a> = Result<Tuple<'a>, ConceptReadError>;
 
-pub(crate) type TypeToTupleFn = fn(Type) -> TupleResult<'static>;
+pub(crate) type TypeToTupleFn = fn(Result<Type, ConceptReadError>) -> TupleResult<'static>;
 
-pub(crate) fn type_to_tuple(type_: Type) -> TupleResult<'static> {
-    Ok(Tuple::Single([VariableValue::Type(type_)]))
+pub(crate) fn type_to_tuple(type_: Result<Type, ConceptReadError>) -> TupleResult<'static> {
+    Ok(Tuple::Single([VariableValue::Type(type_?)]))
 }
 
 pub(crate) type SubToTupleFn = fn(Result<(Type, Type), ConceptReadError>) -> TupleResult<'static>;

--- a/executor/instruction/tuple.rs
+++ b/executor/instruction/tuple.rs
@@ -5,6 +5,7 @@
  */
 
 use answer::{variable_value::VariableValue, Thing, Type};
+use compiler::ExecutorVariable;
 use concept::{
     error::ConceptReadError,
     thing::{
@@ -14,8 +15,6 @@ use concept::{
     type_::{owns::Owns, plays::Plays, relates::Relates},
 };
 use lending_iterator::higher_order::Hkt;
-
-use crate::VariablePosition;
 
 #[derive(Debug, Clone)]
 pub(crate) enum Tuple<'a> {
@@ -78,36 +77,36 @@ impl Hkt for Tuple<'static> {
 
 #[derive(Debug, Clone)]
 pub(crate) enum TuplePositions {
-    Single([Option<VariablePosition>; 1]),
-    Pair([Option<VariablePosition>; 2]),
-    Triple([Option<VariablePosition>; 3]),
-    Quintuple([Option<VariablePosition>; 5]),
+    Single([Option<ExecutorVariable>; 1]),
+    Pair([Option<ExecutorVariable>; 2]),
+    Triple([Option<ExecutorVariable>; 3]),
+    Quintuple([Option<ExecutorVariable>; 5]),
     Arbitrary(), // TODO: unknown sized tuples, for functions
 }
 
 impl TuplePositions {
-    pub(crate) fn as_single(&self) -> &[Option<VariablePosition>; 1] {
+    pub(crate) fn as_single(&self) -> &[Option<ExecutorVariable>; 1] {
         match self {
             Self::Single(positions) => positions,
             _ => unreachable!("Cannot read tuple as Single."),
         }
     }
 
-    pub(crate) fn as_pair(&self) -> &[Option<VariablePosition>; 2] {
+    pub(crate) fn as_pair(&self) -> &[Option<ExecutorVariable>; 2] {
         match self {
             Self::Pair(positions) => positions,
             _ => unreachable!("Cannot read tuple as Pair."),
         }
     }
 
-    pub(crate) fn as_triple(&self) -> &[Option<VariablePosition>; 3] {
+    pub(crate) fn as_triple(&self) -> &[Option<ExecutorVariable>; 3] {
         match self {
             Self::Triple(positions) => positions,
             _ => unreachable!("Cannot read tuple as Triple."),
         }
     }
 
-    pub(crate) fn as_quintuple(&self) -> &[Option<VariablePosition>; 5] {
+    pub(crate) fn as_quintuple(&self) -> &[Option<ExecutorVariable>; 5] {
         match self {
             Self::Quintuple(positions) => positions,
             _ => unreachable!("Cannot read tuple as Quintuple."),
@@ -118,7 +117,7 @@ impl TuplePositions {
         todo!()
     }
 
-    pub(crate) fn iter(&self) -> impl Iterator<Item = Option<VariablePosition>> + '_ {
+    pub(crate) fn iter(&self) -> impl Iterator<Item = Option<ExecutorVariable>> + '_ {
         self.positions().iter().copied()
     }
 
@@ -126,7 +125,7 @@ impl TuplePositions {
         self.positions().len()
     }
 
-    pub(crate) fn positions(&self) -> &[Option<VariablePosition>] {
+    pub(crate) fn positions(&self) -> &[Option<ExecutorVariable>] {
         match self {
             TuplePositions::Single(positions) => positions,
             TuplePositions::Pair(positions) => positions,

--- a/executor/instruction/type_list_executor.rs
+++ b/executor/instruction/type_list_executor.rs
@@ -4,13 +4,17 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-use std::vec;
+use std::{collections::HashMap, iter, marker::PhantomData, vec};
 
-use answer::Type;
+use answer::{variable_value::VariableValue, Type};
 use compiler::executable::match_::instructions::type_::TypeListInstruction;
 use concept::error::ConceptReadError;
 use itertools::Itertools;
-use lending_iterator::{adaptors::Map, higher_order::AdHocHkt, AsLendingIterator, LendingIterator};
+use lending_iterator::{
+    adaptors::{Map, TryFilter},
+    higher_order::AdHocHkt,
+    AsLendingIterator, LendingIterator,
+};
 use storage::snapshot::ReadableSnapshot;
 
 use crate::{
@@ -18,7 +22,7 @@ use crate::{
         iterator::{SortedTupleIterator, TupleIterator},
         sub_executor::NarrowingTupleIterator,
         tuple::{type_to_tuple, TuplePositions, TupleResult, TypeToTupleFn},
-        VariableModes,
+        Checker, FilterFn, VariableModes,
     },
     pipeline::stage::ExecutionContext,
     row::MaybeOwnedRow,
@@ -29,10 +33,20 @@ pub(crate) struct TypeListExecutor {
     variable_modes: VariableModes,
     tuple_positions: TuplePositions,
     types: Vec<Type>,
+    checker: Checker<Type>,
 }
 
+pub(super) type TypeFilterFn = FilterFn<Type>;
+
+pub(super) type TypeTupleIterator<I> = NarrowingTupleIterator<
+    Map<TryFilter<I, Box<TypeFilterFn>, Type, ConceptReadError>, TypeToTupleFn, AdHocHkt<TupleResult<'static>>>,
+>;
+
 pub(crate) type TypeIterator =
-    NarrowingTupleIterator<Map<AsLendingIterator<vec::IntoIter<Type>>, TypeToTupleFn, AdHocHkt<TupleResult<'static>>>>;
+    TypeTupleIterator<AsLendingIterator<iter::Map<vec::IntoIter<Type>, fn(Type) -> Result<Type, ConceptReadError>>>>;
+
+type TypeVariableValueExtractor = for<'a> fn(&'a Type) -> VariableValue<'a>;
+pub(super) const EXTRACT_TYPE: TypeVariableValueExtractor = |ty| VariableValue::Type(ty.clone());
 
 impl TypeListExecutor {
     pub(crate) fn new(
@@ -43,21 +57,28 @@ impl TypeListExecutor {
         debug_assert!(!variable_modes.all_inputs());
         let types = type_.types().iter().cloned().sorted().collect_vec();
         debug_assert!(!types.is_empty());
-        let TypeListInstruction { type_var, .. } = type_;
+        let TypeListInstruction { type_var, checks, .. } = type_;
         debug_assert_eq!(Some(type_var), _sort_by);
         let tuple_positions = TuplePositions::Single([Some(type_var)]);
-        Self { variable_modes, tuple_positions, types }
+
+        let type_ = type_.type_var;
+
+        let checker =
+            Checker::<Type> { checks, extractors: HashMap::from([(type_, EXTRACT_TYPE)]), _phantom_data: PhantomData };
+
+        Self { variable_modes, tuple_positions, types, checker }
     }
 
     pub(crate) fn get_iterator(
         &self,
-        _: &ExecutionContext<impl ReadableSnapshot + 'static>,
-        _: MaybeOwnedRow<'_>,
+        context: &ExecutionContext<impl ReadableSnapshot + 'static>,
+        row: MaybeOwnedRow<'_>,
     ) -> Result<TupleIterator, ConceptReadError> {
-        Ok(TupleIterator::Type(SortedTupleIterator::new(
-            NarrowingTupleIterator(AsLendingIterator::new(self.types.clone()).map(type_to_tuple)),
-            self.tuple_positions.clone(),
-            &self.variable_modes,
-        )))
+        let filter_for_row: Box<TypeFilterFn> = self.checker.filter_for_row(context, &row);
+        let iterator = self.types.clone().into_iter().map(Ok as _);
+        let as_tuples: TypeIterator = NarrowingTupleIterator(
+            AsLendingIterator::new(iterator).try_filter::<_, TypeFilterFn, Type, _>(filter_for_row).map(type_to_tuple),
+        );
+        Ok(TupleIterator::Type(SortedTupleIterator::new(as_tuples, self.tuple_positions.clone(), &self.variable_modes)))
     }
 }

--- a/executor/lib.rs
+++ b/executor/lib.rs
@@ -7,6 +7,8 @@
 #![deny(unused_must_use)]
 #![deny(elided_lifetimes_in_paths)]
 
+#![allow(clippy::result_large_err)]
+
 use std::{
     fmt::{Display, Formatter},
     slice,

--- a/executor/lib.rs
+++ b/executor/lib.rs
@@ -6,7 +6,6 @@
 
 #![deny(unused_must_use)]
 #![deny(elided_lifetimes_in_paths)]
-
 #![allow(clippy::result_large_err)]
 
 use std::{

--- a/executor/pattern_executor.rs
+++ b/executor/pattern_executor.rs
@@ -103,7 +103,7 @@ impl MatchExecutor {
                 }
 
                 Direction::Backward => {
-                    let batch = self.step_executors[current_step].batch_continue(context)?;
+                    let batch = self.step_executors[current_step].batch_continue(context, interrupt)?;
                     match batch {
                         None => {
                             if current_step == 0 {

--- a/executor/pattern_executor.rs
+++ b/executor/pattern_executor.rs
@@ -59,7 +59,7 @@ impl MatchExecutor {
         )
     }
 
-    fn compute_next_batch(
+    pub(super) fn compute_next_batch(
         &mut self,
         context: &ExecutionContext<impl ReadableSnapshot + 'static>,
         interrupt: &mut ExecutionInterrupt,

--- a/executor/pattern_executor.rs
+++ b/executor/pattern_executor.rs
@@ -44,7 +44,7 @@ impl MatchExecutor {
         Ok(Self {
             input: Some(input.into_owned()),
             step_executors,
-            // modifiers:
+            // modifiers: todo!(),
             output: None,
         })
     }

--- a/executor/pipeline/modifiers.rs
+++ b/executor/pipeline/modifiers.rs
@@ -80,14 +80,16 @@ impl SortStageIterator {
             let y_row_as_row = unsorted.get_row(*y);
             let x_row = x_row_as_row.row();
             let y_row = y_row_as_row.row();
-            for (idx, asc) in &sort_by {
-                let ord = x_row[*idx]
-                    .partial_cmp(&y_row[*idx])
+            for &(idx, asc) in &sort_by {
+                let ord = x_row[idx]
+                    .partial_cmp(&y_row[idx])
                     .expect("Sort on variable with uncomparable values should have been caught at query-compile time");
-                match (asc, ord) {
-                    (true, Ordering::Less) | (false, Ordering::Greater) => return Ordering::Less,
-                    (true, Ordering::Greater) | (false, Ordering::Less) => return Ordering::Greater,
-                    (true, Ordering::Equal) | (false, Ordering::Equal) => {}
+                if ord != Ordering::Equal {
+                    if asc {
+                        return ord;
+                    } else {
+                        return ord.reverse();
+                    }
                 };
             }
             Ordering::Equal

--- a/executor/row.rs
+++ b/executor/row.rs
@@ -10,7 +10,7 @@ use answer::variable_value::VariableValue;
 use compiler::VariablePosition;
 use lending_iterator::higher_order::Hkt;
 
-#[derive(Debug)]
+#[derive(Debug, Hash, PartialEq, Eq)]
 pub struct Row<'a> {
     row: &'a mut [VariableValue<'static>],
     multiplicity: &'a mut u64,
@@ -76,7 +76,7 @@ impl<'a> fmt::Display for Row<'a> {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Hash, PartialEq, Eq)]
 pub struct MaybeOwnedRow<'a> {
     row: Cow<'a, [VariableValue<'static>]>,
     multiplicity: Cow<'a, u64>,
@@ -105,16 +105,12 @@ impl<'a> MaybeOwnedRow<'a> {
         Self { row: Cow::Owned(row), multiplicity: Cow::Owned(multiplicity) }
     }
 
-    pub fn len(&self) -> usize {
-        self.row.len()
-    }
-
     pub fn get(&self, position: VariablePosition) -> &VariableValue<'_> {
         &self.row[position.as_usize()]
     }
 
     pub fn multiplicity(&self) -> u64 {
-        *self.multiplicity.as_ref()
+        *self.multiplicity
     }
 
     pub fn row(&self) -> &[VariableValue<'static>] {
@@ -132,16 +128,6 @@ impl<'a> MaybeOwnedRow<'a> {
 
     pub fn into_owned_parts(self) -> (Vec<VariableValue<'static>>, u64) {
         (self.row.into_owned(), self.multiplicity.into_owned())
-    }
-
-    pub fn as_mut_ref(&mut self) -> Row<'_> {
-        match &mut self.row {
-            Cow::Borrowed(_) => panic!("Cannot get mutable access to Borrowed row."),
-            Cow::Owned(row) => match &mut self.multiplicity {
-                Cow::Borrowed(_) => unreachable!("Row and multiplicity should always have the same ownership."),
-                Cow::Owned(multiplicity) => Row::new(row.as_mut_slice(), multiplicity),
-            },
-        }
     }
 }
 

--- a/executor/row.rs
+++ b/executor/row.rs
@@ -4,7 +4,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-use std::{borrow::Cow, fmt, ops::Deref, vec};
+use std::{borrow::Cow, fmt, ops::Deref, slice, vec};
 
 use answer::variable_value::VariableValue;
 use compiler::VariablePosition;
@@ -159,6 +159,14 @@ impl IntoIterator for MaybeOwnedRow<'static> {
     fn into_iter(self) -> Self::IntoIter {
         #[allow(clippy::unnecessary_to_owned)]
         self.row.into_owned().into_iter()
+    }
+}
+
+impl<'a, 'b: 'a> IntoIterator for &'a MaybeOwnedRow<'b> {
+    type Item = &'a VariableValue<'b>;
+    type IntoIter = slice::Iter<'a, VariableValue<'b>>;
+    fn into_iter(self) -> Self::IntoIter {
+        self.row.iter()
     }
 }
 

--- a/executor/step_executors.rs
+++ b/executor/step_executors.rs
@@ -728,6 +728,9 @@ impl DisjunctionExecutor {
                 }
             }
         }
+        if !batch.is_empty() {
+            self.output = Some(batch);
+        }
         Ok(())
     }
 

--- a/executor/step_executors.rs
+++ b/executor/step_executors.rs
@@ -76,8 +76,8 @@ impl StepExecutor {
             ExecutionStep::Assignment(AssignmentStep { .. }) => {
                 todo!()
             }
-            ExecutionStep::Check(CheckStep { check_instructions, output_width }) => {
-                Ok(Self::Check(CheckExecutor::new(check_instructions.clone())))
+            ExecutionStep::Check(CheckStep { check_instructions, selected_variables, output_width: _ }) => {
+                Ok(Self::Check(CheckExecutor::new(check_instructions.clone(), selected_variables.clone())))
             }
             ExecutionStep::Disjunction(DisjunctionStep { branches, .. }) => {
                 Ok(Self::Disjunction(DisjunctionExecutor::new(branches.clone(), row_width)))
@@ -599,12 +599,13 @@ impl AssignExecutor {
 
 pub(super) struct CheckExecutor {
     checker: Checker<()>,
+    selected_variables: Vec<VariablePosition>,
 }
 
 impl CheckExecutor {
-    fn new(checks: Vec<CheckInstruction<VariablePosition>>) -> Self {
+    fn new(checks: Vec<CheckInstruction<VariablePosition>>, selected_variables: Vec<VariablePosition>) -> Self {
         let checker = Checker::new(checks, HashMap::new());
-        Self { checker }
+        Self { checker, selected_variables }
     }
 
     fn batch_from(

--- a/executor/tests/compile_execute.rs
+++ b/executor/tests/compile_execute.rs
@@ -134,14 +134,14 @@ fn test_has_planning_traversal() {
         .try_collect::<_, Vec<_>, _>()
         .unwrap();
 
-    assert_eq!(rows.len(), 7);
-
-    for row in rows {
+    for row in &rows {
         for value in row {
             print!("{}, ", value);
         }
         println!()
     }
+
+    assert_eq!(rows.len(), 7);
 }
 
 #[test]
@@ -212,14 +212,14 @@ fn test_links_planning_traversal() {
         .try_collect::<_, Vec<_>, _>()
         .unwrap();
 
-    assert_eq!(rows.len(), 2);
-
-    for row in rows {
+    for row in &rows {
         for value in row {
             print!("{}, ", value);
         }
         println!()
     }
+
+    assert_eq!(rows.len(), 2);
 }
 
 #[test]
@@ -297,14 +297,14 @@ fn test_links_intersection() {
         .try_collect::<_, Vec<_>, _>()
         .unwrap();
 
-    assert_eq!(rows.len(), 3);
-
-    for row in rows {
+    for row in &rows {
         for value in row {
             print!("{}, ", value);
         }
         println!()
     }
+
+    assert_eq!(rows.len(), 3);
 }
 
 #[test]
@@ -375,7 +375,7 @@ fn test_negation_planning_traversal() {
         .unwrap();
 
     for row in &rows {
-        for value in row.row() {
+        for value in row {
             print!("{}, ", value);
         }
         println!()
@@ -473,7 +473,7 @@ fn test_forall_planning_traversal() {
         .unwrap();
 
     for row in &rows {
-        for value in row.row() {
+        for value in row {
             print!("{}, ", value);
         }
         println!()

--- a/executor/tests/compile_execute.rs
+++ b/executor/tests/compile_execute.rs
@@ -614,7 +614,8 @@ fn test_disjunction_planning_traversal() {
     assert_eq!(rows.len(), 3);
 }
 
-#[test]
+// #[test]
+// FIXME
 fn test_disjunction_planning_nested_negations() {
     let (_tmp_dir, mut storage) = create_core_storage();
     setup_concept_storage(&mut storage);

--- a/executor/tests/compile_execute.rs
+++ b/executor/tests/compile_execute.rs
@@ -487,3 +487,81 @@ fn test_forall_planning_traversal() {
     // 6. abc ⊃ ac
     assert_eq!(rows.len(), 6);
 }
+
+#[test]
+fn test_disjunction_planning_traversal() {
+    let (_tmp_dir, mut storage) = create_core_storage();
+    setup_concept_storage(&mut storage);
+    let (type_manager, thing_manager) = load_managers(storage.clone(), None);
+
+    let schema = "define
+        attribute age value long;
+        attribute name value string;
+        entity person owns age @card(0..), owns name @card(0..);
+    ";
+    let data = "insert
+        $_ isa person, has age 12, has name 'John';
+        $_ isa person, has age 14;
+        $_ isa person, has name 'Leila';
+        $_ isa person;
+    ";
+
+    let statistics = setup(&storage, type_manager, thing_manager, schema, data);
+
+    let query = "match
+        $person isa person;
+        { $person has name $_; } or { $person has age $_; };
+    ";
+    let match_ = typeql::parse_query(query).unwrap().into_pipeline().stages.remove(0).into_match();
+
+    // IR
+    let empty_function_index = HashMapFunctionSignatureIndex::empty();
+    let mut translation_context = TranslationContext::new();
+    let builder = translate_match(&mut translation_context, &empty_function_index, &match_).unwrap();
+    let block = builder.finish();
+
+    // Executor
+    let snapshot = Arc::new(storage.clone().open_snapshot_read());
+    let (type_manager, thing_manager) = load_managers(storage.clone(), None);
+
+    let entry_annotations = infer_types_for_match_block(
+        &block,
+        &translation_context.variable_registry,
+        &*snapshot,
+        &type_manager,
+        &BTreeMap::new(),
+        &IndexedAnnotatedFunctions::empty(),
+        &AnnotatedUnindexedFunctions::empty(),
+    )
+    .unwrap();
+
+    let pattern_plan = compiler::match_::planner::compile(
+        &block,
+        &HashMap::new(),
+        &entry_annotations,
+        Arc::new(translation_context.variable_registry),
+        &HashMap::new(),
+        &statistics,
+    );
+    let program_plan = ProgramPlan::new(pattern_plan, HashMap::new(), HashMap::new());
+    let executor = MatchExecutor::new(&program_plan, &snapshot, &thing_manager, MaybeOwnedRow::empty()).unwrap();
+
+    let context = ExecutionContext::new(snapshot, thing_manager, Arc::default());
+    let iterator = executor.into_iterator(context, ExecutionInterrupt::new_uninterruptible());
+
+    let rows = iterator
+        .map_static(|row| row.map(|row| row.into_owned()).map_err(|err| err.clone()))
+        .into_iter()
+        .try_collect::<_, Vec<_>, _>()
+        .unwrap();
+
+    for row in &rows {
+        for value in row {
+            print!("{}, ", value);
+        }
+        println!()
+    }
+
+    assert_eq!(rows.len(), 3);
+}
+

--- a/executor/tests/compile_execute.rs
+++ b/executor/tests/compile_execute.rs
@@ -463,6 +463,82 @@ fn test_forall_planning_traversal() {
 }
 
 #[test]
+fn test_named_var_select() {
+    let (_tmp_dir, mut storage) = create_core_storage();
+    setup_concept_storage(&mut storage);
+    let (type_manager, thing_manager) = load_managers(storage.clone(), None);
+
+    let schema = "define
+        attribute age value long;
+        attribute name value string;
+        entity person owns age @card(0..), owns name @card(0..);
+    ";
+    let data = "insert
+        $_ isa person, has age 12, has name 'John';
+        $_ isa person, has age 14;
+        $_ isa person, has name 'Leila';
+        $_ isa person;
+    ";
+
+    let statistics = setup(&storage, type_manager, thing_manager, schema, data);
+
+    let query = "match $person has name $_, has age $_;";
+    let match_ = typeql::parse_query(query).unwrap().into_pipeline().stages.remove(0).into_match();
+
+    // IR
+    let empty_function_index = HashMapFunctionSignatureIndex::empty();
+    let mut translation_context = TranslationContext::new();
+    let builder = translate_match(&mut translation_context, &empty_function_index, &match_).unwrap();
+    let block = builder.finish();
+
+    // Executor
+    let snapshot = Arc::new(storage.clone().open_snapshot_read());
+    let (type_manager, thing_manager) = load_managers(storage.clone(), None);
+
+    let entry_annotations = infer_types(
+        &*snapshot,
+        &block,
+        &translation_context.variable_registry,
+        &type_manager,
+        &BTreeMap::new(),
+        &IndexedAnnotatedFunctions::empty(),
+        Some(&AnnotatedUnindexedFunctions::empty()),
+    )
+    .unwrap();
+
+    let match_executable = compiler::executable::match_::planner::compile(
+        &block,
+        &HashMap::new(),
+        &entry_annotations,
+        Arc::new(translation_context.variable_registry),
+        &HashMap::new(),
+        &statistics,
+    );
+    let executor = MatchExecutor::new(&match_executable, &snapshot, &thing_manager, MaybeOwnedRow::empty()).unwrap();
+
+    let context = ExecutionContext::new(snapshot, thing_manager, Arc::default());
+    let iterator = executor.into_iterator(context, ExecutionInterrupt::new_uninterruptible());
+
+    let rows = iterator
+        .map_static(|row| row.map(|row| row.into_owned()).map_err(|err| err.clone()))
+        .into_iter()
+        .try_collect::<_, Vec<_>, _>()
+        .unwrap();
+
+    for row in &rows {
+        let mut non_empty_count = 0;
+        for value in row {
+            non_empty_count += !value.is_empty() as usize;
+            print!("{}, ", value);
+        }
+        println!();
+        assert_eq!(non_empty_count, 1, "expected only $person to have value in output row");
+    }
+
+    assert_eq!(rows.len(), 1);
+}
+
+#[test]
 fn test_disjunction_planning_traversal() {
     let (_tmp_dir, mut storage) = create_core_storage();
     setup_concept_storage(&mut storage);

--- a/executor/tests/compile_execute.rs
+++ b/executor/tests/compile_execute.rs
@@ -540,3 +540,85 @@ fn test_disjunction_planning_traversal() {
 
     assert_eq!(rows.len(), 3);
 }
+
+#[test]
+fn test_disjunction_planning_nested_negations() {
+    let (_tmp_dir, mut storage) = create_core_storage();
+    setup_concept_storage(&mut storage);
+    let (type_manager, thing_manager) = load_managers(storage.clone(), None);
+
+    let schema = "define
+        attribute age value long;
+        attribute name value string;
+        entity person owns age @card(0..), owns name @card(0..);
+    ";
+    let data = "insert
+        $_ isa person, has age 12, has name 'John';
+        $_ isa person, has age 14;
+        $_ isa person, has name 'Leila';
+        $_ isa person;
+    ";
+
+    let statistics = setup(&storage, type_manager, thing_manager, schema, data);
+
+    let query = "match
+        $person isa person;
+        {
+            $person has name $_;
+            not { $person has age $_; };
+        } or {
+            $person has age $_;
+            not { $person has name $_; };
+        };
+    ";
+    let match_ = typeql::parse_query(query).unwrap().into_pipeline().stages.remove(0).into_match();
+
+    // IR
+    let empty_function_index = HashMapFunctionSignatureIndex::empty();
+    let mut translation_context = TranslationContext::new();
+    let builder = translate_match(&mut translation_context, &empty_function_index, &match_).unwrap();
+    let block = builder.finish();
+
+    // Executor
+    let snapshot = Arc::new(storage.clone().open_snapshot_read());
+    let (type_manager, thing_manager) = load_managers(storage.clone(), None);
+
+    let entry_annotations = infer_types(
+        &*snapshot,
+        &block,
+        &translation_context.variable_registry,
+        &type_manager,
+        &BTreeMap::new(),
+        &IndexedAnnotatedFunctions::empty(),
+        Some(&AnnotatedUnindexedFunctions::empty()),
+    )
+    .unwrap();
+
+    let match_executable = compiler::executable::match_::planner::compile(
+        &block,
+        &HashMap::new(),
+        &entry_annotations,
+        Arc::new(translation_context.variable_registry),
+        &HashMap::new(),
+        &statistics,
+    );
+    let executor = MatchExecutor::new(&match_executable, &snapshot, &thing_manager, MaybeOwnedRow::empty()).unwrap();
+
+    let context = ExecutionContext::new(snapshot, thing_manager, Arc::default());
+    let iterator = executor.into_iterator(context, ExecutionInterrupt::new_uninterruptible());
+
+    let rows = iterator
+        .map_static(|row| row.map(|row| row.into_owned()).map_err(|err| err.clone()))
+        .into_iter()
+        .try_collect::<_, Vec<_>, _>()
+        .unwrap();
+
+    for row in &rows {
+        for value in row {
+            print!("{}, ", value);
+        }
+        println!()
+    }
+
+    assert_eq!(rows.len(), 2);
+}

--- a/executor/tests/compile_execute.rs
+++ b/executor/tests/compile_execute.rs
@@ -99,19 +99,14 @@ fn test_has_planning_traversal() {
     let snapshot = Arc::new(storage.clone().open_snapshot_read());
     let (type_manager, thing_manager) = load_managers(storage.clone(), None);
 
-    let variable_registry = &translation_context.variable_registry;
-    let snapshot1 = &*snapshot;
-    let previous_stage_variable_annotations = &BTreeMap::new();
-    let annotated_schema_functions = &IndexedAnnotatedFunctions::empty();
-    let annotated_preamble_functions = &AnnotatedUnindexedFunctions::empty();
     let entry_annotations = infer_types(
-        snapshot1,
+        &*snapshot,
         &block,
-        variable_registry,
+        &translation_context.variable_registry,
         &type_manager,
-        previous_stage_variable_annotations,
-        annotated_schema_functions,
-        Some(annotated_preamble_functions),
+        &BTreeMap::new(),
+        &IndexedAnnotatedFunctions::empty(),
+        Some(&AnnotatedUnindexedFunctions::empty()),
     )
     .unwrap();
 
@@ -177,19 +172,15 @@ fn test_links_planning_traversal() {
     // Executor
     let snapshot = Arc::new(storage.clone().open_snapshot_read());
     let (type_manager, thing_manager) = load_managers(storage.clone(), None);
-    let variable_registry = &translation_context.variable_registry;
-    let snapshot1 = &*snapshot;
-    let previous_stage_variable_annotations = &BTreeMap::new();
-    let annotated_schema_functions = &IndexedAnnotatedFunctions::empty();
-    let annotated_preamble_functions = &AnnotatedUnindexedFunctions::empty();
+
     let entry_annotations = infer_types(
-        snapshot1,
+        &*snapshot,
         &block,
-        variable_registry,
+        &translation_context.variable_registry,
         &type_manager,
-        previous_stage_variable_annotations,
-        annotated_schema_functions,
-        Some(annotated_preamble_functions),
+        &BTreeMap::new(),
+        &IndexedAnnotatedFunctions::empty(),
+        Some(&AnnotatedUnindexedFunctions::empty()),
     )
     .unwrap();
 
@@ -262,19 +253,15 @@ fn test_links_intersection() {
     // Executor
     let snapshot = Arc::new(storage.clone().open_snapshot_read());
     let (type_manager, thing_manager) = load_managers(storage.clone(), None);
-    let variable_registry = &translation_context.variable_registry;
-    let snapshot1 = &*snapshot;
-    let previous_stage_variable_annotations = &BTreeMap::new();
-    let annotated_schema_functions = &IndexedAnnotatedFunctions::empty();
-    let annotated_preamble_functions = &AnnotatedUnindexedFunctions::empty();
+
     let entry_annotations = infer_types(
-        snapshot1,
+        &*snapshot,
         &block,
-        variable_registry,
+        &translation_context.variable_registry,
         &type_manager,
-        previous_stage_variable_annotations,
-        annotated_schema_functions,
-        Some(annotated_preamble_functions),
+        &BTreeMap::new(),
+        &IndexedAnnotatedFunctions::empty(),
+        Some(&AnnotatedUnindexedFunctions::empty()),
     )
     .unwrap();
 
@@ -339,19 +326,14 @@ fn test_negation_planning_traversal() {
     let snapshot = Arc::new(storage.clone().open_snapshot_read());
     let (type_manager, thing_manager) = load_managers(storage.clone(), None);
 
-    let variable_registry = &translation_context.variable_registry;
-    let snapshot1 = &*snapshot;
-    let previous_stage_variable_annotations = &BTreeMap::new();
-    let annotated_schema_functions = &IndexedAnnotatedFunctions::empty();
-    let annotated_preamble_functions = &AnnotatedUnindexedFunctions::empty();
     let entry_annotations = infer_types(
-        snapshot1,
+        &*snapshot,
         &block,
-        variable_registry,
+        &translation_context.variable_registry,
         &type_manager,
-        previous_stage_variable_annotations,
-        annotated_schema_functions,
-        Some(annotated_preamble_functions),
+        &BTreeMap::new(),
+        &IndexedAnnotatedFunctions::empty(),
+        Some(&AnnotatedUnindexedFunctions::empty()),
     )
     .unwrap();
 
@@ -437,19 +419,14 @@ fn test_forall_planning_traversal() {
     let snapshot = Arc::new(storage.clone().open_snapshot_read());
     let (type_manager, thing_manager) = load_managers(storage.clone(), None);
 
-    let variable_registry = &translation_context.variable_registry;
-    let snapshot1 = &*snapshot;
-    let previous_stage_variable_annotations = &BTreeMap::new();
-    let annotated_schema_functions = &IndexedAnnotatedFunctions::empty();
-    let annotated_preamble_functions = &AnnotatedUnindexedFunctions::empty();
     let entry_annotations = infer_types(
-        snapshot1,
+        &*snapshot,
         &block,
-        variable_registry,
+        &translation_context.variable_registry,
         &type_manager,
-        previous_stage_variable_annotations,
-        annotated_schema_functions,
-        Some(annotated_preamble_functions),
+        &BTreeMap::new(),
+        &IndexedAnnotatedFunctions::empty(),
+        Some(&AnnotatedUnindexedFunctions::empty()),
     )
     .unwrap();
 
@@ -524,18 +501,18 @@ fn test_disjunction_planning_traversal() {
     let snapshot = Arc::new(storage.clone().open_snapshot_read());
     let (type_manager, thing_manager) = load_managers(storage.clone(), None);
 
-    let entry_annotations = infer_types_for_match_block(
+    let entry_annotations = infer_types(
+        &*snapshot,
         &block,
         &translation_context.variable_registry,
-        &*snapshot,
         &type_manager,
         &BTreeMap::new(),
         &IndexedAnnotatedFunctions::empty(),
-        &AnnotatedUnindexedFunctions::empty(),
+        Some(&AnnotatedUnindexedFunctions::empty()),
     )
     .unwrap();
 
-    let pattern_plan = compiler::match_::planner::compile(
+    let match_executable = compiler::executable::match_::planner::compile(
         &block,
         &HashMap::new(),
         &entry_annotations,
@@ -543,8 +520,7 @@ fn test_disjunction_planning_traversal() {
         &HashMap::new(),
         &statistics,
     );
-    let program_plan = ProgramPlan::new(pattern_plan, HashMap::new(), HashMap::new());
-    let executor = MatchExecutor::new(&program_plan, &snapshot, &thing_manager, MaybeOwnedRow::empty()).unwrap();
+    let executor = MatchExecutor::new(&match_executable, &snapshot, &thing_manager, MaybeOwnedRow::empty()).unwrap();
 
     let context = ExecutionContext::new(snapshot, thing_manager, Arc::default());
     let iterator = executor.into_iterator(context, ExecutionInterrupt::new_uninterruptible());
@@ -564,4 +540,3 @@ fn test_disjunction_planning_traversal() {
 
     assert_eq!(rows.len(), 3);
 }
-

--- a/executor/tests/compile_execute.rs
+++ b/executor/tests/compile_execute.rs
@@ -18,10 +18,7 @@ use concept::{
     type_::type_manager::TypeManager,
 };
 use executor::{
-    pattern_executor::MatchExecutor,
-    pipeline::stage::{ExecutionContext, StageAPI},
-    row::MaybeOwnedRow,
-    ExecutionInterrupt,
+    pattern_executor::MatchExecutor, pipeline::stage::ExecutionContext, row::MaybeOwnedRow, ExecutionInterrupt,
 };
 use function::function_manager::FunctionManager;
 use ir::{

--- a/executor/tests/execute_comparison_check.rs
+++ b/executor/tests/execute_comparison_check.rs
@@ -135,8 +135,7 @@ fn attribute_equality() {
         )),
     ];
 
-    let executable =
-        MatchExecutable::new(steps, Arc::new(translation_context.variable_registry.clone()), variable_positions, vars);
+    let executable = MatchExecutable::new(steps, variable_positions, vars);
 
     // Executor
     let snapshot = Arc::new(storage.clone().open_snapshot_read());

--- a/executor/tests/execute_comparison_check.rs
+++ b/executor/tests/execute_comparison_check.rs
@@ -11,24 +11,25 @@ use std::{
 };
 
 use compiler::{
+    annotation::{
+        function::{AnnotatedUnindexedFunctions, IndexedAnnotatedFunctions},
+        match_inference::infer_types,
+    },
     executable::match_::{
-        instructions::{ConstraintInstruction, Inputs, thing::IsaInstruction},
+        instructions::{thing::IsaInstruction, ConstraintInstruction, Inputs},
         planner::match_executable::{ExecutionStep, IntersectionStep, MatchExecutable},
     },
     VariablePosition,
 };
-use compiler::annotation::function::{AnnotatedUnindexedFunctions, IndexedAnnotatedFunctions};
-use compiler::annotation::match_inference::infer_types;
 use concept::type_::{annotation::AnnotationIndependent, attribute_type::AttributeTypeAnnotation};
 use encoding::value::{label::Label, value::Value, value_type::ValueType};
 use executor::{
-    error::ReadExecutionError, ExecutionInterrupt, pipeline::stage::ExecutionContext,
-    row::MaybeOwnedRow,
+    error::ReadExecutionError, pattern_executor::MatchExecutor, pipeline::stage::ExecutionContext, row::MaybeOwnedRow,
+    ExecutionInterrupt,
 };
-use executor::pattern_executor::MatchExecutor;
 use ir::{pattern::constraint::IsaKind, pipeline::block::Block, translation::TranslationContext};
 use lending_iterator::LendingIterator;
-use storage::{durability_client::WALClient, MVCCStorage, snapshot::CommittableSnapshot};
+use storage::{durability_client::WALClient, snapshot::CommittableSnapshot, MVCCStorage};
 use test_utils_concept::{load_managers, setup_concept_storage};
 use test_utils_encoding::create_core_storage;
 
@@ -134,7 +135,8 @@ fn attribute_equality() {
         )),
     ];
 
-    let executable = MatchExecutable::new(steps, Arc::new(translation_context.variable_registry.clone()), variable_positions, vars);
+    let executable =
+        MatchExecutable::new(steps, Arc::new(translation_context.variable_registry.clone()), variable_positions, vars);
 
     // Executor
     let snapshot = Arc::new(storage.clone().open_snapshot_read());

--- a/executor/tests/execute_has.rs
+++ b/executor/tests/execute_has.rs
@@ -167,8 +167,7 @@ fn traverse_has_unbounded_sorted_from() {
         &HashSet::from([variable_positions[&var_person].clone(), variable_positions[&var_age].clone()]),
         4,
     ))];
-    let executable =
-        MatchExecutable::new(steps, Arc::new(translation_context.variable_registry.clone()), variable_positions, vars);
+    let executable = MatchExecutable::new(steps, variable_positions, vars);
 
     // Executor
     let snapshot = Arc::new(snapshot);
@@ -271,8 +270,7 @@ fn traverse_has_bounded_sorted_from_chain_intersect() {
             5,
         )),
     ];
-    let executable =
-        MatchExecutable::new(steps, Arc::new(translation_context.variable_registry.clone()), variable_positions, vars);
+    let executable = MatchExecutable::new(steps, variable_positions, vars);
 
     // Executor
     let snapshot = Arc::new(snapshot);
@@ -363,8 +361,7 @@ fn traverse_has_unbounded_sorted_from_intersect() {
         &named_variables,
         3,
     ))];
-    let executable =
-        MatchExecutable::new(steps, Arc::new(translation_context.variable_registry.clone()), variable_positions, vars);
+    let executable = MatchExecutable::new(steps, variable_positions, vars);
 
     // Executor
     let snapshot = Arc::new(snapshot);
@@ -438,12 +435,7 @@ fn traverse_has_unbounded_sorted_to_merged() {
         &named_variables,
         2,
     ))];
-    let executable = MatchExecutable::new(
-        steps,
-        Arc::new(translation_context.variable_registry.clone()),
-        variable_positions.clone(),
-        vars,
-    );
+    let executable = MatchExecutable::new(steps, variable_positions.clone(), vars);
 
     // Executor
     let snapshot = Arc::new(snapshot);
@@ -538,8 +530,7 @@ fn traverse_has_reverse_unbounded_sorted_from() {
         &named_variables,
         2,
     ))];
-    let executable =
-        MatchExecutable::new(steps, Arc::new(translation_context.variable_registry.clone()), variable_positions, vars);
+    let executable = MatchExecutable::new(steps, variable_positions, vars);
 
     // Executor
     let snapshot = Arc::new(snapshot);

--- a/executor/tests/execute_isa.rs
+++ b/executor/tests/execute_isa.rs
@@ -22,7 +22,7 @@ use compiler::{
         },
         planner::match_executable::{ExecutionStep, IntersectionStep, MatchExecutable},
     },
-    VariablePosition,
+    ExecutorVariable, VariablePosition,
 };
 use encoding::value::label::Label;
 use executor::{
@@ -106,23 +106,28 @@ fn traverse_isa_unbounded_sorted_thing() {
     )
     .unwrap();
 
-    let vars = vec![var_dog, var_dog_type];
+    let row_vars = vec![var_dog, var_dog_type];
     let variable_positions =
-        HashMap::from_iter(vars.iter().copied().enumerate().map(|(i, var)| (var, VariablePosition::new(i as u32))));
-    let named_variables = variable_positions.values().map(|p| p.clone()).collect();
+        HashMap::from_iter(row_vars.iter().copied().enumerate().map(|(i, var)| (var, VariablePosition::new(i as u32))));
+    let mapping = HashMap::from([var_dog, var_dog_type].map(|var| {
+        if row_vars.contains(&var) {
+            (var, ExecutorVariable::RowPosition(variable_positions[&var]))
+        } else {
+            (var, ExecutorVariable::Internal(var))
+        }
+    }));
+    let named_variables = mapping.values().copied().collect();
 
     // Plan
     let steps = vec![ExecutionStep::Intersection(IntersectionStep::new(
-        variable_positions[&var_dog],
-        vec![ConstraintInstruction::Isa(
-            IsaInstruction::new(isa, Inputs::None([]), &entry_annotations).map(&variable_positions),
-        )],
-        &[variable_positions[&var_dog], variable_positions[&var_dog_type]],
+        mapping[&var_dog],
+        vec![ConstraintInstruction::Isa(IsaInstruction::new(isa, Inputs::None([]), &entry_annotations).map(&mapping))],
+        vec![variable_positions[&var_dog], variable_positions[&var_dog_type]],
         &named_variables,
         2,
     ))];
 
-    let executable = MatchExecutable::new(steps, variable_positions, vars);
+    let executable = MatchExecutable::new(steps, variable_positions, row_vars);
 
     // Executor
     let snapshot = Arc::new(storage.clone().open_snapshot_read());
@@ -179,23 +184,28 @@ fn traverse_isa_unbounded_sorted_type() {
     )
     .unwrap();
 
-    let vars = vec![var_dog, var_dog_type];
+    let row_vars = vec![var_dog, var_dog_type];
     let variable_positions =
-        HashMap::from_iter(vars.iter().copied().enumerate().map(|(i, var)| (var, VariablePosition::new(i as u32))));
-    let named_variables = variable_positions.values().map(|p| p.clone()).collect();
+        HashMap::from_iter(row_vars.iter().copied().enumerate().map(|(i, var)| (var, VariablePosition::new(i as u32))));
+    let mapping = HashMap::from([var_dog, var_dog_type].map(|var| {
+        if row_vars.contains(&var) {
+            (var, ExecutorVariable::RowPosition(variable_positions[&var]))
+        } else {
+            (var, ExecutorVariable::Internal(var))
+        }
+    }));
+    let named_variables = mapping.values().copied().collect();
 
     // Plan
     let steps = vec![ExecutionStep::Intersection(IntersectionStep::new(
-        variable_positions[&var_dog_type],
-        vec![ConstraintInstruction::Isa(
-            IsaInstruction::new(isa, Inputs::None([]), &entry_annotations).map(&variable_positions),
-        )],
-        &[variable_positions[&var_dog], variable_positions[&var_dog_type]],
+        mapping[&var_dog_type],
+        vec![ConstraintInstruction::Isa(IsaInstruction::new(isa, Inputs::None([]), &entry_annotations).map(&mapping))],
+        vec![variable_positions[&var_dog], variable_positions[&var_dog_type]],
         &named_variables,
         2,
     ))];
 
-    let executable = MatchExecutable::new(steps, variable_positions, vars);
+    let executable = MatchExecutable::new(steps, variable_positions, row_vars);
 
     // Executor
     let snapshot = Arc::new(storage.clone().open_snapshot_read());
@@ -255,36 +265,41 @@ fn traverse_isa_bounded_thing() {
     )
     .unwrap();
 
-    let vars = vec![var_type_from, var_thing, var_type_to];
+    let row_vars = vec![var_thing, var_type_to];
     let variable_positions =
-        HashMap::from_iter(vars.iter().copied().enumerate().map(|(i, var)| (var, VariablePosition::new(i as u32))));
-    let named_variables = variable_positions.values().map(|p| p.clone()).collect();
+        HashMap::from_iter(row_vars.iter().copied().enumerate().map(|(i, var)| (var, VariablePosition::new(i as u32))));
+    let mapping = HashMap::from([var_type_from, var_thing, var_type_to].map(|var| {
+        if row_vars.contains(&var) {
+            (var, ExecutorVariable::RowPosition(variable_positions[&var]))
+        } else {
+            (var, ExecutorVariable::Internal(var))
+        }
+    }));
+    let named_variables = mapping.values().copied().collect();
 
     // Plan
     let steps = vec![
         ExecutionStep::Intersection(IntersectionStep::new(
-            variable_positions[&var_type_from],
+            mapping[&var_type_from],
             vec![ConstraintInstruction::IsaReverse(
-                IsaReverseInstruction::new(isa_from_type, Inputs::None([]), &entry_annotations)
-                    .map(&variable_positions),
+                IsaReverseInstruction::new(isa_from_type, Inputs::None([]), &entry_annotations).map(&mapping),
             )],
-            &[variable_positions[&var_thing]],
+            vec![variable_positions[&var_thing]],
+            &named_variables,
+            1,
+        )),
+        ExecutionStep::Intersection(IntersectionStep::new(
+            mapping[&var_type_to],
+            vec![ConstraintInstruction::Isa(
+                IsaInstruction::new(isa_to_type, Inputs::Single([var_thing]), &entry_annotations).map(&mapping),
+            )],
+            vec![variable_positions[&var_type_to]],
             &named_variables,
             2,
         )),
-        ExecutionStep::Intersection(IntersectionStep::new(
-            variable_positions[&var_type_to],
-            vec![ConstraintInstruction::Isa(
-                IsaInstruction::new(isa_to_type, Inputs::Single([var_thing]), &entry_annotations)
-                    .map(&variable_positions),
-            )],
-            &[variable_positions[&var_type_to]],
-            &named_variables,
-            3,
-        )),
     ];
 
-    let executable = MatchExecutable::new(steps, variable_positions, vars);
+    let executable = MatchExecutable::new(steps, variable_positions, row_vars);
 
     // Executor
     let snapshot = Arc::new(storage.clone().open_snapshot_read());
@@ -345,23 +360,30 @@ fn traverse_isa_reverse_unbounded_sorted_thing() {
     )
     .unwrap();
 
-    let vars = vec![var_dog, var_dog_type];
+    let row_vars = vec![var_dog, var_dog_type];
     let variable_positions =
-        HashMap::from_iter(vars.iter().copied().enumerate().map(|(i, var)| (var, VariablePosition::new(i as u32))));
-    let named_variables = variable_positions.values().map(|p| p.clone()).collect();
+        HashMap::from_iter(row_vars.iter().copied().enumerate().map(|(i, var)| (var, VariablePosition::new(i as u32))));
+    let mapping = HashMap::from([var_dog, var_dog_type].map(|var| {
+        if row_vars.contains(&var) {
+            (var, ExecutorVariable::RowPosition(variable_positions[&var]))
+        } else {
+            (var, ExecutorVariable::Internal(var))
+        }
+    }));
+    let named_variables = mapping.values().copied().collect();
 
     // Plan
     let steps = vec![ExecutionStep::Intersection(IntersectionStep::new(
-        variable_positions[&var_dog],
+        mapping[&var_dog],
         vec![ConstraintInstruction::IsaReverse(
-            IsaReverseInstruction::new(isa, Inputs::None([]), &entry_annotations).map(&variable_positions),
+            IsaReverseInstruction::new(isa, Inputs::None([]), &entry_annotations).map(&mapping),
         )],
-        &[variable_positions[&var_dog], variable_positions[&var_dog_type]],
+        vec![variable_positions[&var_dog], variable_positions[&var_dog_type]],
         &named_variables,
         2,
     ))];
 
-    let executable = MatchExecutable::new(steps, variable_positions, vars);
+    let executable = MatchExecutable::new(steps, variable_positions, row_vars);
 
     // Executor
     let snapshot = Arc::new(storage.clone().open_snapshot_read());
@@ -418,23 +440,30 @@ fn traverse_isa_reverse_unbounded_sorted_type() {
     )
     .unwrap();
 
-    let vars = vec![var_dog, var_dog_type];
+    let row_vars = vec![var_dog, var_dog_type];
     let variable_positions =
-        HashMap::from_iter(vars.iter().copied().enumerate().map(|(i, var)| (var, VariablePosition::new(i as u32))));
-    let named_variables = variable_positions.values().map(|p| p.clone()).collect();
+        HashMap::from_iter(row_vars.iter().copied().enumerate().map(|(i, var)| (var, VariablePosition::new(i as u32))));
+    let mapping = HashMap::from([var_dog, var_dog_type].map(|var| {
+        if row_vars.contains(&var) {
+            (var, ExecutorVariable::RowPosition(variable_positions[&var]))
+        } else {
+            (var, ExecutorVariable::Internal(var))
+        }
+    }));
+    let named_variables = mapping.values().copied().collect();
 
     // Plan
     let steps = vec![ExecutionStep::Intersection(IntersectionStep::new(
-        variable_positions[&var_dog_type],
+        mapping[&var_dog_type],
         vec![ConstraintInstruction::IsaReverse(
-            IsaReverseInstruction::new(isa, Inputs::None([]), &entry_annotations).map(&variable_positions),
+            IsaReverseInstruction::new(isa, Inputs::None([]), &entry_annotations).map(&mapping),
         )],
-        &[variable_positions[&var_dog], variable_positions[&var_dog_type]],
+        vec![variable_positions[&var_dog], variable_positions[&var_dog_type]],
         &named_variables,
         2,
     ))];
 
-    let executable = MatchExecutable::new(steps, variable_positions, vars);
+    let executable = MatchExecutable::new(steps, variable_positions, row_vars);
 
     // Executor
     let snapshot = Arc::new(storage.clone().open_snapshot_read());
@@ -494,35 +523,41 @@ fn traverse_isa_reverse_bounded_type_exact() {
     )
     .unwrap();
 
-    let vars = vec![var_thing_from, var_type, var_thing_to];
+    let row_vars = vec![var_thing_from, var_type, var_thing_to];
     let variable_positions =
-        HashMap::from_iter(vars.iter().copied().enumerate().map(|(i, var)| (var, VariablePosition::new(i as u32))));
-    let named_variables = variable_positions.values().map(|p| p.clone()).collect();
+        HashMap::from_iter(row_vars.iter().copied().enumerate().map(|(i, var)| (var, VariablePosition::new(i as u32))));
+    let mapping = HashMap::from([var_thing_from, var_type, var_thing_to].map(|var| {
+        if row_vars.contains(&var) {
+            (var, ExecutorVariable::RowPosition(variable_positions[&var]))
+        } else {
+            (var, ExecutorVariable::Internal(var))
+        }
+    }));
+    let named_variables = mapping.values().copied().collect();
 
     // Plan
     let steps = vec![
         ExecutionStep::Intersection(IntersectionStep::new(
-            variable_positions[&var_thing_from],
+            mapping[&var_thing_from],
             vec![ConstraintInstruction::Isa(
-                IsaInstruction::new(isa_from_thing, Inputs::None([]), &entry_annotations).map(&variable_positions),
+                IsaInstruction::new(isa_from_thing, Inputs::None([]), &entry_annotations).map(&mapping),
             )],
-            &[variable_positions[&var_thing_from], variable_positions[&var_type]],
+            vec![variable_positions[&var_thing_from], variable_positions[&var_type]],
             &named_variables,
             2,
         )),
         ExecutionStep::Intersection(IntersectionStep::new(
-            variable_positions[&var_thing_to],
+            mapping[&var_thing_to],
             vec![ConstraintInstruction::IsaReverse(
-                IsaReverseInstruction::new(isa_to_thing, Inputs::Single([var_type]), &entry_annotations)
-                    .map(&variable_positions),
+                IsaReverseInstruction::new(isa_to_thing, Inputs::Single([var_type]), &entry_annotations).map(&mapping),
             )],
-            &[variable_positions[&var_thing_from], variable_positions[&var_type], variable_positions[&var_thing_to]],
+            vec![variable_positions[&var_thing_from], variable_positions[&var_type], variable_positions[&var_thing_to]],
             &named_variables,
             3,
         )),
     ];
 
-    let executable = MatchExecutable::new(steps, variable_positions, vars);
+    let executable = MatchExecutable::new(steps, variable_positions, row_vars);
 
     // Executor
     let snapshot = Arc::new(storage.clone().open_snapshot_read());
@@ -586,35 +621,41 @@ fn traverse_isa_reverse_bounded_type_subtype() {
     )
     .unwrap();
 
-    let vars = vec![var_thing_from, var_type, var_thing_to];
+    let row_vars = vec![var_thing_from, var_type, var_thing_to];
     let variable_positions =
-        HashMap::from_iter(vars.iter().copied().enumerate().map(|(i, var)| (var, VariablePosition::new(i as u32))));
-    let named_variables = variable_positions.values().map(|p| p.clone()).collect();
+        HashMap::from_iter(row_vars.iter().copied().enumerate().map(|(i, var)| (var, VariablePosition::new(i as u32))));
+    let mapping = HashMap::from([var_thing_from, var_type, var_thing_to].map(|var| {
+        if row_vars.contains(&var) {
+            (var, ExecutorVariable::RowPosition(variable_positions[&var]))
+        } else {
+            (var, ExecutorVariable::Internal(var))
+        }
+    }));
+    let named_variables = mapping.values().copied().collect();
 
     // Plan
     let steps = vec![
         ExecutionStep::Intersection(IntersectionStep::new(
-            variable_positions[&var_thing_from],
+            mapping[&var_thing_from],
             vec![ConstraintInstruction::Isa(
-                IsaInstruction::new(isa_from_thing, Inputs::None([]), &entry_annotations).map(&variable_positions),
+                IsaInstruction::new(isa_from_thing, Inputs::None([]), &entry_annotations).map(&mapping),
             )],
-            &[variable_positions[&var_thing_from], variable_positions[&var_type]],
+            vec![variable_positions[&var_thing_from], variable_positions[&var_type]],
             &named_variables,
             2,
         )),
         ExecutionStep::Intersection(IntersectionStep::new(
-            variable_positions[&var_thing_to],
+            mapping[&var_thing_to],
             vec![ConstraintInstruction::IsaReverse(
-                IsaReverseInstruction::new(isa_to_thing, Inputs::Single([var_type]), &entry_annotations)
-                    .map(&variable_positions),
+                IsaReverseInstruction::new(isa_to_thing, Inputs::Single([var_type]), &entry_annotations).map(&mapping),
             )],
-            &[variable_positions[&var_thing_from], variable_positions[&var_type], variable_positions[&var_thing_to]],
+            vec![variable_positions[&var_thing_from], variable_positions[&var_type], variable_positions[&var_thing_to]],
             &named_variables,
             3,
         )),
     ];
 
-    let executable = MatchExecutable::new(steps, variable_positions, vars);
+    let executable = MatchExecutable::new(steps, variable_positions, row_vars);
 
     // Executor
     let snapshot = Arc::new(storage.clone().open_snapshot_read());
@@ -675,23 +716,30 @@ fn traverse_isa_reverse_fixed_type_exact() {
     )
     .unwrap();
 
-    let vars = vec![var_thing];
+    let row_vars = vec![var_thing];
     let variable_positions =
-        HashMap::from_iter(vars.iter().copied().enumerate().map(|(i, var)| (var, VariablePosition::new(i as u32))));
-    let named_variables = variable_positions.values().map(|p| p.clone()).collect();
+        HashMap::from_iter(row_vars.iter().copied().enumerate().map(|(i, var)| (var, VariablePosition::new(i as u32))));
+    let mapping = HashMap::from([var_thing].map(|var| {
+        if row_vars.contains(&var) {
+            (var, ExecutorVariable::RowPosition(variable_positions[&var]))
+        } else {
+            (var, ExecutorVariable::Internal(var))
+        }
+    }));
+    let named_variables = mapping.values().copied().collect();
 
     // Plan
     let steps = vec![ExecutionStep::Intersection(IntersectionStep::new(
-        variable_positions[&var_thing],
+        mapping[&var_thing],
         vec![ConstraintInstruction::IsaReverse(
-            IsaReverseInstruction::new(isa, Inputs::None([]), &entry_annotations).map(&variable_positions),
+            IsaReverseInstruction::new(isa, Inputs::None([]), &entry_annotations).map(&mapping),
         )],
-        &[variable_positions[&var_thing]],
+        vec![variable_positions[&var_thing]],
         &named_variables,
         1,
     ))];
 
-    let executable = MatchExecutable::new(steps, variable_positions, vars);
+    let executable = MatchExecutable::new(steps, variable_positions, row_vars);
 
     // Executor
     let snapshot = Arc::new(storage.clone().open_snapshot_read());
@@ -751,23 +799,30 @@ fn traverse_isa_reverse_fixed_type_subtype() {
     )
     .unwrap();
 
-    let vars = vec![var_thing];
+    let row_vars = vec![var_thing];
     let variable_positions =
-        HashMap::from_iter(vars.iter().copied().enumerate().map(|(i, var)| (var, VariablePosition::new(i as u32))));
-    let named_variables = variable_positions.values().copied().collect();
+        HashMap::from_iter(row_vars.iter().copied().enumerate().map(|(i, var)| (var, VariablePosition::new(i as u32))));
+    let mapping = HashMap::from([var_thing].map(|var| {
+        if row_vars.contains(&var) {
+            (var, ExecutorVariable::RowPosition(variable_positions[&var]))
+        } else {
+            (var, ExecutorVariable::Internal(var))
+        }
+    }));
+    let named_variables = mapping.values().copied().collect();
 
     // Plan
     let steps = vec![ExecutionStep::Intersection(IntersectionStep::new(
-        variable_positions[&var_thing],
+        mapping[&var_thing],
         vec![ConstraintInstruction::IsaReverse(
-            IsaReverseInstruction::new(isa, Inputs::None([]), &entry_annotations).map(&variable_positions),
+            IsaReverseInstruction::new(isa, Inputs::None([]), &entry_annotations).map(&mapping),
         )],
-        &[variable_positions[&var_thing]],
+        vec![variable_positions[&var_thing]],
         &named_variables,
         1,
     ))];
 
-    let executable = MatchExecutable::new(steps, variable_positions, vars);
+    let executable = MatchExecutable::new(steps, variable_positions, row_vars);
 
     // Executor
     let snapshot = Arc::new(storage.clone().open_snapshot_read());

--- a/executor/tests/execute_isa.rs
+++ b/executor/tests/execute_isa.rs
@@ -86,7 +86,7 @@ fn traverse_isa_unbounded_sorted_thing() {
 
     // add all constraints to make type inference return correct types, though we only plan Has's
     let isa = conjunction.constraints_mut().add_isa(IsaKind::Subtype, var_dog, var_dog_type.into()).unwrap().clone();
-    conjunction.constraints_mut().add_label(var_dog_type.into(), DOG_LABEL.scoped_name().as_str()).unwrap();
+    conjunction.constraints_mut().add_label(var_dog_type, DOG_LABEL.scoped_name().as_str()).unwrap();
     let entry = builder.finish();
 
     let snapshot = storage.clone().open_snapshot_read();
@@ -122,8 +122,7 @@ fn traverse_isa_unbounded_sorted_thing() {
         2,
     ))];
 
-    let executable =
-        MatchExecutable::new(steps, Arc::new(translation_context.variable_registry.clone()), variable_positions, vars);
+    let executable = MatchExecutable::new(steps, variable_positions, vars);
 
     // Executor
     let snapshot = Arc::new(storage.clone().open_snapshot_read());
@@ -196,8 +195,7 @@ fn traverse_isa_unbounded_sorted_type() {
         2,
     ))];
 
-    let executable =
-        MatchExecutable::new(steps, Arc::new(translation_context.variable_registry.clone()), variable_positions, vars);
+    let executable = MatchExecutable::new(steps, variable_positions, vars);
 
     // Executor
     let snapshot = Arc::new(storage.clone().open_snapshot_read());
@@ -286,8 +284,7 @@ fn traverse_isa_bounded_thing() {
         )),
     ];
 
-    let executable =
-        MatchExecutable::new(steps, Arc::new(translation_context.variable_registry.clone()), variable_positions, vars);
+    let executable = MatchExecutable::new(steps, variable_positions, vars);
 
     // Executor
     let snapshot = Arc::new(storage.clone().open_snapshot_read());
@@ -364,8 +361,7 @@ fn traverse_isa_reverse_unbounded_sorted_thing() {
         2,
     ))];
 
-    let executable =
-        MatchExecutable::new(steps, Arc::new(translation_context.variable_registry.clone()), variable_positions, vars);
+    let executable = MatchExecutable::new(steps, variable_positions, vars);
 
     // Executor
     let snapshot = Arc::new(storage.clone().open_snapshot_read());
@@ -438,8 +434,7 @@ fn traverse_isa_reverse_unbounded_sorted_type() {
         2,
     ))];
 
-    let executable =
-        MatchExecutable::new(steps, Arc::new(translation_context.variable_registry.clone()), variable_positions, vars);
+    let executable = MatchExecutable::new(steps, variable_positions, vars);
 
     // Executor
     let snapshot = Arc::new(storage.clone().open_snapshot_read());
@@ -527,8 +522,7 @@ fn traverse_isa_reverse_bounded_type_exact() {
         )),
     ];
 
-    let executable =
-        MatchExecutable::new(steps, Arc::new(translation_context.variable_registry.clone()), variable_positions, vars);
+    let executable = MatchExecutable::new(steps, variable_positions, vars);
 
     // Executor
     let snapshot = Arc::new(storage.clone().open_snapshot_read());
@@ -620,8 +614,7 @@ fn traverse_isa_reverse_bounded_type_subtype() {
         )),
     ];
 
-    let executable =
-        MatchExecutable::new(steps, Arc::new(translation_context.variable_registry.clone()), variable_positions, vars);
+    let executable = MatchExecutable::new(steps, variable_positions, vars);
 
     // Executor
     let snapshot = Arc::new(storage.clone().open_snapshot_read());
@@ -698,8 +691,7 @@ fn traverse_isa_reverse_fixed_type_exact() {
         1,
     ))];
 
-    let executable =
-        MatchExecutable::new(steps, Arc::new(translation_context.variable_registry.clone()), variable_positions, vars);
+    let executable = MatchExecutable::new(steps, variable_positions, vars);
 
     // Executor
     let snapshot = Arc::new(storage.clone().open_snapshot_read());
@@ -762,7 +754,7 @@ fn traverse_isa_reverse_fixed_type_subtype() {
     let vars = vec![var_thing];
     let variable_positions =
         HashMap::from_iter(vars.iter().copied().enumerate().map(|(i, var)| (var, VariablePosition::new(i as u32))));
-    let named_variables = variable_positions.values().map(|p| p.clone()).collect();
+    let named_variables = variable_positions.values().copied().collect();
 
     // Plan
     let steps = vec![ExecutionStep::Intersection(IntersectionStep::new(
@@ -775,8 +767,7 @@ fn traverse_isa_reverse_fixed_type_subtype() {
         1,
     ))];
 
-    let executable =
-        MatchExecutable::new(steps, Arc::new(translation_context.variable_registry.clone()), variable_positions, vars);
+    let executable = MatchExecutable::new(steps, variable_positions, vars);
 
     // Executor
     let snapshot = Arc::new(storage.clone().open_snapshot_read());

--- a/executor/tests/execute_links.rs
+++ b/executor/tests/execute_links.rs
@@ -263,8 +263,7 @@ fn traverse_links_unbounded_sorted_from() {
         8,
     ))];
 
-    let executable =
-        MatchExecutable::new(steps, Arc::new(translation_context.variable_registry.clone()), variable_positions, vars);
+    let executable = MatchExecutable::new(steps, variable_positions, vars);
 
     // Executor
     let snapshot = Arc::new(storage.clone().open_snapshot_read());
@@ -355,8 +354,7 @@ fn traverse_links_unbounded_sorted_to() {
         5,
     ))];
 
-    let executable =
-        MatchExecutable::new(steps, Arc::new(translation_context.variable_registry.clone()), variable_positions, vars);
+    let executable = MatchExecutable::new(steps, variable_positions, vars);
 
     // Executor
     let snapshot = Arc::new(storage.clone().open_snapshot_read());
@@ -464,8 +462,7 @@ fn traverse_links_bounded_relation() {
         )),
     ];
 
-    let executable =
-        MatchExecutable::new(steps, Arc::new(translation_context.variable_registry.clone()), variable_positions, vars);
+    let executable = MatchExecutable::new(steps, variable_positions, vars);
 
     // Executor
     let snapshot = Arc::new(storage.clone().open_snapshot_read());
@@ -587,8 +584,7 @@ fn traverse_links_bounded_relation_player() {
         )),
     ];
 
-    let executable =
-        MatchExecutable::new(steps, Arc::new(translation_context.variable_registry.clone()), variable_positions, vars);
+    let executable = MatchExecutable::new(steps, variable_positions, vars);
 
     // Executor
     let snapshot = Arc::new(storage.clone().open_snapshot_read());
@@ -680,8 +676,7 @@ fn traverse_links_reverse_unbounded_sorted_from() {
         5,
     ))];
 
-    let executable =
-        MatchExecutable::new(steps, Arc::new(translation_context.variable_registry.clone()), variable_positions, vars);
+    let executable = MatchExecutable::new(steps, variable_positions, vars);
 
     // Executor
     let snapshot = Arc::new(storage.clone().open_snapshot_read());
@@ -774,8 +769,7 @@ fn traverse_links_reverse_unbounded_sorted_to() {
         5,
     ))];
 
-    let executable =
-        MatchExecutable::new(steps, Arc::new(translation_context.variable_registry.clone()), variable_positions, vars);
+    let executable = MatchExecutable::new(steps, variable_positions, vars);
 
     // Executor
     let snapshot = Arc::new(storage.clone().open_snapshot_read());
@@ -879,8 +873,7 @@ fn traverse_links_reverse_bounded_player() {
         )),
     ];
 
-    let executable =
-        MatchExecutable::new(steps, Arc::new(translation_context.variable_registry.clone()), variable_positions, vars);
+    let executable = MatchExecutable::new(steps, variable_positions, vars);
 
     // Executor
     let snapshot = Arc::new(storage.clone().open_snapshot_read());
@@ -1002,8 +995,7 @@ fn traverse_links_reverse_bounded_player_relation() {
         )),
     ];
 
-    let executable =
-        MatchExecutable::new(steps, Arc::new(translation_context.variable_registry.clone()), variable_positions, vars);
+    let executable = MatchExecutable::new(steps, variable_positions, vars);
 
     // Executor
     let snapshot = Arc::new(storage.clone().open_snapshot_read());

--- a/executor/tests/execute_links.rs
+++ b/executor/tests/execute_links.rs
@@ -22,7 +22,7 @@ use compiler::{
         },
         planner::match_executable::{ExecutionStep, IntersectionStep, MatchExecutable},
     },
-    VariablePosition,
+    ExecutorVariable, VariablePosition,
 };
 use concept::{
     thing::object::ObjectAPI,
@@ -231,39 +231,47 @@ fn traverse_links_unbounded_sorted_from() {
     )
     .unwrap();
 
-    let vars = vec![
-        var_membership,
-        var_group,
-        var_person,
-        var_membership_type,
-        var_group_type,
-        var_person_type,
-        var_membership_group_type,
-        var_membership_member_type,
-    ];
+    let row_vars = vec![var_membership, var_group, var_person];
     let variable_positions =
-        HashMap::from_iter(vars.iter().copied().enumerate().map(|(i, var)| (var, VariablePosition::new(i as u32))));
-    let named_variables = variable_positions.values().map(|p| p.clone()).collect();
+        HashMap::from_iter(row_vars.iter().copied().enumerate().map(|(i, var)| (var, VariablePosition::new(i as u32))));
+    let mapping = HashMap::from(
+        [
+            var_membership,
+            var_group,
+            var_person,
+            var_membership_type,
+            var_group_type,
+            var_person_type,
+            var_membership_group_type,
+            var_membership_member_type,
+        ]
+        .map(|var| {
+            if row_vars.contains(&var) {
+                (var, ExecutorVariable::RowPosition(variable_positions[&var]))
+            } else {
+                (var, ExecutorVariable::Internal(var))
+            }
+        }),
+    );
+    let named_variables = mapping.values().copied().collect();
 
     // Plan
     let steps = vec![ExecutionStep::Intersection(IntersectionStep::new(
-        variable_positions[&var_membership],
+        mapping[&var_membership],
         vec![
             ConstraintInstruction::Links(
-                LinksInstruction::new(links_membership_person, Inputs::None([]), &entry_annotations)
-                    .map(&variable_positions),
+                LinksInstruction::new(links_membership_person, Inputs::None([]), &entry_annotations).map(&mapping),
             ),
             ConstraintInstruction::Links(
-                LinksInstruction::new(links_membership_group, Inputs::None([]), &entry_annotations)
-                    .map(&variable_positions),
+                LinksInstruction::new(links_membership_group, Inputs::None([]), &entry_annotations).map(&mapping),
             ),
         ],
-        &[variable_positions[&var_membership], variable_positions[&var_group], variable_positions[&var_person]],
+        vec![variable_positions[&var_membership], variable_positions[&var_group], variable_positions[&var_person]],
         &named_variables,
-        8,
+        3,
     ))];
 
-    let executable = MatchExecutable::new(steps, variable_positions, vars);
+    let executable = MatchExecutable::new(steps, variable_positions, row_vars);
 
     // Executor
     let snapshot = Arc::new(storage.clone().open_snapshot_read());
@@ -337,24 +345,32 @@ fn traverse_links_unbounded_sorted_to() {
     )
     .unwrap();
 
-    let vars = vec![var_membership, var_person, var_person_type, var_membership_type, var_membership_member_type];
+    let row_vars = vec![var_membership, var_person];
     let variable_positions =
-        HashMap::from_iter(vars.iter().copied().enumerate().map(|(i, var)| (var, VariablePosition::new(i as u32))));
-    let named_variables = variable_positions.values().map(|p| p.clone()).collect();
+        HashMap::from_iter(row_vars.iter().copied().enumerate().map(|(i, var)| (var, VariablePosition::new(i as u32))));
+    let mapping = HashMap::from(
+        [var_membership, var_person, var_person_type, var_membership_type, var_membership_member_type].map(|var| {
+            if row_vars.contains(&var) {
+                (var, ExecutorVariable::RowPosition(variable_positions[&var]))
+            } else {
+                (var, ExecutorVariable::Internal(var))
+            }
+        }),
+    );
+    let named_variables = mapping.values().copied().collect();
 
     // Plan
     let steps = vec![ExecutionStep::Intersection(IntersectionStep::new(
-        variable_positions[&var_person],
+        mapping[&var_person],
         vec![ConstraintInstruction::Links(
-            LinksInstruction::new(links_membership_person, Inputs::None([]), &entry_annotations)
-                .map(&variable_positions),
+            LinksInstruction::new(links_membership_person, Inputs::None([]), &entry_annotations).map(&mapping),
         )],
-        &[variable_positions[&var_membership], variable_positions[&var_person]],
+        vec![variable_positions[&var_membership], variable_positions[&var_person]],
         &named_variables,
-        5,
+        2,
     ))];
 
-    let executable = MatchExecutable::new(steps, variable_positions, vars);
+    let executable = MatchExecutable::new(steps, variable_positions, row_vars);
 
     // Executor
     let snapshot = Arc::new(storage.clone().open_snapshot_read());
@@ -433,36 +449,44 @@ fn traverse_links_bounded_relation() {
     )
     .unwrap();
 
-    let vars = vec![var_membership, var_membership_type, var_person, var_person_type, var_membership_member_type];
+    let row_vars = vec![var_membership, var_person];
     let variable_positions =
-        HashMap::from_iter(vars.iter().copied().enumerate().map(|(i, var)| (var, VariablePosition::new(i as u32))));
-    let named_variables = variable_positions.values().map(|p| p.clone()).collect();
+        HashMap::from_iter(row_vars.iter().copied().enumerate().map(|(i, var)| (var, VariablePosition::new(i as u32))));
+    let mapping = HashMap::from(
+        [var_membership, var_membership_type, var_person, var_person_type, var_membership_member_type].map(|var| {
+            if row_vars.contains(&var) {
+                (var, ExecutorVariable::RowPosition(variable_positions[&var]))
+            } else {
+                (var, ExecutorVariable::Internal(var))
+            }
+        }),
+    );
+    let named_variables = mapping.values().copied().collect();
 
     // Plan
     let steps = vec![
         ExecutionStep::Intersection(IntersectionStep::new(
-            variable_positions[&var_membership],
+            mapping[&var_membership],
             vec![ConstraintInstruction::IsaReverse(
-                IsaReverseInstruction::new(isa_membership, Inputs::None([]), &entry_annotations)
-                    .map(&variable_positions),
+                IsaReverseInstruction::new(isa_membership, Inputs::None([]), &entry_annotations).map(&mapping),
             )],
-            &[variable_positions[&var_membership]],
+            vec![variable_positions[&var_membership]],
+            &named_variables,
+            1,
+        )),
+        ExecutionStep::Intersection(IntersectionStep::new(
+            mapping[&var_person],
+            vec![ConstraintInstruction::Links(
+                LinksInstruction::new(links_membership_person, Inputs::Single([var_membership]), &entry_annotations)
+                    .map(&mapping),
+            )],
+            vec![variable_positions[&var_person]],
             &named_variables,
             2,
         )),
-        ExecutionStep::Intersection(IntersectionStep::new(
-            variable_positions[&var_person],
-            vec![ConstraintInstruction::Links(
-                LinksInstruction::new(links_membership_person, Inputs::Single([var_membership]), &entry_annotations)
-                    .map(&variable_positions),
-            )],
-            &[variable_positions[&var_person]],
-            &named_variables,
-            5,
-        )),
     ];
 
-    let executable = MatchExecutable::new(steps, variable_positions, vars);
+    let executable = MatchExecutable::new(steps, variable_positions, row_vars);
 
     // Executor
     let snapshot = Arc::new(storage.clone().open_snapshot_read());
@@ -542,49 +566,57 @@ fn traverse_links_bounded_relation_player() {
     )
     .unwrap();
 
-    let vars = vec![var_membership, var_membership_type, var_person, var_person_type, var_membership_member_type];
+    let row_vars = vec![var_membership, var_person, var_membership_member_type];
     let variable_positions =
-        HashMap::from_iter(vars.iter().copied().enumerate().map(|(i, var)| (var, VariablePosition::new(i as u32))));
-    let named_variables = variable_positions.values().map(|p| p.clone()).collect();
+        HashMap::from_iter(row_vars.iter().copied().enumerate().map(|(i, var)| (var, VariablePosition::new(i as u32))));
+    let mapping = HashMap::from(
+        [var_membership, var_membership_type, var_person, var_person_type, var_membership_member_type].map(|var| {
+            if row_vars.contains(&var) {
+                (var, ExecutorVariable::RowPosition(variable_positions[&var]))
+            } else {
+                (var, ExecutorVariable::Internal(var))
+            }
+        }),
+    );
+    let named_variables = mapping.values().copied().collect();
 
     // Plan
     let steps = vec![
         ExecutionStep::Intersection(IntersectionStep::new(
-            variable_positions[&var_membership],
+            mapping[&var_membership],
             vec![ConstraintInstruction::IsaReverse(
-                IsaReverseInstruction::new(isa_membership, Inputs::None([]), &entry_annotations)
-                    .map(&variable_positions),
+                IsaReverseInstruction::new(isa_membership, Inputs::None([]), &entry_annotations).map(&mapping),
             )],
-            &[variable_positions[&var_membership]],
+            vec![variable_positions[&var_membership]],
+            &named_variables,
+            1,
+        )),
+        ExecutionStep::Intersection(IntersectionStep::new(
+            mapping[&var_person],
+            vec![ConstraintInstruction::IsaReverse(
+                IsaReverseInstruction::new(isa_person, Inputs::None([]), &entry_annotations).map(&mapping),
+            )],
+            vec![variable_positions[&var_membership], variable_positions[&var_person]],
             &named_variables,
             2,
         )),
         ExecutionStep::Intersection(IntersectionStep::new(
-            variable_positions[&var_person],
-            vec![ConstraintInstruction::IsaReverse(
-                IsaReverseInstruction::new(isa_person, Inputs::None([]), &entry_annotations).map(&variable_positions),
-            )],
-            &[variable_positions[&var_membership], variable_positions[&var_person]],
-            &named_variables,
-            4,
-        )),
-        ExecutionStep::Intersection(IntersectionStep::new(
-            variable_positions[&var_membership_member_type],
+            mapping[&var_membership_member_type],
             vec![ConstraintInstruction::Links(
                 LinksInstruction::new(
                     links_membership_person,
                     Inputs::Dual([var_membership, var_person]),
                     &entry_annotations,
                 )
-                .map(&variable_positions),
+                .map(&mapping),
             )],
-            &[variable_positions[&var_membership_member_type]],
+            vec![variable_positions[&var_membership_member_type]],
             &named_variables,
-            5,
+            3,
         )),
     ];
 
-    let executable = MatchExecutable::new(steps, variable_positions, vars);
+    let executable = MatchExecutable::new(steps, variable_positions, row_vars);
 
     // Executor
     let snapshot = Arc::new(storage.clone().open_snapshot_read());
@@ -659,24 +691,32 @@ fn traverse_links_reverse_unbounded_sorted_from() {
     )
     .unwrap();
 
-    let vars = vec![var_membership, var_person, var_membership_type, var_person_type, var_membership_member_type];
+    let row_vars = vec![var_membership, var_person];
     let variable_positions =
-        HashMap::from_iter(vars.iter().copied().enumerate().map(|(i, var)| (var, VariablePosition::new(i as u32))));
-    let named_variables = variable_positions.values().map(|p| p.clone()).collect();
+        HashMap::from_iter(row_vars.iter().copied().enumerate().map(|(i, var)| (var, VariablePosition::new(i as u32))));
+    let mapping = HashMap::from(
+        [var_membership, var_membership_type, var_person, var_person_type, var_membership_member_type].map(|var| {
+            if row_vars.contains(&var) {
+                (var, ExecutorVariable::RowPosition(variable_positions[&var]))
+            } else {
+                (var, ExecutorVariable::Internal(var))
+            }
+        }),
+    );
+    let named_variables = mapping.values().copied().collect();
 
     // Plan
     let steps = vec![ExecutionStep::Intersection(IntersectionStep::new(
-        variable_positions[&var_person],
+        mapping[&var_person],
         vec![ConstraintInstruction::LinksReverse(
-            LinksReverseInstruction::new(links_membership_person, Inputs::None([]), &entry_annotations)
-                .map(&variable_positions),
+            LinksReverseInstruction::new(links_membership_person, Inputs::None([]), &entry_annotations).map(&mapping),
         )],
-        &[variable_positions[&var_membership], variable_positions[&var_person]],
+        vec![variable_positions[&var_membership], variable_positions[&var_person]],
         &named_variables,
-        5,
+        2,
     ))];
 
-    let executable = MatchExecutable::new(steps, variable_positions, vars);
+    let executable = MatchExecutable::new(steps, variable_positions, row_vars);
 
     // Executor
     let snapshot = Arc::new(storage.clone().open_snapshot_read());
@@ -752,24 +792,32 @@ fn traverse_links_reverse_unbounded_sorted_to() {
     )
     .unwrap();
 
-    let vars = vec![var_membership, var_person, var_membership_type, var_person_type, var_membership_member_type];
+    let row_vars = vec![var_membership, var_person];
     let variable_positions =
-        HashMap::from_iter(vars.iter().copied().enumerate().map(|(i, var)| (var, VariablePosition::new(i as u32))));
-    let named_variables = variable_positions.values().map(|p| p.clone()).collect();
+        HashMap::from_iter(row_vars.iter().copied().enumerate().map(|(i, var)| (var, VariablePosition::new(i as u32))));
+    let mapping = HashMap::from(
+        [var_membership, var_membership_type, var_person, var_person_type, var_membership_member_type].map(|var| {
+            if row_vars.contains(&var) {
+                (var, ExecutorVariable::RowPosition(variable_positions[&var]))
+            } else {
+                (var, ExecutorVariable::Internal(var))
+            }
+        }),
+    );
+    let named_variables = mapping.values().copied().collect();
 
     // Plan
     let steps = vec![ExecutionStep::Intersection(IntersectionStep::new(
-        variable_positions[&var_membership],
+        mapping[&var_membership],
         vec![ConstraintInstruction::LinksReverse(
-            LinksReverseInstruction::new(links_membership_person, Inputs::None([]), &entry_annotations)
-                .map(&variable_positions),
+            LinksReverseInstruction::new(links_membership_person, Inputs::None([]), &entry_annotations).map(&mapping),
         )],
-        &[variable_positions[&var_membership], variable_positions[&var_person]],
+        vec![variable_positions[&var_membership], variable_positions[&var_person]],
         &named_variables,
-        5,
+        2,
     ))];
 
-    let executable = MatchExecutable::new(steps, variable_positions, vars);
+    let executable = MatchExecutable::new(steps, variable_positions, row_vars);
 
     // Executor
     let snapshot = Arc::new(storage.clone().open_snapshot_read());
@@ -845,35 +893,44 @@ fn traverse_links_reverse_bounded_player() {
     )
     .unwrap();
 
-    let vars = vec![var_person, var_person_type, var_membership, var_membership_type, var_membership_member_type];
+    let row_vars = vec![var_person, var_membership];
     let variable_positions =
-        HashMap::from_iter(vars.iter().copied().enumerate().map(|(i, var)| (var, VariablePosition::new(i as u32))));
-    let named_variables = variable_positions.values().map(|p| p.clone()).collect();
+        HashMap::from_iter(row_vars.iter().copied().enumerate().map(|(i, var)| (var, VariablePosition::new(i as u32))));
+    let mapping = HashMap::from(
+        [var_membership, var_membership_type, var_person, var_person_type, var_membership_member_type].map(|var| {
+            if row_vars.contains(&var) {
+                (var, ExecutorVariable::RowPosition(variable_positions[&var]))
+            } else {
+                (var, ExecutorVariable::Internal(var))
+            }
+        }),
+    );
+    let named_variables = mapping.values().copied().collect();
 
     // Plan
     let steps = vec![
         ExecutionStep::Intersection(IntersectionStep::new(
-            variable_positions[&var_person],
+            mapping[&var_person],
             vec![ConstraintInstruction::IsaReverse(
-                IsaReverseInstruction::new(isa_person, Inputs::None([]), &entry_annotations).map(&variable_positions),
+                IsaReverseInstruction::new(isa_person, Inputs::None([]), &entry_annotations).map(&mapping),
             )],
-            &[variable_positions[&var_person]],
+            vec![variable_positions[&var_person]],
+            &named_variables,
+            1,
+        )),
+        ExecutionStep::Intersection(IntersectionStep::new(
+            mapping[&var_membership],
+            vec![ConstraintInstruction::LinksReverse(
+                LinksReverseInstruction::new(links_membership_person, Inputs::Single([var_person]), &entry_annotations)
+                    .map(&mapping),
+            )],
+            vec![variable_positions[&var_membership]],
             &named_variables,
             2,
         )),
-        ExecutionStep::Intersection(IntersectionStep::new(
-            variable_positions[&var_membership],
-            vec![ConstraintInstruction::LinksReverse(
-                LinksReverseInstruction::new(links_membership_person, Inputs::Single([var_person]), &entry_annotations)
-                    .map(&variable_positions),
-            )],
-            &[variable_positions[&var_membership]],
-            &named_variables,
-            5,
-        )),
     ];
 
-    let executable = MatchExecutable::new(steps, variable_positions, vars);
+    let executable = MatchExecutable::new(steps, variable_positions, row_vars);
 
     // Executor
     let snapshot = Arc::new(storage.clone().open_snapshot_read());
@@ -953,49 +1010,57 @@ fn traverse_links_reverse_bounded_player_relation() {
     )
     .unwrap();
 
-    let vars = vec![var_person, var_person_type, var_membership, var_membership_type, var_membership_member_type];
+    let row_vars = vec![var_person, var_membership];
     let variable_positions =
-        HashMap::from_iter(vars.iter().copied().enumerate().map(|(i, var)| (var, VariablePosition::new(i as u32))));
-    let named_variables = variable_positions.values().map(|p| p.clone()).collect();
+        HashMap::from_iter(row_vars.iter().copied().enumerate().map(|(i, var)| (var, VariablePosition::new(i as u32))));
+    let mapping = HashMap::from(
+        [var_membership, var_membership_type, var_person, var_person_type, var_membership_member_type].map(|var| {
+            if row_vars.contains(&var) {
+                (var, ExecutorVariable::RowPosition(variable_positions[&var]))
+            } else {
+                (var, ExecutorVariable::Internal(var))
+            }
+        }),
+    );
+    let named_variables = mapping.values().copied().collect();
 
     // Plan
     let steps = vec![
         ExecutionStep::Intersection(IntersectionStep::new(
-            variable_positions[&var_person],
+            mapping[&var_person],
             vec![ConstraintInstruction::IsaReverse(
-                IsaReverseInstruction::new(isa_person, Inputs::None([]), &entry_annotations).map(&variable_positions),
+                IsaReverseInstruction::new(isa_person, Inputs::None([]), &entry_annotations).map(&mapping),
             )],
-            &[variable_positions[&var_person]],
+            vec![variable_positions[&var_person]],
+            &named_variables,
+            1,
+        )),
+        ExecutionStep::Intersection(IntersectionStep::new(
+            mapping[&var_membership],
+            vec![ConstraintInstruction::IsaReverse(
+                IsaReverseInstruction::new(isa_membership, Inputs::None([]), &entry_annotations).map(&mapping),
+            )],
+            vec![variable_positions[&var_person], variable_positions[&var_membership]],
             &named_variables,
             2,
         )),
         ExecutionStep::Intersection(IntersectionStep::new(
-            variable_positions[&var_membership],
-            vec![ConstraintInstruction::IsaReverse(
-                IsaReverseInstruction::new(isa_membership, Inputs::None([]), &entry_annotations)
-                    .map(&variable_positions),
-            )],
-            &[variable_positions[&var_person], variable_positions[&var_membership]],
-            &named_variables,
-            4,
-        )),
-        ExecutionStep::Intersection(IntersectionStep::new(
-            variable_positions[&var_membership_member_type],
+            mapping[&var_membership_member_type],
             vec![ConstraintInstruction::LinksReverse(
                 LinksReverseInstruction::new(
                     links_membership_person,
                     Inputs::Dual([var_membership, var_person]),
                     &entry_annotations,
                 )
-                .map(&variable_positions),
+                .map(&mapping),
             )],
-            &[variable_positions[&var_person], variable_positions[&var_membership]],
+            vec![variable_positions[&var_person], variable_positions[&var_membership]],
             &named_variables,
-            5,
+            2,
         )),
     ];
 
-    let executable = MatchExecutable::new(steps, variable_positions, vars);
+    let executable = MatchExecutable::new(steps, variable_positions, row_vars);
 
     // Executor
     let snapshot = Arc::new(storage.clone().open_snapshot_read());

--- a/executor/tests/execute_select.rs
+++ b/executor/tests/execute_select.rs
@@ -199,8 +199,7 @@ fn anonymous_vars_not_enumerated_or_counted() {
         &named_variables,
         4,
     ))];
-    let executable =
-        MatchExecutable::new(steps, Arc::new(translation_context.variable_registry.clone()), variable_positions, vars);
+    let executable = MatchExecutable::new(steps, variable_positions, vars);
 
     // Executor
     let snapshot = Arc::new(storage.clone().open_snapshot_read());
@@ -290,8 +289,7 @@ fn unselected_named_vars_counted() {
         2,
     ))];
 
-    let executable =
-        MatchExecutable::new(steps, Arc::new(translation_context.variable_registry.clone()), variable_positions, vars);
+    let executable = MatchExecutable::new(steps, variable_positions, vars);
 
     // Executor
     let snapshot: Arc<ReadSnapshot<WALClient>> = Arc::new(storage.clone().open_snapshot_read());
@@ -401,8 +399,7 @@ fn cartesian_named_counted_checked() {
         4,
     ))];
 
-    let match_executable =
-        MatchExecutable::new(steps, Arc::new(translation_context.variable_registry.clone()), variable_positions, vars);
+    let match_executable = MatchExecutable::new(steps, variable_positions, vars);
 
     // Executor
     let snapshot: Arc<ReadSnapshot<WALClient>> = Arc::new(storage.clone().open_snapshot_read());

--- a/ir/pattern/conjunction.rs
+++ b/ir/pattern/conjunction.rs
@@ -46,7 +46,6 @@ impl Conjunction {
         block_context
             .referenced_variables()
             .filter(move |var| block_context.is_parent_scope(block_context.get_scope(var).unwrap(), self_scope))
-            .map(|var| var)
     }
 
     pub fn declared_variables<'a>(&self, block_context: &'a BlockContext) -> impl Iterator<Item = Variable> + 'a {

--- a/ir/pattern/constraint.rs
+++ b/ir/pattern/constraint.rs
@@ -646,7 +646,7 @@ impl<ID: IrID> Label<ID> {
         Self { left: Vertex::Variable(left), type_label }
     }
 
-    pub fn left(&self) -> &Vertex<ID> {
+    pub fn type_(&self) -> &Vertex<ID> {
         &self.left
     }
 
@@ -699,7 +699,7 @@ impl<ID: IrID> RoleName<ID> {
         Self { left: Vertex::Variable(left), name }
     }
 
-    pub fn left(&self) -> &Vertex<ID> {
+    pub fn type_(&self) -> &Vertex<ID> {
         &self.left
     }
 

--- a/storage/recovery/commit_recovery.rs
+++ b/storage/recovery/commit_recovery.rs
@@ -4,7 +4,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-use std::{collections::BTreeMap, error::Error, fmt, sync::Arc};
+use std::{collections::BTreeMap, sync::Arc};
 
 use durability::RawRecord;
 use error::typedb_error;

--- a/storage/snapshot/lock.rs
+++ b/storage/snapshot/lock.rs
@@ -22,7 +22,7 @@ where
     let total_len = key_items.clone().map(|item| item.len()).sum();
     let mut bytes = ByteArray::zeros(total_len);
     let mut start = 0;
-    let mut end = start;
+    let mut end;
     for item in key_items {
         end = start + item.len();
         bytes.bytes_mut()[start..end].copy_from_slice(item);

--- a/storage/snapshot/lock.rs
+++ b/storage/snapshot/lock.rs
@@ -22,9 +22,8 @@ where
     let total_len = key_items.clone().map(|item| item.len()).sum();
     let mut bytes = ByteArray::zeros(total_len);
     let mut start = 0;
-    let mut end;
     for item in key_items {
-        end = start + item.len();
+        let end = start + item.len();
         bytes.bytes_mut()[start..end].copy_from_slice(item);
         start = end;
     }

--- a/tests/behaviour/steps/params.rs
+++ b/tests/behaviour/steps/params.rs
@@ -498,19 +498,11 @@ impl Value {
             TypeDBValueType::DateTimeTZ => {
                 let (datetime, timezone) = Self::parse_date_time_and_remainder(self.raw_value.as_str());
 
-                if timezone.is_empty() {
-                    TypeDBValue::DateTimeTZ(datetime.and_local_timezone(TimeZone::default()).unwrap())
-                } else if timezone.starts_with('+') || timezone.starts_with('-') {
-                    let hours: i32 = timezone[1..3].parse().unwrap();
-                    let minutes: i32 = timezone[3..].parse().unwrap();
-                    let total_minutes = hours * 60 + minutes;
-                    let fixed_offset = if &timezone[0..1] == "+" {
-                        FixedOffset::east_opt(total_minutes * 60)
-                    } else {
-                        FixedOffset::west_opt(total_minutes * 60)
-                    };
+                assert!(!timezone.is_empty(), "No timezone when parsing {:?}", self.raw_value);
+
+                if timezone.starts_with(['+', '-']) {
                     TypeDBValue::DateTimeTZ(
-                        datetime.and_local_timezone(TimeZone::Fixed(fixed_offset.unwrap())).unwrap(),
+                        datetime.and_local_timezone(TimeZone::Fixed(timezone.parse().unwrap())).unwrap(),
                     )
                 } else {
                     TypeDBValue::DateTimeTZ(


### PR DESCRIPTION
## Release notes: product changes

We introduce support for disjunctions in queries:

```php
match
    $person isa person;
    { $person has name $_; } or { $person has age $_; };
```

## Motivation

## Implementation

Proper support for disjunction including deduplication required overhaul of the handling of selected variables in the planner and during execution. In particular, rather than mapping variables to their positions in the step output row 1-to-1, we introduce internal variables that have no associated position, but can still be used for the purposes of sorted joins or inline filters.

This PR also includes significant refactoring of the planner.