### PR TITLE
3.0 Rename Ok.Empty to Ok.Done. Add query_type to the Done response

### DIFF
--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -33,10 +33,11 @@ def vaticle_typedb_common():
     )
 
 def vaticle_typedb_protocol():
+    # TODO: return typedb
     git_repository(
         name = "vaticle_typedb_protocol",
-        remote = "https://github.com/vaticle/typedb-protocol",
-        tag = "3.0.0-alpha-6",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_protocol
+        remote = "https://github.com/farost/typedb-protocol",
+        commit = "7aebfba90425d05d150c026145d82f17e4b97faa",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_protocol
     )
 
 def vaticle_typedb_behaviour():

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -33,16 +33,15 @@ def vaticle_typedb_common():
     )
 
 def vaticle_typedb_protocol():
-    # TODO: return typedb
     git_repository(
         name = "vaticle_typedb_protocol",
-        remote = "https://github.com/farost/typedb-protocol",
-        commit = "7aebfba90425d05d150c026145d82f17e4b97faa",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_protocol
+        remote = "https://github.com/typedb/typedb-protocol",
+        commit = "56eb6ef6db0d0721800f46512e2ee5e02aad6adb",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_protocol
     )
 
 def vaticle_typedb_behaviour():
     git_repository(
         name = "vaticle_typedb_behaviour",
         remote = "https://github.com/typedb/typedb-behaviour",
-        commit = "332c3b5c33b4faee3dd7d8418da2717d43b26b35",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_behaviour
+        commit = "dc0373ff351d1f104c56f2fed7799bdeaf32d9f1",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_behaviour
     )

--- a/server/service/response_builders.rs
+++ b/server/service/response_builders.rs
@@ -105,8 +105,12 @@ pub(crate) mod transaction {
         transaction_server_res(req_id, message)
     }
 
-    pub(crate) fn query_res_ok_empty() -> typedb_protocol::query::initial_res::ok::Ok {
-        typedb_protocol::query::initial_res::ok::Ok::Empty(typedb_protocol::query::initial_res::ok::Empty {})
+    pub(crate) fn query_res_ok_done(
+        query_type: typedb_protocol::query::Type,
+    ) -> typedb_protocol::query::initial_res::ok::Ok {
+        typedb_protocol::query::initial_res::ok::Ok::Done(typedb_protocol::query::initial_res::ok::Done {
+            query_type: query_type.into(),
+        })
     }
 
     pub(crate) fn query_res_ok_concept_row_stream(


### PR DESCRIPTION
## Release notes: product changes
We add a `query_type` field to all the `Query.InitialRes.Ok` protobuf messages to support retrieval of this information for any `QueryAnswer` on the client side.
Additionally, the `Ok.Empty` message was renamed to `Ok.Done`.

## Motivation
Supporting the [protobuf changes](https://github.com/typedb/typedb-protocol/pull/211).
