### PR TITLE
Expression support

### DIFF
--- a/compiler/annotation/expression/block_compiler.rs
+++ b/compiler/annotation/expression/block_compiler.rs
@@ -41,7 +41,7 @@ struct BlockExpressionsCompilationContext<'block, Snapshot: ReadableSnapshot> {
     type_manager: &'block TypeManager,
     type_annotations: &'block TypeAnnotations,
 
-    compiled_expressions: HashMap<Variable, ExecutableExpression>,
+    compiled_expressions: HashMap<Variable, ExecutableExpression<Variable>>,
     variable_value_types: HashMap<Variable, ExpressionValueType>,
     visited_expressions: HashSet<Variable>,
 }
@@ -54,7 +54,7 @@ pub fn compile_expressions<'block, Snapshot: ReadableSnapshot>(
     parameters: &'block ParameterRegistry,
     type_annotations: &'block TypeAnnotations,
     input_value_type_annotations: &mut BTreeMap<Variable, ExpressionValueType>,
-) -> Result<HashMap<Variable, ExecutableExpression>, ExpressionCompileError> {
+) -> Result<HashMap<Variable, ExecutableExpression<Variable>>, ExpressionCompileError> {
     let mut context = BlockExpressionsCompilationContext {
         block,
         variable_registry,

--- a/compiler/annotation/expression/compiled_expression.rs
+++ b/compiler/annotation/expression/compiled_expression.rs
@@ -7,7 +7,7 @@
 use std::fmt::{Display, Formatter};
 
 use answer::variable::Variable;
-use encoding::value::value_type::{ValueType, ValueTypeCategory};
+use encoding::value::value_type::ValueType;
 use ir::pattern::ParameterID;
 
 use crate::annotation::expression::instructions::op_codes::ExpressionOpCode;

--- a/compiler/annotation/expression/compiled_expression.rs
+++ b/compiler/annotation/expression/compiled_expression.rs
@@ -4,28 +4,30 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-use std::fmt::{Display, Formatter};
+use std::{
+    collections::HashMap,
+    fmt::{Display, Formatter},
+};
 
-use answer::variable::Variable;
 use encoding::value::value_type::ValueType;
-use ir::pattern::ParameterID;
+use ir::pattern::{IrID, ParameterID};
 
 use crate::annotation::expression::instructions::op_codes::ExpressionOpCode;
 
 #[derive(Debug, Clone)]
-pub struct ExecutableExpression {
+pub struct ExecutableExpression<ID> {
     pub(crate) instructions: Vec<ExpressionOpCode>,
-    pub(crate) variables: Vec<Variable>,
+    pub(crate) variables: Vec<ID>,
     pub(crate) constants: Vec<ParameterID>,
     pub(crate) return_type: ExpressionValueType,
 }
 
-impl ExecutableExpression {
+impl<ID> ExecutableExpression<ID> {
     pub fn instructions(&self) -> &[ExpressionOpCode] {
         &self.instructions
     }
 
-    pub fn variables(&self) -> &[Variable] {
+    pub fn variables(&self) -> &[ID] {
         self.variables.as_slice()
     }
 
@@ -35,6 +37,18 @@ impl ExecutableExpression {
 
     pub fn return_type(&self) -> &ExpressionValueType {
         &self.return_type
+    }
+}
+
+impl<ID: IrID> ExecutableExpression<ID> {
+    pub fn map<T: IrID>(self, mapping: &HashMap<ID, T>) -> ExecutableExpression<T> {
+        let Self { instructions, variables, constants, return_type } = self;
+        ExecutableExpression {
+            instructions,
+            variables: variables.into_iter().map(|var| mapping[&var]).collect(),
+            constants,
+            return_type,
+        }
     }
 }
 

--- a/compiler/annotation/expression/expression_compiler.rs
+++ b/compiler/annotation/expression/expression_compiler.rs
@@ -67,7 +67,7 @@ impl<'this> ExpressionCompilationContext<'this> {
         expression_tree: &ExpressionTree<Variable>,
         variable_value_categories: &HashMap<Variable, ExpressionValueType>,
         parameters: &ParameterRegistry,
-    ) -> Result<ExecutableExpression, ExpressionCompileError> {
+    ) -> Result<ExecutableExpression<Variable>, ExpressionCompileError> {
         debug_assert!(expression_tree.variables().all(|var| variable_value_categories.contains_key(&var)));
         let mut builder = ExpressionCompilationContext::empty(expression_tree, variable_value_categories, parameters);
         builder.compile_recursive(expression_tree.get_root())?;

--- a/compiler/annotation/expression/instructions/mod.rs
+++ b/compiler/annotation/expression/instructions/mod.rs
@@ -36,6 +36,7 @@ pub(crate) fn check_operation<T>(checked_operation_result: Option<T>) -> Result<
     }
 }
 
+#[derive(Clone)]
 pub enum ExpressionEvaluationError {
     CheckedOperationFailed,
     CastFailed,

--- a/compiler/annotation/match_inference.rs
+++ b/compiler/annotation/match_inference.rs
@@ -125,7 +125,7 @@ pub fn infer_types(
     graph.collect_type_annotations(&mut vertex_annotations, &mut constraint_annotations);
     let type_annotations = TypeAnnotations::new(vertex_annotations, constraint_annotations);
     debug_assert!(block.block_context().referenced_variables().all(|var| {
-        match variable_registry.get_variable_category(var.clone()) {
+        match variable_registry.get_variable_category(var) {
             None => todo!("Safe to ignore. But can we know the ValueTypeCategory of an assignment at translation?"),
             Some(VariableCategory::Value) | Some(VariableCategory::ValueList) => true,
             Some(_) => type_annotations.vertex_annotations_of(&Vertex::Variable(var)).is_some(),

--- a/compiler/annotation/pipeline.rs
+++ b/compiler/annotation/pipeline.rs
@@ -57,7 +57,7 @@ pub enum AnnotatedStage {
         block: Block,
         block_annotations: TypeAnnotations,
         // expressions skip annotation and go straight to executable, breaking the abstraction a bit...
-        executable_expressions: HashMap<Variable, ExecutableExpression>,
+        executable_expressions: HashMap<Variable, ExecutableExpression<Variable>>,
     },
     Insert {
         block: Block,

--- a/compiler/executable/function.rs
+++ b/compiler/executable/function.rs
@@ -53,7 +53,7 @@ pub(crate) fn compile_function(
         stages,
         arguments.into_iter(),
     )?;
-    let returns = compile_return_operation(&mut executable_stages, return_)?;
+    let returns = compile_return_operation(&executable_stages, return_)?;
     Ok(ExecutableFunction { executable_stages, argument_positions, returns })
 }
 

--- a/compiler/executable/match_/planner/match_executable.rs
+++ b/compiler/executable/match_/planner/match_executable.rs
@@ -105,7 +105,7 @@ pub struct IntersectionStep {
     pub sort_variable: ExecutorVariable,
     pub instructions: Vec<(ConstraintInstruction<ExecutorVariable>, VariableModes)>,
     new_variables: Vec<VariablePosition>,
-    output_width: u32,
+    pub output_width: u32,
     input_variables: Vec<VariablePosition>,
     pub selected_variables: Vec<VariablePosition>,
 }
@@ -162,6 +162,7 @@ pub struct UnsortedJoinStep {
     new_variables: Vec<VariablePosition>,
     input_variables: Vec<VariablePosition>,
     selected_variables: Vec<VariablePosition>,
+    pub output_width: u32,
 }
 
 impl UnsortedJoinStep {
@@ -169,6 +170,7 @@ impl UnsortedJoinStep {
         iterate_instruction: ConstraintInstruction<ExecutorVariable>,
         check_instructions: Vec<ConstraintInstruction<ExecutorVariable>>,
         selected_variables: &[VariablePosition],
+        output_width: u32,
     ) -> Self {
         let mut input_variables = Vec::with_capacity(check_instructions.len() * 2);
         let mut new_variables = Vec::with_capacity(5);
@@ -199,6 +201,7 @@ impl UnsortedJoinStep {
             new_variables,
             input_variables,
             selected_variables: selected_variables.to_owned(),
+            output_width,
         }
     }
 

--- a/compiler/executable/match_/planner/match_executable.rs
+++ b/compiler/executable/match_/planner/match_executable.rs
@@ -4,15 +4,16 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-use std::collections::{HashMap, HashSet};
-
-use answer::variable::Variable;
-use ir::pattern::{
-    constraint::{Constraint, ExpressionBinding},
-    IrID,
+use std::{
+    collections::{HashMap, HashSet},
+    slice,
 };
 
+use answer::variable::Variable;
+use ir::pattern::{constraint::Constraint, IrID};
+
 use crate::{
+    annotation::expression::compiled_expression::ExecutableExpression,
     executable::match_::instructions::{CheckInstruction, ConstraintInstruction, VariableModes},
     ExecutorVariable, VariablePosition,
 };
@@ -212,18 +213,33 @@ impl UnsortedJoinStep {
 
 #[derive(Clone, Debug)]
 pub struct AssignmentStep {
-    assign_instruction: ExpressionBinding<VariablePosition>,
-    check_instructions: Vec<ConstraintInstruction<VariablePosition>>,
-    unbound: [VariablePosition; 1],
+    pub expression: ExecutableExpression<VariablePosition>,
+    pub input_positions: Vec<VariablePosition>,
+    pub unbound: ExecutorVariable,
+    pub selected_variables: Vec<VariablePosition>,
+    pub output_width: u32,
 }
 
 impl AssignmentStep {
+    pub fn new(
+        expression: ExecutableExpression<VariablePosition>,
+        input_positions: Vec<VariablePosition>,
+        unbound: ExecutorVariable,
+        selected_variables: Vec<VariablePosition>,
+        output_width: u32,
+    ) -> Self {
+        Self { expression, input_positions, unbound, selected_variables, output_width }
+    }
+
     fn new_variables(&self) -> &[VariablePosition] {
-        &self.unbound
+        match &self.unbound {
+            ExecutorVariable::RowPosition(pos) => slice::from_ref(pos),
+            ExecutorVariable::Internal(_) => &[],
+        }
     }
 
     fn output_width(&self) -> u32 {
-        todo!()
+        self.output_width
     }
 }
 

--- a/compiler/executable/match_/planner/plan.rs
+++ b/compiler/executable/match_/planner/plan.rs
@@ -27,7 +27,6 @@ use ir::{
 };
 use itertools::{chain, Itertools};
 
-use super::ExpressionBuilder;
 use crate::{
     annotation::{expression::compiled_expression::ExecutableExpression, type_annotations::TypeAnnotations},
     executable::match_::{
@@ -52,8 +51,8 @@ use crate::{
                 ComparisonPlanner, Costed, Direction, DisjunctionPlanner, ElementCost, ExpressionPlanner,
                 FunctionCallPlanner, Input, NegationPlanner, PlannerVertex,
             },
-            DisjunctionBuilder, IntersectionBuilder, MatchExecutableBuilder, NegationBuilder, StepBuilder,
-            StepInstructionsBuilder,
+            DisjunctionBuilder, ExpressionBuilder, IntersectionBuilder, MatchExecutableBuilder, NegationBuilder,
+            StepBuilder, StepInstructionsBuilder,
         },
     },
     ExecutorVariable, VariablePosition,

--- a/compiler/executable/match_/planner/plan.rs
+++ b/compiler/executable/match_/planner/plan.rs
@@ -634,6 +634,7 @@ impl ConjunctionPlan<'_> {
                             || match_builder.selected_variables.contains(&self.graph.index_to_variable[&output]);
                         let has_consumers = || self.consumers_of_var(output).next().is_some();
                         if is_selected() || has_consumers() {
+                            match_builder.finish_one();
                             match_builder.register_output(self.graph.index_to_variable[&output]);
                         } else {
                             match_builder.register_internal(self.graph.index_to_variable[&output]);
@@ -695,6 +696,7 @@ impl ConjunctionPlan<'_> {
         if match_builder.produced_so_far.contains(&variable) {
             return;
         }
+
 
         for producer in self.producers_of_var(var) {
             match &self.graph.elements()[&VertexId::Pattern(producer)] {

--- a/compiler/executable/match_/planner/plan.rs
+++ b/compiler/executable/match_/planner/plan.rs
@@ -697,7 +697,6 @@ impl ConjunctionPlan<'_> {
             return;
         }
 
-
         for producer in self.producers_of_var(var) {
             match &self.graph.elements()[&VertexId::Pattern(producer)] {
                 PlannerVertex::Variable(_) => unreachable!("encountered variable @ pattern id {producer:?}"),

--- a/compiler/executable/match_/planner/vertex/mod.rs
+++ b/compiler/executable/match_/planner/vertex/mod.rs
@@ -79,7 +79,7 @@ impl PlannerVertex<'_> {
             Self::Variable(_) => Box::new(iter::empty()),
             Self::Constraint(inner) => inner.variables(),
             Self::Comparison(inner) => Box::new(inner.variables()),
-            Self::Expression(_inner) => todo!(),
+            Self::Expression(inner) => Box::new(inner.variables()),
             Self::FunctionCall(inner) => Box::new(inner.variables()),
             Self::Negation(inner) => Box::new(inner.variables()),
             Self::Disjunction(inner) => Box::new(inner.variables()),
@@ -153,9 +153,10 @@ impl Costed for PlannerVertex<'_> {
             Self::Variable(inner) => inner.cost(inputs, graph),
             Self::Constraint(inner) => inner.cost(inputs, graph),
 
-            Self::FunctionCall(inner) => inner.cost(inputs, graph),
             Self::Comparison(inner) => inner.cost(inputs, graph),
-            Self::Expression(_) => todo!("expression cost"),
+
+            Self::Expression(inner) => inner.cost(inputs, graph),
+            Self::FunctionCall(inner) => inner.cost(inputs, graph),
 
             Self::Negation(inner) => inner.cost(inputs, graph),
             Self::Disjunction(inner) => inner.cost(inputs, graph),
@@ -193,15 +194,15 @@ impl Input {
 
 #[derive(Clone, Debug)]
 pub(crate) struct ExpressionPlanner<'a> {
+    pub expression: &'a ExecutableExpression<Variable>,
     inputs: Vec<VariableVertexId>,
-    output: VariableVertexId,
+    pub output: VariableVertexId,
     cost: ElementCost,
-    pub expression: &'a ExecutableExpression,
 }
 
 impl<'a> ExpressionPlanner<'a> {
     pub(crate) fn from_expression(
-        expression: &'a ExecutableExpression,
+        expression: &'a ExecutableExpression<Variable>,
         inputs: Vec<VariableVertexId>,
         output: VariableVertexId,
     ) -> Self {

--- a/compiler/executable/match_/planner/vertex/mod.rs
+++ b/compiler/executable/match_/planner/vertex/mod.rs
@@ -49,19 +49,7 @@ impl PlannerVertex<'_> {
             Self::Variable(inner) => inner.is_valid(index, ordered, graph),
             Self::Constraint(inner) => inner.is_valid(index, ordered, graph),
 
-            Self::Comparison(ComparisonPlanner { lhs, rhs, .. }) => {
-                if let &Input::Variable(lhs) = lhs {
-                    if !ordered.contains(&VertexId::Variable(lhs)) {
-                        return false;
-                    }
-                }
-                if let &Input::Variable(rhs) = rhs {
-                    if !ordered.contains(&VertexId::Variable(rhs)) {
-                        return false;
-                    }
-                }
-                true
-            }
+            Self::Comparison(inner) => inner.is_valid(index, ordered, graph),
 
             Self::Expression(inner) => inner.is_valid(index, ordered, graph),
 
@@ -267,6 +255,20 @@ impl<'a> ComparisonPlanner<'a> {
             lhs: Input::from_vertex(comparison.lhs(), variable_index),
             rhs: Input::from_vertex(comparison.rhs(), variable_index),
         }
+    }
+
+    fn is_valid(&self, _index: VertexId, ordered: &[VertexId], _graph: &Graph<'_>) -> bool {
+        if let Input::Variable(lhs) = self.lhs {
+            if !ordered.contains(&VertexId::Variable(lhs)) {
+                return false;
+            }
+        }
+        if let Input::Variable(rhs) = self.rhs {
+            if !ordered.contains(&VertexId::Variable(rhs)) {
+                return false;
+            }
+        }
+        true
     }
 
     pub(crate) fn variables(&self) -> impl Iterator<Item = VariableVertexId> {

--- a/compiler/executable/match_/planner/vertex/variable.rs
+++ b/compiler/executable/match_/planner/vertex/variable.rs
@@ -64,34 +64,34 @@ impl VariableVertex {
             Self::Input(_inner) => todo!(),
             Self::Type(_inner) => todo!(),
             Self::Thing(inner) => inner.add_is(other),
-            Self::Value(_inner) => todo!(),
+            Self::Value(_inner) => unreachable!(),
         }
     }
 
     pub(crate) fn add_equal(&mut self, other: Input) {
         match self {
             Self::Input(_) => (),
-            Self::Value(_) => todo!(),
-            Self::Thing(inner) => inner.add_equal(other),
             Self::Type(_) => unreachable!(),
+            Self::Thing(inner) => inner.add_equal(other),
+            Self::Value(inner) => inner.add_equal(other),
         }
     }
 
     pub(crate) fn add_lower_bound(&mut self, other: Input) {
         match self {
             Self::Input(_) => (),
-            Self::Value(_inner) => todo!(),
-            Self::Thing(inner) => inner.add_lower_bound(other),
             Self::Type(_) => unreachable!(),
+            Self::Thing(inner) => inner.add_lower_bound(other),
+            Self::Value(inner) => inner.add_lower_bound(other),
         }
     }
 
     pub(crate) fn add_upper_bound(&mut self, other: Input) {
         match self {
             Self::Input(_) => (),
-            Self::Value(_inner) => todo!(),
-            Self::Thing(inner) => inner.add_upper_bound(other),
             Self::Type(_) => unreachable!(),
+            Self::Thing(inner) => inner.add_upper_bound(other),
+            Self::Value(inner) => inner.add_upper_bound(other),
         }
     }
 
@@ -354,6 +354,10 @@ impl Costed for ThingPlanner {
 pub(crate) struct ValuePlanner {
     variable: Variable,
     binding: Option<PatternVertexId>,
+
+    bound_value_equal: HashSet<Input>,
+    bound_value_below: HashSet<Input>,
+    bound_value_above: HashSet<Input>,
 }
 
 impl fmt::Debug for ValuePlanner {
@@ -364,11 +368,17 @@ impl fmt::Debug for ValuePlanner {
 
 impl ValuePlanner {
     pub(crate) fn from_variable(variable: Variable) -> Self {
-        Self { variable, binding: None }
+        Self {
+            variable,
+            binding: None,
+            bound_value_equal: HashSet::new(),
+            bound_value_below: HashSet::new(),
+            bound_value_above: HashSet::new(),
+        }
     }
 
     fn expected_size(&self, _inputs: &[VertexId]) -> f64 {
-        todo!("value planner expected size")
+        1.0 // TODO
     }
 
     fn set_binding(&mut self, binding_pattern: PatternVertexId) {
@@ -382,6 +392,18 @@ impl ValuePlanner {
             let adjacent = graph.variable_to_pattern().get(&index).unwrap();
             ordered.iter().filter_map(VertexId::as_pattern_id).any(|id| adjacent.contains(&id))
         }
+    }
+
+    pub(crate) fn add_equal(&mut self, other: Input) {
+        self.bound_value_equal.insert(other);
+    }
+
+    pub(crate) fn add_lower_bound(&mut self, other: Input) {
+        self.bound_value_below.insert(other);
+    }
+
+    pub(crate) fn add_upper_bound(&mut self, other: Input) {
+        self.bound_value_above.insert(other);
     }
 }
 

--- a/compiler/executable/pipeline.rs
+++ b/compiler/executable/pipeline.rs
@@ -113,7 +113,7 @@ pub fn compile_pipeline(
         &schema_and_preamble_functions,
         annotated_stages,
         annotated_fetch,
-        &input_variables,
+        input_variables,
     )?;
     Ok(ExecutablePipeline { executable_functions: schema_and_preamble_functions, executable_stages, executable_fetch })
 }
@@ -134,7 +134,7 @@ pub fn compile_stages_and_fetch(
         variable_registry.clone(),
         available_functions,
         annotated_stages,
-        input_variables.into_iter().cloned(),
+        input_variables.iter().cloned(),
     )?;
     let stages_variable_positions =
         executable_stages.last().map(|stage: &ExecutableStage| stage.output_row_mapping()).unwrap_or(HashMap::new());
@@ -145,7 +145,7 @@ pub fn compile_stages_and_fetch(
                 .map_err(|err| ExecutableCompilationError::FetchCompliation { typedb_source: err })
         })
         .transpose()?
-        .map(|fetch| Arc::new(fetch));
+        .map(Arc::new);
     Ok((input_positions, executable_stages, executable_fetch))
 }
 

--- a/executor/batch.rs
+++ b/executor/batch.rs
@@ -69,7 +69,7 @@ impl FixedBatch {
         self.row_internal_mut(index)
     }
 
-    pub(crate) fn append<T>(&mut self, mut writer: impl FnMut(Row<'_>) -> T) -> T {
+    pub(crate) fn append<T>(&mut self, writer: impl FnOnce(Row<'_>) -> T) -> T {
         debug_assert!(!self.is_full());
         let row = self.row_internal_mut(self.entries);
         let result = writer(row);

--- a/executor/error.rs
+++ b/executor/error.rs
@@ -10,7 +10,6 @@ use error::typedb_error;
 
 use crate::InterruptType;
 
-
 typedb_error!(
     pub ReadExecutionError(component = "Read execution", prefix = "REX") {
         Interrupted(1, "Execution interrupted by to a concurrent {interrupt}.", interrupt: InterruptType),

--- a/executor/error.rs
+++ b/executor/error.rs
@@ -4,10 +4,12 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
+use compiler::annotation::expression::instructions::ExpressionEvaluationError;
 use concept::error::ConceptReadError;
 use error::typedb_error;
 
 use crate::InterruptType;
+
 
 typedb_error!(
     pub ReadExecutionError(component = "Read execution", prefix = "REX") {
@@ -15,5 +17,6 @@ typedb_error!(
         ConceptRead(2, "Concept read error.", ( source: ConceptReadError )),
         CreatingIterator(3, "Error creating iterator from {instruction_name} instruction.", instruction_name: String, ( source: ConceptReadError )),
         AdvancingIteratorTo(4, "Error moving iterator (by steps or seek) to target value.", ( source: ConceptReadError )),
+        ExpressionEvaluate(5, "Error evaluating expression", ( source: ExpressionEvaluationError )),
     }
 );

--- a/executor/step_executors.rs
+++ b/executor/step_executors.rs
@@ -55,24 +55,32 @@ impl StepExecutor {
         snapshot: &Arc<impl ReadableSnapshot + 'static>,
         thing_manager: &Arc<ThingManager>,
     ) -> Result<Self, ConceptReadError> {
-        let row_width = step.output_width();
         match step {
             ExecutionStep::Intersection(IntersectionStep {
-                sort_variable, instructions, selected_variables, ..
+                sort_variable,
+                instructions,
+                selected_variables,
+                output_width,
+                ..
             }) => {
                 let executor = IntersectionExecutor::new(
                     *sort_variable,
                     instructions.clone(),
-                    row_width,
+                    *output_width,
                     selected_variables.clone(),
                     snapshot,
                     thing_manager,
                 )?;
                 Ok(Self::SortedJoin(executor))
             }
-            ExecutionStep::UnsortedJoin(UnsortedJoinStep { iterate_instruction, check_instructions, .. }) => {
+            ExecutionStep::UnsortedJoin(UnsortedJoinStep {
+                iterate_instruction,
+                check_instructions,
+                output_width,
+                ..
+            }) => {
                 let executor =
-                    UnsortedJoinExecutor::new(iterate_instruction.clone(), check_instructions.clone(), row_width);
+                    UnsortedJoinExecutor::new(iterate_instruction.clone(), check_instructions.clone(), *output_width);
                 Ok(Self::UnsortedJoin(executor))
             }
             ExecutionStep::Assignment(AssignmentStep {
@@ -91,8 +99,12 @@ impl StepExecutor {
             ExecutionStep::Check(CheckStep { check_instructions, selected_variables, output_width }) => Ok(
                 Self::Check(CheckExecutor::new(check_instructions.clone(), selected_variables.clone(), *output_width)),
             ),
-            ExecutionStep::Disjunction(DisjunctionStep { branches, .. }) => {
-                Ok(Self::Disjunction(DisjunctionExecutor::new(branches.clone(), row_width)))
+            ExecutionStep::Disjunction(DisjunctionStep { branches, selected_variables, output_width }) => {
+                Ok(Self::Disjunction(DisjunctionExecutor::new(
+                    branches.clone(),
+                    selected_variables.clone(),
+                    *output_width,
+                )))
             }
             ExecutionStep::Negation(NegationStep { negation: negation_plan, selected_variables, output_width }) => {
                 // TODO: add limit 1, filters if they aren't there already?
@@ -736,13 +748,17 @@ pub(super) struct DisjunctionExecutor {
     input: Option<Peekable<FixedBatchRowIterator>>,
     output: Option<FixedBatch>,
 
+    selected_variables: Vec<VariablePosition>,
     output_width: u32, // we should at least make sure all branches have the same batch width
 }
 
 impl DisjunctionExecutor {
-    fn new(branches: Vec<MatchExecutable>, output_width: u32) -> DisjunctionExecutor {
-        assert!(branches.iter().all(|executable| executable.outputs().len() == output_width as usize));
-        Self { branches, current_iterator: None, input: None, output: None, output_width }
+    fn new(
+        branches: Vec<MatchExecutable>,
+        selected_variables: Vec<VariablePosition>,
+        output_width: u32,
+    ) -> DisjunctionExecutor {
+        Self { branches, current_iterator: None, input: None, output: None, selected_variables, output_width }
     }
 
     fn batch_from(
@@ -782,7 +798,12 @@ impl DisjunctionExecutor {
                 let next = iterator.next();
                 match next {
                     Some(output_row) => {
-                        batch.append(|mut row| row.copy_from(output_row.row(), output_row.multiplicity()))
+                        batch.append(|mut row| {
+                            row.set_multiplicity(output_row.multiplicity());
+                            for &position in &self.selected_variables {
+                                row.set(position, output_row.get(position).clone().into_owned())
+                            }
+                        });
                     }
                     None => self.current_iterator = None,
                 }

--- a/executor/tests/compile_execute.rs
+++ b/executor/tests/compile_execute.rs
@@ -158,6 +158,7 @@ fn test_expression_planning_traversal() {
     let query = "match
         $person_1 isa person, has age == $age_1;
         $person_2 isa person, has age == $age_2;
+        $age_1 = 10;
         $age_2 = $age_1 + 2;
     ";
     let match_ = typeql::parse_query(query).unwrap().into_pipeline().stages.remove(0).into_match();
@@ -204,7 +205,7 @@ fn test_expression_planning_traversal() {
     );
     let executor = MatchExecutor::new(&match_executable, &snapshot, &thing_manager, MaybeOwnedRow::empty()).unwrap();
 
-    let context = ExecutionContext::new(snapshot, thing_manager, Arc::default());
+    let context = ExecutionContext::new(snapshot, thing_manager, Arc::new(translation_context.parameters.clone()));
     let iterator = executor.into_iterator(context, ExecutionInterrupt::new_uninterruptible());
 
     let rows = iterator
@@ -220,7 +221,7 @@ fn test_expression_planning_traversal() {
         println!()
     }
 
-    assert_eq!(rows.len(), 2);
+    assert_eq!(rows.len(), 1);
 }
 
 #[test]

--- a/executor/tests/compile_execute.rs
+++ b/executor/tests/compile_execute.rs
@@ -10,6 +10,7 @@ use std::{
 };
 
 use compiler::annotation::{
+    expression::block_compiler::compile_expressions,
     function::{AnnotatedUnindexedFunctions, IndexedAnnotatedFunctions},
     match_inference::infer_types,
 };
@@ -134,6 +135,92 @@ fn test_has_planning_traversal() {
     }
 
     assert_eq!(rows.len(), 7);
+}
+
+#[test]
+fn test_expression_planning_traversal() {
+    let (_tmp_dir, mut storage) = create_core_storage();
+    setup_concept_storage(&mut storage);
+    let (type_manager, thing_manager) = load_managers(storage.clone(), None);
+
+    let schema = "define
+        attribute age value long;
+        entity person owns age @card(0..);
+    ";
+    let data = "insert
+        $_ isa person, has age 10;
+        $_ isa person, has age 12;
+        $_ isa person, has age 14;
+    ";
+
+    let statistics = setup(&storage, type_manager, thing_manager, schema, data);
+
+    let query = "match
+        $person_1 isa person, has age == $age_1;
+        $person_2 isa person, has age == $age_2;
+        $age_2 = $age_1 + 2;
+    ";
+    let match_ = typeql::parse_query(query).unwrap().into_pipeline().stages.remove(0).into_match();
+
+    // IR
+    let empty_function_index = HashMapFunctionSignatureIndex::empty();
+    let mut translation_context = TranslationContext::new();
+    let builder = translate_match(&mut translation_context, &empty_function_index, &match_).unwrap();
+    let block = builder.finish();
+
+    // Executor
+    let snapshot = Arc::new(storage.clone().open_snapshot_read());
+    let (type_manager, thing_manager) = load_managers(storage.clone(), None);
+
+    let entry_annotations = infer_types(
+        &*snapshot,
+        &block,
+        &translation_context.variable_registry,
+        &type_manager,
+        &BTreeMap::new(),
+        &IndexedAnnotatedFunctions::empty(),
+        Some(&AnnotatedUnindexedFunctions::empty()),
+    )
+    .unwrap();
+
+    let compiled_expressions = compile_expressions(
+        &*snapshot,
+        &type_manager,
+        &block,
+        &mut translation_context.variable_registry,
+        &translation_context.parameters,
+        &entry_annotations,
+        &mut BTreeMap::new(),
+    )
+    .unwrap();
+
+    let match_executable = compiler::executable::match_::planner::compile(
+        &block,
+        &HashMap::new(),
+        &entry_annotations,
+        Arc::new(translation_context.variable_registry),
+        &compiled_expressions,
+        &statistics,
+    );
+    let executor = MatchExecutor::new(&match_executable, &snapshot, &thing_manager, MaybeOwnedRow::empty()).unwrap();
+
+    let context = ExecutionContext::new(snapshot, thing_manager, Arc::default());
+    let iterator = executor.into_iterator(context, ExecutionInterrupt::new_uninterruptible());
+
+    let rows = iterator
+        .map_static(|row| row.map(|row| row.into_owned()).map_err(|err| err.clone()))
+        .into_iter()
+        .try_collect::<_, Vec<_>, _>()
+        .unwrap();
+
+    for row in &rows {
+        for value in row {
+            print!("{}, ", value);
+        }
+        println!()
+    }
+
+    assert_eq!(rows.len(), 2);
 }
 
 #[test]

--- a/executor/tests/compile_execute.rs
+++ b/executor/tests/compile_execute.rs
@@ -648,7 +648,7 @@ fn test_disjunction_planning_traversal() {
 
     let query = "match
         $person isa person;
-        { $person has name $_; } or { $person has age $_; };
+        { $person has name $n; } or { $person has age $a; };
     ";
     let match_ = typeql::parse_query(query).unwrap().into_pipeline().stages.remove(0).into_match();
 

--- a/executor/tests/compile_execute.rs
+++ b/executor/tests/compile_execute.rs
@@ -156,9 +156,8 @@ fn test_expression_planning_traversal() {
     let statistics = setup(&storage, type_manager, thing_manager, schema, data);
 
     let query = "match
-        $person_1 isa person, has age == $age_1;
+        $person_1 isa person, has age $age_1;
         $person_2 isa person, has age == $age_2;
-        $age_1 = 10;
         $age_2 = $age_1 + 2;
     ";
     let match_ = typeql::parse_query(query).unwrap().into_pipeline().stages.remove(0).into_match();
@@ -221,7 +220,7 @@ fn test_expression_planning_traversal() {
         println!()
     }
 
-    assert_eq!(rows.len(), 1);
+    assert_eq!(rows.len(), 2);
 }
 
 #[test]


### PR DESCRIPTION
## Release notes: product changes

We add expression execution to match queries:

```php
match
    $person_1 isa person, has age $age_1;
    $person_2 isa person, has age $age_2;
    $age_2 == $age_1 + 2;
```

## Motivation

## Implementation

This PR also includes stability improvements around disjunctions and comparisons.