### PR TITLE
Fetch execution

### DIFF
--- a/answer/lib.rs
+++ b/answer/lib.rs
@@ -30,11 +30,21 @@ use storage::snapshot::ReadableSnapshot;
 pub mod variable;
 pub mod variable_value;
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Clone)]
 pub enum Concept<'a> {
     Type(Type),
     Thing(Thing<'a>),
     Value(Value<'a>),
+}
+
+impl<'a> fmt::Display for Concept<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Concept::Type(type_) => write!(f, "{}", type_),
+            Concept::Thing(thing) => write!(f, "{}", thing),
+            Concept::Value(value) => write!(f, "{}", value),
+        }
+    }
 }
 
 #[derive(Debug, Clone, Hash, Eq, PartialEq, Ord, PartialOrd)]

--- a/compiler/annotation/expression/mod.rs
+++ b/compiler/annotation/expression/mod.rs
@@ -9,7 +9,6 @@ use std::{
     fmt::{Debug, Display, Formatter},
 };
 
-use answer::variable::Variable;
 use concept::error::ConceptReadError;
 use encoding::value::value_type::ValueTypeCategory;
 use ir::pattern::{expression::Operator, variable_category::VariableCategory};

--- a/compiler/executable/fetch/executable.rs
+++ b/compiler/executable/fetch/executable.rs
@@ -23,10 +23,10 @@ use crate::{
 };
 
 pub struct ExecutableFetch {
-    object_instruction: FetchObjectInstruction,
+    pub object_instruction: FetchObjectInstruction,
 }
 
-enum FetchSomeInstruction {
+pub enum FetchSomeInstruction {
     SingleVar(VariablePosition),
     SingleAttribute(VariablePosition, AttributeType<'static>),
     SingleFunction(ExecutableFunction),
@@ -39,14 +39,16 @@ enum FetchSomeInstruction {
     ListAttributesFromList(VariablePosition, AttributeType<'static>),
 }
 
-enum FetchObjectInstruction {
+pub enum FetchObjectInstruction {
     Entries(HashMap<ParameterID, FetchSomeInstruction>),
     Attributes(VariablePosition),
 }
 
-struct ExecutableFetchListSubFetch {
-    stages: Vec<ExecutableStage>,
-    fetch: ExecutableFetch,
+pub struct ExecutableFetchListSubFetch {
+    pub variable_registry: Arc<VariableRegistry>,
+    pub input_position_mapping: HashMap<VariablePosition, VariablePosition>,
+    pub stages: Vec<ExecutableStage>,
+    pub fetch: Arc<ExecutableFetch>,
 }
 
 pub fn compile_fetch(
@@ -118,17 +120,22 @@ fn compile_some(
         }
         AnnotatedFetchSome::ListSubFetch(sub_fetch) => {
             let AnnotatedFetchListSubFetch { variable_registry, input_variables, stages, fetch } = sub_fetch;
-            let (compiled_stages, compiled_fetch) = compile_stages_and_fetch(
-                statistics,
-                Arc::new(variable_registry),
-                available_functions,
-                stages,
-                Some(fetch),
-                input_variables,
-            )
-            .map_err(|err| FetchCompilationError::SubFetchCompilation { typedb_source: Box::new(err) })?;
+            let registry = Arc::new(variable_registry);
+            let (input_positions, compiled_stages, compiled_fetch) =
+                compile_stages_and_fetch(statistics, registry.clone(), stages, Some(fetch), &input_variables)
+                    .map_err(|err| FetchCompilationError::SubFetchCompilation { typedb_source: Box::new(err) })?;
+            let input_position_remapping = input_variables
+                .into_iter()
+                .map(|var| {
+                    let parent_position = variable_positions.get(&var).unwrap();
+                    let child_position = input_positions.get(&var).unwrap();
+                    (*parent_position, *child_position)
+                })
+                .collect();
 
             Ok(FetchSomeInstruction::ListSubFetch(ExecutableFetchListSubFetch {
+                variable_registry: registry,
+                input_position_mapping: input_position_remapping,
                 stages: compiled_stages,
                 fetch: compiled_fetch.unwrap(),
             }))

--- a/compiler/executable/fetch/executable.rs
+++ b/compiler/executable/fetch/executable.rs
@@ -16,7 +16,7 @@ use crate::{
     executable::{
         function::{compile_function, ExecutableFunction},
         match_::planner::function_plan::ExecutableFunctionRegistry,
-        pipeline::{compile_pipeline, compile_stages_and_fetch, ExecutableStage},
+        pipeline::{compile_stages_and_fetch, ExecutableStage},
         ExecutableCompilationError,
     },
     VariablePosition,
@@ -121,9 +121,15 @@ fn compile_some(
         AnnotatedFetchSome::ListSubFetch(sub_fetch) => {
             let AnnotatedFetchListSubFetch { variable_registry, input_variables, stages, fetch } = sub_fetch;
             let registry = Arc::new(variable_registry);
-            let (input_positions, compiled_stages, compiled_fetch) =
-                compile_stages_and_fetch(statistics, registry.clone(), stages, Some(fetch), &input_variables)
-                    .map_err(|err| FetchCompilationError::SubFetchCompilation { typedb_source: Box::new(err) })?;
+            let (input_positions, compiled_stages, compiled_fetch) = compile_stages_and_fetch(
+                statistics,
+                registry.clone(),
+                available_functions,
+                stages,
+                Some(fetch),
+                &input_variables,
+            )
+            .map_err(|err| FetchCompilationError::SubFetchCompilation { typedb_source: Box::new(err) })?;
             let input_position_remapping = input_variables
                 .into_iter()
                 .map(|var| {

--- a/compiler/executable/function.rs
+++ b/compiler/executable/function.rs
@@ -4,8 +4,10 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-use std::{collections::HashMap, sync::Arc};
-use std::collections::HashSet;
+use std::{
+    collections::{HashMap, HashSet},
+    sync::Arc,
+};
 
 use answer::variable::Variable;
 use concept::thing::statistics::Statistics;
@@ -44,9 +46,13 @@ pub(crate) fn compile_function(
     function: AnnotatedFunction,
 ) -> Result<ExecutableFunction, ExecutableCompilationError> {
     let AnnotatedFunction { variable_registry, arguments, stages, return_ } = function;
-    let arguments_set = HashSet::from_iter(arguments.into_iter());
-    let (_argument_positions, mut executable_stages) =
-        compile_pipeline_stages(statistics, Arc::new(variable_registry), stages, &arguments_set)?;
+    let (argument_positions, mut executable_stages) = compile_pipeline_stages(
+        statistics,
+        Arc::new(variable_registry),
+        schema_functions,
+        stages,
+        arguments.into_iter(),
+    )?;
     let returns = compile_return_operation(&mut executable_stages, return_)?;
     Ok(ExecutableFunction { executable_stages, argument_positions, returns })
 }

--- a/compiler/executable/function.rs
+++ b/compiler/executable/function.rs
@@ -5,6 +5,7 @@
  */
 
 use std::{collections::HashMap, sync::Arc};
+use std::collections::HashSet;
 
 use answer::variable::Variable;
 use concept::thing::statistics::Statistics;
@@ -43,19 +44,15 @@ pub(crate) fn compile_function(
     function: AnnotatedFunction,
 ) -> Result<ExecutableFunction, ExecutableCompilationError> {
     let AnnotatedFunction { variable_registry, arguments, stages, return_ } = function;
-    let (mut executable_stages, mut argument_positions) = compile_pipeline_stages(
-        statistics,
-        Arc::new(variable_registry),
-        schema_functions,
-        stages,
-        arguments.clone().into_iter(),
-    )?;
+    let arguments_set = HashSet::from_iter(arguments.into_iter());
+    let (_argument_positions, mut executable_stages) =
+        compile_pipeline_stages(statistics, Arc::new(variable_registry), stages, &arguments_set)?;
     let returns = compile_return_operation(&mut executable_stages, return_)?;
     Ok(ExecutableFunction { executable_stages, argument_positions, returns })
 }
 
 fn compile_return_operation(
-    executable_stages: &mut Vec<ExecutableStage>,
+    executable_stages: &[ExecutableStage],
     return_: AnnotatedFunctionReturn,
 ) -> Result<ExecutableReturn, ExecutableCompilationError> {
     let variable_positions =

--- a/compiler/executable/match_/planner/match_executable.rs
+++ b/compiler/executable/match_/planner/match_executable.rs
@@ -50,10 +50,6 @@ impl MatchExecutable {
         self.steps.last().unwrap().selected_variables()
     }
 
-    pub fn variable_registry(&self) -> &VariableRegistry {
-        &self.variable_registry
-    }
-
     pub fn variable_positions(&self) -> &HashMap<Variable, VariablePosition> {
         &self.variable_positions
     }

--- a/compiler/executable/pipeline.rs
+++ b/compiler/executable/pipeline.rs
@@ -36,20 +36,20 @@ use crate::{
 pub struct ExecutablePipeline {
     pub executable_functions: ExecutableFunctionRegistry,
     pub executable_stages: Vec<ExecutableStage>,
-    pub executable_fetch: Option<ExecutableFetch>,
+    pub executable_fetch: Option<Arc<ExecutableFetch>>,
 }
 
 pub enum ExecutableStage {
-    Match(MatchExecutable),
-    Insert(InsertExecutable),
-    Delete(DeleteExecutable),
+    Match(Arc<MatchExecutable>),
+    Insert(Arc<InsertExecutable>),
+    Delete(Arc<DeleteExecutable>),
 
-    Select(SelectExecutable),
-    Sort(SortExecutable),
-    Offset(OffsetExecutable),
-    Limit(LimitExecutable),
-    Require(RequireExecutable),
-    Reduce(ReduceExecutable),
+    Select(Arc<SelectExecutable>),
+    Sort(Arc<SortExecutable>),
+    Offset(Arc<OffsetExecutable>),
+    Limit(Arc<LimitExecutable>),
+    Require(Arc<RequireExecutable>),
+    Reduce(Arc<ReduceExecutable>),
 }
 
 impl ExecutableStage {
@@ -86,7 +86,7 @@ pub fn compile_pipeline(
     annotated_preamble: AnnotatedUnindexedFunctions,
     annotated_stages: Vec<AnnotatedStage>,
     annotated_fetch: Option<AnnotatedFetch>,
-    input_variables: HashSet<Variable>,
+    input_variables: &HashSet<Variable>,
 ) -> Result<ExecutablePipeline, ExecutableCompilationError> {
     // TODO: Cache compiled schema functions?
     let mut executable_schema_functions = HashMap::new();
@@ -107,13 +107,13 @@ pub fn compile_pipeline(
 
     let schema_and_preamble_functions: ExecutableFunctionRegistry =
         ExecutableFunctionRegistry::new(arced_executable_schema_functions, executable_preamble_functions);
-    let (executable_stages, executable_fetch) = compile_stages_and_fetch(
+    let (_input_positions, executable_stages, executable_fetch) =compile_stages_and_fetch(
         statistics,
         variable_registry,
         &schema_and_preamble_functions,
         annotated_stages,
         annotated_fetch,
-        input_variables,
+        &input_variables,
     )?;
     Ok(ExecutablePipeline { executable_functions: schema_and_preamble_functions, executable_stages, executable_fetch })
 }
@@ -124,9 +124,9 @@ pub fn compile_stages_and_fetch(
     available_functions: &ExecutableFunctionRegistry,
     annotated_stages: Vec<AnnotatedStage>,
     annotated_fetch: Option<AnnotatedFetch>,
-    input_variables: HashSet<Variable>,
-) -> Result<(Vec<ExecutableStage>, Option<ExecutableFetch>), ExecutableCompilationError> {
-    let (executable_stages, _) = compile_pipeline_stages(
+    input_variables: &HashSet<Variable>,
+) -> Result<(HashMap<Variable, VariablePosition>, Vec<ExecutableStage>, Option<Arc<ExecutableFetch>>), ExecutableCompilationError> {
+    let (input_positions, executable_stages) = compile_pipeline_stages(
         statistics,
         variable_registry.clone(),
         available_functions,
@@ -141,8 +141,9 @@ pub fn compile_stages_and_fetch(
             compile_fetch(statistics, available_functions, fetch, &stages_variable_positions)
                 .map_err(|err| ExecutableCompilationError::FetchCompliation { typedb_source: err })
         })
-        .transpose()?;
-    Ok((executable_stages, executable_fetch))
+        .transpose()?
+        .map(|fetch| Arc::new(fetch));
+    Ok((input_positions, executable_stages, executable_fetch))
 }
 
 pub(crate) fn compile_pipeline_stages(
@@ -151,22 +152,19 @@ pub(crate) fn compile_pipeline_stages(
     functions: &ExecutableFunctionRegistry,
     annotated_stages: Vec<AnnotatedStage>,
     input_variables: impl Iterator<Item = Variable>,
-) -> Result<(Vec<ExecutableStage>, HashMap<Variable, VariablePosition>), ExecutableCompilationError> {
+) -> Result<(HashMap<Variable, VariablePosition>, Vec<ExecutableStage>), ExecutableCompilationError> {
     let mut executable_stages = Vec::with_capacity(annotated_stages.len());
-    let pipeline_input_variable_positions = input_variables
-        .enumerate()
-        .map(|(i, var)| (var, VariablePosition { position: i as u32 }))
-        .collect::<HashMap<_, _>>();
+    let input_variable_positions =
+        input_variables.iter().enumerate().map(|(i, var)| (*var, VariablePosition { position: i as u32 })).collect();
     for stage in annotated_stages {
-        let stage_input_variable_positions = executable_stages
-            .last()
-            .map(|stage: &ExecutableStage| stage.output_row_mapping())
-            .unwrap_or_else(|| pipeline_input_variable_positions.clone());
-        let executable_stage =
-            compile_stage(statistics, variable_registry.clone(), &stage_input_variable_positions, stage, functions)?;
+        let executable_stage = match executable_stages.last().map(|stage: &ExecutableStage| stage.output_row_mapping())
+        {
+            Some(row_mapping) => compile_stage(statistics, variable_registry.clone(), &row_mapping, stage)?,
+            None => compile_stage(statistics, variable_registry.clone(), &input_variable_positions, stage)?,
+        };
         executable_stages.push(executable_stage);
     }
-    Ok((executable_stages, pipeline_input_variable_positions))
+    Ok((input_variable_positions, executable_stages))
 }
 
 fn compile_stage(
@@ -187,7 +185,7 @@ fn compile_stage(
                 statistics,
                 // functions,
             );
-            Ok(ExecutableStage::Match(plan))
+            Ok(ExecutableStage::Match(Arc::new(plan)))
         }
         AnnotatedStage::Insert { block, annotations } => {
             let plan = crate::executable::insert::executable::compile(
@@ -197,7 +195,7 @@ fn compile_stage(
                 annotations,
             )
             .map_err(|source| ExecutableCompilationError::InsertExecutableCompilation { source })?;
-            Ok(ExecutableStage::Insert(plan))
+            Ok(ExecutableStage::Insert(Arc::new(plan)))
         }
         AnnotatedStage::Delete { block, deleted_variables, annotations } => {
             let plan = crate::executable::delete::executable::compile(
@@ -207,7 +205,7 @@ fn compile_stage(
                 deleted_variables,
             )
             .map_err(|source| ExecutableCompilationError::DeleteExecutableCompilation { source })?;
-            Ok(ExecutableStage::Delete(plan))
+            Ok(ExecutableStage::Delete(Arc::new(plan)))
         }
         AnnotatedStage::Select(select) => {
             let mut retained_positions = HashSet::with_capacity(select.variables.len());
@@ -217,30 +215,30 @@ fn compile_stage(
                 retained_positions.insert(pos);
                 output_row_mapping.insert(variable, pos);
             }
-            Ok(ExecutableStage::Select(SelectExecutable { retained_positions, output_row_mapping }))
+            Ok(ExecutableStage::Select(Arc::new(SelectExecutable { retained_positions, output_row_mapping })))
         }
-        AnnotatedStage::Sort(sort) => Ok(ExecutableStage::Sort(SortExecutable {
+        AnnotatedStage::Sort(sort) => Ok(ExecutableStage::Sort(Arc::new(SortExecutable {
             sort_on: sort.variables.clone(),
             output_row_mapping: input_variables.clone(),
-        })),
-        AnnotatedStage::Offset(offset) => Ok(ExecutableStage::Offset(OffsetExecutable {
+        }))),
+        AnnotatedStage::Offset(offset) => Ok(ExecutableStage::Offset(Arc::new(OffsetExecutable {
             offset: offset.offset(),
             output_row_mapping: input_variables.clone(),
-        })),
-        AnnotatedStage::Limit(limit) => Ok(ExecutableStage::Limit(LimitExecutable {
+        }))),
+        AnnotatedStage::Limit(limit) => Ok(ExecutableStage::Limit(Arc::new(LimitExecutable {
             limit: limit.limit(),
             output_row_mapping: input_variables.clone(),
-        })),
+        }))),
         AnnotatedStage::Require(require) => {
             let mut required_positions = HashSet::with_capacity(require.variables.len());
             for &variable in &require.variables {
                 let pos = input_variables[&variable];
                 required_positions.insert(pos);
             }
-            Ok(ExecutableStage::Require(RequireExecutable {
+            Ok(ExecutableStage::Require(Arc::new(RequireExecutable {
                 required: required_positions,
                 output_row_mapping: input_variables.clone(),
-            }))
+            })))
         }
         AnnotatedStage::Reduce(reduce, typed_reducers) => {
             debug_assert_eq!(reduce.assigned_reductions.len(), typed_reducers.len());
@@ -261,11 +259,11 @@ fn compile_stage(
                 let reducer_on_position = reducer_on_variable.clone().map(input_variables);
                 reductions.push(reducer_on_position);
             }
-            Ok(ExecutableStage::Reduce(ReduceExecutable {
+            Ok(ExecutableStage::Reduce(Arc::new(ReduceExecutable {
                 reductions: reductions,
                 input_group_positions,
                 output_row_mapping,
-            }))
+            })))
         }
     }
 }

--- a/concept/type_/attribute_type.rs
+++ b/concept/type_/attribute_type.rs
@@ -7,6 +7,7 @@
 use std::{
     collections::{HashMap, HashSet},
     fmt::{Display, Formatter},
+    sync::Arc,
 };
 
 use encoding::{
@@ -117,6 +118,14 @@ impl<'a> TypeAPI<'a> for AttributeType<'a> {
         type_manager: &'m TypeManager,
     ) -> Result<MaybeOwns<'m, Label<'static>>, ConceptReadError> {
         type_manager.get_attribute_type_label(snapshot, self.clone().into_owned())
+    }
+
+    fn get_label_arc<'m>(
+        &self,
+        snapshot: &impl ReadableSnapshot,
+        type_manager: &'m TypeManager,
+    ) -> Result<Arc<Label<'static>>, ConceptReadError> {
+        type_manager.get_attribute_type_label_arc(snapshot, self.clone().into_owned())
     }
 
     fn get_supertype(

--- a/concept/type_/entity_type.rs
+++ b/concept/type_/entity_type.rs
@@ -7,6 +7,7 @@
 use std::{
     collections::HashSet,
     fmt::{Display, Formatter},
+    sync::Arc,
 };
 
 use encoding::{
@@ -113,6 +114,14 @@ impl<'a> TypeAPI<'a> for EntityType<'a> {
         type_manager: &'m TypeManager,
     ) -> Result<MaybeOwns<'m, Label<'static>>, ConceptReadError> {
         type_manager.get_entity_type_label(snapshot, self.clone().into_owned())
+    }
+
+    fn get_label_arc<'m>(
+        &self,
+        snapshot: &impl ReadableSnapshot,
+        type_manager: &'m TypeManager,
+    ) -> Result<Arc<Label<'static>>, ConceptReadError> {
+        type_manager.get_entity_type_label_arc(snapshot, self.clone().into_owned())
     }
 
     fn get_supertype(

--- a/concept/type_/mod.rs
+++ b/concept/type_/mod.rs
@@ -9,6 +9,7 @@ use std::{
     fmt::{Display, Formatter},
     hash::Hash,
     iter,
+    sync::Arc,
 };
 
 use bytes::{byte_reference::ByteReference, Bytes};
@@ -114,6 +115,12 @@ pub trait TypeAPI<'a>: ConceptAPI<'a> + TypeVertexEncoding<'a> + Sized + Clone +
         snapshot: &impl ReadableSnapshot,
         type_manager: &'m TypeManager,
     ) -> Result<MaybeOwns<'m, Label<'static>>, ConceptReadError>;
+
+    fn get_label_arc<'m>(
+        &self,
+        snapshot: &impl ReadableSnapshot,
+        type_manager: &'m TypeManager,
+    ) -> Result<Arc<Label<'static>>, ConceptReadError>;
 
     fn get_supertype(
         &self,

--- a/concept/type_/object_type.rs
+++ b/concept/type_/object_type.rs
@@ -4,7 +4,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-use std::collections::HashSet;
+use std::{collections::HashSet, sync::Arc};
 
 use encoding::{
     error::{EncodingError, EncodingError::UnexpectedPrefix},
@@ -254,6 +254,14 @@ impl<'a> TypeAPI<'a> for ObjectType<'a> {
         type_manager: &'m TypeManager,
     ) -> Result<MaybeOwns<'m, Label<'static>>, ConceptReadError> {
         with_object_type!(self, |object| { object.get_label(snapshot, type_manager) })
+    }
+
+    fn get_label_arc<'m>(
+        &self,
+        snapshot: &impl ReadableSnapshot,
+        type_manager: &'m TypeManager,
+    ) -> Result<Arc<Label<'static>>, ConceptReadError> {
+        with_object_type!(self, |object| { object.get_label_arc(snapshot, type_manager) })
     }
 
     fn get_supertype(

--- a/concept/type_/relation_type.rs
+++ b/concept/type_/relation_type.rs
@@ -7,6 +7,7 @@
 use std::{
     collections::HashSet,
     fmt::{Display, Formatter},
+    sync::Arc,
 };
 
 use encoding::{
@@ -118,6 +119,14 @@ impl<'a> TypeAPI<'a> for RelationType<'a> {
         type_manager: &'m TypeManager,
     ) -> Result<MaybeOwns<'m, Label<'static>>, ConceptReadError> {
         type_manager.get_relation_type_label(snapshot, self.clone().into_owned())
+    }
+
+    fn get_label_arc<'m>(
+        &self,
+        snapshot: &impl ReadableSnapshot,
+        type_manager: &'m TypeManager,
+    ) -> Result<Arc<Label<'static>>, ConceptReadError> {
+        type_manager.get_relation_type_label_arc(snapshot, self.clone().into_owned())
     }
 
     fn get_supertype(

--- a/concept/type_/role_type.rs
+++ b/concept/type_/role_type.rs
@@ -7,6 +7,7 @@
 use std::{
     collections::{HashMap, HashSet},
     fmt::{Display, Formatter},
+    sync::Arc,
 };
 
 use encoding::{
@@ -112,6 +113,14 @@ impl<'a> TypeAPI<'a> for RoleType<'a> {
         type_manager: &'m TypeManager,
     ) -> Result<MaybeOwns<'m, Label<'static>>, ConceptReadError> {
         type_manager.get_role_type_label(snapshot, self.clone().into_owned())
+    }
+
+    fn get_label_arc<'m>(
+        &self,
+        snapshot: &impl ReadableSnapshot,
+        type_manager: &'m TypeManager,
+    ) -> Result<Arc<Label<'static>>, ConceptReadError> {
+        type_manager.get_role_type_label_arc(snapshot, self.clone().into_owned())
     }
 
     fn get_supertype(

--- a/concept/type_/type_manager/type_cache/kind_cache.rs
+++ b/concept/type_/type_manager/type_cache/kind_cache.rs
@@ -4,7 +4,10 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-use std::collections::{HashMap, HashSet};
+use std::{
+    collections::{HashMap, HashSet},
+    sync::Arc,
+};
 
 use bytes::Bytes;
 use encoding::{
@@ -93,7 +96,7 @@ pub(crate) struct RelatesCache {
 #[derive(Debug)]
 pub(crate) struct CommonTypeCache<T: KindAPI<'static>> {
     pub(super) type_: T,
-    pub(super) label: Label<'static>,
+    pub(super) label: Arc<Label<'static>>,
     pub(super) annotations_declared: HashSet<T::AnnotationType>,
     pub(super) constraints: HashSet<TypeConstraint<T>>,
     // TODO: Should these all be sets instead of vec?
@@ -315,7 +318,7 @@ impl<T: KindAPI<'static, SelfStatic = T>> CommonTypeCache<T> {
     where
         Snapshot: ReadableSnapshot,
     {
-        let label = TypeReader::get_label(snapshot, type_.clone()).unwrap().unwrap();
+        let label = Arc::new(TypeReader::get_label(snapshot, type_.clone()).unwrap().unwrap());
         let annotations_declared = TypeReader::get_type_annotations_declared(snapshot, type_.clone()).unwrap();
         let constraints = TypeReader::get_type_constraints(snapshot, type_.clone()).unwrap();
         let supertype = TypeReader::get_supertype(snapshot, type_.clone()).unwrap();

--- a/concept/type_/type_manager/type_cache/type_cache.rs
+++ b/concept/type_/type_manager/type_cache/type_cache.rs
@@ -55,10 +55,10 @@ pub struct TypeCache {
 
     struct_definitions: Box<[Option<StructDefinitionCache>]>,
 
-    entity_types_index_label: HashMap<Label<'static>, EntityType<'static>>,
-    relation_types_index_label: HashMap<Label<'static>, RelationType<'static>>,
-    role_types_index_label: HashMap<Label<'static>, RoleType<'static>>,
-    attribute_types_index_label: HashMap<Label<'static>, AttributeType<'static>>,
+    entity_types_index_label: HashMap<Arc<Label<'static>>, EntityType<'static>>,
+    relation_types_index_label: HashMap<Arc<Label<'static>>, RelationType<'static>>,
+    role_types_index_label: HashMap<Arc<Label<'static>>, RoleType<'static>>,
+    attribute_types_index_label: HashMap<Arc<Label<'static>>, AttributeType<'static>>,
     struct_definition_index_by_name: HashMap<String, DefinitionKey<'static>>,
 
     role_types_by_name: HashMap<String, Vec<RoleType<'static>>>,
@@ -154,7 +154,7 @@ impl TypeCache {
 
     fn build_label_to_type_index<T: KindAPI<'static>, Cache: HasCommonTypeCache<T>>(
         type_cache_array: &[Option<Cache>],
-    ) -> HashMap<Label<'static>, T> {
+    ) -> HashMap<Arc<Label<'static>>, T> {
         type_cache_array
             .iter()
             .flatten()
@@ -257,6 +257,14 @@ impl TypeCache {
         CACHE: HasCommonTypeCache<T::SelfStatic> + 'this,
     {
         &T::get_cache(self, type_).common_type_cache().label
+    }
+
+    pub(crate) fn get_label_owned<'a, 'this, T, CACHE>(&'this self, type_: T) -> Arc<Label<'static>>
+    where
+        T: KindAPI<'a> + CacheGetter<CacheType = CACHE>,
+        CACHE: HasCommonTypeCache<T::SelfStatic> + 'this,
+    {
+        T::get_cache(self, type_).common_type_cache().label.clone()
     }
 
     pub(crate) fn get_annotations_declared<'a, 'this, T, CACHE>(

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -35,8 +35,8 @@ def vaticle_typedb_common():
 def vaticle_typedb_protocol():
     git_repository(
         name = "vaticle_typedb_protocol",
-        remote = "https://github.com/typedb/typedb-protocol",
-        tag = "3.0.0-alpha-3",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_protocol
+        remote = "https://github.com/vaticle/typedb-protocol",
+        commit = "94b79eb376e853a0a1c2b1ac838cb9d61f385100",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_protocol
     )
 
 def vaticle_typedb_behaviour():

--- a/executor/batch.rs
+++ b/executor/batch.rs
@@ -85,8 +85,8 @@ impl FixedBatch {
     }
 }
 
-impl From<MaybeOwnedRow<'static>> for FixedBatch {
-    fn from(row: MaybeOwnedRow<'static>) -> Self {
+impl<'a> From<MaybeOwnedRow<'a>> for FixedBatch {
+    fn from(row: MaybeOwnedRow<'a>) -> Self {
         let width = row.len() as u32;
         let mut multiplicities = FixedBatch::INIT_MULTIPLICITIES;
         multiplicities[0] = row.multiplicity();

--- a/executor/document.rs
+++ b/executor/document.rs
@@ -1,0 +1,117 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+use core::fmt;
+use std::{collections::HashMap, fmt::Formatter, sync::Arc};
+
+use answer::Concept;
+use encoding::{graph::type_::Kind, value::label::Label};
+use ir::pattern::ParameterID;
+
+#[derive(Debug, Clone)]
+pub struct ConceptDocument {
+    pub root: DocumentNode,
+}
+
+impl fmt::Display for ConceptDocument {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        fmt::Display::fmt(&self.root, f)
+    }
+}
+
+#[derive(Debug, Clone)]
+pub enum DocumentNode {
+    List(DocumentList),
+    Map(DocumentMap),
+    Leaf(DocumentLeaf),
+}
+
+impl DocumentNode {
+    pub(crate) fn as_list_mut(&mut self) -> &mut DocumentList {
+        if let Self::List(list) = self {
+            list
+        } else {
+            panic!("Node is not a list node.")
+        }
+    }
+}
+
+impl fmt::Display for DocumentNode {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::List(list) => fmt::Display::fmt(list, f),
+            Self::Map(map) => fmt::Display::fmt(map, f),
+            Self::Leaf(leaf) => fmt::Display::fmt(leaf, f),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub enum DocumentMap {
+    UserKeys(HashMap<ParameterID, DocumentNode>),
+    GeneratedKeys(HashMap<Arc<Label<'static>>, DocumentNode>),
+}
+
+impl fmt::Display for DocumentMap {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{{")?;
+        match self {
+            Self::UserKeys(map) => {
+                for (key, value) in map {
+                    write!(f, " \"{}\": {},", key, value)?;
+                }
+            }
+            Self::GeneratedKeys(map) => {
+                for (key, value) in map {
+                    write!(f, " \"{}\": {},", key, value)?;
+                }
+            }
+        }
+        write!(f, " }}")
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct DocumentList {
+    pub list: Vec<DocumentNode>,
+}
+
+impl DocumentList {
+    pub(crate) fn new() -> DocumentList {
+        Self { list: Vec::new() }
+    }
+
+    pub(crate) fn new_from(list: Vec<DocumentNode>) -> DocumentList {
+        Self { list }
+    }
+}
+
+impl fmt::Display for DocumentList {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "[")?;
+        for node in &self.list {
+            write!(f, " {},", node)?
+        }
+        write!(f, " ]")
+    }
+}
+
+#[derive(Debug, Clone)]
+pub enum DocumentLeaf {
+    Empty,
+    Concept(Concept<'static>),
+    Kind(Kind),
+}
+
+impl fmt::Display for DocumentLeaf {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            DocumentLeaf::Empty => write!(f, "empty"),
+            DocumentLeaf::Concept(concept) => write!(f, "{concept}"),
+            DocumentLeaf::Kind(kind) => write!(f, "{kind}"),
+        }
+    }
+}

--- a/executor/lib.rs
+++ b/executor/lib.rs
@@ -16,6 +16,7 @@ use compiler::VariablePosition;
 use tokio::sync::broadcast::error::TryRecvError;
 
 pub mod batch;
+pub mod document;
 pub mod error;
 pub mod expression_executor;
 mod function_executor;

--- a/executor/pipeline/delete.rs
+++ b/executor/pipeline/delete.rs
@@ -22,12 +22,12 @@ use crate::{
 };
 
 pub struct DeleteStageExecutor<PreviousStage> {
-    executable: DeleteExecutable,
+    executable: Arc<DeleteExecutable>,
     previous: PreviousStage,
 }
 
 impl<PreviousStage> DeleteStageExecutor<PreviousStage> {
-    pub fn new(executable: DeleteExecutable, previous: PreviousStage) -> Self {
+    pub fn new(executable: Arc<DeleteExecutable>, previous: PreviousStage) -> Self {
         Self { executable, previous }
     }
 }

--- a/executor/pipeline/fetch.rs
+++ b/executor/pipeline/fetch.rs
@@ -4,18 +4,384 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-use std::marker::PhantomData;
+use std::{collections::HashMap, marker::PhantomData, sync::Arc};
 
-use answer::Concept;
-use compiler::executable::fetch::executable::ExecutableFetch;
+use answer::{variable_value::VariableValue, Concept, Thing};
+use compiler::{
+    executable::fetch::executable::{
+        ExecutableFetch, ExecutableFetchListSubFetch, FetchObjectInstruction, FetchSomeInstruction,
+    },
+    VariablePosition,
+};
+use concept::{
+    error::ConceptReadError,
+    thing::{object::ObjectAPI, thing_manager::ThingManager},
+    type_::{
+        attribute_type::AttributeType,
+        constraint::{Constraint, ConstraintDescription},
+        Capability, OwnerAPI, TypeAPI,
+    },
+};
+use encoding::value::label::Label;
+use error::typedb_error;
+use ir::{pattern::ParameterID, pipeline::ParameterRegistry};
+use lending_iterator::LendingIterator;
 use storage::snapshot::ReadableSnapshot;
 
+use crate::{
+    document::{ConceptDocument, DocumentLeaf, DocumentList, DocumentMap, DocumentNode},
+    pipeline::{
+        pipeline::Pipeline,
+        stage::{ExecutionContext, StageAPI},
+        PipelineExecutionError,
+    },
+    row::MaybeOwnedRow,
+    ExecutionInterrupt,
+};
+
 pub struct FetchStageExecutor<Snapshot: ReadableSnapshot> {
-    ph: PhantomData<Snapshot>,
+    executable: Arc<ExecutableFetch>,
+    _phantom: PhantomData<Snapshot>,
 }
 
-impl<Snapshot: ReadableSnapshot> FetchStageExecutor<Snapshot> {
-    pub(crate) fn new(executable: ExecutableFetch) -> Self {
-        todo!()
+impl<Snapshot: ReadableSnapshot + 'static> FetchStageExecutor<Snapshot> {
+    pub(crate) fn new(executable: Arc<ExecutableFetch>) -> Self {
+        Self { executable, _phantom: PhantomData::default() }
+    }
+
+    pub(crate) fn into_iterator<PreviousStage: StageAPI<Snapshot>>(
+        self,
+        previous_iterator: PreviousStage::OutputIterator,
+        context: ExecutionContext<Snapshot>,
+        interrupt: ExecutionInterrupt,
+    ) -> (impl Iterator<Item = Result<ConceptDocument, PipelineExecutionError>>, ExecutionContext<Snapshot>) {
+        let ExecutionContext { snapshot, thing_manager, parameters } = context.clone();
+        let executable = self.executable;
+        let documents_iterator = previous_iterator
+            .map_static(move |row_result| match row_result {
+                Ok(row) => execute_fetch(
+                    &executable,
+                    snapshot.clone(),
+                    thing_manager.clone(),
+                    parameters.clone(),
+                    row.as_reference(),
+                    interrupt.clone(),
+                )
+                .map_err(|err| PipelineExecutionError::FetchError { typedb_source: err }),
+                Err(err) => Err(err.clone()),
+            })
+            .into_iter();
+        (documents_iterator, context)
     }
 }
+
+fn execute_fetch(
+    fetch: &ExecutableFetch,
+    snapshot: Arc<impl ReadableSnapshot + 'static>,
+    thing_manager: Arc<ThingManager>,
+    parameters: Arc<ParameterRegistry>,
+    row: MaybeOwnedRow<'_>,
+    interrupt: ExecutionInterrupt,
+) -> Result<ConceptDocument, FetchExecutionError> {
+    let node = execute_object(&fetch.object_instruction, snapshot, thing_manager, parameters, row, interrupt)?;
+    Ok(ConceptDocument { root: node })
+}
+
+fn execute_fetch_some(
+    fetch_some: &FetchSomeInstruction,
+    snapshot: Arc<impl ReadableSnapshot + 'static>,
+    thing_manager: Arc<ThingManager>,
+    parameters: Arc<ParameterRegistry>,
+    row: MaybeOwnedRow<'_>,
+    interrupt: ExecutionInterrupt,
+) -> Result<DocumentNode, FetchExecutionError> {
+    match fetch_some {
+        FetchSomeInstruction::SingleVar(position) => {
+            Ok(variable_value_to_document(row.get(*position).as_reference()))
+        }
+        FetchSomeInstruction::SingleAttribute(position, attribute_type) => {
+            let variable_value = row.get(*position).as_reference();
+            match variable_value {
+                VariableValue::Empty => {
+                    Ok(DocumentNode::Leaf(DocumentLeaf::Empty))
+                },
+                VariableValue::Thing(Thing::Entity(entity)) => {
+                    execute_attribute_single(entity, attribute_type.clone(), snapshot, thing_manager)
+                        .map(|leaf| DocumentNode::Leaf(leaf))
+                }
+                VariableValue::Thing(Thing::Relation(relation)) => {
+                    execute_attribute_single(relation, attribute_type.clone(), snapshot, thing_manager)
+                        .map(|leaf| DocumentNode::Leaf(leaf))
+                }
+                VariableValue::Thing(Thing::Attribute(_)) => Err(FetchExecutionError::FetchAttributesOfAttribute {}),
+                VariableValue::Type(_) => Err(FetchExecutionError::FetchAttributesOfType {}),
+                VariableValue::Value(_) => Err(FetchExecutionError::FetchAttributesOfValue {}),
+                VariableValue::ThingList(_) | VariableValue::ValueList(_) => Err(FetchExecutionError::FetchAttributesOfList {}),
+            }
+        }
+        FetchSomeInstruction::SingleFunction(function) => {
+            Err(FetchExecutionError::Unimplemented {
+                description: "Fetch expressions and match-return subqueries are not available yet (try a match-fetch subquery instead?).".to_owned()
+            })
+        }
+        FetchSomeInstruction::Object(object) => {
+            execute_object(object, snapshot, thing_manager, parameters, row, interrupt)
+        }
+        FetchSomeInstruction::ListFunction(function) => {
+            Err(FetchExecutionError::Unimplemented {
+                description: "Fetch expressions and match-return subqueries are not available yet (try a match-fetch subquery instead?).".to_owned()
+            })
+        }
+        FetchSomeInstruction::ListSubFetch(ExecutableFetchListSubFetch { input_position_mapping, variable_registry, stages, fetch }) => {
+            let pipeline = if input_position_mapping.is_empty() {
+                Pipeline::build_read_pipeline(
+                    snapshot,
+                    thing_manager,
+                    &variable_registry,
+                    &**stages,
+                    Some(fetch.clone()),
+                    parameters,
+                    None
+                )
+            } else {
+                let max_position = input_position_mapping.values().max().map(|pos| pos.as_usize()).unwrap();
+                let mut initial_row = vec![VariableValue::Empty; max_position + 1];
+                input_position_mapping.iter().for_each(|(parent_row_position, local_row_position)| {
+                    initial_row[local_row_position.as_usize()] = row[parent_row_position.as_usize()].as_reference().into_owned();
+                });
+                let initial_row = MaybeOwnedRow::new_owned(initial_row, row.multiplicity());
+                Pipeline::build_read_pipeline(
+                    snapshot,
+                    thing_manager,
+                    &variable_registry,
+                    &**stages,
+                    Some(fetch.clone()),
+                    parameters,
+                    Some(initial_row)
+                )
+            };
+
+            let (iterator, _context) = pipeline.into_documents_iterator(interrupt)
+                .map_err(|(err, _context)| FetchExecutionError::SubFetch { typedb_source: Box::new(err) })?;
+
+            let mut nodes = Vec::new();
+            for result in iterator {
+                nodes.push(
+                    result.map_err(|err| FetchExecutionError::SubFetch { typedb_source: Box::new(err) })?.root
+                );
+            }
+            Ok(DocumentNode::List(DocumentList::new_from(nodes)))
+        }
+        FetchSomeInstruction::ListAttributesAsList(position, attribute_type) => {
+            let variable_value = row.get(*position).as_reference();
+            match variable_value {
+                VariableValue::Empty => {
+                    Ok(DocumentNode::Leaf(DocumentLeaf::Empty))
+                },
+                VariableValue::Thing(Thing::Entity(entity)) => {
+                    execute_attributes_list(entity, attribute_type.clone(), snapshot, thing_manager)
+                        .map(|list| DocumentNode::List(list))
+                }
+                VariableValue::Thing(Thing::Relation(relation)) => {
+                    execute_attributes_list(relation, attribute_type.clone(), snapshot, thing_manager)
+                        .map(|list| DocumentNode::List(list))
+                }
+                VariableValue::Thing(Thing::Attribute(_)) => Err(FetchExecutionError::FetchAttributesOfAttribute {}),
+                VariableValue::Type(_) => Err(FetchExecutionError::FetchAttributesOfType {}),
+                VariableValue::Value(_) => Err(FetchExecutionError::FetchAttributesOfValue {}),
+                VariableValue::ThingList(_) | VariableValue::ValueList(_) => Err(FetchExecutionError::FetchAttributesOfList {}),
+            }
+        }
+        FetchSomeInstruction::ListAttributesFromList(_, _) => {
+            Err(FetchExecutionError::Unimplemented { description: "List attributes are not available yet.".to_string() })
+        }
+    }
+}
+
+fn execute_object(
+    fetch_object: &FetchObjectInstruction,
+    snapshot: Arc<impl ReadableSnapshot + 'static>,
+    thing_manager: Arc<ThingManager>,
+    parameters: Arc<ParameterRegistry>,
+    row: MaybeOwnedRow<'_>,
+    interrupt: ExecutionInterrupt,
+) -> Result<DocumentNode, FetchExecutionError> {
+    match fetch_object {
+        FetchObjectInstruction::Entries(entries) => {
+            let object = execute_object_entries(entries, snapshot, thing_manager, parameters, row, interrupt)?;
+            Ok(DocumentNode::Map(object))
+        }
+        FetchObjectInstruction::Attributes(position) => {
+            execute_object_attributes(*position, snapshot, thing_manager, row)
+        }
+    }
+}
+
+fn execute_object_attributes(
+    variable_position: VariablePosition,
+    snapshot: Arc<impl ReadableSnapshot>,
+    thing_manager: Arc<ThingManager>,
+    row: MaybeOwnedRow<'_>,
+) -> Result<DocumentNode, FetchExecutionError> {
+    let concept = row.get(variable_position);
+    match concept {
+        VariableValue::Empty => Ok(DocumentNode::Leaf(DocumentLeaf::Empty)),
+        VariableValue::Thing(Thing::Entity(entity)) => {
+            execute_attributes_all(entity.as_reference(), snapshot, thing_manager)
+        }
+        VariableValue::Thing(Thing::Relation(relation)) => {
+            execute_attributes_all(relation.as_reference(), snapshot, thing_manager)
+        }
+        VariableValue::Thing(Thing::Attribute(_)) => Err(FetchExecutionError::FetchAttributesOfAttribute {}),
+        VariableValue::Type(_) => Err(FetchExecutionError::FetchAttributesOfType {}),
+        VariableValue::Value(_) => Err(FetchExecutionError::FetchAttributesOfValue {}),
+        VariableValue::ThingList(_) | VariableValue::ValueList(_) => Err(FetchExecutionError::FetchAttributesOfList {}),
+    }
+}
+
+fn execute_attributes_all<'a>(
+    object: impl ObjectAPI<'a>,
+    snapshot: Arc<impl ReadableSnapshot>,
+    thing_manager: Arc<ThingManager>,
+) -> Result<DocumentNode, FetchExecutionError> {
+    let mut iter = object.get_has_unordered(snapshot.as_ref(), &thing_manager);
+    let mut map: HashMap<Arc<Label<'static>>, DocumentNode> = HashMap::new();
+    while let Some(result) = iter.next() {
+        let (attribute, count) = result.map_err(|err| FetchExecutionError::ConceptReadError { source: err })?;
+        let attr_type = attribute.type_();
+        let label = attr_type
+            .get_label_arc(snapshot.as_ref(), thing_manager.type_manager())
+            .map_err(|err| FetchExecutionError::ConceptReadError { source: err })?;
+        let owner_type = object.type_();
+        let ownership = owner_type
+            .get_owns_attribute(snapshot.as_ref(), thing_manager.type_manager(), attr_type)
+            .map_err(|err| FetchExecutionError::ConceptReadError { source: err })?
+            .unwrap();
+        let cardinalities = ownership
+            .get_cardinality_constraints(snapshot.as_ref(), thing_manager.type_manager())
+            .map_err(|err| FetchExecutionError::ConceptReadError { source: err })?;
+        let is_single = cardinalities
+            .into_iter()
+            .filter_map(|constraint| {
+                if let ConstraintDescription::Cardinality(cardinality) = constraint.description() {
+                    cardinality.end()
+                } else {
+                    unreachable!()
+                }
+            })
+            .max()
+            .map(|max| max > 1)
+            .unwrap_or(false);
+
+        let leaf = DocumentNode::Leaf(DocumentLeaf::Concept(Concept::Thing(Thing::Attribute(attribute.into_owned()))));
+        if is_single {
+            map.insert(label, leaf);
+        } else {
+            let entry = map.entry(label).or_insert_with(|| DocumentNode::List(DocumentList::new()));
+            for _ in 0..count {
+                entry.as_list_mut().list.push(leaf.clone())
+            }
+        }
+    }
+    Ok(DocumentNode::Map(DocumentMap::GeneratedKeys(map)))
+}
+
+fn execute_attribute_single<'a>(
+    object: impl ObjectAPI<'a>,
+    attribute_type: AttributeType<'static>,
+    snapshot: Arc<impl ReadableSnapshot>,
+    thing_manager: Arc<ThingManager>,
+) -> Result<DocumentLeaf, FetchExecutionError> {
+    let mut iter = object
+        .get_has_type_unordered(snapshot.as_ref(), thing_manager.as_ref(), attribute_type)
+        .map_err(|err| FetchExecutionError::ConceptReadError { source: err })?;
+    let attribute = iter.next();
+    match attribute {
+        None => Ok(DocumentLeaf::Empty),
+        Some(Err(err)) => Err(FetchExecutionError::ConceptReadError { source: err }),
+        Some(Ok((attribute, count))) => {
+            debug_assert!(count <= 1);
+            Ok(DocumentLeaf::Concept(Concept::Thing(Thing::Attribute(attribute.into_owned()))))
+        }
+    }
+}
+
+fn execute_attributes_list<'a>(
+    object: impl ObjectAPI<'a>,
+    attribute_type: AttributeType<'static>,
+    snapshot: Arc<impl ReadableSnapshot>,
+    thing_manager: Arc<ThingManager>,
+) -> Result<DocumentList, FetchExecutionError> {
+    let mut list = DocumentList::new();
+    let mut iter = object
+        .get_has_type_unordered(snapshot.as_ref(), thing_manager.as_ref(), attribute_type)
+        .map_err(|err| FetchExecutionError::ConceptReadError { source: err })?;
+    while let Some(result) = iter.next() {
+        match result {
+            Ok((attribute, count)) => {
+                for _ in 0..count {
+                    list.list.push(DocumentNode::Leaf(DocumentLeaf::Concept(Concept::Thing(Thing::Attribute(
+                        attribute.as_reference().into_owned(),
+                    )))));
+                }
+            }
+            Err(err) => return Err(FetchExecutionError::ConceptReadError { source: err }),
+        }
+    }
+    Ok(list)
+}
+
+fn execute_object_entries(
+    entries: &HashMap<ParameterID, FetchSomeInstruction>,
+    snapshot: Arc<impl ReadableSnapshot + 'static>,
+    thing_manager: Arc<ThingManager>,
+    parameters: Arc<ParameterRegistry>,
+    row: MaybeOwnedRow<'_>,
+    interrupt: ExecutionInterrupt,
+) -> Result<DocumentMap, FetchExecutionError> {
+    let mut map = HashMap::with_capacity(entries.len());
+    for (id, fetch_some) in entries {
+        map.insert(
+            *id,
+            execute_fetch_some(
+                fetch_some,
+                snapshot.clone(),
+                thing_manager.clone(),
+                parameters.clone(),
+                row.as_reference(),
+                interrupt.clone(),
+            )?,
+        );
+    }
+    Ok(DocumentMap::UserKeys(map))
+}
+
+fn variable_value_to_document(variable_value: VariableValue<'_>) -> DocumentNode {
+    match variable_value.into_owned() {
+        VariableValue::Empty => DocumentNode::Leaf(DocumentLeaf::Empty),
+        VariableValue::Type(type_) => DocumentNode::Leaf(DocumentLeaf::Concept(Concept::Type(type_))),
+        VariableValue::Thing(thing) => DocumentNode::Leaf(DocumentLeaf::Concept(Concept::Thing(thing))),
+        VariableValue::Value(value) => DocumentNode::Leaf(DocumentLeaf::Concept(Concept::Value(value))),
+        VariableValue::ThingList(_) => {
+            todo!()
+        }
+        VariableValue::ValueList(_) => {
+            todo!()
+        }
+    }
+}
+
+typedb_error!(
+    pub FetchExecutionError(component = "Fetch execution", prefix = "FEX") {
+        Unimplemented(0, "Unimplemented: {description}.", description: String),
+
+        FetchAttributesOfType(1, "Received unexpected Type instead of Entity or Relation while fetching owned attributes."),
+        FetchAttributesOfAttribute(2, "Received unexpected Attribute instead of Entity or Relation while fetching owned attributes."),
+        FetchAttributesOfValue(3, "Received unexpected Value instead of Entity or Relation while fetching owned attributes."),
+        FetchAttributesOfList(4, "Received unexpected List instead of Entity or Relation while fetching owned attributes."),
+
+        SubFetch(10, "Error executing sub fetch.", ( typedb_source : Box<PipelineExecutionError>)),
+
+        ConceptReadError(30, "Unexpected failed to read concept.", ( source: ConceptReadError )),
+    }
+);

--- a/executor/pipeline/insert.rs
+++ b/executor/pipeline/insert.rs
@@ -27,12 +27,12 @@ use crate::{
 };
 
 pub struct InsertStageExecutor<PreviousStage> {
-    executable: InsertExecutable,
+    executable: Arc<InsertExecutable>,
     previous: PreviousStage,
 }
 
 impl<PreviousStage> InsertStageExecutor<PreviousStage> {
-    pub fn new(executable: InsertExecutable, previous: PreviousStage) -> Self {
+    pub fn new(executable: Arc<InsertExecutable>, previous: PreviousStage) -> Self {
         Self { executable, previous }
     }
 

--- a/executor/pipeline/match_.rs
+++ b/executor/pipeline/match_.rs
@@ -4,6 +4,8 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
+use std::sync::Arc;
+
 use compiler::executable::match_::planner::match_executable::MatchExecutable;
 use lending_iterator::{LendingIterator, Peekable};
 use storage::snapshot::ReadableSnapshot;
@@ -19,12 +21,12 @@ use crate::{
 };
 
 pub struct MatchStageExecutor<PreviousStage> {
-    executable: MatchExecutable,
+    executable: Arc<MatchExecutable>,
     previous: PreviousStage,
 }
 
 impl<PreviousStage> MatchStageExecutor<PreviousStage> {
-    pub fn new(executable: MatchExecutable, previous: PreviousStage) -> Self {
+    pub fn new(executable: Arc<MatchExecutable>, previous: PreviousStage) -> Self {
         Self { executable, previous }
     }
 }
@@ -50,7 +52,7 @@ where
 
 pub struct MatchStageIterator<Snapshot: ReadableSnapshot + 'static, Iterator> {
     context: ExecutionContext<Snapshot>,
-    executable: MatchExecutable,
+    executable: Arc<MatchExecutable>,
     source_iterator: Iterator,
     current_iterator: Option<Peekable<PatternIterator<Snapshot>>>,
     interrupt: ExecutionInterrupt,
@@ -59,7 +61,7 @@ pub struct MatchStageIterator<Snapshot: ReadableSnapshot + 'static, Iterator> {
 impl<Snapshot: ReadableSnapshot + 'static, Iterator> MatchStageIterator<Snapshot, Iterator> {
     fn new(
         iterator: Iterator,
-        executable: MatchExecutable,
+        executable: Arc<MatchExecutable>,
         context: ExecutionContext<Snapshot>,
         interrupt: ExecutionInterrupt,
     ) -> Self {

--- a/executor/pipeline/mod.rs
+++ b/executor/pipeline/mod.rs
@@ -16,7 +16,7 @@ use crate::{
     batch::Batch,
     error::ReadExecutionError,
     pipeline::{
-        fetch::FetchStageExecutor,
+        fetch::{FetchExecutionError, FetchStageExecutor},
         stage::{ExecutionContext, StageAPI, StageIterator},
     },
     row::MaybeOwnedRow,
@@ -77,5 +77,6 @@ typedb_error!(
         InitialisingMatchIterator(5, "Error initialising Match clause iterator.", ( source: ConceptReadError )),
         WriteError(6, "Error executing write operation.", ( typedb_source: WriteError )),
         ReadPatternExecution(7, "Error executing a read pattern.", ( typedb_source : ReadExecutionError )),
+        FetchError(8, "Error executing fetch operation.", ( typedb_source: FetchExecutionError )),
     }
 );

--- a/executor/pipeline/reduce.rs
+++ b/executor/pipeline/reduce.rs
@@ -4,6 +4,8 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
+use std::sync::Arc;
+
 use compiler::executable::reduce::ReduceExecutable;
 use storage::snapshot::ReadableSnapshot;
 
@@ -18,12 +20,12 @@ use crate::{
 };
 
 pub struct ReduceStageExecutor<PreviousStage> {
-    executable: ReduceExecutable,
+    executable: Arc<ReduceExecutable>,
     previous: PreviousStage,
 }
 
 impl<PreviousStage> ReduceStageExecutor<PreviousStage> {
-    pub fn new(executable: ReduceExecutable, previous: PreviousStage) -> Self {
+    pub fn new(executable: Arc<ReduceExecutable>, previous: PreviousStage) -> Self {
         Self { executable, previous }
     }
 }
@@ -52,7 +54,7 @@ where
 
 fn reduce_iterator<Snapshot: ReadableSnapshot>(
     context: &ExecutionContext<Snapshot>,
-    executable: ReduceExecutable,
+    executable: Arc<ReduceExecutable>,
     iterator: impl StageIterator,
 ) -> Result<Batch, PipelineExecutionError> {
     let mut iterator = iterator;

--- a/executor/tests/writes.rs
+++ b/executor/tests/writes.rs
@@ -188,7 +188,7 @@ fn execute_insert<Snapshot: WritableSnapshot + 'static>(
         input_rows,
         ExecutionContext { snapshot, thing_manager, parameters: Arc::new(translation_context.parameters) },
     );
-    let insert_executor = InsertStageExecutor::new(insert_plan, initial);
+    let insert_executor = InsertStageExecutor::new(Arc::new(insert_plan), initial);
     let (output_iter, context) =
         insert_executor.into_iterator(ExecutionInterrupt::new_uninterruptible()).map_err(|(err, _)| match err {
             PipelineExecutionError::WriteError { typedb_source } => typedb_source,
@@ -268,7 +268,7 @@ fn execute_delete<Snapshot: WritableSnapshot + 'static>(
         input_rows,
         ExecutionContext { snapshot, thing_manager, parameters: Arc::new(translation_context.parameters) },
     );
-    let delete_executor = DeleteStageExecutor::new(delete_plan, initial);
+    let delete_executor = DeleteStageExecutor::new(Arc::new(delete_plan), initial);
     let (output_iter, context) =
         delete_executor.into_iterator(ExecutionInterrupt::new_uninterruptible()).map_err(|(err, _)| match err {
             PipelineExecutionError::WriteError { typedb_source } => typedb_source,

--- a/main.rs
+++ b/main.rs
@@ -8,6 +8,7 @@
 #![deny(elided_lifetimes_in_paths)]
 
 use logger::initialise_logging_global;
+use resource::constants::server::ASCII_LOGO;
 use server::parameters::config::Config;
 
 #[tokio::main]

--- a/main.rs
+++ b/main.rs
@@ -8,7 +8,6 @@
 #![deny(elided_lifetimes_in_paths)]
 
 use logger::initialise_logging_global;
-use resource::constants::server::ASCII_LOGO;
 use server::parameters::config::Config;
 
 #[tokio::main]

--- a/query/query_manager.rs
+++ b/query/query_manager.rs
@@ -96,18 +96,19 @@ impl QueryManager {
             annotated_preamble,
             annotated_stages,
             annotated_fetch,
-            HashSet::with_capacity(0),
+            &HashSet::with_capacity(0),
         )
         .map_err(|err| QueryError::ExecutableCompilation { typedb_source: err })?;
 
         // 4: Executor
         Ok(Pipeline::build_read_pipeline(
             snapshot,
-            &variable_registry,
             thing_manager,
-            executable_stages,
+            variable_registry.as_ref(),
+            &executable_stages,
             executable_fetch,
-            parameters,
+            Arc::new(parameters),
+            None,
         ))
     }
 
@@ -164,7 +165,7 @@ impl QueryManager {
             annotated_preamble,
             annotated_stages,
             annotated_fetch,
-            HashSet::with_capacity(0),
+            &HashSet::with_capacity(0),
         );
         let ExecutablePipeline { executable_functions, executable_stages, executable_fetch } = match executable_pipeline
         {
@@ -179,7 +180,7 @@ impl QueryManager {
             thing_manager,
             executable_stages,
             executable_fetch,
-            value_parameters,
+            Arc::new(value_parameters),
         ))
     }
 

--- a/server/BUILD
+++ b/server/BUILD
@@ -25,6 +25,7 @@ rust_library(
         "//encoding",
         "//executor",
         "//function",
+        "//ir",
         "//query",
         "//storage",
         "//resource",

--- a/server/service/document.rs
+++ b/server/service/document.rs
@@ -1,0 +1,180 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+use std::collections::HashMap;
+
+use answer::{Concept, Thing, Type};
+use concept::{error::ConceptReadError, thing::thing_manager::ThingManager, type_::type_manager::TypeManager};
+use executor::document::{ConceptDocument, DocumentLeaf, DocumentList, DocumentMap, DocumentNode};
+use ir::pipeline::ParameterRegistry;
+use itertools::Itertools;
+use storage::snapshot::ReadableSnapshot;
+
+use crate::service::concept::{
+    encode_attribute, encode_attribute_type, encode_entity_type, encode_relation_type, encode_role_type, encode_value,
+};
+
+pub(crate) fn encode_document(
+    document: ConceptDocument,
+    snapshot: &impl ReadableSnapshot,
+    type_manager: &TypeManager,
+    thing_manager: &ThingManager,
+    parameters: &ParameterRegistry,
+) -> Result<typedb_protocol::ConceptDocument, ConceptReadError> {
+    Ok(typedb_protocol::ConceptDocument {
+        root: Some(encode_node(document.root, snapshot, type_manager, thing_manager, parameters)?),
+    })
+}
+
+fn encode_node(
+    node: DocumentNode,
+    snapshot: &impl ReadableSnapshot,
+    type_manager: &TypeManager,
+    thing_manager: &ThingManager,
+    parameters: &ParameterRegistry,
+) -> Result<typedb_protocol::concept_document::Node, ConceptReadError> {
+    match node {
+        DocumentNode::List(list) => Ok(typedb_protocol::concept_document::Node {
+            node: Some(typedb_protocol::concept_document::node::Node::List(encode_list(
+                list,
+                snapshot,
+                type_manager,
+                thing_manager,
+                parameters,
+            )?)),
+        }),
+        DocumentNode::Map(map) => Ok(typedb_protocol::concept_document::Node {
+            node: Some(typedb_protocol::concept_document::node::Node::Map(encode_map(
+                map,
+                snapshot,
+                type_manager,
+                thing_manager,
+                parameters,
+            )?)),
+        }),
+        DocumentNode::Leaf(leaf) => Ok(typedb_protocol::concept_document::Node {
+            node: Some(typedb_protocol::concept_document::node::Node::Leaf(encode_leaf(
+                leaf,
+                snapshot,
+                type_manager,
+                thing_manager,
+            )?)),
+        }),
+    }
+}
+
+fn encode_map(
+    map: DocumentMap,
+    snapshot: &impl ReadableSnapshot,
+    type_manager: &TypeManager,
+    thing_manager: &ThingManager,
+    parameters: &ParameterRegistry,
+) -> Result<typedb_protocol::concept_document::node::Map, ConceptReadError> {
+    let encoded_map = match map {
+        DocumentMap::UserKeys(map) => {
+            let mut encoded_map = HashMap::with_capacity(map.len());
+            for (key, value) in map.into_iter() {
+                let key_name = parameters.fetch_key(key).unwrap();
+                let encoded_value = encode_node(value, snapshot, type_manager, thing_manager, parameters)?;
+                encoded_map.insert(key_name.to_owned(), encoded_value);
+            }
+            encoded_map
+        }
+        DocumentMap::GeneratedKeys(map) => {
+            let mut encoded_map = HashMap::with_capacity(map.len());
+            for (key, value) in map.into_iter() {
+                let encoded_value = encode_node(value, snapshot, type_manager, thing_manager, parameters)?;
+                encoded_map.insert(key.scoped_name().as_str().to_owned(), encoded_value);
+            }
+            encoded_map
+        }
+    };
+
+    Ok(typedb_protocol::concept_document::node::Map { map: encoded_map })
+}
+
+fn encode_list(
+    list: DocumentList,
+    snapshot: &impl ReadableSnapshot,
+    type_manager: &TypeManager,
+    thing_manager: &ThingManager,
+    parameters: &ParameterRegistry,
+) -> Result<typedb_protocol::concept_document::node::List, ConceptReadError> {
+    let encoded_list = list
+        .list
+        .into_iter()
+        .map(|node| encode_node(node, snapshot, type_manager, thing_manager, parameters))
+        .try_collect()?;
+    Ok(typedb_protocol::concept_document::node::List { list: encoded_list })
+}
+
+fn encode_leaf(
+    leaf: DocumentLeaf,
+    snapshot: &impl ReadableSnapshot,
+    type_manager: &TypeManager,
+    thing_manager: &ThingManager,
+) -> Result<typedb_protocol::concept_document::node::Leaf, ConceptReadError> {
+    match leaf {
+        DocumentLeaf::Empty => Ok(typedb_protocol::concept_document::node::Leaf {
+            leaf: Some(typedb_protocol::concept_document::node::leaf::Leaf::Empty(
+                typedb_protocol::concept_document::node::leaf::Empty {},
+            )),
+        }),
+        DocumentLeaf::Concept(concept) => Ok(typedb_protocol::concept_document::node::Leaf {
+            leaf: Some(match concept {
+                Concept::Type(Type::Entity(entity_type)) => {
+                    typedb_protocol::concept_document::node::leaf::Leaf::EntityType(encode_entity_type(
+                        &entity_type,
+                        snapshot,
+                        type_manager,
+                    )?)
+                }
+                Concept::Type(Type::Relation(relation_type)) => {
+                    typedb_protocol::concept_document::node::leaf::Leaf::RelationType(encode_relation_type(
+                        &relation_type,
+                        snapshot,
+                        type_manager,
+                    )?)
+                }
+                Concept::Type(Type::Attribute(attribute_type)) => {
+                    typedb_protocol::concept_document::node::leaf::Leaf::AttributeType(encode_attribute_type(
+                        &attribute_type,
+                        snapshot,
+                        type_manager,
+                    )?)
+                }
+                Concept::Type(Type::RoleType(role_type)) => {
+                    typedb_protocol::concept_document::node::leaf::Leaf::RoleType(encode_role_type(
+                        &role_type,
+                        snapshot,
+                        type_manager,
+                    )?)
+                }
+                Concept::Thing(Thing::Entity(entity)) => {
+                    unreachable!()
+                }
+                Concept::Thing(Thing::Relation(relation)) => {
+                    unreachable!()
+                }
+                Concept::Thing(Thing::Attribute(attribute)) => {
+                    typedb_protocol::concept_document::node::leaf::Leaf::Attribute(encode_attribute(
+                        &attribute,
+                        snapshot,
+                        type_manager,
+                        thing_manager,
+                        false,
+                    )?)
+                }
+                Concept::Value(value) => {
+                    typedb_protocol::concept_document::node::leaf::Leaf::Value(encode_value(value))
+                }
+            }),
+        }),
+        DocumentLeaf::Kind(_) => {
+            todo!()
+        }
+    }
+}

--- a/server/service/mod.rs
+++ b/server/service/mod.rs
@@ -4,9 +4,11 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-mod answer;
+mod concept;
+mod document;
 mod error;
 mod response_builders;
+mod row;
 pub(crate) mod transaction_service;
 pub(crate) mod typedb_service;
 

--- a/server/service/response_builders.rs
+++ b/server/service/response_builders.rs
@@ -121,9 +121,11 @@ pub(crate) mod transaction {
         )
     }
 
-    pub(crate) fn query_res_ok_readable_concept_tree_stream() -> typedb_protocol::query::initial_res::ok::Ok {
-        typedb_protocol::query::initial_res::ok::Ok::ReadableConceptTreeStream(
-            typedb_protocol::query::initial_res::ok::ReadableConceptTreeStream {},
+    pub(crate) fn query_res_ok_concept_document_stream(
+        query_type: typedb_protocol::query::Type,
+    ) -> typedb_protocol::query::initial_res::ok::Ok {
+        typedb_protocol::query::initial_res::ok::Ok::ConceptDocumentStream(
+            typedb_protocol::query::initial_res::ok::ConceptDocumentStream { query_type: query_type.into() },
         )
     }
 
@@ -153,7 +155,17 @@ pub(crate) mod transaction {
         }
     }
 
-    pub(crate) fn query_res_part_from_concept_tree() {
+    pub(crate) fn query_res_part_from_concept_documents(
+        messages: Vec<typedb_protocol::ConceptDocument>,
+    ) -> typedb_protocol::query::ResPart {
+        typedb_protocol::query::ResPart {
+            res: Some(typedb_protocol::query::res_part::Res::DocumentsRes(
+                typedb_protocol::query::res_part::ConceptDocumentsRes { documents: messages },
+            )),
+        }
+    }
+
+    pub(crate) fn query_res_part_from_concept_document() {
         todo!()
     }
 

--- a/server/service/row.rs
+++ b/server/service/row.rs
@@ -1,0 +1,68 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+use answer::variable_value::VariableValue;
+use compiler::VariablePosition;
+use concept::{error::ConceptReadError, thing::thing_manager::ThingManager, type_::type_manager::TypeManager};
+use executor::row::MaybeOwnedRow;
+use storage::snapshot::ReadableSnapshot;
+
+use crate::service::concept::{encode_thing_concept, encode_type_concept, encode_value};
+
+pub(crate) fn encode_row(
+    row: MaybeOwnedRow<'_>,
+    columns: &[(String, VariablePosition)],
+    snapshot: &impl ReadableSnapshot,
+    type_manager: &TypeManager,
+    thing_manager: &ThingManager,
+) -> Result<typedb_protocol::ConceptRow, ConceptReadError> {
+    // TODO: multiplicity?
+    let mut encoded_row = Vec::with_capacity(columns.len());
+    for (_, position) in columns {
+        let variable_value = row.get(*position);
+        let row_entry = encode_row_entry(variable_value, snapshot, type_manager, thing_manager)?;
+        encoded_row.push(typedb_protocol::RowEntry { entry: Some(row_entry) });
+    }
+    Ok(typedb_protocol::ConceptRow { row: encoded_row })
+}
+
+pub(crate) fn encode_row_entry(
+    variable_value: &VariableValue<'_>,
+    snapshot: &impl ReadableSnapshot,
+    type_manager: &TypeManager,
+    thing_manager: &ThingManager,
+) -> Result<typedb_protocol::row_entry::Entry, ConceptReadError> {
+    match variable_value {
+        VariableValue::Empty => Ok(typedb_protocol::row_entry::Entry::Empty(typedb_protocol::row_entry::Empty {})),
+        VariableValue::Type(type_) => {
+            Ok(typedb_protocol::row_entry::Entry::Concept(encode_type_concept(type_, snapshot, type_manager)?))
+        }
+        VariableValue::Thing(thing) => Ok(typedb_protocol::row_entry::Entry::Concept(encode_thing_concept(
+            thing,
+            snapshot,
+            type_manager,
+            thing_manager,
+            true,
+        )?)),
+        VariableValue::Value(value) => Ok(typedb_protocol::row_entry::Entry::Value(encode_value(value.as_reference()))),
+        VariableValue::ThingList(thing_list) => {
+            let mut encoded = Vec::with_capacity(thing_list.len());
+            for thing in thing_list.iter() {
+                encoded.push(encode_thing_concept(thing, snapshot, type_manager, thing_manager, true)?);
+            }
+            Ok(typedb_protocol::row_entry::Entry::ConceptList(typedb_protocol::row_entry::ConceptList {
+                concepts: encoded,
+            }))
+        }
+        VariableValue::ValueList(value_list) => {
+            let mut encoded = Vec::with_capacity(value_list.len());
+            for value in value_list.iter() {
+                encoded.push(encode_value(value.as_reference()))
+            }
+            Ok(typedb_protocol::row_entry::Entry::ValueList(typedb_protocol::row_entry::ValueList { values: encoded }))
+        }
+    }
+}


### PR DESCRIPTION
## Release notes: product changes

We implement fetch execution, given an executable pipeline that may contain a Fetch terminal stage.

Note: we have commented out `match-return` subqueries, fetching of expressions (`{ "val" : $x + 1 }`), and fetching of function outputs (`"val": mean_salary($person)`), as these require function-body evaluation under the hood - this is not yet implemented.