### PR TITLE
Add database name validation for database creation

### DIFF
--- a/database/BUILD
+++ b/database/BUILD
@@ -21,6 +21,7 @@ rust_library(
         "//storage",
         "//durability",
 
+        "@vaticle_typeql//rust:typeql",
         "@crates//:itertools",
         "@crates//:rocksdb",
         "@crates//:tracing",

--- a/database/database.rs
+++ b/database/database.rs
@@ -408,6 +408,12 @@ typedb_error!(
 );
 
 typedb_error!(
+    pub DatabaseCreateError(component = "Database create", prefix = "DBC") {
+        InvalidName(1, "Cannot create database since '{name}' is not a valid database name.", name: String),
+    }
+);
+
+typedb_error!(
     pub DatabaseDeleteError(component = "Database delete", prefix = "DBD") {
         DoesNotExist(1, "Cannot delete database since it does not exist."),
         InUse(2, "Cannot delete database since it is in use."),
@@ -418,23 +424,25 @@ typedb_error!(
 
 typedb_error!(
     pub DatabaseResetError(component = "Database reset", prefix = "DBR") {
-        InUse(1, "Database cannot be reset since it is in use."),
-        StorageInUse(2, "Database cannot be reset since the storage is in use."),
+        DatabaseDelete(1, "Cannot delete database.", ( typedb_source: DatabaseDeleteError )),
+        DatabaseCreate(2, "Cannot create database.", ( typedb_source: DatabaseCreateError )),
+        InUse(3, "Database cannot be reset since it is in use."),
+        StorageInUse(4, "Database cannot be reset since the storage is in use."),
         CorruptionPartialResetStorageInUse(
-            3,
+            5,
             "Corruption warning: database reset failed partway because the storage is still in use.",
             ( typedb_source: StorageResetError )
         ),
         CorruptionPartialResetKeyGeneratorInUse(
-            4,
+            6,
             "Corruption warning: Database reset failed partway because the schema key generator is still in use."
         ),
         CorruptionPartialResetTypeVertexGeneratorInUse(
-            5,
+            7,
             "Corruption warning: Database reset failed partway because the type key generator is still in use."
         ),
         CorruptionPartialResetThingVertexGeneratorInUse(
-            6,
+            8,
             "Corruption warning: Dataaase reset failed partway because the instance key generator is still in use."
         ),
     }

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -22,7 +22,7 @@ def vaticle_typeql():
     git_repository(
         name = "vaticle_typeql",
         remote = "https://github.com/typedb/typeql",
-        commit = "e8f6d1cef1cf9e3f89f6dbcd590f29541b59544e",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typeql
+        commit = "08439833aa7ddeacad96476e567c184cc3fadda4",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typeql
     )
 
 def vaticle_typedb_common():

--- a/server/service/typedb_service.rs
+++ b/server/service/typedb_service.rs
@@ -121,8 +121,10 @@ impl typedb_protocol::type_db_server::TypeDb for TypeDBService {
         request: Request<typedb_protocol::database_manager::create::Req>,
     ) -> Result<Response<typedb_protocol::database_manager::create::Res>, Status> {
         let message = request.into_inner();
-        self.database_manager.create_database(message.name.clone());
-        Ok(Response::new(database_create_res(message.name, &self.address)))
+        self.database_manager
+            .create_database(message.name.clone())
+            .map(|_| Response::new(database_create_res(message.name, &self.address)))
+            .map_err(|err| err.into_error_message().into_status())
     }
 
     async fn database_schema(

--- a/tests/behaviour/steps/connection/database.rs
+++ b/tests/behaviour/steps/connection/database.rs
@@ -13,8 +13,8 @@ use server::{typedb, typedb::Server};
 
 use crate::{generic_step, params, util, Context};
 
-async fn server_create_database(server: &'_ Server, name: String) {
-    server.database_manager().create_database(&name);
+async fn server_create_database(server: &'_ Server, name: String, may_error: params::MayError) {
+    may_error.check(server.database_manager().create_database(&name));
 }
 
 async fn server_delete_database(server: &'_ Server, name: String, may_error: params::MayError) {
@@ -22,11 +22,17 @@ async fn server_delete_database(server: &'_ Server, name: String, may_error: par
 }
 
 #[apply(generic_step)]
-#[step(expr = "connection create database: {word}")]
-pub async fn connection_create_database(context: &mut Context, name: String) {
+#[step(expr = "connection create database: {word}{may_error}")]
+pub async fn connection_create_database(context: &mut Context, name: String, may_error: params::MayError) {
     let server = context.server().unwrap().lock().unwrap();
-    server_create_database(&server, name).await;
+    server_create_database(&server, name, may_error).await;
     drop(server)
+}
+
+#[apply(generic_step)]
+#[step(expr = "connection create database with empty name{may_error}")] // TODO: Maybe we can just pass ""?
+pub async fn connection_create_database_with_an_empty_name(context: &mut Context, may_error: params::MayError) {
+    connection_create_database(context, "".to_string(), may_error).await
 }
 
 #[apply(generic_step)]
@@ -34,7 +40,7 @@ pub async fn connection_create_database(context: &mut Context, name: String) {
 pub async fn connection_create_databases(context: &mut Context, step: &Step) {
     let server = context.server().unwrap().lock().unwrap();
     for name in util::iter_table(step) {
-        server_create_database(&server, name.into()).await;
+        server_create_database(&server, name.into(), params::MayError::False).await;
     }
     drop(server)
 }
@@ -43,7 +49,8 @@ pub async fn connection_create_databases(context: &mut Context, step: &Step) {
 #[step(expr = "connection create database(s) in parallel:")]
 pub async fn connection_create_databases_in_parallel(context: &mut Context, step: &Step) {
     let server = context.server().unwrap().lock().unwrap();
-    join_all(util::iter_table(step).map(|name| server_create_database(&server, name.into()))).await;
+    join_all(util::iter_table(step).map(|name| server_create_database(&server, name.into(), params::MayError::False)))
+        .await;
     drop(server)
 }
 

--- a/tests/behaviour/steps/connection/database.rs
+++ b/tests/behaviour/steps/connection/database.rs
@@ -30,7 +30,7 @@ pub async fn connection_create_database(context: &mut Context, name: String, may
 }
 
 #[apply(generic_step)]
-#[step(expr = "connection create database with empty name{may_error}")] // TODO: Maybe we can just pass ""?
+#[step(expr = "connection create database with empty name{may_error}")]
 pub async fn connection_create_database_with_an_empty_name(context: &mut Context, may_error: params::MayError) {
     connection_create_database(context, "".to_string(), may_error).await
 }

--- a/tests/behaviour/steps/params.rs
+++ b/tests/behaviour/steps/params.rs
@@ -459,7 +459,7 @@ impl Value {
     ];
     const DATE_FORMAT: &'static str = "%Y-%m-%d";
 
-    const FRACTIONAL_ZEROES: usize = 18;
+    const FRACTIONAL_ZEROES: usize = 19;
 
     pub fn into_typedb(self, value_type: TypeDBValueType) -> TypeDBValue<'static> {
         match value_type {
@@ -527,13 +527,14 @@ impl Value {
                 };
                 TypeDBValue::String(Cow::Owned(value.to_string()))
             }
+            // TODO: Could compare string representations like in driver
             TypeDBValueType::Struct(_) => todo!(),
         }
     }
 
     fn parse_decimal_fraction_part(value: &str) -> u64 {
         assert!(Self::FRACTIONAL_ZEROES >= value.len());
-        10_u64.pow((Self::FRACTIONAL_ZEROES - value.len() + 1) as u32) * value.trim().parse::<u64>().unwrap()
+        10_u64.pow((Self::FRACTIONAL_ZEROES - value.len()) as u32) * value.trim().parse::<u64>().unwrap()
     }
 
     fn parse_date_time_and_remainder(value: &str) -> (NaiveDateTime, &str) {


### PR DESCRIPTION
## Release notes: product changes
We add validation of names for created databases. Now, all database names should be valid TypeQL identifiers. 

## Implementation
We reuse TypeQL `is_valid_identifier` to have a single source of truth for identifier formats.