### PR TITLE
Fix document answers streaming for fetch

### DIFF
--- a/query/tests/fetch.rs
+++ b/query/tests/fetch.rs
@@ -21,10 +21,10 @@ fn define_schema(storage: Arc<MVCCStorage<WALClient>>, type_manager: &TypeManage
 
     let query_str = r#"
     define
-    attribute name value string;
-    attribute age value long;
-    relation friendship relates friend;
-    entity person owns name @card(0..), owns age, plays friendship:friend;
+      attribute name value string;
+      attribute age value long;
+      relation friendship relates friend @card(0..);
+      entity person owns name @card(0..), owns age, plays friendship:friend @card(0..);
     "#;
     let schema_query = typeql::parse_query(query_str).unwrap().into_schema();
     query_manager.execute_schema(&mut snapshot, &type_manager, &thing_manager, schema_query).unwrap();


### PR DESCRIPTION
## Release notes: product changes
We fix document answers streaming for fetch in order to complete the first version of `fetch` queries execution.

## Motivation
There were incorrect assertions that didn't allow the server to process correct requests.

