### PR TITLE
Implement tabling machinery for cyclic functions

### DIFF
--- a/compiler/annotation/function.rs
+++ b/compiler/annotation/function.rs
@@ -91,15 +91,13 @@ impl IndexedAnnotatedFunctions {
     pub fn empty() -> Self {
         Self { functions: HashMap::new() }
     }
-    pub fn iter_functions(&self) -> impl Iterator<Item = (&DefinitionKey<'static>, &AnnotatedFunction)> {
-        self.functions.iter()
-    }
 }
 
 pub trait AnnotatedFunctions {
     type ID;
 
     fn get_function(&self, id: Self::ID) -> Option<&AnnotatedFunction>;
+    fn iter_functions(&self) -> impl Iterator<Item = (Self::ID, &AnnotatedFunction)>;
 
     fn is_empty(&self) -> bool;
 }
@@ -109,6 +107,10 @@ impl AnnotatedFunctions for IndexedAnnotatedFunctions {
 
     fn get_function(&self, id: Self::ID) -> Option<&AnnotatedFunction> {
         self.functions.get(&id)
+    }
+
+    fn iter_functions(&self) -> impl Iterator<Item = (DefinitionKey<'static>, &AnnotatedFunction)> {
+        self.functions.iter().map(|(key, function)| (key.clone(), function))
     }
 
     fn is_empty(&self) -> bool {
@@ -141,6 +143,10 @@ impl AnnotatedFunctions for AnnotatedUnindexedFunctions {
 
     fn get_function(&self, id: Self::ID) -> Option<&AnnotatedFunction> {
         self.unindexed_functions.get(id)
+    }
+
+    fn iter_functions(&self) -> impl Iterator<Item = (usize, &AnnotatedFunction)> {
+        self.unindexed_functions.iter().enumerate()
     }
 
     fn is_empty(&self) -> bool {

--- a/compiler/executable/fetch/executable.rs
+++ b/compiler/executable/fetch/executable.rs
@@ -105,7 +105,7 @@ fn compile_some(
             Ok(FetchSomeInstruction::SingleAttribute(*position, attribute_type))
         }
         AnnotatedFetchSome::SingleFunction(function) => {
-            let compiled = compile_function(statistics, available_functions, function)
+            let compiled = compile_function(statistics, available_functions, function, false)
                 .map_err(|err| FetchCompilationError::AnonymousFunctionCompilation { typedb_source: Box::new(err) })?;
             Ok(FetchSomeInstruction::SingleFunction(compiled))
         }
@@ -114,7 +114,7 @@ fn compile_some(
             Ok(FetchSomeInstruction::Object(Box::new(compiled)))
         }
         AnnotatedFetchSome::ListFunction(function) => {
-            let compiled = compile_function(statistics, available_functions, function)
+            let compiled = compile_function(statistics, available_functions, function, false)
                 .map_err(|err| FetchCompilationError::AnonymousFunctionCompilation { typedb_source: Box::new(err) })?;
             Ok(FetchSomeInstruction::ListFunction(compiled))
         }

--- a/compiler/executable/fetch/executable.rs
+++ b/compiler/executable/fetch/executable.rs
@@ -21,6 +21,7 @@ use crate::{
     },
     VariablePosition,
 };
+use crate::executable::function::FunctionTablingType;
 
 pub struct ExecutableFetch {
     pub object_instruction: FetchObjectInstruction,
@@ -105,7 +106,7 @@ fn compile_some(
             Ok(FetchSomeInstruction::SingleAttribute(*position, attribute_type))
         }
         AnnotatedFetchSome::SingleFunction(function) => {
-            let compiled = compile_function(statistics, available_functions, function, false)
+            let compiled = compile_function(statistics, available_functions, function, FunctionTablingType::Untabled)
                 .map_err(|err| FetchCompilationError::AnonymousFunctionCompilation { typedb_source: Box::new(err) })?;
             Ok(FetchSomeInstruction::SingleFunction(compiled))
         }
@@ -114,7 +115,7 @@ fn compile_some(
             Ok(FetchSomeInstruction::Object(Box::new(compiled)))
         }
         AnnotatedFetchSome::ListFunction(function) => {
-            let compiled = compile_function(statistics, available_functions, function, false)
+            let compiled = compile_function(statistics, available_functions, function, FunctionTablingType::Untabled)
                 .map_err(|err| FetchCompilationError::AnonymousFunctionCompilation { typedb_source: Box::new(err) })?;
             Ok(FetchSomeInstruction::ListFunction(compiled))
         }

--- a/compiler/executable/fetch/executable.rs
+++ b/compiler/executable/fetch/executable.rs
@@ -14,14 +14,13 @@ use ir::{pattern::ParameterID, pipeline::VariableRegistry};
 use crate::{
     annotation::fetch::{AnnotatedFetch, AnnotatedFetchListSubFetch, AnnotatedFetchObject, AnnotatedFetchSome},
     executable::{
-        function::{compile_function, ExecutableFunction},
+        function::{compile_function, ExecutableFunction, FunctionTablingType},
         match_::planner::function_plan::ExecutableFunctionRegistry,
         pipeline::{compile_stages_and_fetch, ExecutableStage},
         ExecutableCompilationError,
     },
     VariablePosition,
 };
-use crate::executable::function::FunctionTablingType;
 
 pub struct ExecutableFetch {
     pub object_instruction: FetchObjectInstruction,
@@ -107,7 +106,9 @@ fn compile_some(
         }
         AnnotatedFetchSome::SingleFunction(function) => {
             let compiled = compile_function(statistics, available_functions, function, FunctionTablingType::Untabled)
-                .map_err(|err| FetchCompilationError::AnonymousFunctionCompilation { typedb_source: Box::new(err) })?;
+                .map_err(|err| FetchCompilationError::AnonymousFunctionCompilation {
+                typedb_source: Box::new(err),
+            })?;
             Ok(FetchSomeInstruction::SingleFunction(compiled))
         }
         AnnotatedFetchSome::Object(object) => {
@@ -116,7 +117,9 @@ fn compile_some(
         }
         AnnotatedFetchSome::ListFunction(function) => {
             let compiled = compile_function(statistics, available_functions, function, FunctionTablingType::Untabled)
-                .map_err(|err| FetchCompilationError::AnonymousFunctionCompilation { typedb_source: Box::new(err) })?;
+                .map_err(|err| FetchCompilationError::AnonymousFunctionCompilation {
+                typedb_source: Box::new(err),
+            })?;
             Ok(FetchSomeInstruction::ListFunction(compiled))
         }
         AnnotatedFetchSome::ListSubFetch(sub_fetch) => {

--- a/compiler/executable/function.rs
+++ b/compiler/executable/function.rs
@@ -92,7 +92,7 @@ pub fn determine_tabling_requirements(
 ) -> HashMap<FunctionID, bool> {
     let mut cycle_detection: HashMap<FunctionID, TablingRequirement> =
         functions.keys().map(|function_id| (function_id.clone(), TablingRequirement::Unexplored)).collect();
-    for (function_id, function) in functions {
+    for (function_id, _) in functions {
         if cycle_detection[function_id] == TablingRequirement::Unexplored {
             determine_tabling_requirements_impl(functions, &mut cycle_detection, function_id)
         }

--- a/compiler/executable/function.rs
+++ b/compiler/executable/function.rs
@@ -4,8 +4,10 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-use std::{collections::HashMap, sync::Arc};
-use std::collections::HashSet;
+use std::{
+    collections::{HashMap, HashSet},
+    sync::Arc,
+};
 
 use answer::variable::Variable;
 use concept::thing::statistics::Statistics;

--- a/compiler/executable/function.rs
+++ b/compiler/executable/function.rs
@@ -5,13 +5,21 @@
  */
 
 use std::{collections::HashMap, sync::Arc};
+use std::collections::HashSet;
 
 use answer::variable::Variable;
 use concept::thing::statistics::Statistics;
+use ir::{
+    pattern::{conjunction::Conjunction, constraint::Constraint, nested_pattern::NestedPattern},
+    pipeline::function_signature::FunctionID,
+};
 use typeql::schema::definable::function::SingleSelector;
 
 use crate::{
-    annotation::function::{AnnotatedFunction, AnnotatedFunctionReturn},
+    annotation::{
+        function::{AnnotatedFunction, AnnotatedFunctionReturn},
+        pipeline::AnnotatedStage,
+    },
     executable::{
         match_::planner::function_plan::ExecutableFunctionRegistry,
         pipeline::{compile_pipeline_stages, ExecutableStage},
@@ -36,11 +44,11 @@ pub enum ExecutableReturn {
     Reduce(Vec<ReduceInstruction<VariablePosition>>),
 }
 
-// TODO: Don't bother maintaining this function. It'll have to disappear into the planner.
 pub(crate) fn compile_function(
     statistics: &Statistics,
     schema_functions: &ExecutableFunctionRegistry, // Can't have preamble in them when you're compiling functions
     function: AnnotatedFunction,
+    is_tabled: bool,
 ) -> Result<ExecutableFunction, ExecutableCompilationError> {
     let AnnotatedFunction { variable_registry, arguments, stages, return_ } = function;
     let (argument_positions, executable_stages) = compile_pipeline_stages(
@@ -50,8 +58,9 @@ pub(crate) fn compile_function(
         stages,
         arguments.into_iter(),
     )?;
+
     let returns = compile_return_operation(&executable_stages, return_)?;
-    Ok(ExecutableFunction { executable_stages, argument_positions, returns, is_tabled: false })
+    Ok(ExecutableFunction { executable_stages, argument_positions, returns, is_tabled })
 }
 
 fn compile_return_operation(
@@ -72,6 +81,100 @@ fn compile_return_operation(
             let positional_reducers =
                 instructions.into_iter().map(|reducer| reducer.map(&variable_positions)).collect();
             Ok(ExecutableReturn::Reduce(positional_reducers))
+        }
+    }
+}
+
+pub fn determine_tabling_requirements(
+    functions: &HashMap<FunctionID, &AnnotatedFunction>,
+) -> HashMap<FunctionID, bool> {
+    let mut cycle_detection: HashMap<FunctionID, TablingRequirement> =
+        functions.keys().map(|function_id| (function_id.clone(), TablingRequirement::Unexplored)).collect();
+    for (function_id, function) in functions {
+        if cycle_detection[function_id] == TablingRequirement::Unexplored {
+            determine_tabling_requirements_impl(functions, &mut cycle_detection, function_id)
+        }
+    }
+    cycle_detection
+        .into_iter()
+        .map(|(function_id, tabling_requirement)| match tabling_requirement {
+            TablingRequirement::KnownTabled => (function_id, true),
+            TablingRequirement::KnownUntabled => (function_id, false),
+            TablingRequirement::Unexplored | TablingRequirement::UnknownInStack => unreachable!(),
+        })
+        .collect()
+}
+
+#[derive(PartialEq, Eq)]
+enum TablingRequirement {
+    Unexplored,
+    UnknownInStack,
+    KnownTabled,
+    KnownUntabled,
+}
+
+pub fn determine_tabling_requirements_impl(
+    to_compile: &HashMap<FunctionID, &AnnotatedFunction>,
+    cycle_detection: &mut HashMap<FunctionID, TablingRequirement>,
+    function_id: &FunctionID,
+) {
+    // Recurse, and compile on our way out.
+    match cycle_detection[function_id] {
+        TablingRequirement::KnownTabled | TablingRequirement::KnownUntabled => {}
+        TablingRequirement::UnknownInStack => {
+            // We should only need to table these, and not other ones in the cycle.
+            cycle_detection.insert(function_id.clone(), TablingRequirement::KnownTabled);
+        }
+        TablingRequirement::Unexplored => {
+            cycle_detection.insert(function_id.clone(), TablingRequirement::UnknownInStack);
+            let function = to_compile.get(function_id).unwrap();
+            for called_id in all_calls_in_pipeline(&function.stages) {
+                if to_compile.contains_key(&called_id) {
+                    determine_tabling_requirements_impl(to_compile, cycle_detection, &called_id);
+                }
+            }
+            match cycle_detection[function_id] {
+                TablingRequirement::UnknownInStack => {
+                    cycle_detection.insert(function_id.clone(), TablingRequirement::KnownUntabled);
+                }
+                TablingRequirement::KnownTabled => {}
+                TablingRequirement::Unexplored | TablingRequirement::KnownUntabled => unreachable!(),
+            }
+        }
+    }
+}
+
+fn all_calls_in_pipeline(stages: &Vec<AnnotatedStage>) -> HashSet<FunctionID> {
+    let match_stage_conjunctions = stages.iter().filter_map(|stage| match stage {
+        AnnotatedStage::Match { block, .. } => Some(block.conjunction()),
+        _ => None,
+    });
+    let mut call_accumulator = HashSet::new();
+    for conjunction in match_stage_conjunctions {
+        all_calls_in_conjunction(conjunction, &mut call_accumulator);
+    }
+    call_accumulator
+}
+
+fn all_calls_in_conjunction(conjunction: &Conjunction, call_accumulator: &mut HashSet<FunctionID>) {
+    for constraint in conjunction.constraints() {
+        if let Constraint::FunctionCallBinding(binding) = constraint {
+            call_accumulator.insert(binding.function_call().function_id());
+        }
+    }
+    for nested in conjunction.nested_patterns() {
+        match nested {
+            NestedPattern::Disjunction(disjunction) => {
+                for inner in disjunction.conjunctions() {
+                    all_calls_in_conjunction(inner, call_accumulator);
+                }
+            }
+            NestedPattern::Optional(optional) => {
+                all_calls_in_conjunction(optional.conjunction(), call_accumulator);
+            }
+            NestedPattern::Negation(negation) => {
+                all_calls_in_conjunction(negation.conjunction(), call_accumulator);
+            }
         }
     }
 }

--- a/compiler/executable/match_/planner/function_plan.rs
+++ b/compiler/executable/match_/planner/function_plan.rs
@@ -51,16 +51,3 @@ impl ExecutableFunctionRegistry {
         Self::empty()
     }
 }
-//
-// pub fn plan_functions(
-//     statistics: &Statistics,
-//     precompiled_functions: &ExecutableFunctionRegistry,
-//     functions: &HashMap<FunctionID, AnnotatedFunction>,
-// ) -> HashMap<FunctionID, ExecutableFunction> {
-//     let mut compiled = HashMap::new();
-//     for (function_id, function) in functions {
-//         // TODO: Actual compilation will likely plan all the functions together, as in 2.x
-//     }
-//     Ok(compiled)
-// }
-//

--- a/compiler/executable/match_/planner/mod.rs
+++ b/compiler/executable/match_/planner/mod.rs
@@ -28,6 +28,7 @@ use crate::{
     },
     ExecutorVariable, VariablePosition,
 };
+use crate::executable::match_::planner::function_plan::ExecutableFunctionRegistry;
 
 pub mod function_plan;
 pub mod match_executable;
@@ -39,6 +40,7 @@ pub fn compile(
     input_variables: &HashMap<Variable, VariablePosition>,
     type_annotations: &TypeAnnotations,
     variable_registry: Arc<VariableRegistry>,
+    function_registry: &ExecutableFunctionRegistry, // TODO: When we have actual function costs
     expressions: &HashMap<Variable, ExecutableExpression<Variable>>,
     statistics: &Statistics,
 ) -> MatchExecutable {

--- a/compiler/executable/match_/planner/mod.rs
+++ b/compiler/executable/match_/planner/mod.rs
@@ -19,6 +19,7 @@ use crate::{
     executable::match_::{
         instructions::{CheckInstruction, ConstraintInstruction},
         planner::{
+            function_plan::ExecutableFunctionRegistry,
             match_executable::{
                 AssignmentStep, CheckStep, DisjunctionStep, ExecutionStep, FunctionCallStep, IntersectionStep,
                 MatchExecutable, NegationStep,
@@ -28,7 +29,6 @@ use crate::{
     },
     ExecutorVariable, VariablePosition,
 };
-use crate::executable::match_::planner::function_plan::ExecutableFunctionRegistry;
 
 pub mod function_plan;
 pub mod match_executable;

--- a/compiler/executable/match_/planner/mod.rs
+++ b/compiler/executable/match_/planner/mod.rs
@@ -40,7 +40,6 @@ pub fn compile(
     input_variables: &HashMap<Variable, VariablePosition>,
     type_annotations: &TypeAnnotations,
     variable_registry: Arc<VariableRegistry>,
-    function_registry: &ExecutableFunctionRegistry, // TODO: When we have actual function costs
     expressions: &HashMap<Variable, ExecutableExpression<Variable>>,
     statistics: &Statistics,
 ) -> MatchExecutable {

--- a/compiler/executable/match_/planner/plan.rs
+++ b/compiler/executable/match_/planner/plan.rs
@@ -576,21 +576,7 @@ impl<'a> ConjunctionPlanBuilder<'a> {
     }
 
     pub(super) fn plan(self) -> ConjunctionPlan<'a> {
-        // eprintln!("[{}:{}] variables = {:?}", file!(), line!(), self.graph.variable_index);
-        //
-        // eprintln!("[{}:{}] elements = {{", file!(), line!());
-        // for (i, el) in &self.graph.elements {
-        //     eprintln!("    {:?}: {:?}", i, el);
-        // }
-        // eprintln!("}}");
-        //
-        // eprintln!("[{}:{}] adjacency = {{", file!(), line!());
-        // for (i, el) in &self.graph.pattern_to_variable {
-        //     eprintln!("    {:?}: {:?}", i, el);
-        // }
-        // eprintln!("}}");
         let ordering = self.initialise_greedy_ordering();
-        // eprintln!("[{}:{}] ordering = {:?}", file!(), line!(), ordering);
         let element_to_order = ordering.iter().copied().enumerate().map(|(order, index)| (index, order)).collect();
 
         let cost = ordering

--- a/compiler/executable/match_/planner/plan.rs
+++ b/compiler/executable/match_/planner/plan.rs
@@ -515,7 +515,7 @@ impl<'a> ConjunctionPlanBuilder<'a> {
         let mut intersection_variable: Option<VariableVertexId> = None;
 
         while !open_set.is_empty() {
-            eprintln!("while-ordering: {:?}", ordering);
+            // eprintln!("while-ordering: {:?}", ordering);
             let (next, _cost) = open_set
                 .iter()
                 .filter(|&&elem| self.graph.elements[&elem].is_valid(elem, &ordering, &self.graph))

--- a/compiler/executable/match_/planner/plan.rs
+++ b/compiler/executable/match_/planner/plan.rs
@@ -515,7 +515,6 @@ impl<'a> ConjunctionPlanBuilder<'a> {
         let mut intersection_variable: Option<VariableVertexId> = None;
 
         while !open_set.is_empty() {
-            // eprintln!("while-ordering: {:?}", ordering);
             let (next, _cost) = open_set
                 .iter()
                 .filter(|&&elem| self.graph.elements[&elem].is_valid(elem, &ordering, &self.graph))
@@ -1160,6 +1159,8 @@ impl fmt::Debug for Graph<'_> {
         f.debug_struct(type_name_of_val(self))
             .field("variable_index", &self.variable_index)
             .field("elements", &self.elements)
+            .field("pattern_to_variable", &self.pattern_to_variable)
+            .field("variable_to_pattern", &self.variable_to_pattern)
             .finish()
     }
 }

--- a/compiler/executable/match_/planner/plan.rs
+++ b/compiler/executable/match_/planner/plan.rs
@@ -439,11 +439,11 @@ impl<'a> ConjunctionPlanBuilder<'a> {
             .assigned()
             .iter()
             .map(|vertex| {
-                let Vertex::Variable(variable) = vertex else { todo!("Unreachable?") };
+                let Vertex::Variable(variable) = vertex else { unreachable!() };
                 self.graph.variable_index[variable]
             })
             .collect();
-        // TODO: This is just a mock
+        // TODO: Use the real cost when we have function planning
         let element_cost = ElementCost { per_input: 1.0, per_output: 1.0, branching_factor: 1.0 };
         self.graph.push_function_call(FunctionCallPlanner::from_constraint(
             call_binding,

--- a/compiler/executable/match_/planner/vertex/mod.rs
+++ b/compiler/executable/match_/planner/vertex/mod.rs
@@ -69,7 +69,6 @@ impl PlannerVertex<'_> {
         if !is_valid {
             return false;
         }
-
         let mut ordered = ordered.to_owned();
         ordered.push(index);
         self.variables().all(|var| {
@@ -232,8 +231,8 @@ impl Costed for ExpressionPlanner<'_> {
 #[derive(Debug, Clone)]
 pub(crate) struct FunctionCallPlanner<'a> {
     pub call_binding: &'a FunctionCallBinding<Variable>,
-    arguments: Vec<VariableVertexId>,
-    assigned: Vec<VariableVertexId>,
+    pub(super) arguments: Vec<VariableVertexId>,
+    pub(super) assigned: Vec<VariableVertexId>,
     cost: ElementCost,
 }
 

--- a/compiler/executable/pipeline.rs
+++ b/compiler/executable/pipeline.rs
@@ -199,11 +199,10 @@ fn compile_stage(
                 input_variables,
                 block_annotations,
                 variable_registry,
+                functions,
                 executable_expressions,
                 statistics,
-                // functions,
             );
-            eprintln!("{:?}", plan.steps);
             Ok(ExecutableStage::Match(Arc::new(plan)))
         }
         AnnotatedStage::Insert { block, annotations } => {

--- a/compiler/executable/pipeline.rs
+++ b/compiler/executable/pipeline.rs
@@ -203,6 +203,7 @@ fn compile_stage(
                 statistics,
                 // functions,
             );
+            eprintln!("{:?}", plan.steps);
             Ok(ExecutableStage::Match(Arc::new(plan)))
         }
         AnnotatedStage::Insert { block, annotations } => {

--- a/compiler/executable/pipeline.rs
+++ b/compiler/executable/pipeline.rs
@@ -12,8 +12,7 @@ use std::{
 
 use answer::variable::Variable;
 use concept::thing::statistics::Statistics;
-use ir::pipeline::function_signature::FunctionID;
-use ir::pipeline::VariableRegistry;
+use ir::pipeline::{function_signature::FunctionID, VariableRegistry};
 
 use crate::{
     annotation::{

--- a/compiler/executable/pipeline.rs
+++ b/compiler/executable/pipeline.rs
@@ -199,7 +199,6 @@ fn compile_stage(
                 input_variables,
                 block_annotations,
                 variable_registry,
-                functions,
                 executable_expressions,
                 statistics,
             );

--- a/executor/error.rs
+++ b/executor/error.rs
@@ -19,5 +19,7 @@ typedb_error!(
         AdvancingIteratorTo(4, "Error moving iterator (by steps or seek) to target value.", ( source: ConceptReadError )),
         ExpressionEvaluate(5, "Error evaluating expression", ( source: ExpressionEvaluationError )),
         TabledFunctionLockError(6, "The table function lock was poisoned", function_id: FunctionID, arguments: MaybeOwnedRow<'static>),
+
+        UnimplementedCyclicFunctions(999, "A data-cycle was detected."),
     }
 );

--- a/executor/error.rs
+++ b/executor/error.rs
@@ -9,8 +9,7 @@ use concept::error::ConceptReadError;
 use error::typedb_error;
 use ir::pipeline::function_signature::FunctionID;
 
-use crate::InterruptType;
-use crate::row::MaybeOwnedRow;
+use crate::{row::MaybeOwnedRow, InterruptType};
 
 typedb_error!(
     pub ReadExecutionError(component = "Read execution", prefix = "REX") {

--- a/executor/error.rs
+++ b/executor/error.rs
@@ -7,8 +7,10 @@
 use compiler::annotation::expression::instructions::ExpressionEvaluationError;
 use concept::error::ConceptReadError;
 use error::typedb_error;
+use ir::pipeline::function_signature::FunctionID;
 
 use crate::InterruptType;
+use crate::row::MaybeOwnedRow;
 
 typedb_error!(
     pub ReadExecutionError(component = "Read execution", prefix = "REX") {
@@ -17,5 +19,6 @@ typedb_error!(
         CreatingIterator(3, "Error creating iterator from {instruction_name} instruction.", instruction_name: String, ( source: ConceptReadError )),
         AdvancingIteratorTo(4, "Error moving iterator (by steps or seek) to target value.", ( source: ConceptReadError )),
         ExpressionEvaluate(5, "Error evaluating expression", ( source: ExpressionEvaluationError )),
+        TabledFunctionLockError(6, "The table function lock was poisoned", function_id: FunctionID, arguments: MaybeOwnedRow<'static>),
     }
 );

--- a/executor/error.rs
+++ b/executor/error.rs
@@ -18,7 +18,6 @@ typedb_error!(
         CreatingIterator(3, "Error creating iterator from {instruction_name} instruction.", instruction_name: String, ( source: ConceptReadError )),
         AdvancingIteratorTo(4, "Error moving iterator (by steps or seek) to target value.", ( source: ConceptReadError )),
         ExpressionEvaluate(5, "Error evaluating expression", ( source: ExpressionEvaluationError )),
-        TabledFunctionLockError(6, "The table function lock was poisoned", function_id: FunctionID, arguments: MaybeOwnedRow<'static>),
 
         UnimplementedCyclicFunctions(999, "A cyclic function-call was detected. The results are sound but may be incomplete. This will be fixed in a later alpha release."),
     }

--- a/executor/error.rs
+++ b/executor/error.rs
@@ -20,6 +20,6 @@ typedb_error!(
         ExpressionEvaluate(5, "Error evaluating expression", ( source: ExpressionEvaluationError )),
         TabledFunctionLockError(6, "The table function lock was poisoned", function_id: FunctionID, arguments: MaybeOwnedRow<'static>),
 
-        UnimplementedCyclicFunctions(999, "A data-cycle was detected."),
+        UnimplementedCyclicFunctions(999, "A cyclic function-call was detected. The results are sound but may be incomplete. This will be fixed in a later alpha release."),
     }
 );

--- a/executor/match_executor.rs
+++ b/executor/match_executor.rs
@@ -17,11 +17,12 @@ use crate::{
     batch::{FixedBatch, FixedBatchRowIterator},
     error::ReadExecutionError,
     pipeline::stage::ExecutionContext,
-    read::{create_executors_for_pipeline, pattern_executor::PatternExecutor, TODO_REMOVE_create_executors_for_match},
+    read::{
+        pattern_executor::PatternExecutor, tabled_functions::TabledFunctions, TODO_REMOVE_create_executors_for_match,
+    },
     row::MaybeOwnedRow,
     ExecutionInterrupt,
 };
-use crate::read::tabled_functions::TabledFunctions;
 
 pub struct MatchExecutor {
     entry: PatternExecutor,

--- a/executor/pipeline/match_.rs
+++ b/executor/pipeline/match_.rs
@@ -95,7 +95,7 @@ where
             };
 
             let executor =
-                MatchExecutor::new(&self.executable, snapshot, thing_manager, input_row, &self.function_registry)
+                MatchExecutor::new(&self.executable, snapshot, thing_manager, input_row, self.function_registry.clone())
                     .map_err(|err| PipelineExecutionError::InitialisingMatchIterator { source: err });
 
             match executor {

--- a/executor/pipeline/match_.rs
+++ b/executor/pipeline/match_.rs
@@ -94,9 +94,14 @@ where
                 Err(err) => return Some(Err(err)),
             };
 
-            let executor =
-                MatchExecutor::new(&self.executable, snapshot, thing_manager, input_row, self.function_registry.clone())
-                    .map_err(|err| PipelineExecutionError::InitialisingMatchIterator { source: err });
+            let executor = MatchExecutor::new(
+                &self.executable,
+                snapshot,
+                thing_manager,
+                input_row,
+                self.function_registry.clone(),
+            )
+            .map_err(|err| PipelineExecutionError::InitialisingMatchIterator { source: err });
 
             match executor {
                 Ok(executor) => {

--- a/executor/pipeline/pipeline.rs
+++ b/executor/pipeline/pipeline.rs
@@ -36,6 +36,7 @@ use crate::{
     row::MaybeOwnedRow,
     ExecutionInterrupt,
 };
+use crate::read::tabled_functions::TabledFunctions;
 
 pub enum Pipeline<Snapshot: ReadableSnapshot, Nonterminals: StageAPI<Snapshot>> {
     Unfetched(Nonterminals, HashMap<String, VariablePosition>),

--- a/executor/pipeline/pipeline.rs
+++ b/executor/pipeline/pipeline.rs
@@ -33,10 +33,10 @@ use crate::{
         stage::{ExecutionContext, ReadPipelineStage, StageAPI, WritePipelineStage},
         PipelineExecutionError,
     },
+    read::tabled_functions::TabledFunctions,
     row::MaybeOwnedRow,
     ExecutionInterrupt,
 };
-use crate::read::tabled_functions::TabledFunctions;
 
 pub enum Pipeline<Snapshot: ReadableSnapshot, Nonterminals: StageAPI<Snapshot>> {
     Unfetched(Nonterminals, HashMap<String, VariablePosition>),

--- a/executor/pipeline/pipeline.rs
+++ b/executor/pipeline/pipeline.rs
@@ -33,7 +33,6 @@ use crate::{
         stage::{ExecutionContext, ReadPipelineStage, StageAPI, WritePipelineStage},
         PipelineExecutionError,
     },
-    read::tabled_functions::TabledFunctions,
     row::MaybeOwnedRow,
     ExecutionInterrupt,
 };

--- a/executor/read/mod.rs
+++ b/executor/read/mod.rs
@@ -34,7 +34,6 @@ pub(super) fn TODO_REMOVE_create_executors_for_match(
     function_registry: &ExecutableFunctionRegistry,
     match_executable: &MatchExecutable,
 ) -> Result<PatternExecutor, ConceptReadError> {
-    eprintln!("--- Start creating executors for entry ---");
     let executors = step_executor::create_executors_for_match(
         snapshot,
         thing_manager,
@@ -42,7 +41,6 @@ pub(super) fn TODO_REMOVE_create_executors_for_match(
         match_executable,
         &mut HashSet::new(),
     )?;
-    eprintln!("--- End creating executors for entry ---");
     Ok(PatternExecutor::new(executors))
 }
 

--- a/executor/read/mod.rs
+++ b/executor/read/mod.rs
@@ -14,10 +14,14 @@ use concept::{error::ConceptReadError, thing::thing_manager::ThingManager};
 use ir::pipeline::function_signature::FunctionID;
 use storage::snapshot::ReadableSnapshot;
 
-use crate::read::{pattern_executor::PatternExecutor, step_executor::create_executors_for_pipeline_stages};
-use crate::read::pattern_executor::{BranchIndex, InstructionIndex};
-use crate::read::tabled_functions::TableIndex;
-use crate::row::MaybeOwnedRow;
+use crate::{
+    read::{
+        pattern_executor::{BranchIndex, InstructionIndex, PatternExecutor},
+        step_executor::create_executors_for_pipeline_stages,
+        tabled_functions::TableIndex,
+    },
+    row::MaybeOwnedRow,
+};
 
 mod collecting_stage_executor;
 pub mod expression_executor;
@@ -68,12 +72,20 @@ pub(crate) enum SuspendPoint {
 }
 
 impl SuspendPoint {
-    fn new_tabled_call(instruction_index: InstructionIndex, next_table_row: TableIndex, input_row: MaybeOwnedRow<'static>) -> Self {
-        Self::TabledCall(TabledCallSuspension { instruction_index, next_table_row, input_row } )
+    fn new_tabled_call(
+        instruction_index: InstructionIndex,
+        next_table_row: TableIndex,
+        input_row: MaybeOwnedRow<'static>,
+    ) -> Self {
+        Self::TabledCall(TabledCallSuspension { instruction_index, next_table_row, input_row })
     }
 
-    fn new_nested(instruction_index: InstructionIndex, branch_index: BranchIndex, input_row: MaybeOwnedRow<'static>) -> Self {
-        Self::Nested(NestedSuspension { instruction_index, branch_index, input_row } )
+    fn new_nested(
+        instruction_index: InstructionIndex,
+        branch_index: BranchIndex,
+        input_row: MaybeOwnedRow<'static>,
+    ) -> Self {
+        Self::Nested(NestedSuspension { instruction_index, branch_index, input_row })
     }
 }
 

--- a/executor/read/mod.rs
+++ b/executor/read/mod.rs
@@ -22,6 +22,7 @@ mod immediate_executor;
 mod nested_pattern_executor;
 pub(crate) mod pattern_executor;
 mod step_executor;
+pub(crate) mod tabled_functions;
 
 pub(super) fn TODO_REMOVE_create_executors_for_match(
     snapshot: &Arc<impl ReadableSnapshot + 'static>,

--- a/executor/read/mod.rs
+++ b/executor/read/mod.rs
@@ -24,6 +24,7 @@ pub(crate) mod pattern_executor;
 mod step_executor;
 pub(crate) mod tabled_functions;
 
+// And use the below one instead
 pub(super) fn TODO_REMOVE_create_executors_for_match(
     snapshot: &Arc<impl ReadableSnapshot + 'static>,
     thing_manager: &Arc<ThingManager>,

--- a/executor/read/mod.rs
+++ b/executor/read/mod.rs
@@ -16,7 +16,7 @@ use storage::snapshot::ReadableSnapshot;
 
 use crate::{
     read::{
-        pattern_executor::{BranchIndex, InstructionIndex, PatternExecutor},
+        pattern_executor::{BranchIndex, ExecutorIndex, PatternExecutor},
         step_executor::create_executors_for_pipeline_stages,
         tabled_functions::TableIndex,
     },
@@ -74,32 +74,32 @@ pub(crate) enum SuspendPoint {
 
 impl SuspendPoint {
     fn new_tabled_call(
-        instruction_index: InstructionIndex,
+        executor_index: ExecutorIndex,
         next_table_row: TableIndex,
         input_row: MaybeOwnedRow<'static>,
     ) -> Self {
-        Self::TabledCall(TabledCallSuspension { instruction_index, next_table_row, input_row })
+        Self::TabledCall(TabledCallSuspension { executor_index, next_table_row, input_row })
     }
 
     fn new_nested(
-        instruction_index: InstructionIndex,
+        executor_index: ExecutorIndex,
         branch_index: BranchIndex,
         input_row: MaybeOwnedRow<'static>,
     ) -> Self {
-        Self::Nested(NestedSuspension { instruction_index, branch_index, input_row })
+        Self::Nested(NestedSuspension { executor_index, branch_index, input_row })
     }
 }
 
 #[derive(Debug)]
 pub(super) struct TabledCallSuspension {
-    pub(crate) instruction_index: InstructionIndex,
+    pub(crate) executor_index: ExecutorIndex,
     pub(crate) input_row: MaybeOwnedRow<'static>,
     pub(crate) next_table_row: TableIndex,
 }
 
 #[derive(Debug)]
 pub(super) struct NestedSuspension {
-    pub(crate) instruction_index: InstructionIndex,
+    pub(crate) executor_index: ExecutorIndex,
     pub(crate) branch_index: BranchIndex,
     pub(crate) input_row: MaybeOwnedRow<'static>,
 }

--- a/executor/read/mod.rs
+++ b/executor/read/mod.rs
@@ -28,8 +28,9 @@ pub mod expression_executor;
 mod immediate_executor;
 mod nested_pattern_executor;
 pub(crate) mod pattern_executor;
-mod step_executor;
-pub(crate) mod tabled_functions;
+pub(crate) mod step_executor;
+pub(crate) mod tabled_call_executor;
+pub mod tabled_functions;
 
 // And use the below one instead
 pub(super) fn TODO_REMOVE_create_executors_for_match(

--- a/executor/read/nested_pattern_executor.rs
+++ b/executor/read/nested_pattern_executor.rs
@@ -103,10 +103,7 @@ impl NestedPatternResultMapper {
         }
     }
 
-    pub(super) fn map_output(
-        &mut self,
-        subquery_result: Option<FixedBatch>,
-    ) -> NestedPatternResult {
+    pub(super) fn map_output(&mut self, subquery_result: Option<FixedBatch>) -> NestedPatternResult {
         match self {
             Self::Identity(mapper) => mapper.map_output(subquery_result),
             Self::Negation(mapper) => mapper.map_output(subquery_result),
@@ -137,7 +134,7 @@ impl NestedPatternResult {
 }
 
 pub(super) struct NegationMapper {
-    input: MaybeOwnedRow<'static>
+    input: MaybeOwnedRow<'static>,
 }
 pub(super) struct IdentityMapper;
 pub(super) struct InlinedFunctionMapper {
@@ -187,7 +184,12 @@ impl NestedPatternResultMapperTrait for IdentityMapper {
 }
 
 impl InlinedFunctionMapper {
-    pub(crate) fn new(input: MaybeOwnedRow<'static>, arguments: Vec<VariablePosition>, assigned: Vec<VariablePosition>, output_width: u32) -> Self {
+    pub(crate) fn new(
+        input: MaybeOwnedRow<'static>,
+        arguments: Vec<VariablePosition>,
+        assigned: Vec<VariablePosition>,
+        output_width: u32,
+    ) -> Self {
         Self { input, arguments, assigned, output_width }
     }
 }

--- a/executor/read/pattern_executor.rs
+++ b/executor/read/pattern_executor.rs
@@ -201,10 +201,11 @@ impl PatternExecutor {
                     executable.prepare(batch, context)?;
                     self.control_stack.push(ControlInstruction::ExecuteImmediate(next_instruction_index));
                 }
-                StepExecutors::Nested(_) => self
-                    .control_stack
-                    .push(ControlInstruction::MapRowBatchToRowForNested(next_instruction_index, batch.into_iterator())),
-                StepExecutors::TabledCall(_) => {
+                StepExecutors::Nested(_) => self.control_stack.push(
+                    ControlInstruction::MapRowBatchToRowForNested(next_instruction_index, batch.into_iterator())
+                ),
+                StepExecutors::TabledCall(tabled_call_executor) => {
+                    // tabled_call_executor.prepare(batch);
                     self.control_stack.push(ControlInstruction::TabledCall(next_instruction_index))
                 }
                 StepExecutors::CollectingStage(collecting_stage) => {

--- a/executor/read/pattern_executor.rs
+++ b/executor/read/pattern_executor.rs
@@ -43,6 +43,8 @@ pub(super) enum ControlInstruction {
     MapRowBatchToRowForNested(InstructionIndex, FixedBatchRowIterator),
     ExecuteNested(InstructionIndex, BranchIndex, NestedPatternResultMapper),
 
+    TabledCall(InstructionIndex),
+
     CollectingStage(InstructionIndex),
     StreamCollected(InstructionIndex, CollectedStageIterator),
 
@@ -122,6 +124,9 @@ impl PatternExecutor {
                         self.prepare_next_instruction_and_push_to_stack(context, index.next(), batch)?;
                     }
                 }
+                ControlInstruction::TabledCall(index) => {
+                    todo!()
+                }
                 ControlInstruction::CollectingStage(index) => {
                     let (pattern, mut collector) = executors[index.0].unwrap_collecting_stage().to_parts_mut();
                     match pattern.compute_next_batch(context, interrupt)? {
@@ -166,6 +171,7 @@ impl PatternExecutor {
                 StepExecutors::Nested(_) => self
                     .control_stack
                     .push(ControlInstruction::MapRowBatchToRowForNested(next_instruction_index, batch.into_iterator())),
+                StepExecutors::TabledCall(_) => self.control_stack.push(ControlInstruction::TabledCall(next_instruction_index)),
                 StepExecutors::CollectingStage(collecting_stage) => {
                     collecting_stage.prepare(batch);
                     self.control_stack.push(ControlInstruction::CollectingStage(next_instruction_index));

--- a/executor/read/pattern_executor.rs
+++ b/executor/read/pattern_executor.rs
@@ -170,14 +170,15 @@ impl PatternExecutor {
                                     tabled_functions,
                                     suspend_points,
                                 )?;
-                                if let Some(batch) = &batch_opt {
-                                    executor.add_batch_to_table(&function_state, batch);
+                                if let Some(batch) = batch_opt {
+                                    let deduplicated_batch = executor.add_batch_to_table(&function_state, batch);
+                                    Some(deduplicated_batch)
                                 } else {
                                     if !suspend_points.is_empty() {
                                         suspend_point_accumulator.push(executor.create_suspend_point_for(index))
                                     }
+                                    None
                                 }
-                                batch_opt
                             }
                             Err(TryLockError::WouldBlock) => {
                                 suspend_point_accumulator.push(executor.create_suspend_point_for(index));

--- a/executor/read/pattern_executor.rs
+++ b/executor/read/pattern_executor.rs
@@ -4,10 +4,9 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-use std::{ops::DerefMut, sync::TryLockError};
+use std::ops::DerefMut;
 
 use compiler::VariablePosition;
-use itertools::Either;
 use lending_iterator::LendingIterator;
 use storage::snapshot::ReadableSnapshot;
 

--- a/executor/read/pattern_executor.rs
+++ b/executor/read/pattern_executor.rs
@@ -159,7 +159,7 @@ impl PatternExecutor {
                     let executor = executors[index.0].unwrap_tabled_call();
                     let call_key = executor.active_call_key().unwrap();
                     let function_state = tabled_functions.get_or_create_function_state(context, call_key)?;
-                    let found = match executor.try_read_next_batch(&function_state)? {
+                    let found = match executor.try_read_next_batch(&function_state) {
                         TabledCallResult::RetrievedFromTable(batch) => Some(batch),
                         TabledCallResult::Suspend => {
                             suspend_point_accumulator.push(executor.create_suspend_point_for(index));

--- a/executor/read/pattern_executor.rs
+++ b/executor/read/pattern_executor.rs
@@ -43,20 +43,44 @@ impl InstructionIndex {
 }
 
 pub(super) enum ControlInstruction {
-    Start(FixedBatch),
+    Start {
+        input_batch: FixedBatch,
+    },
 
-    ExecuteImmediate(InstructionIndex),
+    ExecuteImmediate {
+        index: InstructionIndex,
+    },
 
-    MapRowBatchToRowForNested(InstructionIndex, FixedBatchRowIterator),
-    ExecuteNested(InstructionIndex, BranchIndex, NestedPatternResultMapper, MaybeOwnedRow<'static>),
+    MapRowBatchToRowForNested {
+        index: InstructionIndex,
+        iterator: FixedBatchRowIterator,
+    },
+    ExecuteNested {
+        index: InstructionIndex,
+        branch_index: BranchIndex,
+        mapper: NestedPatternResultMapper,
+        input: MaybeOwnedRow<'static>,
+    },
 
-    TabledCall(InstructionIndex), // TODO: Use a FunctionMapper
+    TabledCall {
+        index: InstructionIndex,
+    }, // TODO: Use a FunctionMapper
 
-    CollectingStage(InstructionIndex),
-    StreamCollected(InstructionIndex, CollectedStageIterator),
-    ReshapeForReturn(InstructionIndex, FixedBatch),
+    CollectingStage {
+        index: InstructionIndex,
+    },
+    StreamCollected {
+        index: InstructionIndex,
+        iterator: CollectedStageIterator,
+    },
+    ReshapeForReturn {
+        index: InstructionIndex,
+        to_reshape: FixedBatch,
+    },
 
-    Yield(FixedBatch),
+    Yield {
+        batch: FixedBatch,
+    },
 }
 
 pub(crate) struct PatternExecutor {
@@ -82,7 +106,7 @@ impl PatternExecutor {
     pub(crate) fn prepare(&mut self, input_batch: FixedBatch) {
         debug_assert!(self.control_stack.is_empty());
         self.reset();
-        self.control_stack.push(ControlInstruction::Start(input_batch));
+        self.control_stack.push(ControlInstruction::Start { input_batch });
     }
 
     pub(super) fn reset(&mut self) {
@@ -105,33 +129,33 @@ impl PatternExecutor {
             }
 
             match control_stack.pop().unwrap() {
-                ControlInstruction::Start(batch) => {
-                    self.prepare_next_instruction_and_push_to_stack(context, InstructionIndex(0), batch)?;
+                ControlInstruction::Start { input_batch } => {
+                    self.prepare_next_instruction_and_push_to_stack(context, InstructionIndex(0), input_batch)?;
                 }
-                ControlInstruction::ExecuteImmediate(index) => {
+                ControlInstruction::ExecuteImmediate { index } => {
                     let executor = executors[index.0].unwrap_immediate();
                     if let Some(batch) = executor.batch_continue(context, interrupt)? {
-                        control_stack.push(ControlInstruction::ExecuteImmediate(index));
+                        control_stack.push(ControlInstruction::ExecuteImmediate { index });
                         self.prepare_next_instruction_and_push_to_stack(context, index.next(), batch)?;
                     }
                 }
-                ControlInstruction::MapRowBatchToRowForNested(index, mut iter) => {
-                    if let Some(row_result) = iter.next() {
+                ControlInstruction::MapRowBatchToRowForNested { index, mut iterator } => {
+                    if let Some(row_result) = iterator.next() {
                         let unmapped_input = row_result.unwrap().into_owned();
-                        control_stack.push(ControlInstruction::MapRowBatchToRowForNested(index, iter));
+                        control_stack.push(ControlInstruction::MapRowBatchToRowForNested { index, iterator });
                         match &mut executors[index.0] {
                             StepExecutors::Nested(_) => {
                                 self.prepare_and_push_nested_pattern(index, unmapped_input);
                             }
                             StepExecutors::TabledCall(tabled_call_executor) => {
                                 tabled_call_executor.prepare(unmapped_input);
-                                control_stack.push(ControlInstruction::TabledCall(index));
+                                control_stack.push(ControlInstruction::TabledCall { index });
                             }
                             _ => unreachable!(),
                         }
                     }
                 }
-                ControlInstruction::ExecuteNested(index, branch_index, mut mapper, input) => {
+                ControlInstruction::ExecuteNested { index, branch_index, mut mapper, input } => {
                     // TODO: This bit desperately needs a cleanup.
                     let branch = &mut executors[index.0].unwrap_branch().get_branch(branch_index);
                     let suspend_point_len_before = suspend_point_accumulator.len();
@@ -142,12 +166,7 @@ impl PatternExecutor {
                     }
                     let (must_retry, mapped) = mapper.map_output(unmapped).into_parts();
                     if must_retry {
-                        control_stack.push(ControlInstruction::ExecuteNested(
-                            index,
-                            branch_index,
-                            mapper,
-                            input.clone(),
-                        ));
+                        control_stack.push(ControlInstruction::ExecuteNested { index, branch_index, mapper, input });
                     } else {
                         branch.reset();
                     }
@@ -155,7 +174,7 @@ impl PatternExecutor {
                         self.prepare_next_instruction_and_push_to_stack(context, index.next(), batch)?;
                     }
                 }
-                ControlInstruction::TabledCall(index) => {
+                ControlInstruction::TabledCall { index } => {
                     let executor = executors[index.0].unwrap_tabled_call();
                     let call_key = executor.active_call_key().unwrap();
                     let function_state = tabled_functions.get_or_create_function_state(context, call_key)?;
@@ -186,34 +205,34 @@ impl PatternExecutor {
                         }
                     };
                     if let Some(batch) = found {
-                        self.control_stack.push(ControlInstruction::TabledCall(index.clone()));
+                        self.control_stack.push(ControlInstruction::TabledCall { index: index.clone() });
                         let mapped = executor.map_output(batch);
                         self.prepare_next_instruction_and_push_to_stack(context, index.next(), mapped)?;
                     } else {
                         // TODO: This looks like the place to consider a retry?
                     }
                 }
-                ControlInstruction::CollectingStage(index) => {
+                ControlInstruction::CollectingStage { index } => {
                     let (pattern, mut collector) = executors[index.0].unwrap_collecting_stage().to_parts_mut();
                     // Distinct isn't a collecting stage. We should use fresh suspend_point_accumulators here.
                     match pattern.batch_continue(context, interrupt, tabled_functions, suspend_point_accumulator)? {
                         Some(batch) => {
                             collector.accept(context, batch);
-                            self.control_stack.push(ControlInstruction::CollectingStage(index))
+                            self.control_stack.push(ControlInstruction::CollectingStage { index })
                         }
                         None => {
                             let iterator = collector.into_iterator();
-                            self.control_stack.push(ControlInstruction::StreamCollected(index, iterator))
+                            self.control_stack.push(ControlInstruction::StreamCollected { index, iterator })
                         }
                     }
                 }
-                ControlInstruction::StreamCollected(index, mut collected_iterator) => {
-                    if let Some(batch) = collected_iterator.batch_continue()? {
-                        self.control_stack.push(ControlInstruction::StreamCollected(index, collected_iterator));
+                ControlInstruction::StreamCollected { index, mut iterator } => {
+                    if let Some(batch) = iterator.batch_continue()? {
+                        self.control_stack.push(ControlInstruction::StreamCollected { index, iterator });
                         self.prepare_next_instruction_and_push_to_stack(context, index.next(), batch)?;
                     }
                 }
-                ControlInstruction::ReshapeForReturn(index, batch) => {
+                ControlInstruction::ReshapeForReturn { index, to_reshape: batch } => {
                     let return_positions = executors[index.0].unwrap_reshape();
                     let mut batch_iter = batch.into_iterator();
                     let mut output_batch = FixedBatch::new(return_positions.len() as u32);
@@ -227,7 +246,7 @@ impl PatternExecutor {
                     }
                     self.prepare_next_instruction_and_push_to_stack(context, index.next(), output_batch)?;
                 }
-                ControlInstruction::Yield(batch) => {
+                ControlInstruction::Yield { batch } => {
                     return Ok(Some(batch));
                 }
             }
@@ -242,28 +261,32 @@ impl PatternExecutor {
         batch: FixedBatch,
     ) -> Result<(), ReadExecutionError> {
         if next_instruction_index.0 >= self.executors.len() {
-            self.control_stack.push(ControlInstruction::Yield(batch));
+            self.control_stack.push(ControlInstruction::Yield { batch });
         } else {
             match &mut self.executors[next_instruction_index.0] {
                 StepExecutors::Immediate(executable) => {
                     executable.prepare(batch, context)?;
-                    self.control_stack.push(ControlInstruction::ExecuteImmediate(next_instruction_index));
+                    self.control_stack.push(ControlInstruction::ExecuteImmediate { index: next_instruction_index });
                 }
-                StepExecutors::Nested(_) => self
-                    .control_stack
-                    .push(ControlInstruction::MapRowBatchToRowForNested(next_instruction_index, batch.into_iterator())),
+                StepExecutors::Nested(_) => self.control_stack.push(ControlInstruction::MapRowBatchToRowForNested {
+                    index: next_instruction_index,
+                    iterator: batch.into_iterator(),
+                }),
                 StepExecutors::TabledCall(_) => {
-                    self.control_stack.push(ControlInstruction::MapRowBatchToRowForNested(
-                        next_instruction_index,
-                        batch.into_iterator(),
-                    ));
+                    self.control_stack.push(ControlInstruction::MapRowBatchToRowForNested {
+                        index: next_instruction_index,
+                        iterator: batch.into_iterator(),
+                    });
                 }
                 StepExecutors::CollectingStage(collecting_stage) => {
                     collecting_stage.prepare(batch);
-                    self.control_stack.push(ControlInstruction::CollectingStage(next_instruction_index));
+                    self.control_stack.push(ControlInstruction::CollectingStage { index: next_instruction_index });
                 }
                 StepExecutors::ReshapeForReturn(_) => {
-                    self.control_stack.push(ControlInstruction::ReshapeForReturn(next_instruction_index, batch))
+                    self.control_stack.push(ControlInstruction::ReshapeForReturn {
+                        index: next_instruction_index,
+                        to_reshape: batch,
+                    });
                 }
             }
         }
@@ -277,24 +300,24 @@ impl PatternExecutor {
                     let mut mapper = NestedPatternResultMapper::Identity(IdentityMapper);
                     let mapped_input = mapper.map_input(&input);
                     branch.prepare(FixedBatch::from(mapped_input));
-                    self.control_stack.push(ControlInstruction::ExecuteNested(
+                    self.control_stack.push(ControlInstruction::ExecuteNested {
                         index,
-                        BranchIndex(branch_index),
+                        branch_index: BranchIndex(branch_index),
                         mapper,
-                        input.clone().into_owned(),
-                    ))
+                        input: input.clone().into_owned(),
+                    })
                 }
             }
             NestedPatternExecutor::Negation { inner } => {
                 let mut mapper = NestedPatternResultMapper::Negation(NegationMapper::new(input.clone().into_owned()));
                 let mapped_input = mapper.map_input(&input);
                 inner.prepare(FixedBatch::from(mapped_input));
-                self.control_stack.push(ControlInstruction::ExecuteNested(
+                self.control_stack.push(ControlInstruction::ExecuteNested {
                     index,
-                    BranchIndex(0),
+                    branch_index: BranchIndex(0),
                     mapper,
-                    input.clone().into_owned(),
-                ));
+                    input: input.clone().into_owned(),
+                });
             }
             NestedPatternExecutor::InlinedFunction { inner, arg_mapping, return_mapping, output_width } => {
                 let mut mapper = NestedPatternResultMapper::InlinedFunction(InlinedFunctionMapper::new(
@@ -305,34 +328,34 @@ impl PatternExecutor {
                 ));
                 let mapped_input = mapper.map_input(&input);
                 inner.prepare(FixedBatch::from(mapped_input));
-                self.control_stack.push(ControlInstruction::ExecuteNested(
+                self.control_stack.push(ControlInstruction::ExecuteNested {
                     index,
-                    BranchIndex(0),
+                    branch_index: BranchIndex(0),
                     mapper,
-                    input.clone().into_owned(),
-                ));
+                    input: input.clone().into_owned(),
+                });
             }
             NestedPatternExecutor::Offset { inner, offset } => {
                 let mut mapper = NestedPatternResultMapper::Offset(OffsetMapper::new(*offset));
                 let mapped_input = mapper.map_input(&input);
                 inner.prepare(FixedBatch::from(mapped_input));
-                self.control_stack.push(ControlInstruction::ExecuteNested(
+                self.control_stack.push(ControlInstruction::ExecuteNested {
                     index,
-                    BranchIndex(0),
+                    branch_index: BranchIndex(0),
                     mapper,
-                    input.clone().into_owned(),
-                ));
+                    input: input.clone().into_owned(),
+                });
             }
             NestedPatternExecutor::Limit { inner, limit } => {
                 let mut mapper = NestedPatternResultMapper::Limit(LimitMapper::new(*limit));
                 let mapped_input = mapper.map_input(&input);
                 inner.prepare(FixedBatch::from(mapped_input));
-                self.control_stack.push(ControlInstruction::ExecuteNested(
+                self.control_stack.push(ControlInstruction::ExecuteNested {
                     index,
-                    BranchIndex(0),
+                    branch_index: BranchIndex(0),
                     mapper,
-                    input.clone().into_owned(),
-                ));
+                    input: input.clone().into_owned(),
+                });
             }
         }
     }

--- a/executor/read/pattern_executor.rs
+++ b/executor/read/pattern_executor.rs
@@ -158,7 +158,7 @@ impl PatternExecutor {
                     let executor = executors[index.0].unwrap_tabled_call();
                     let call_key = executor.active_call_key().unwrap();
                     let function_state = tabled_functions.get_or_create_function_state(context, call_key)?;
-                    let found = match executor.batch_continue_or_function_pattern(&function_state) {
+                    let found = match executor.read_table_or_get_executor(&function_state) {
                         Either::Left(batch) => Some(batch),
                         Either::Right(pattern_mutex) => match pattern_mutex.try_lock() {
                             Ok(mut executor_state) => {

--- a/executor/read/step_executor.rs
+++ b/executor/read/step_executor.rs
@@ -82,8 +82,6 @@ pub(super) fn create_executors_for_match(
     match_executable: &MatchExecutable,
     tmp__recursion_validation: &mut HashSet<FunctionID>,
 ) -> Result<Vec<StepExecutors>, ConceptReadError> {
-    // eprintln!("{:?}", match_executable.steps());
-
     let mut steps = Vec::with_capacity(match_executable.steps().len());
     for step in match_executable.steps() {
         match step {

--- a/executor/read/step_executor.rs
+++ b/executor/read/step_executor.rs
@@ -27,8 +27,8 @@ use crate::read::{
     immediate_executor::ImmediateExecutor,
     nested_pattern_executor::NestedPatternExecutor,
     pattern_executor::PatternExecutor,
+    tabled_functions::TabledCallExecutor,
 };
-use crate::read::tabled_functions::TabledCallExecutor;
 
 pub(super) enum StepExecutors {
     Immediate(ImmediateExecutor),
@@ -111,14 +111,13 @@ pub(super) fn create_executors_for_match(
                     let executor = TabledCallExecutor::new(
                         function_call.function_id.clone(),
                         function_call.arguments.clone(),
-                        function_call.assigned.clone()
+                        function_call.assigned.clone(),
                     );
-                    StepExecutors::TabledCall(executor)
+                    steps.push(StepExecutors::TabledCall(executor))
                 } else {
                     if tmp__recursion_validation.contains(&function_call.function_id) {
-                        todo!(
-                            "Recursive functions are unsupported in this release. Continuing would overflow the stack"
-                        )
+                        // TODO: This validation can be removed once planning correctly identifies those to be tabled.
+                        unreachable!("Something that should have been tabled has not been tabled.")
                     } else {
                         tmp__recursion_validation.insert(function_call.function_id.clone());
                     }

--- a/executor/read/step_executor.rs
+++ b/executor/read/step_executor.rs
@@ -28,11 +28,13 @@ use crate::read::{
     nested_pattern_executor::NestedPatternExecutor,
     pattern_executor::PatternExecutor,
 };
+use crate::read::tabled_functions::TabledCallExecutor;
 
 pub(super) enum StepExecutors {
     Immediate(ImmediateExecutor),
     Nested(NestedPatternExecutor),
     CollectingStage(CollectingStageExecutor),
+    TabledCall(TabledCallExecutor),
     ReshapeForReturn(Vec<VariablePosition>),
 }
 
@@ -99,7 +101,12 @@ pub(super) fn create_executors_for_match(
             ExecutionStep::FunctionCall(function_call) => {
                 let function = function_registry.get(function_call.function_id.clone());
                 if function.is_tabled {
-                    todo!()
+                    let executor = TabledCallExecutor::new(
+                        function_call.function_id.clone(),
+                        function_call.arguments.clone(),
+                        function_call.assigned.clone()
+                    );
+                    StepExecutors::TabledCall(executor)
                 } else {
                     if tmp__recursion_validation.contains(&function_call.function_id) {
                         todo!(

--- a/executor/read/step_executor.rs
+++ b/executor/read/step_executor.rs
@@ -179,8 +179,6 @@ pub(super) fn create_executors_for_function(
     executable_function: &ExecutableFunction,
     tmp__recursion_validation: &mut HashSet<FunctionID>,
 ) -> Result<Vec<StepExecutors>, ConceptReadError> {
-    // TODO: Support full pipelines
-    debug_assert!(executable_function.executable_stages.len() == 1);
     let executable_stages = &executable_function.executable_stages;
     let mut steps = create_executors_for_pipeline_stages(
         snapshot,

--- a/executor/read/step_executor.rs
+++ b/executor/read/step_executor.rs
@@ -53,6 +53,13 @@ impl StepExecutors {
         }
     }
 
+    pub(crate) fn unwrap_tabled_call(&mut self) -> &mut TabledCallExecutor {
+        match self {
+            StepExecutors::TabledCall(step) => step,
+            _ => unreachable!(),
+        }
+    }
+
     pub(crate) fn unwrap_collecting_stage(&mut self) -> &mut CollectingStageExecutor {
         match self {
             StepExecutors::CollectingStage(step) => step,

--- a/executor/read/step_executor.rs
+++ b/executor/read/step_executor.rs
@@ -66,6 +66,13 @@ impl StepExecutors {
             _ => panic!("bad unwrap"),
         }
     }
+
+    pub(crate) fn unwrap_reshape(&self) -> &Vec<VariablePosition> {
+        match self {
+            StepExecutors::ReshapeForReturn(return_positions) => return_positions,
+            _ => panic!("bad unwrap"),
+        }
+    }
 }
 
 pub(super) fn create_executors_for_match(
@@ -112,6 +119,7 @@ pub(super) fn create_executors_for_match(
                         function_call.function_id.clone(),
                         function_call.arguments.clone(),
                         function_call.assigned.clone(),
+                        function_call.output_width,
                     );
                     steps.push(StepExecutors::TabledCall(executor))
                 } else {
@@ -121,15 +129,14 @@ pub(super) fn create_executors_for_match(
                     } else {
                         tmp__recursion_validation.insert(function_call.function_id.clone());
                     }
-                    let inner = create_executors_for_pipeline_stages(
+                    let inner_executors = create_executors_for_function(
                         snapshot,
                         thing_manager,
                         function_registry,
-                        &function.executable_stages,
-                        &function.executable_stages.len() - 1,
+                        function,
                         tmp__recursion_validation,
                     )?;
-                    let inner = PatternExecutor::new(inner);
+                    let inner = PatternExecutor::new(inner_executors);
                     tmp__recursion_validation.remove(&function_call.function_id);
                     let step = NestedPatternExecutor::new_inlined_function(inner, function_call);
                     steps.push(step.into())

--- a/executor/read/step_executor.rs
+++ b/executor/read/step_executor.rs
@@ -82,6 +82,8 @@ pub(super) fn create_executors_for_match(
     match_executable: &MatchExecutable,
     tmp__recursion_validation: &mut HashSet<FunctionID>,
 ) -> Result<Vec<StepExecutors>, ConceptReadError> {
+    // eprintln!("{:?}", match_executable.steps());
+
     let mut steps = Vec::with_capacity(match_executable.steps().len());
     for step in match_executable.steps() {
         match step {

--- a/executor/read/step_executor.rs
+++ b/executor/read/step_executor.rs
@@ -23,10 +23,8 @@ use itertools::Itertools;
 use storage::snapshot::ReadableSnapshot;
 
 use crate::read::{
-    collecting_stage_executor::CollectingStageExecutor,
-    immediate_executor::ImmediateExecutor,
-    nested_pattern_executor::NestedPatternExecutor,
-    pattern_executor::PatternExecutor,
+    collecting_stage_executor::CollectingStageExecutor, immediate_executor::ImmediateExecutor,
+    nested_pattern_executor::NestedPatternExecutor, pattern_executor::PatternExecutor,
     tabled_functions::TabledCallExecutor,
 };
 

--- a/executor/read/step_executor.rs
+++ b/executor/read/step_executor.rs
@@ -25,7 +25,7 @@ use storage::snapshot::ReadableSnapshot;
 use crate::read::{
     collecting_stage_executor::CollectingStageExecutor, immediate_executor::ImmediateExecutor,
     nested_pattern_executor::NestedPatternExecutor, pattern_executor::PatternExecutor,
-    tabled_functions::TabledCallExecutor,
+    tabled_call_executor::TabledCallExecutor,
 };
 
 pub(super) enum StepExecutors {
@@ -73,7 +73,7 @@ impl StepExecutors {
     }
 }
 
-pub(super) fn create_executors_for_match(
+pub(crate) fn create_executors_for_match(
     snapshot: &Arc<impl ReadableSnapshot + 'static>,
     thing_manager: &Arc<ThingManager>,
     function_registry: &ExecutableFunctionRegistry,
@@ -170,7 +170,7 @@ pub(super) fn create_executors_for_match(
     Ok(steps)
 }
 
-pub(super) fn create_executors_for_function(
+pub(crate) fn create_executors_for_function(
     snapshot: &Arc<impl ReadableSnapshot + 'static>,
     thing_manager: &Arc<ThingManager>,
     function_registry: &ExecutableFunctionRegistry,

--- a/executor/read/step_executor.rs
+++ b/executor/read/step_executor.rs
@@ -8,7 +8,7 @@ use std::{collections::HashSet, sync::Arc};
 
 use compiler::{
     executable::{
-        function::{ExecutableFunction, ExecutableReturn},
+        function::{ExecutableFunction, ExecutableReturn, FunctionTablingType},
         match_::planner::{
             function_plan::ExecutableFunctionRegistry,
             match_executable::{ExecutionStep, MatchExecutable},
@@ -20,7 +20,6 @@ use compiler::{
 use concept::{error::ConceptReadError, thing::thing_manager::ThingManager};
 use ir::pipeline::function_signature::FunctionID;
 use itertools::Itertools;
-use compiler::executable::function::FunctionTablingType;
 use storage::snapshot::ReadableSnapshot;
 
 use crate::read::{

--- a/executor/read/step_executor.rs
+++ b/executor/read/step_executor.rs
@@ -20,6 +20,7 @@ use compiler::{
 use concept::{error::ConceptReadError, thing::thing_manager::ThingManager};
 use ir::pipeline::function_signature::FunctionID;
 use itertools::Itertools;
+use compiler::executable::function::FunctionTablingType;
 use storage::snapshot::ReadableSnapshot;
 
 use crate::read::{
@@ -112,7 +113,7 @@ pub(crate) fn create_executors_for_match(
             }
             ExecutionStep::FunctionCall(function_call) => {
                 let function = function_registry.get(function_call.function_id.clone());
-                if function.is_tabled {
+                if function.is_tabled == FunctionTablingType::Tabled {
                     let executor = TabledCallExecutor::new(
                         function_call.function_id.clone(),
                         function_call.arguments.clone(),

--- a/executor/read/tabled_call_executor.rs
+++ b/executor/read/tabled_call_executor.rs
@@ -1,0 +1,118 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+use std::sync::Mutex;
+
+use compiler::VariablePosition;
+use ir::pipeline::function_signature::FunctionID;
+use itertools::Either;
+use lending_iterator::LendingIterator;
+use storage::snapshot::ReadableSnapshot;
+
+use crate::{
+    batch::FixedBatch,
+    read::{
+        pattern_executor::InstructionIndex,
+        tabled_functions::{CallKey, TableIndex, TabledFunctionPatternExecutorState, TabledFunctionState},
+        SuspendPoint, TabledCallSuspension,
+    },
+    row::MaybeOwnedRow,
+};
+
+pub(crate) struct TabledCallExecutor {
+    function_id: FunctionID,
+    argument_positions: Vec<VariablePosition>,
+    assignment_positions: Vec<VariablePosition>,
+    output_width: u32,
+    active_executor: Option<TabledCallExecutorState>,
+}
+
+impl TabledCallExecutor {
+    pub(crate) fn add_batch_to_table(&mut self, state: &TabledFunctionState, batch: FixedBatch) -> FixedBatch {
+        let deduplicated_batch = state.add_batch_to_table(batch);
+        *self.active_executor.as_mut().unwrap().next_table_row += deduplicated_batch.len() as usize;
+        deduplicated_batch
+    }
+}
+
+pub struct TabledCallExecutorState {
+    pub(crate) call_key: CallKey,
+    pub(crate) input: MaybeOwnedRow<'static>,
+    pub(crate) next_table_row: TableIndex,
+}
+
+impl TabledCallExecutor {
+    pub(crate) fn new(
+        function_id: FunctionID,
+        argument_positions: Vec<VariablePosition>,
+        assignment_positions: Vec<VariablePosition>,
+        output_width: u32,
+    ) -> Self {
+        Self { function_id, argument_positions, assignment_positions, output_width, active_executor: None }
+    }
+
+    pub(crate) fn prepare(&mut self, input: MaybeOwnedRow<'static>) {
+        let arguments = MaybeOwnedRow::new_owned(
+            self.argument_positions.iter().map(|pos| input.get(pos.clone()).to_owned()).collect(),
+            input.multiplicity(),
+        );
+        let call_key = CallKey { function_id: self.function_id.clone(), arguments };
+        self.active_executor = Some(TabledCallExecutorState { call_key, input, next_table_row: TableIndex(0) });
+    }
+
+    pub(crate) fn active_call_key(&self) -> Option<&CallKey> {
+        self.active_executor.as_ref().map(|active| &active.call_key)
+    }
+
+    pub(crate) fn map_output(&self, returned_batch: FixedBatch) -> FixedBatch {
+        let mut output_batch = FixedBatch::new(self.output_width);
+        for return_index in 0..returned_batch.len() {
+            // TODO: Deduplicate?
+            let returned_row = returned_batch.get_row(return_index);
+            output_batch.append(|mut output_row| {
+                for (i, element) in self.active_executor.as_ref().unwrap().input.iter().enumerate() {
+                    output_row.set(VariablePosition::new(i as u32), element.clone());
+                }
+                for (returned_index, output_position) in self.assignment_positions.iter().enumerate() {
+                    output_row.set(output_position.clone(), returned_row[returned_index].clone().into_owned());
+                }
+            });
+        }
+        output_batch
+    }
+
+    pub(crate) fn read_table_or_get_executor<'a>(
+        &mut self,
+        tabled_function_state: &'a TabledFunctionState,
+    ) -> Either<FixedBatch, &'a Mutex<TabledFunctionPatternExecutorState>> {
+        // Maybe return a batch?
+        let executor = self.active_executor.as_mut().unwrap();
+        let read_index = &mut *executor.next_table_row;
+
+        let table_read = tabled_function_state.table.read().unwrap();
+        if *read_index < table_read.len() {
+            let mut batch = FixedBatch::new(table_read.width());
+            while !batch.is_full() && *read_index < table_read.len() {
+                batch.append(|mut write_to| {
+                    write_to.copy_from_row(table_read.get_row(*read_index).unwrap().as_reference());
+                });
+                *read_index += 1;
+            }
+            Either::Left(batch)
+        } else {
+            drop(table_read);
+            Either::Right(&tabled_function_state.executor_state)
+        }
+    }
+
+    pub(crate) fn create_suspend_point_for(&self, instruction_index: InstructionIndex) -> SuspendPoint {
+        SuspendPoint::TabledCall(TabledCallSuspension {
+            instruction_index,
+            input_row: self.active_executor.as_ref().unwrap().input.clone().into_owned(),
+            next_table_row: self.active_executor.as_ref().unwrap().next_table_row,
+        })
+    }
+}

--- a/executor/read/tabled_call_executor.rs
+++ b/executor/read/tabled_call_executor.rs
@@ -4,22 +4,19 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-use std::sync::{Arc, Mutex, MutexGuard, TryLockError};
+use std::sync::{MutexGuard, TryLockError};
 
 use compiler::VariablePosition;
 use ir::pipeline::function_signature::FunctionID;
-use itertools::Either;
 use lending_iterator::LendingIterator;
 use storage::snapshot::ReadableSnapshot;
-use tokio::sync::RwLockReadGuard;
 
 use crate::{
     batch::FixedBatch,
-    error::ReadExecutionError,
     read::{
-        pattern_executor::{InstructionIndex, PatternExecutor},
+        pattern_executor::InstructionIndex,
         tabled_call_executor::TabledCallResult::Suspend,
-        tabled_functions::{AnswerTable, CallKey, TableIndex, TabledFunctionPatternExecutorState, TabledFunctionState},
+        tabled_functions::{CallKey, TableIndex, TabledFunctionPatternExecutorState, TabledFunctionState},
         SuspendPoint, TabledCallSuspension,
     },
     row::MaybeOwnedRow,

--- a/executor/read/tabled_call_executor.rs
+++ b/executor/read/tabled_call_executor.rs
@@ -109,7 +109,7 @@ impl TabledCallExecutor {
             match tabled_function_state.executor_state.try_lock() {
                 Ok(executor_mutex_guard) => TabledCallResult::MustExecutePattern(executor_mutex_guard),
                 Err(TryLockError::WouldBlock) => Suspend,
-                Err(TryLockError::Poisoned(_)) => panic!("The mutex on a tabled function was poisoned")
+                Err(TryLockError::Poisoned(_)) => panic!("The mutex on a tabled function was poisoned"),
             }
         }
     }

--- a/executor/read/tabled_call_executor.rs
+++ b/executor/read/tabled_call_executor.rs
@@ -14,7 +14,7 @@ use storage::snapshot::ReadableSnapshot;
 use crate::{
     batch::FixedBatch,
     read::{
-        pattern_executor::InstructionIndex,
+        pattern_executor::ExecutorIndex,
         tabled_call_executor::TabledCallResult::Suspend,
         tabled_functions::{CallKey, TableIndex, TabledFunctionPatternExecutorState, TabledFunctionState},
         SuspendPoint, TabledCallSuspension,
@@ -82,9 +82,9 @@ impl TabledCallExecutor {
         output_batch
     }
 
-    pub(crate) fn create_suspend_point_for(&self, instruction_index: InstructionIndex) -> SuspendPoint {
+    pub(crate) fn create_suspend_point_for(&self, executor_index: ExecutorIndex) -> SuspendPoint {
         SuspendPoint::TabledCall(TabledCallSuspension {
-            instruction_index,
+            executor_index,
             input_row: self.active_executor.as_ref().unwrap().input.clone().into_owned(),
             next_table_row: self.active_executor.as_ref().unwrap().next_table_row,
         })

--- a/executor/read/tabled_functions.rs
+++ b/executor/read/tabled_functions.rs
@@ -1,0 +1,96 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+use std::collections::HashMap;
+use std::sync::{Arc, RwLock};
+use itertools::Either;
+use compiler::VariablePosition;
+use ir::pipeline::function_signature::FunctionID;
+use crate::batch::FixedBatch;
+use crate::read::pattern_executor::PatternExecutor;
+use crate::row::MaybeOwnedRow;
+
+
+// TODO: Rearrange file
+
+pub struct TabledFunctions {
+    state: HashMap<CallKey, RwLock<TabledFunctionState>>,
+}
+
+pub(super) struct CallKey {
+    function_id: FunctionID,
+    arguments: MaybeOwnedRow<'static>,
+}
+
+struct SuspendPoint {
+    // TODO
+}
+
+struct TabledFunctionState {
+    table: AnswerTable, // TODO: Need a structure which can de-duplicate & preserve insertion order.
+    suspend_points: Vec<SuspendPoint>,
+    pattern_executor: PatternExecutor,
+    // can_clean: bool, // TODO: Apparently you only need to keep the table if it's a call that causes a suspend.
+}
+
+struct AnswerTable {
+    answers: Vec<MaybeOwnedRow<'static>>
+}
+
+impl AnswerTable {
+    fn read_answer(&mut self, index: usize) -> Option<MaybeOwnedRow<'_>> {
+        self.answers.get(index).map(|row| row.as_reference())
+    }
+
+    fn may_add_row(&mut self, row: MaybeOwnedRow<'static>) -> Option<usize> {
+        if self.answers.contains(&row) {
+            None
+        } else {
+            let ret = Some(self.answers.len() - 1);
+            self.answers.push(row);
+            ret
+        }
+    }
+}
+
+pub(crate) struct TabledCallExecutor {
+    function_id: FunctionID,
+    argument_positions: Vec<VariablePosition>,
+    assignment_positions: Vec<VariablePosition>,
+    active_executor: Option<TabledCallExecutorState>,
+}
+
+pub struct TabledCallExecutorState {
+    arguments: MaybeOwnedRow<'static>,
+    next_index: usize,
+}
+
+impl TabledCallExecutor {
+    pub(crate) fn new(function_id: FunctionID, argument_positions: Vec<VariablePosition>, assignment_positions: Vec<VariablePosition>) -> Self {
+        Self { function_id, argument_positions, assignment_positions, active_executor: None }
+    }
+
+    fn prepare(&mut self, arguments: MaybeOwnedRow<'static>) {
+        self.active_executor = Some(TabledCallExecutorState { arguments, next_index: 0 })
+    }
+
+    fn batch_continue_or_function_pattern<'a>(&mut self, tabled_function_state: &'a mut TabledFunctionState) -> Either<FixedBatch, &'a mut PatternExecutor> { // Maybe return a batch?
+        let executor = self.active_executor.as_mut().unwrap();
+        if executor.next_index < tabled_function_state.table.answers.len() {
+            let answer_vec = &tabled_function_state.table.answers;
+            let mut batch = FixedBatch::new(answer_vec.last().unwrap().len() as u32);
+            while !batch.is_full() && executor.next_index < answer_vec.len() {
+                batch.append(|mut write_to| {
+                    write_to.copy_from_row(answer_vec.get(executor.next_index).unwrap().as_reference());
+                });
+                executor.next_index += 1;
+            }
+            Either::Left(batch)
+        } else {
+            Either::Right(&mut tabled_function_state.pattern_executor)
+        }
+    }
+}

--- a/executor/read/tabled_functions.rs
+++ b/executor/read/tabled_functions.rs
@@ -92,6 +92,7 @@ pub(crate) struct TabledCallExecutor {
 
 pub struct TabledCallExecutorState {
     pub(crate) call_key: CallKey,
+    pub(crate) input: MaybeOwnedRow<'static>,
     pub(crate) next_index: usize,
 }
 
@@ -104,9 +105,11 @@ impl TabledCallExecutor {
         Self { function_id, argument_positions, assignment_positions, active_executor: None }
     }
 
-    pub(crate) fn prepare(&mut self, arguments: MaybeOwnedRow<'static>) {
-        let call_key = CallKey { function_id: self.function_id.clone(), arguments };
-        self.active_executor = Some(TabledCallExecutorState { call_key, next_index: 0 });
+    pub(crate) fn prepare(&mut self, input: MaybeOwnedRow<'static>) {
+        todo!()
+        // let arguments = self.argument_positions.iter().map(|pos| input.get(pos.clone())).collect();
+        // let call_key = CallKey { function_id: self.function_id.clone(), arguments };
+        // self.active_executor = Some(TabledCallExecutorState { call_key, input, next_index: 0 });
     }
 
     pub(crate) fn active_call_key(&self) -> Option<&CallKey> {

--- a/executor/read/tabled_functions.rs
+++ b/executor/read/tabled_functions.rs
@@ -6,10 +6,9 @@
 
 use std::{
     collections::{HashMap, HashSet},
-    sync::{Arc, Mutex, MutexGuard, RwLock, TryLockError, TryLockResult},
+    sync::{Arc, Mutex},
 };
 
-use clap::Parser;
 use compiler::{executable::match_::planner::function_plan::ExecutableFunctionRegistry, VariablePosition};
 use ir::pipeline::function_signature::FunctionID;
 use itertools::Either;
@@ -19,16 +18,18 @@ use crate::{
     batch::FixedBatch,
     error::ReadExecutionError,
     pipeline::stage::ExecutionContext,
-    read::{pattern_executor::PatternExecutor, step_executor::create_executors_for_pipeline_stages},
+    read::{pattern_executor::PatternExecutor},
     row::MaybeOwnedRow,
 };
+use crate::read::pattern_executor::{BranchIndex, InstructionIndex};
 use crate::read::step_executor::create_executors_for_function;
+use crate::read::{SuspendPoint, TabledCallSuspension};
 
 // TODO: Rearrange file
 
 pub struct TabledFunctions {
     function_registry: Arc<ExecutableFunctionRegistry>,
-    state: HashMap<CallKey, Arc<Mutex<TabledFunctionState>>>,
+    state: HashMap<CallKey, Arc<TabledFunctionState>>,
 }
 
 impl TabledFunctions {
@@ -36,7 +37,7 @@ impl TabledFunctions {
         &mut self,
         context: &ExecutionContext<impl ReadableSnapshot + 'static>,
         call_key: &CallKey,
-    ) -> Result<Arc<Mutex<TabledFunctionState>>, ReadExecutionError> {
+    ) -> Result<Arc<TabledFunctionState>, ReadExecutionError> {
         if !self.state.contains_key(call_key) {
             let function = &self.function_registry.get(call_key.function_id.clone());
             let executors = create_executors_for_function(
@@ -50,7 +51,7 @@ impl TabledFunctions {
             let pattern_executor = PatternExecutor::new(executors);
             self.state.insert(
                 call_key.clone(),
-                Arc::new(Mutex::new(TabledFunctionState::build_and_prepare(pattern_executor, &call_key.arguments))),
+                Arc::new(TabledFunctionState::build_and_prepare(pattern_executor, &call_key.arguments)),
             );
         }
         Ok(self.state.get(call_key).unwrap().clone())
@@ -69,21 +70,31 @@ pub(crate) struct CallKey {
     pub(crate) arguments: MaybeOwnedRow<'static>,
 }
 
-struct SuspendPoint {
-    // TODO
-}
+#[derive(Debug, Copy, Clone)]
+pub(crate) struct TableIndex(usize);
+
 
 pub(crate) struct TabledFunctionState {
     table: AnswerTable, // TODO: Need a structure which can de-duplicate & preserve insertion order.
-    suspend_points: Vec<SuspendPoint>,
-    pattern_executor: PatternExecutor,
+    executor_state: Mutex<TabledFunctionPatternExecutorState>,
     // can_clean: bool, // TODO: Apparently you only need to keep the table if it's a call that causes a suspend.
+}
+
+pub(crate) struct TabledFunctionPatternExecutorState {
+    pub(crate) suspend_points: Vec<SuspendPoint>,
+    pub(crate) pattern_executor: PatternExecutor,
 }
 
 impl TabledFunctionState {
     fn build_and_prepare(mut pattern_executor: PatternExecutor, args: &MaybeOwnedRow<'_>) -> Self {
         pattern_executor.prepare(FixedBatch::from(args.as_reference()));
-        Self { table: AnswerTable { answers: Vec::new() }, suspend_points: Vec::new(), pattern_executor }
+        Self {
+            table: AnswerTable { answers: Vec::new() },
+            executor_state: Mutex::new(TabledFunctionPatternExecutorState {
+                pattern_executor,
+                suspend_points: Vec::new(),
+            })
+        }
     }
 }
 
@@ -118,7 +129,7 @@ pub(crate) struct TabledCallExecutor {
 pub struct TabledCallExecutorState {
     pub(crate) call_key: CallKey,
     pub(crate) input: MaybeOwnedRow<'static>,
-    pub(crate) next_index: usize,
+    pub(crate) next_table_row: TableIndex,
 }
 
 impl TabledCallExecutor {
@@ -137,7 +148,7 @@ impl TabledCallExecutor {
             input.multiplicity(),
         );
         let call_key = CallKey { function_id: self.function_id.clone(), arguments };
-        self.active_executor = Some(TabledCallExecutorState { call_key, input, next_index: 0 });
+        self.active_executor = Some(TabledCallExecutorState { call_key, input, next_table_row: TableIndex(0) });
     }
 
     pub(crate) fn active_call_key(&self) -> Option<&CallKey> {
@@ -163,22 +174,31 @@ impl TabledCallExecutor {
 
     pub(crate) fn batch_continue_or_function_pattern<'a>(
         &mut self,
-        tabled_function_state: &'a mut TabledFunctionState,
-    ) -> Either<FixedBatch, &'a mut PatternExecutor> {
+        tabled_function_state: &'a TabledFunctionState,
+    ) -> Either<FixedBatch, &'a Mutex<TabledFunctionPatternExecutorState>> {
         // Maybe return a batch?
         let executor = self.active_executor.as_mut().unwrap();
-        if executor.next_index < tabled_function_state.table.answers.len() {
+        let read_index = &mut executor.next_table_row.0;
+        if *read_index < tabled_function_state.table.answers.len() {
             let answer_vec = &tabled_function_state.table.answers;
             let mut batch = FixedBatch::new(answer_vec.last().unwrap().len() as u32);
-            while !batch.is_full() && executor.next_index < answer_vec.len() {
+            while !batch.is_full() && *read_index < answer_vec.len() {
                 batch.append(|mut write_to| {
-                    write_to.copy_from_row(answer_vec.get(executor.next_index).unwrap().as_reference());
+                    write_to.copy_from_row(answer_vec.get(*read_index).unwrap().as_reference());
                 });
-                executor.next_index += 1;
+                *read_index += 1;
             }
             Either::Left(batch)
         } else {
-            Either::Right(&mut tabled_function_state.pattern_executor)
+            Either::Right(&tabled_function_state.executor_state)
         }
+    }
+
+    pub(crate) fn create_suspend_point_for(&self, instruction_index: InstructionIndex) -> SuspendPoint {
+        SuspendPoint::TabledCall(TabledCallSuspension {
+            instruction_index,
+            input_row: self.active_executor.as_ref().unwrap().input.clone().into_owned(),
+            next_table_row: self.active_executor.as_ref().unwrap().next_table_row
+        })
     }
 }

--- a/executor/read/tabled_functions.rs
+++ b/executor/read/tabled_functions.rs
@@ -4,18 +4,19 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-use std::collections::HashMap;
-use std::sync::{Arc, Mutex, MutexGuard, RwLock, TryLockError, TryLockResult};
-use itertools::Either;
-use clap::Parser;
-use compiler::executable::match_::planner::function_plan::ExecutableFunctionRegistry;
-use compiler::VariablePosition;
-use ir::pipeline::function_signature::FunctionID;
-use crate::batch::FixedBatch;
-use crate::error::ReadExecutionError;
-use crate::read::pattern_executor::PatternExecutor;
-use crate::row::MaybeOwnedRow;
+use std::{
+    collections::HashMap,
+    sync::{Arc, Mutex, MutexGuard, RwLock, TryLockError, TryLockResult},
+};
 
+use clap::Parser;
+use compiler::{executable::match_::planner::function_plan::ExecutableFunctionRegistry, VariablePosition};
+use ir::pipeline::function_signature::FunctionID;
+use itertools::Either;
+
+use crate::{
+    batch::FixedBatch, error::ReadExecutionError, read::pattern_executor::PatternExecutor, row::MaybeOwnedRow,
+};
 
 // TODO: Rearrange file
 
@@ -26,7 +27,7 @@ pub struct TabledFunctions {
 
 impl TabledFunctions {
     pub(crate) fn get_or_create_state_mutex(&mut self, call_key: &CallKey) -> Arc<Mutex<TabledFunctionState>> {
-        if ! self.state.contains_key(call_key) {
+        if !self.state.contains_key(call_key) {
             self.state.insert(call_key.clone(), Arc::new(Mutex::new(TabledFunctionState::new())));
         }
         self.state.get(call_key).unwrap().clone()
@@ -63,7 +64,7 @@ impl TabledFunctionState {
 }
 
 struct AnswerTable {
-    answers: Vec<MaybeOwnedRow<'static>>
+    answers: Vec<MaybeOwnedRow<'static>>,
 }
 
 impl AnswerTable {
@@ -95,7 +96,11 @@ pub struct TabledCallExecutorState {
 }
 
 impl TabledCallExecutor {
-    pub(crate) fn new(function_id: FunctionID, argument_positions: Vec<VariablePosition>, assignment_positions: Vec<VariablePosition>) -> Self {
+    pub(crate) fn new(
+        function_id: FunctionID,
+        argument_positions: Vec<VariablePosition>,
+        assignment_positions: Vec<VariablePosition>,
+    ) -> Self {
         Self { function_id, argument_positions, assignment_positions, active_executor: None }
     }
 
@@ -108,7 +113,11 @@ impl TabledCallExecutor {
         self.active_executor.as_ref().map(|active| &active.call_key)
     }
 
-    pub(crate) fn batch_continue_or_function_pattern<'a>(&mut self, tabled_function_state: &'a mut TabledFunctionState) -> Either<FixedBatch, &'a mut PatternExecutor> { // Maybe return a batch?
+    pub(crate) fn batch_continue_or_function_pattern<'a>(
+        &mut self,
+        tabled_function_state: &'a mut TabledFunctionState,
+    ) -> Either<FixedBatch, &'a mut PatternExecutor> {
+        // Maybe return a batch?
         let executor = self.active_executor.as_mut().unwrap();
         if executor.next_index < tabled_function_state.table.answers.len() {
             let answer_vec = &tabled_function_state.table.answers;

--- a/executor/read/tabled_functions.rs
+++ b/executor/read/tabled_functions.rs
@@ -9,9 +9,8 @@ use std::{
     sync::{Arc, Mutex, RwLock},
 };
 
-use compiler::{executable::match_::planner::function_plan::ExecutableFunctionRegistry, VariablePosition};
+use compiler::executable::{function::ExecutableReturn, match_::planner::function_plan::ExecutableFunctionRegistry};
 use ir::pipeline::function_signature::FunctionID;
-use itertools::Either;
 use lending_iterator::LendingIterator;
 use storage::snapshot::ReadableSnapshot;
 
@@ -19,15 +18,9 @@ use crate::{
     batch::FixedBatch,
     error::ReadExecutionError,
     pipeline::stage::ExecutionContext,
-    read::{
-        pattern_executor::{InstructionIndex, PatternExecutor},
-        step_executor::create_executors_for_function,
-        SuspendPoint, TabledCallSuspension,
-    },
+    read::{pattern_executor::PatternExecutor, step_executor::create_executors_for_function, SuspendPoint},
     row::MaybeOwnedRow,
 };
-
-// TODO: Rearrange file
 
 pub struct TabledFunctions {
     function_registry: Arc<ExecutableFunctionRegistry>,
@@ -35,6 +28,10 @@ pub struct TabledFunctions {
 }
 
 impl TabledFunctions {
+    pub(crate) fn new(function_registry: Arc<ExecutableFunctionRegistry>) -> Self {
+        Self { state: HashMap::new(), function_registry }
+    }
+
     pub(crate) fn get_or_create_function_state(
         &mut self,
         context: &ExecutionContext<impl ReadableSnapshot + 'static>,
@@ -51,18 +48,16 @@ impl TabledFunctions {
             )
             .map_err(|source| ReadExecutionError::ConceptRead { source })?;
             let pattern_executor = PatternExecutor::new(executors);
+            let width = match &function.returns {
+                ExecutableReturn::Stream(v) => v.len() as u32,
+                _ => todo!(),
+            };
             self.state.insert(
                 call_key.clone(),
-                Arc::new(TabledFunctionState::build_and_prepare(pattern_executor, &call_key.arguments)),
+                Arc::new(TabledFunctionState::build_and_prepare(pattern_executor, &call_key.arguments, width)),
             );
         }
         Ok(self.state.get(call_key).unwrap().clone())
-    }
-}
-
-impl TabledFunctions {
-    pub(crate) fn new(function_registry: Arc<ExecutableFunctionRegistry>) -> Self {
-        Self { state: HashMap::new(), function_registry }
     }
 }
 
@@ -73,11 +68,24 @@ pub(crate) struct CallKey {
 }
 
 #[derive(Debug, Copy, Clone)]
-pub(crate) struct TableIndex(usize);
+pub(crate) struct TableIndex(pub(crate) usize);
+impl std::ops::Deref for TableIndex {
+    type Target = usize;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl std::ops::DerefMut for TableIndex {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
 
 pub(crate) struct TabledFunctionState {
-    table: RwLock<AnswerTable>, // TODO: Need a structure which can de-duplicate & preserve insertion order.
-    executor_state: Mutex<TabledFunctionPatternExecutorState>,
+    pub(crate) table: RwLock<AnswerTable>, // TODO: Need a structure which can de-duplicate & preserve insertion order.
+    pub(crate) executor_state: Mutex<TabledFunctionPatternExecutorState>,
     // can_clean: bool, // TODO: Apparently you only need to keep the table if it's a call that causes a suspend.
 }
 
@@ -87,10 +95,10 @@ pub(crate) struct TabledFunctionPatternExecutorState {
 }
 
 impl TabledFunctionState {
-    fn build_and_prepare(mut pattern_executor: PatternExecutor, args: &MaybeOwnedRow<'_>) -> Self {
+    fn build_and_prepare(mut pattern_executor: PatternExecutor, args: &MaybeOwnedRow<'_>, answer_width: u32) -> Self {
         pattern_executor.prepare(FixedBatch::from(args.as_reference()));
         Self {
-            table: RwLock::new(AnswerTable { answers: Vec::new() }),
+            table: RwLock::new(AnswerTable { answers: Vec::new(), width: answer_width }),
             executor_state: Mutex::new(TabledFunctionPatternExecutorState {
                 pattern_executor,
                 suspend_points: Vec::new(),
@@ -98,7 +106,7 @@ impl TabledFunctionState {
         }
     }
 
-    fn add_batch_to_table(&self, batch: FixedBatch) -> FixedBatch {
+    pub(crate) fn add_batch_to_table(&self, batch: FixedBatch) -> FixedBatch {
         if !batch.is_empty() {
             let mut deduplicated_batch = FixedBatch::new(batch.get_row(0).len() as u32);
             let mut table = self.table.write().unwrap();
@@ -106,9 +114,7 @@ impl TabledFunctionState {
             while let Some(row_result) = batch_iter.next() {
                 let row = row_result.unwrap();
                 if table.try_add_row(row.as_reference()) {
-                    deduplicated_batch.append(|mut write_to| {
-                        write_to.copy_from_row(row)
-                    })
+                    deduplicated_batch.append(|mut write_to| write_to.copy_from_row(row))
                 }
             }
             deduplicated_batch
@@ -118,8 +124,10 @@ impl TabledFunctionState {
     }
 }
 
-struct AnswerTable {
+pub(crate) struct AnswerTable {
+    // TODO: use a better data-structure. XSB has an "answer-trie" though a LinkedHashSet might do.
     answers: Vec<MaybeOwnedRow<'static>>,
+    width: u32,
 }
 
 impl AnswerTable {
@@ -135,99 +143,16 @@ impl AnswerTable {
             false
         }
     }
-}
 
-pub(crate) struct TabledCallExecutor {
-    function_id: FunctionID,
-    argument_positions: Vec<VariablePosition>,
-    assignment_positions: Vec<VariablePosition>,
-    output_width: u32,
-    active_executor: Option<TabledCallExecutorState>,
-}
-
-impl TabledCallExecutor {
-    pub(crate) fn add_batch_to_table(&mut self, state: &TabledFunctionState, batch: FixedBatch) -> FixedBatch {
-        let deduplicated_batch = state.add_batch_to_table(batch);
-        self.active_executor.as_mut().unwrap().next_table_row.0 += deduplicated_batch.len() as usize;
-        deduplicated_batch
-    }
-}
-
-pub struct TabledCallExecutorState {
-    pub(crate) call_key: CallKey,
-    pub(crate) input: MaybeOwnedRow<'static>,
-    pub(crate) next_table_row: TableIndex,
-}
-
-impl TabledCallExecutor {
-    pub(crate) fn new(
-        function_id: FunctionID,
-        argument_positions: Vec<VariablePosition>,
-        assignment_positions: Vec<VariablePosition>,
-        output_width: u32,
-    ) -> Self {
-        Self { function_id, argument_positions, assignment_positions, output_width, active_executor: None }
+    pub(crate) fn width(&self) -> u32 {
+        self.width
     }
 
-    pub(crate) fn prepare(&mut self, input: MaybeOwnedRow<'static>) {
-        let arguments = MaybeOwnedRow::new_owned(
-            self.argument_positions.iter().map(|pos| input.get(pos.clone()).to_owned()).collect(),
-            input.multiplicity(),
-        );
-        let call_key = CallKey { function_id: self.function_id.clone(), arguments };
-        self.active_executor = Some(TabledCallExecutorState { call_key, input, next_table_row: TableIndex(0) });
+    pub(crate) fn len(&self) -> usize {
+        self.answers.len()
     }
 
-    pub(crate) fn active_call_key(&self) -> Option<&CallKey> {
-        self.active_executor.as_ref().map(|active| &active.call_key)
-    }
-
-    pub(crate) fn map_output(&self, returned_batch: FixedBatch) -> FixedBatch {
-        let mut output_batch = FixedBatch::new(self.output_width);
-        for return_index in 0..returned_batch.len() {
-            // TODO: Deduplicate?
-            let returned_row = returned_batch.get_row(return_index);
-            output_batch.append(|mut output_row| {
-                for (i, element) in self.active_executor.as_ref().unwrap().input.iter().enumerate() {
-                    output_row.set(VariablePosition::new(i as u32), element.clone());
-                }
-                for (returned_index, output_position) in self.assignment_positions.iter().enumerate() {
-                    output_row.set(output_position.clone(), returned_row[returned_index].clone().into_owned());
-                }
-            });
-        }
-        output_batch
-    }
-
-    pub(crate) fn batch_continue_or_function_pattern<'a>(
-        &mut self,
-        tabled_function_state: &'a TabledFunctionState,
-    ) -> Either<FixedBatch, &'a Mutex<TabledFunctionPatternExecutorState>> {
-        // Maybe return a batch?
-        let executor = self.active_executor.as_mut().unwrap();
-        let read_index = &mut executor.next_table_row.0;
-
-        let table_read = tabled_function_state.table.read().unwrap();
-        if *read_index < table_read.answers.len() {
-            let mut batch = FixedBatch::new(table_read.answers.last().unwrap().len() as u32);
-            while !batch.is_full() && *read_index < table_read.answers.len() {
-                batch.append(|mut write_to| {
-                    write_to.copy_from_row(table_read.answers.get(*read_index).unwrap().as_reference());
-                });
-                *read_index += 1;
-            }
-            Either::Left(batch)
-        } else {
-            drop(table_read);
-            Either::Right(&tabled_function_state.executor_state)
-        }
-    }
-
-    pub(crate) fn create_suspend_point_for(&self, instruction_index: InstructionIndex) -> SuspendPoint {
-        SuspendPoint::TabledCall(TabledCallSuspension {
-            instruction_index,
-            input_row: self.active_executor.as_ref().unwrap().input.clone().into_owned(),
-            next_table_row: self.active_executor.as_ref().unwrap().next_table_row,
-        })
+    pub(crate) fn get_row(&self, index: usize) -> Option<MaybeOwnedRow<'_>> {
+        self.answers.get(index).map(|row| row.as_reference())
     }
 }

--- a/executor/row.rs
+++ b/executor/row.rs
@@ -162,7 +162,7 @@ impl<'a> fmt::Display for MaybeOwnedRow<'a> {
         for value in &*self.row {
             write!(f, "{value}  ")?
         }
-        writeln!(f, "]")?;
+        write!(f, "]")?;
         Ok(())
     }
 }

--- a/executor/tests/compile_execute.rs
+++ b/executor/tests/compile_execute.rs
@@ -220,7 +220,7 @@ fn test_expression_planning_traversal() {
         &snapshot,
         &thing_manager,
         MaybeOwnedRow::empty(),
-        &ExecutableFunctionRegistry::empty(),
+        Arc::new(ExecutableFunctionRegistry::empty()),
     )
     .unwrap();
 

--- a/executor/tests/compile_execute.rs
+++ b/executor/tests/compile_execute.rs
@@ -127,7 +127,7 @@ fn test_has_planning_traversal() {
         &snapshot,
         &thing_manager,
         MaybeOwnedRow::empty(),
-        &ExecutableFunctionRegistry::empty(),
+        Arc::new(ExecutableFunctionRegistry::empty()),
     )
     .unwrap();
 
@@ -301,7 +301,7 @@ fn test_links_planning_traversal() {
         &snapshot,
         &thing_manager,
         MaybeOwnedRow::empty(),
-        &ExecutableFunctionRegistry::empty(),
+        Arc::new(ExecutableFunctionRegistry::empty()),
     )
     .unwrap();
 
@@ -389,7 +389,7 @@ fn test_links_intersection() {
         &snapshot,
         &thing_manager,
         MaybeOwnedRow::empty(),
-        &ExecutableFunctionRegistry::empty(),
+        Arc::new(ExecutableFunctionRegistry::empty()),
     )
     .unwrap();
 
@@ -468,7 +468,7 @@ fn test_negation_planning_traversal() {
         &snapshot,
         &thing_manager,
         MaybeOwnedRow::empty(),
-        &ExecutableFunctionRegistry::empty(),
+        Arc::new(ExecutableFunctionRegistry::empty()),
     )
     .unwrap();
 
@@ -568,7 +568,7 @@ fn test_forall_planning_traversal() {
         &snapshot,
         &thing_manager,
         MaybeOwnedRow::empty(),
-        &ExecutableFunctionRegistry::empty(),
+        Arc::new(ExecutableFunctionRegistry::empty()),
     )
     .unwrap();
 
@@ -654,7 +654,7 @@ fn test_named_var_select() {
         &snapshot,
         &thing_manager,
         MaybeOwnedRow::empty(),
-        &ExecutableFunctionRegistry::empty(),
+        Arc::new(ExecutableFunctionRegistry::empty()),
     )
     .unwrap();
 
@@ -740,7 +740,7 @@ fn test_disjunction_planning_traversal() {
         &snapshot,
         &thing_manager,
         MaybeOwnedRow::empty(),
-        &ExecutableFunctionRegistry::empty(),
+        Arc::new(ExecutableFunctionRegistry::empty()),
     )
     .unwrap();
 
@@ -830,7 +830,7 @@ fn test_disjunction_planning_nested_negations() {
         &snapshot,
         &thing_manager,
         MaybeOwnedRow::empty(),
-        &ExecutableFunctionRegistry::empty(),
+        Arc::new(ExecutableFunctionRegistry::empty()),
     )
     .unwrap();
 

--- a/executor/tests/compile_execute.rs
+++ b/executor/tests/compile_execute.rs
@@ -119,6 +119,7 @@ fn test_has_planning_traversal() {
         &HashMap::new(),
         &entry_annotations,
         Arc::new(translation_context.variable_registry),
+        &ExecutableFunctionRegistry::empty(),
         &HashMap::new(),
         &statistics,
     );
@@ -212,6 +213,7 @@ fn test_expression_planning_traversal() {
         &HashMap::new(),
         &entry_annotations,
         Arc::new(translation_context.variable_registry),
+        &ExecutableFunctionRegistry::empty(),
         &compiled_expressions,
         &statistics,
     );
@@ -293,6 +295,7 @@ fn test_links_planning_traversal() {
         &HashMap::new(),
         &entry_annotations,
         Arc::new(translation_context.variable_registry),
+        &ExecutableFunctionRegistry::empty(),
         &HashMap::new(),
         &statistics,
     );
@@ -381,6 +384,7 @@ fn test_links_intersection() {
         &HashMap::new(),
         &entry_annotations,
         Arc::new(translation_context.variable_registry),
+        &ExecutableFunctionRegistry::empty(),
         &HashMap::new(),
         &statistics,
     );
@@ -460,6 +464,7 @@ fn test_negation_planning_traversal() {
         &HashMap::new(),
         &entry_annotations,
         Arc::new(translation_context.variable_registry),
+        &ExecutableFunctionRegistry::empty(),
         &HashMap::new(),
         &statistics,
     );
@@ -560,6 +565,7 @@ fn test_forall_planning_traversal() {
         &HashMap::new(),
         &entry_annotations,
         Arc::new(translation_context.variable_registry),
+        &ExecutableFunctionRegistry::empty(),
         &HashMap::new(),
         &statistics,
     );
@@ -646,6 +652,7 @@ fn test_named_var_select() {
         &HashMap::new(),
         &entry_annotations,
         Arc::new(translation_context.variable_registry),
+        &ExecutableFunctionRegistry::empty(),
         &HashMap::new(),
         &statistics,
     );
@@ -732,6 +739,7 @@ fn test_disjunction_planning_traversal() {
         &HashMap::new(),
         &entry_annotations,
         Arc::new(translation_context.variable_registry),
+        &ExecutableFunctionRegistry::empty(),
         &HashMap::new(),
         &statistics,
     );
@@ -822,6 +830,7 @@ fn test_disjunction_planning_nested_negations() {
         &HashMap::new(),
         &entry_annotations,
         Arc::new(translation_context.variable_registry),
+        &ExecutableFunctionRegistry::empty(),
         &HashMap::new(),
         &statistics,
     );

--- a/executor/tests/compile_execute.rs
+++ b/executor/tests/compile_execute.rs
@@ -119,7 +119,6 @@ fn test_has_planning_traversal() {
         &HashMap::new(),
         &entry_annotations,
         Arc::new(translation_context.variable_registry),
-        &ExecutableFunctionRegistry::empty(),
         &HashMap::new(),
         &statistics,
     );
@@ -213,7 +212,6 @@ fn test_expression_planning_traversal() {
         &HashMap::new(),
         &entry_annotations,
         Arc::new(translation_context.variable_registry),
-        &ExecutableFunctionRegistry::empty(),
         &compiled_expressions,
         &statistics,
     );
@@ -295,7 +293,6 @@ fn test_links_planning_traversal() {
         &HashMap::new(),
         &entry_annotations,
         Arc::new(translation_context.variable_registry),
-        &ExecutableFunctionRegistry::empty(),
         &HashMap::new(),
         &statistics,
     );
@@ -384,7 +381,6 @@ fn test_links_intersection() {
         &HashMap::new(),
         &entry_annotations,
         Arc::new(translation_context.variable_registry),
-        &ExecutableFunctionRegistry::empty(),
         &HashMap::new(),
         &statistics,
     );
@@ -464,7 +460,6 @@ fn test_negation_planning_traversal() {
         &HashMap::new(),
         &entry_annotations,
         Arc::new(translation_context.variable_registry),
-        &ExecutableFunctionRegistry::empty(),
         &HashMap::new(),
         &statistics,
     );
@@ -565,7 +560,6 @@ fn test_forall_planning_traversal() {
         &HashMap::new(),
         &entry_annotations,
         Arc::new(translation_context.variable_registry),
-        &ExecutableFunctionRegistry::empty(),
         &HashMap::new(),
         &statistics,
     );
@@ -652,7 +646,6 @@ fn test_named_var_select() {
         &HashMap::new(),
         &entry_annotations,
         Arc::new(translation_context.variable_registry),
-        &ExecutableFunctionRegistry::empty(),
         &HashMap::new(),
         &statistics,
     );
@@ -739,7 +732,6 @@ fn test_disjunction_planning_traversal() {
         &HashMap::new(),
         &entry_annotations,
         Arc::new(translation_context.variable_registry),
-        &ExecutableFunctionRegistry::empty(),
         &HashMap::new(),
         &statistics,
     );
@@ -830,7 +822,6 @@ fn test_disjunction_planning_nested_negations() {
         &HashMap::new(),
         &entry_annotations,
         Arc::new(translation_context.variable_registry),
-        &ExecutableFunctionRegistry::empty(),
         &HashMap::new(),
         &statistics,
     );

--- a/executor/tests/execute_function.rs
+++ b/executor/tests/execute_function.rs
@@ -30,14 +30,7 @@ struct Context {
     _tmp_dir: TempDir,
 }
 
-fn setup_common() -> Context {
-    let (_tmp_dir, mut storage) = create_core_storage();
-    setup_concept_storage(&mut storage);
-
-    let (type_manager, thing_manager) = load_managers(storage.clone(), None);
-    let function_manager = FunctionManager::new(Arc::new(DefinitionKeyGenerator::new()), None);
-    let query_manager = QueryManager::new();
-    let schema = r#"
+const COMMON_SCHEMA: &str = r#"
     define
         attribute age value long;
         attribute name value string;
@@ -45,6 +38,14 @@ fn setup_common() -> Context {
         entity organisation plays membership:group;
         relation membership relates member, relates group;
     "#;
+fn setup_common(schema: &str) -> Context {
+    let (_tmp_dir, mut storage) = create_core_storage();
+    setup_concept_storage(&mut storage);
+
+    let (type_manager, thing_manager) = load_managers(storage.clone(), None);
+    let function_manager = FunctionManager::new(Arc::new(DefinitionKeyGenerator::new()), None);
+    let query_manager = QueryManager::new();
+
     let mut snapshot = storage.clone().open_snapshot_schema();
     let define = typeql::parse_query(schema).unwrap().into_schema();
     query_manager.execute_schema(&mut snapshot, &type_manager, &thing_manager, define).unwrap();
@@ -79,7 +80,7 @@ fn run_read_query(context: &Context, query: &str) -> Vec<Result<MaybeOwnedRow<'s
 
 #[test]
 fn function_compiles() {
-    let context = setup_common();
+    let context = setup_common(COMMON_SCHEMA);
     let snapshot = context.storage.clone().open_snapshot_write();
     let insert_query_str = r#"insert
         $p1 isa person, has name "Alice", has age 1, has age 5;
@@ -225,7 +226,7 @@ fn function_compiles() {
 
 #[test]
 fn function_binary() {
-    let context = setup_common();
+    let context = setup_common(COMMON_SCHEMA);
     let snapshot = context.storage.clone().open_snapshot_write();
     let insert_query_str = r#"insert
         $p1 isa person, has name "Alice", has age 1, has age 5;
@@ -268,5 +269,62 @@ fn function_binary() {
         "#;
         let rows = run_read_query(&context, query);
         assert_eq!(rows.len(), 2); // Symmetrically Alice & Charlie
+    }
+}
+
+#[test]
+fn simple_tabled() {
+    let custom_schema = r#"define
+        attribute name value string;
+        entity node, owns name @card(0..), plays edge:from, plays edge:to;
+        relation edge, relates from, relates to;
+    "#;
+    let context = setup_common(custom_schema);
+    let snapshot = context.storage.clone().open_snapshot_write();
+    let insert_query_str = r#"insert
+        $n1 isa node, has name "n1";
+        $n2 isa node, has name "n2";
+        $n3 isa node, has name "n3";
+
+        (from: $n1, to: $n2) isa edge;
+        (from: $n2, to: $n3) isa edge;
+    "#;
+    let insert_query = typeql::parse_query(insert_query_str).unwrap().into_pipeline();
+    let insert_pipeline = context
+        .query_manager
+        .prepare_write_pipeline(
+            snapshot,
+            &context.type_manager,
+            context.thing_manager.clone(),
+            &context.function_manager,
+            &insert_query,
+        )
+        .unwrap();
+    let (mut iterator, ExecutionContext { snapshot, .. }) =
+        insert_pipeline.into_rows_iterator(ExecutionInterrupt::new_uninterruptible()).unwrap();
+
+    assert_matches!(iterator.next(), Some(Ok(_)));
+    assert_matches!(iterator.next(), None);
+    let snapshot = Arc::into_inner(snapshot).unwrap();
+    snapshot.commit().unwrap();
+
+    {
+        // // quadratic tabling reachability.
+        let query = r#"
+            with
+            fun reachable($from: node) -> { node }:
+            match
+                $to isa node;
+                {
+                 (from: $from, to: $middle) isa edge; $to in reachable($middle); } or
+                { (from: $from, to: $to) isa edge;  }; # Do we have is yet?
+            return { $to };
+
+            match
+                $from isa node, has name "n1";
+                $to in reachable($from);
+        "#;
+        let rows = run_read_query(&context, query);
+        assert_eq!(rows.len(), 2);
     }
 }

--- a/executor/tests/execute_function.rs
+++ b/executor/tests/execute_function.rs
@@ -309,16 +309,15 @@ fn simple_tabled() {
     snapshot.commit().unwrap();
 
     {
-        // // quadratic tabling reachability.
+        // quadratic tabling reachability.
         let query = r#"
             with
             fun reachable($from: node) -> { node }:
             match
-                $to isa node;
-                {
-                 (from: $from, to: $middle) isa edge; $to in reachable($middle); } or
-                { (from: $from, to: $to) isa edge;  }; # Do we have is yet?
-            return { $to };
+                $return-me has name $name;
+                { (from: $from, to: $middle) isa edge; $indirect in reachable($middle); $indirect has name $name; } or
+                { (from: $from, to: $direct) isa edge; $direct has name $name; }; # Do we have is yet?
+            return { $return-me };
 
             match
                 $from isa node, has name "n1";

--- a/executor/tests/execute_function.rs
+++ b/executor/tests/execute_function.rs
@@ -56,7 +56,7 @@ fn setup_common(schema: &str) -> Context {
     Context { _tmp_dir, storage, type_manager, function_manager, query_manager, thing_manager }
 }
 
-fn run_read_query(context: &Context, query: &str) -> Vec<Result<MaybeOwnedRow<'static>, PipelineExecutionError>> {
+fn run_read_query(context: &Context, query: &str) -> Result<Vec<MaybeOwnedRow<'static>>, PipelineExecutionError> {
     let snapshot = Arc::new(context.storage.clone().open_snapshot_read());
     let match_ = typeql::parse_query(query).unwrap().into_pipeline();
     let pipeline = context
@@ -72,7 +72,7 @@ fn run_read_query(context: &Context, query: &str) -> Vec<Result<MaybeOwnedRow<'s
 
     let (mut iterator, _) = pipeline.into_rows_iterator(ExecutionInterrupt::new_uninterruptible()).unwrap();
 
-    let rows: Vec<Result<MaybeOwnedRow<'static>, PipelineExecutionError>> =
+    let rows: Result<Vec<MaybeOwnedRow<'static>>, PipelineExecutionError> =
         iterator.map_static(|row| row.map(|row| row.into_owned()).map_err(|err| err.clone())).collect();
 
     rows
@@ -117,7 +117,7 @@ fn function_compiles() {
                 $p isa person;
                 $z in get_ages($p);
         "#;
-        let rows = run_read_query(&context, query);
+        let rows = run_read_query(&context, query).unwrap();
         assert_eq!(rows.len(), 3);
     }
 
@@ -134,7 +134,7 @@ fn function_compiles() {
                 $p isa person;
                 $z in get_ages($p);
         "#;
-        let rows = run_read_query(&context, query);
+        let rows = run_read_query(&context, query).unwrap();
         assert_eq!(rows.len(), 1);
     }
 
@@ -151,7 +151,7 @@ fn function_compiles() {
                 $p isa person;
                 $z in get_ages($p);
         "#;
-        let rows = run_read_query(&context, query);
+        let rows = run_read_query(&context, query).unwrap();
         assert_eq!(rows.len(), 0);
     }
 
@@ -168,7 +168,7 @@ fn function_compiles() {
                 $p isa person;
                 $z in get_ages($p);
         "#;
-        let rows = run_read_query(&context, query);
+        let rows = run_read_query(&context, query).unwrap();
         assert_eq!(rows.len(), 0);
     }
 
@@ -185,7 +185,7 @@ fn function_compiles() {
                 $p isa person;
                 $z in get_ages($p);
         "#;
-        let rows = run_read_query(&context, query);
+        let rows = run_read_query(&context, query).unwrap();
         assert_eq!(rows.len(), 2);
     }
 
@@ -202,7 +202,7 @@ fn function_compiles() {
                 $p isa person;
                 $z in get_ages($p);
         "#;
-        let rows = run_read_query(&context, query);
+        let rows = run_read_query(&context, query).unwrap();
         assert_eq!(rows.len(), 3);
     }
 
@@ -219,7 +219,7 @@ fn function_compiles() {
                 $p isa person;
                 $z in get_ages($p);
         "#;
-        let rows = run_read_query(&context, query);
+        let rows = run_read_query(&context, query).unwrap();
         assert_eq!(rows.len(), 2);
     }
 }
@@ -267,7 +267,7 @@ fn function_binary() {
                 $name1 != $name2;
                 $same_age in same_age_check($p1, $p2);
         "#;
-        let rows = run_read_query(&context, query);
+        let rows = run_read_query(&context, query).unwrap();
         assert_eq!(rows.len(), 2); // Symmetrically Alice & Charlie
     }
 }
@@ -323,7 +323,7 @@ fn simple_tabled() {
                 $from isa node, has name "n1";
                 $to in reachable($from);
         "#;
-        let rows = run_read_query(&context, query);
+        let rows = run_read_query(&context, query).unwrap();
         assert_eq!(rows.len(), 2);
     }
 }

--- a/executor/tests/execute_has.rs
+++ b/executor/tests/execute_has.rs
@@ -187,7 +187,7 @@ fn traverse_has_unbounded_sorted_from() {
         &snapshot,
         &thing_manager,
         MaybeOwnedRow::empty(),
-        &ExecutableFunctionRegistry::empty(),
+        Arc::new(ExecutableFunctionRegistry::empty()),
     )
     .unwrap();
 
@@ -302,7 +302,7 @@ fn traverse_has_bounded_sorted_from_chain_intersect() {
         &snapshot,
         &thing_manager,
         MaybeOwnedRow::empty(),
-        &ExecutableFunctionRegistry::empty(),
+        Arc::new(ExecutableFunctionRegistry::empty()),
     )
     .unwrap();
 
@@ -408,7 +408,7 @@ fn traverse_has_unbounded_sorted_from_intersect() {
         &snapshot,
         &thing_manager,
         MaybeOwnedRow::empty(),
-        &ExecutableFunctionRegistry::empty(),
+        Arc::new(ExecutableFunctionRegistry::empty()),
     )
     .unwrap();
 
@@ -496,7 +496,7 @@ fn traverse_has_unbounded_sorted_to_merged() {
         &snapshot,
         &thing_manager,
         MaybeOwnedRow::empty(),
-        &ExecutableFunctionRegistry::empty(),
+        Arc::new(ExecutableFunctionRegistry::empty()),
     )
     .unwrap();
 
@@ -605,7 +605,7 @@ fn traverse_has_reverse_unbounded_sorted_from() {
         &snapshot,
         &thing_manager,
         MaybeOwnedRow::empty(),
-        &ExecutableFunctionRegistry::empty(),
+        Arc::new(ExecutableFunctionRegistry::empty()),
     )
     .unwrap();
 

--- a/executor/tests/execute_isa.rs
+++ b/executor/tests/execute_isa.rs
@@ -139,7 +139,7 @@ fn traverse_isa_unbounded_sorted_thing() {
         &snapshot,
         &thing_manager,
         MaybeOwnedRow::empty(),
-        &ExecutableFunctionRegistry::empty(),
+        Arc::new(ExecutableFunctionRegistry::empty()),
     )
     .unwrap();
 
@@ -224,7 +224,7 @@ fn traverse_isa_unbounded_sorted_type() {
         &snapshot,
         &thing_manager,
         MaybeOwnedRow::empty(),
-        &ExecutableFunctionRegistry::empty(),
+        Arc::new(ExecutableFunctionRegistry::empty()),
     )
     .unwrap();
 
@@ -325,7 +325,7 @@ fn traverse_isa_bounded_thing() {
         &snapshot,
         &thing_manager,
         MaybeOwnedRow::empty(),
-        &ExecutableFunctionRegistry::empty(),
+        Arc::new(ExecutableFunctionRegistry::empty()),
     )
     .unwrap();
 
@@ -416,7 +416,7 @@ fn traverse_isa_reverse_unbounded_sorted_thing() {
         &snapshot,
         &thing_manager,
         MaybeOwnedRow::empty(),
-        &ExecutableFunctionRegistry::empty(),
+        Arc::new(ExecutableFunctionRegistry::empty()),
     )
     .unwrap();
 
@@ -503,7 +503,7 @@ fn traverse_isa_reverse_unbounded_sorted_type() {
         &snapshot,
         &thing_manager,
         MaybeOwnedRow::empty(),
-        &ExecutableFunctionRegistry::empty(),
+        Arc::new(ExecutableFunctionRegistry::empty()),
     )
     .unwrap();
 
@@ -604,7 +604,7 @@ fn traverse_isa_reverse_bounded_type_exact() {
         &snapshot,
         &thing_manager,
         MaybeOwnedRow::empty(),
-        &ExecutableFunctionRegistry::empty(),
+        Arc::new(ExecutableFunctionRegistry::empty()),
     )
     .unwrap();
 
@@ -709,7 +709,7 @@ fn traverse_isa_reverse_bounded_type_subtype() {
         &snapshot,
         &thing_manager,
         MaybeOwnedRow::empty(),
-        &ExecutableFunctionRegistry::empty(),
+        Arc::new(ExecutableFunctionRegistry::empty()),
     )
     .unwrap();
 
@@ -800,7 +800,7 @@ fn traverse_isa_reverse_fixed_type_exact() {
         &snapshot,
         &thing_manager,
         MaybeOwnedRow::empty(),
-        &ExecutableFunctionRegistry::empty(),
+        Arc::new(ExecutableFunctionRegistry::empty()),
     )
     .unwrap();
 
@@ -890,7 +890,7 @@ fn traverse_isa_reverse_fixed_type_subtype() {
         &snapshot,
         &thing_manager,
         MaybeOwnedRow::empty(),
-        &ExecutableFunctionRegistry::empty(),
+        Arc::new(ExecutableFunctionRegistry::empty()),
     )
     .unwrap();
 

--- a/executor/tests/execute_links.rs
+++ b/executor/tests/execute_links.rs
@@ -283,7 +283,7 @@ fn traverse_links_unbounded_sorted_from() {
         &snapshot,
         &thing_manager,
         MaybeOwnedRow::empty(),
-        &ExecutableFunctionRegistry::empty(),
+        Arc::new(ExecutableFunctionRegistry::empty()),
     )
     .unwrap();
 
@@ -389,7 +389,7 @@ fn traverse_links_unbounded_sorted_to() {
         &snapshot,
         &thing_manager,
         MaybeOwnedRow::empty(),
-        &ExecutableFunctionRegistry::empty(),
+        Arc::new(ExecutableFunctionRegistry::empty()),
     )
     .unwrap();
 
@@ -512,7 +512,7 @@ fn traverse_links_bounded_relation() {
         &snapshot,
         &thing_manager,
         MaybeOwnedRow::empty(),
-        &ExecutableFunctionRegistry::empty(),
+        Arc::new(ExecutableFunctionRegistry::empty()),
     )
     .unwrap();
 
@@ -649,7 +649,7 @@ fn traverse_links_bounded_relation_player() {
         &snapshot,
         &thing_manager,
         MaybeOwnedRow::empty(),
-        &ExecutableFunctionRegistry::empty(),
+        Arc::new(ExecutableFunctionRegistry::empty()),
     )
     .unwrap();
 
@@ -756,7 +756,7 @@ fn traverse_links_reverse_unbounded_sorted_from() {
         &snapshot,
         &thing_manager,
         MaybeOwnedRow::empty(),
-        &ExecutableFunctionRegistry::empty(),
+        Arc::new(ExecutableFunctionRegistry::empty()),
     )
     .unwrap();
 
@@ -864,7 +864,7 @@ fn traverse_links_reverse_unbounded_sorted_to() {
         &snapshot,
         &thing_manager,
         MaybeOwnedRow::empty(),
-        &ExecutableFunctionRegistry::empty(),
+        Arc::new(ExecutableFunctionRegistry::empty()),
     )
     .unwrap();
 
@@ -984,7 +984,7 @@ fn traverse_links_reverse_bounded_player() {
         &snapshot,
         &thing_manager,
         MaybeOwnedRow::empty(),
-        &ExecutableFunctionRegistry::empty(),
+        Arc::new(ExecutableFunctionRegistry::empty()),
     )
     .unwrap();
 
@@ -1121,7 +1121,7 @@ fn traverse_links_reverse_bounded_player_relation() {
         &snapshot,
         &thing_manager,
         MaybeOwnedRow::empty(),
-        &ExecutableFunctionRegistry::empty(),
+        Arc::new(ExecutableFunctionRegistry::empty()),
     )
     .unwrap();
 

--- a/executor/tests/execute_select.rs
+++ b/executor/tests/execute_select.rs
@@ -216,7 +216,7 @@ fn anonymous_vars_not_enumerated_or_counted() {
         &snapshot,
         &thing_manager,
         MaybeOwnedRow::empty(),
-        &ExecutableFunctionRegistry::empty(),
+        Arc::new(ExecutableFunctionRegistry::empty()),
     )
     .unwrap();
 
@@ -317,7 +317,7 @@ fn unselected_named_vars_counted() {
         &snapshot,
         &thing_manager,
         MaybeOwnedRow::empty(),
-        &ExecutableFunctionRegistry::empty(),
+        Arc::new(ExecutableFunctionRegistry::empty()),
     )
     .unwrap();
 
@@ -441,7 +441,7 @@ fn cartesian_named_counted_checked() {
         &snapshot,
         &thing_manager,
         MaybeOwnedRow::empty(),
-        &ExecutableFunctionRegistry::empty(),
+        Arc::new(ExecutableFunctionRegistry::empty()),
     )
     .unwrap();
 

--- a/ir/pattern/conjunction.rs
+++ b/ir/pattern/conjunction.rs
@@ -43,8 +43,7 @@ impl Conjunction {
 
     pub fn captured_variables<'a>(&'a self, block_context: &'a BlockContext) -> impl Iterator<Item = Variable> + 'a {
         let self_scope = self.scope_id;
-        self
-            .referenced_variables()
+        self.referenced_variables()
             .filter(move |var| block_context.is_parent_scope(block_context.get_scope(var).unwrap(), self_scope))
     }
 
@@ -57,15 +56,15 @@ impl Conjunction {
     }
 
     pub fn referenced_variables(&self) -> impl Iterator<Item = Variable> + '_ {
-        self.constraints.iter().flat_map(|constraint| constraint.ids()).chain(
-            self.nested_patterns.iter().flat_map(|nested| -> Box<dyn Iterator<Item = Variable>> {
+        self.constraints.iter().flat_map(|constraint| constraint.ids()).chain(self.nested_patterns.iter().flat_map(
+            |nested| -> Box<dyn Iterator<Item = Variable>> {
                 match nested {
                     NestedPattern::Disjunction(disjunction) => Box::new(disjunction.referenced_variables()),
                     NestedPattern::Negation(negation) => Box::new(negation.referenced_variables()),
                     NestedPattern::Optional(_) => todo!(),
                 }
-            })
-        )
+            },
+        ))
     }
 }
 

--- a/ir/pattern/constraint.rs
+++ b/ir/pattern/constraint.rs
@@ -4,8 +4,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-use std::{collections::HashMap, fmt};
-use std::ops::Deref;
+use std::{collections::HashMap, fmt, ops::Deref};
 
 use answer::variable::Variable;
 use itertools::Itertools;

--- a/ir/pattern/constraint.rs
+++ b/ir/pattern/constraint.rs
@@ -5,6 +5,7 @@
  */
 
 use std::{collections::HashMap, fmt};
+use std::ops::Deref;
 
 use answer::variable::Variable;
 use itertools::Itertools;
@@ -29,6 +30,13 @@ pub struct Constraints {
     left_constrained_index: HashMap<Variable, Vec<Constraint<Variable>>>,
     right_constrained_index: HashMap<Variable, Vec<Constraint<Variable>>>,
     filter_constrained_index: HashMap<Variable, Vec<Constraint<Variable>>>,
+}
+
+impl Deref for Constraints {
+    type Target = [Constraint<Variable>];
+    fn deref(&self) -> &Self::Target {
+        self.constraints.as_slice()
+    }
 }
 
 impl Constraints {

--- a/ir/pattern/disjunction.rs
+++ b/ir/pattern/disjunction.rs
@@ -31,6 +31,10 @@ impl Disjunction {
     pub fn conjunctions(&self) -> &[Conjunction] {
         &self.conjunctions
     }
+
+    pub(crate) fn referenced_variables(&self) -> impl Iterator<Item = Variable> + '_ {
+        self.conjunctions().iter().flat_map(|conjunction| conjunction.referenced_variables())
+    }
 }
 
 impl Scope for Disjunction {

--- a/ir/pattern/negation.rs
+++ b/ir/pattern/negation.rs
@@ -5,6 +5,7 @@
  */
 
 use std::fmt;
+use answer::variable::Variable;
 
 use crate::{
     pattern::{
@@ -33,6 +34,10 @@ impl Negation {
 
     pub fn conjunction(&self) -> &Conjunction {
         &self.conjunction
+    }
+
+    pub(crate) fn referenced_variables(&self) -> impl Iterator<Item = Variable> + '_ {
+        self.conjunction().referenced_variables()
     }
 }
 

--- a/ir/pattern/negation.rs
+++ b/ir/pattern/negation.rs
@@ -5,6 +5,7 @@
  */
 
 use std::fmt;
+
 use answer::variable::Variable;
 
 use crate::{


### PR DESCRIPTION
## Release notes: product changes
Introduces machinery needed to support finding the fixed-point of cyclic function calls. Cyclic functions now run, and return an incomplete set of results followed by an error. It is possible that the planner chooses a plan.

## Motivation
Reasonable waypoint towards full support.

## Implementation
Implements state for the tabled-functions as well as executors for tabled function calls.
