### PR TITLE
Functions have their own parameter registry

### DIFF
--- a/compiler/annotation/function.rs
+++ b/compiler/annotation/function.rs
@@ -27,6 +27,7 @@ use ir::{
 use itertools::Either;
 use storage::snapshot::ReadableSnapshot;
 use typeql::{schema::definable::function::SingleSelector, type_::NamedType, TypeRef, TypeRefAny};
+use ir::pipeline::ParameterRegistry;
 
 use crate::{
     annotation::{
@@ -46,6 +47,7 @@ pub enum FunctionParameterAnnotation {
 #[derive(Debug, Clone)]
 pub struct AnnotatedFunction {
     pub variable_registry: VariableRegistry,
+    pub parameter_registry: ParameterRegistry,
     pub arguments: Vec<Variable>,
     pub stages: Vec<AnnotatedStage>,
     pub return_: AnnotatedFunctionReturn,
@@ -288,6 +290,7 @@ fn annotate_function_impl(
     )?;
     Ok(AnnotatedFunction {
         variable_registry: context.variable_registry.clone(),
+        parameter_registry: context.parameters.clone(),
         arguments: arguments.clone(),
         stages,
         return_,

--- a/compiler/annotation/function.rs
+++ b/compiler/annotation/function.rs
@@ -20,14 +20,13 @@ use encoding::{
 use ir::{
     pipeline::{
         function::{Function, FunctionBody, ReturnOperation},
-        VariableRegistry,
+        ParameterRegistry, VariableRegistry,
     },
     translation::tokens::translate_value_type,
 };
 use itertools::Either;
 use storage::snapshot::ReadableSnapshot;
 use typeql::{schema::definable::function::SingleSelector, type_::NamedType, TypeRef, TypeRefAny};
-use ir::pipeline::ParameterRegistry;
 
 use crate::{
     annotation::{

--- a/compiler/annotation/type_seeder.rs
+++ b/compiler/annotation/type_seeder.rs
@@ -486,15 +486,16 @@ impl<'this, Snapshot: ReadableSnapshot> TypeGraphSeedingContext<'this, Snapshot>
                 }
                 Constraint::Has(has) => edges.push(self.seed_edge(constraint, has, vertices)?),
                 Constraint::Comparison(cmp) => {
-                    let both_variables_annotatable = cmp.left().is_variable() && cmp.right().is_variable() &&
-                        cmp.ids().all(|variable| {
+                    let both_variables_annotatable = cmp.left().is_variable()
+                        && cmp.right().is_variable()
+                        && cmp.ids().all(|variable| {
                             let category = self.variable_registry.get_variable_category(variable);
                             category.unwrap_or(VariableCategory::Value) == VariableCategory::Attribute
                         });
                     if both_variables_annotatable {
                         edges.push(self.seed_edge(constraint, cmp, vertices)?)
                     }
-                },
+                }
                 Constraint::Owns(owns) => edges.push(self.seed_edge(constraint, owns, vertices)?),
                 Constraint::Relates(relates) => edges.push(self.seed_edge(constraint, relates, vertices)?),
                 Constraint::Plays(plays) => edges.push(self.seed_edge(constraint, plays, vertices)?),

--- a/compiler/annotation/type_seeder.rs
+++ b/compiler/annotation/type_seeder.rs
@@ -485,7 +485,16 @@ impl<'this, Snapshot: ReadableSnapshot> TypeGraphSeedingContext<'this, Snapshot>
                     edges.push(self.seed_edge(constraint, &player_role, vertices)?);
                 }
                 Constraint::Has(has) => edges.push(self.seed_edge(constraint, has, vertices)?),
-                Constraint::Comparison(cmp) => edges.push(self.seed_edge(constraint, cmp, vertices)?),
+                Constraint::Comparison(cmp) => {
+                    let both_variables_annotatable = cmp.left().is_variable() && cmp.right().is_variable() &&
+                        cmp.ids().all(|variable| {
+                            let category = self.variable_registry.get_variable_category(variable);
+                            category.unwrap_or(VariableCategory::Value) == VariableCategory::Attribute
+                        });
+                    if both_variables_annotatable {
+                        edges.push(self.seed_edge(constraint, cmp, vertices)?)
+                    }
+                },
                 Constraint::Owns(owns) => edges.push(self.seed_edge(constraint, owns, vertices)?),
                 Constraint::Relates(relates) => edges.push(self.seed_edge(constraint, relates, vertices)?),
                 Constraint::Plays(plays) => edges.push(self.seed_edge(constraint, plays, vertices)?),

--- a/compiler/executable/function.rs
+++ b/compiler/executable/function.rs
@@ -13,10 +13,9 @@ use answer::variable::Variable;
 use concept::thing::statistics::Statistics;
 use ir::{
     pattern::{conjunction::Conjunction, constraint::Constraint, nested_pattern::NestedPattern},
-    pipeline::function_signature::FunctionID,
+    pipeline::{function_signature::FunctionID, ParameterRegistry},
 };
 use typeql::schema::definable::function::SingleSelector;
-use ir::pipeline::ParameterRegistry;
 
 use crate::{
     annotation::{
@@ -70,7 +69,13 @@ pub(crate) fn compile_function(
     )?;
 
     let returns = compile_return_operation(&executable_stages, return_)?;
-    Ok(ExecutableFunction { executable_stages, argument_positions, returns, parameter_registry: Arc::new(parameter_registry), is_tabled })
+    Ok(ExecutableFunction {
+        executable_stages,
+        argument_positions,
+        returns,
+        parameter_registry: Arc::new(parameter_registry),
+        is_tabled,
+    })
 }
 
 fn compile_return_operation(

--- a/compiler/executable/function.rs
+++ b/compiler/executable/function.rs
@@ -16,6 +16,7 @@ use ir::{
     pipeline::function_signature::FunctionID,
 };
 use typeql::schema::definable::function::SingleSelector;
+use ir::pipeline::ParameterRegistry;
 
 use crate::{
     annotation::{
@@ -36,6 +37,7 @@ pub struct ExecutableFunction {
     pub argument_positions: HashMap<Variable, VariablePosition>,
     pub returns: ExecutableReturn,
     pub is_tabled: FunctionTablingType,
+    pub parameter_registry: Arc<ParameterRegistry>,
     // pub plan_cost: f64, // TODO: Where do we fit this in?
 }
 
@@ -58,7 +60,7 @@ pub(crate) fn compile_function(
     function: AnnotatedFunction,
     is_tabled: FunctionTablingType,
 ) -> Result<ExecutableFunction, ExecutableCompilationError> {
-    let AnnotatedFunction { variable_registry, arguments, stages, return_ } = function;
+    let AnnotatedFunction { variable_registry, parameter_registry, arguments, stages, return_ } = function;
     let (argument_positions, executable_stages) = compile_pipeline_stages(
         statistics,
         Arc::new(variable_registry),
@@ -68,7 +70,7 @@ pub(crate) fn compile_function(
     )?;
 
     let returns = compile_return_operation(&executable_stages, return_)?;
-    Ok(ExecutableFunction { executable_stages, argument_positions, returns, is_tabled })
+    Ok(ExecutableFunction { executable_stages, argument_positions, returns, parameter_registry: Arc::new(parameter_registry), is_tabled })
 }
 
 fn compile_return_operation(

--- a/executor/read/nested_pattern_executor.rs
+++ b/executor/read/nested_pattern_executor.rs
@@ -4,9 +4,10 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
+use std::sync::Arc;
 use answer::variable_value::VariableValue;
 use compiler::{executable::match_::planner::match_executable::FunctionCallStep, VariablePosition};
-use lending_iterator::LendingIterator;
+use ir::pipeline::ParameterRegistry;
 
 use crate::{
     batch::FixedBatch,
@@ -32,6 +33,7 @@ pub(super) enum NestedPatternExecutor {
         arg_mapping: Vec<VariablePosition>,
         return_mapping: Vec<VariablePosition>,
         output_width: u32,
+        parameter_registry: Arc<ParameterRegistry>,
     },
     Offset {
         inner: PatternExecutor,
@@ -61,12 +63,13 @@ impl NestedPatternExecutor {
         Self::Disjunction { branches, selected_variables, output_width }
     }
 
-    pub(crate) fn new_inlined_function(inner: PatternExecutor, function_call: &FunctionCallStep) -> Self {
+    pub(crate) fn new_inlined_function(inner: PatternExecutor, function_call: &FunctionCallStep, parameter_registry: Arc<ParameterRegistry>) -> Self {
         Self::InlinedFunction {
             inner,
             arg_mapping: function_call.arguments.clone(),
             return_mapping: function_call.assigned.clone(),
             output_width: function_call.output_width,
+            parameter_registry
         }
     }
 

--- a/executor/read/nested_pattern_executor.rs
+++ b/executor/read/nested_pattern_executor.rs
@@ -5,6 +5,7 @@
  */
 
 use std::sync::Arc;
+
 use answer::variable_value::VariableValue;
 use compiler::{executable::match_::planner::match_executable::FunctionCallStep, VariablePosition};
 use ir::pipeline::ParameterRegistry;
@@ -63,13 +64,17 @@ impl NestedPatternExecutor {
         Self::Disjunction { branches, selected_variables, output_width }
     }
 
-    pub(crate) fn new_inlined_function(inner: PatternExecutor, function_call: &FunctionCallStep, parameter_registry: Arc<ParameterRegistry>) -> Self {
+    pub(crate) fn new_inlined_function(
+        inner: PatternExecutor,
+        function_call: &FunctionCallStep,
+        parameter_registry: Arc<ParameterRegistry>,
+    ) -> Self {
         Self::InlinedFunction {
             inner,
             arg_mapping: function_call.arguments.clone(),
             return_mapping: function_call.assigned.clone(),
             output_width: function_call.output_width,
-            parameter_registry
+            parameter_registry,
         }
     }
 

--- a/executor/read/step_executor.rs
+++ b/executor/read/step_executor.rs
@@ -136,7 +136,7 @@ pub(crate) fn create_executors_for_match(
                     )?;
                     let inner = PatternExecutor::new(inner_executors);
                     tmp__recursion_validation.remove(&function_call.function_id);
-                    let step = NestedPatternExecutor::new_inlined_function(inner, function_call);
+                    let step = NestedPatternExecutor::new_inlined_function(inner, function_call, function.parameter_registry.clone());
                     steps.push(step.into())
                 }
             }

--- a/executor/read/step_executor.rs
+++ b/executor/read/step_executor.rs
@@ -136,7 +136,11 @@ pub(crate) fn create_executors_for_match(
                     )?;
                     let inner = PatternExecutor::new(inner_executors);
                     tmp__recursion_validation.remove(&function_call.function_id);
-                    let step = NestedPatternExecutor::new_inlined_function(inner, function_call, function.parameter_registry.clone());
+                    let step = NestedPatternExecutor::new_inlined_function(
+                        inner,
+                        function_call,
+                        function.parameter_registry.clone(),
+                    );
                     steps.push(step.into())
                 }
             }

--- a/executor/read/tabled_functions.rs
+++ b/executor/read/tabled_functions.rs
@@ -11,6 +11,7 @@ use std::{
 
 use compiler::executable::{function::ExecutableReturn, match_::planner::function_plan::ExecutableFunctionRegistry};
 use ir::pipeline::function_signature::FunctionID;
+use ir::pipeline::ParameterRegistry;
 use lending_iterator::LendingIterator;
 use storage::snapshot::ReadableSnapshot;
 
@@ -54,7 +55,7 @@ impl TabledFunctions {
             };
             self.state.insert(
                 call_key.clone(),
-                Arc::new(TabledFunctionState::build_and_prepare(pattern_executor, &call_key.arguments, width)),
+                Arc::new(TabledFunctionState::build_and_prepare(pattern_executor, &call_key.arguments, width, function.parameter_registry.clone())),
             );
         }
         Ok(self.state.get(call_key).unwrap().clone())
@@ -70,16 +71,18 @@ pub(crate) struct TabledFunctionState {
 pub(crate) struct TabledFunctionPatternExecutorState {
     pub(crate) suspend_points: Vec<SuspendPoint>,
     pub(crate) pattern_executor: PatternExecutor,
+    pub(crate) parameters: Arc<ParameterRegistry>,
 }
 
 impl TabledFunctionState {
-    fn build_and_prepare(mut pattern_executor: PatternExecutor, args: &MaybeOwnedRow<'_>, answer_width: u32) -> Self {
+    fn build_and_prepare(mut pattern_executor: PatternExecutor, args: &MaybeOwnedRow<'_>, answer_width: u32, parameters: Arc<ParameterRegistry>) -> Self {
         pattern_executor.prepare(FixedBatch::from(args.as_reference()));
         Self {
             table: RwLock::new(AnswerTable { answers: Vec::new(), width: answer_width }),
             executor_state: Mutex::new(TabledFunctionPatternExecutorState {
                 pattern_executor,
                 suspend_points: Vec::new(),
+                parameters
             }),
         }
     }

--- a/executor/read/tabled_functions.rs
+++ b/executor/read/tabled_functions.rs
@@ -10,8 +10,7 @@ use std::{
 };
 
 use compiler::executable::{function::ExecutableReturn, match_::planner::function_plan::ExecutableFunctionRegistry};
-use ir::pipeline::function_signature::FunctionID;
-use ir::pipeline::ParameterRegistry;
+use ir::pipeline::{function_signature::FunctionID, ParameterRegistry};
 use lending_iterator::LendingIterator;
 use storage::snapshot::ReadableSnapshot;
 
@@ -55,7 +54,12 @@ impl TabledFunctions {
             };
             self.state.insert(
                 call_key.clone(),
-                Arc::new(TabledFunctionState::build_and_prepare(pattern_executor, &call_key.arguments, width, function.parameter_registry.clone())),
+                Arc::new(TabledFunctionState::build_and_prepare(
+                    pattern_executor,
+                    &call_key.arguments,
+                    width,
+                    function.parameter_registry.clone(),
+                )),
             );
         }
         Ok(self.state.get(call_key).unwrap().clone())
@@ -75,14 +79,19 @@ pub(crate) struct TabledFunctionPatternExecutorState {
 }
 
 impl TabledFunctionState {
-    fn build_and_prepare(mut pattern_executor: PatternExecutor, args: &MaybeOwnedRow<'_>, answer_width: u32, parameters: Arc<ParameterRegistry>) -> Self {
+    fn build_and_prepare(
+        mut pattern_executor: PatternExecutor,
+        args: &MaybeOwnedRow<'_>,
+        answer_width: u32,
+        parameters: Arc<ParameterRegistry>,
+    ) -> Self {
         pattern_executor.prepare(FixedBatch::from(args.as_reference()));
         Self {
             table: RwLock::new(AnswerTable { answers: Vec::new(), width: answer_width }),
             executor_state: Mutex::new(TabledFunctionPatternExecutorState {
                 pattern_executor,
                 suspend_points: Vec::new(),
-                parameters
+                parameters,
             }),
         }
     }

--- a/executor/tests/execute_function.rs
+++ b/executor/tests/execute_function.rs
@@ -382,9 +382,9 @@ fn fibonacci() {
             fun ith_fibonacci_number($i: long) -> { long }:
             match
                 $ret isa number;
-                { $i == 0; $ret == 1; $ret isa number; } or
                 { $i == 1; $ret == 1; $ret isa number; } or
-                { $i > 1;
+                { $i == 2; $ret == 1; $ret isa number; } or
+                { $i > 2;
                      $i1 = $i - 1;
                      $i2 = $i - 2;
                      $combined = ith_fibonacci_number($i1) +  ith_fibonacci_number($i2);
@@ -394,11 +394,11 @@ fn fibonacci() {
             return { $ret };
 
             match
-                $f_6 = ith_fibonacci_number(6);
+                $f_7 = ith_fibonacci_number(7);
         "#;
         let (rows, positions) = run_read_query(&context, query).unwrap();
         assert_eq!(rows.len(), 1);
-        let f_6_position = positions.get("f_6").unwrap().clone();
-        assert_eq!(rows[0].get(f_6_position).as_value().clone().unwrap_long(), 13);
+        let f_7_position = positions.get("f_7").unwrap().clone();
+        assert_eq!(rows[0].get(f_7_position).as_value().clone().unwrap_long(), 13);
     }
 }

--- a/executor/tests/execute_function.rs
+++ b/executor/tests/execute_function.rs
@@ -4,11 +4,10 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-use std::collections::HashMap;
-use std::sync::Arc;
+use std::{collections::HashMap, sync::Arc};
+
 use answer::variable_value::VariableValue;
 use compiler::VariablePosition;
-
 use concept::{thing::thing_manager::ThingManager, type_::type_manager::TypeManager};
 use encoding::graph::definition::definition_key_generator::DefinitionKeyGenerator;
 use executor::{
@@ -59,7 +58,10 @@ fn setup_common(schema: &str) -> Context {
     Context { _tmp_dir, storage, type_manager, function_manager, query_manager, thing_manager }
 }
 
-fn run_read_query(context: &Context, query: &str) -> Result<(Vec<MaybeOwnedRow<'static>>, HashMap<String, VariablePosition>), PipelineExecutionError> {
+fn run_read_query(
+    context: &Context,
+    query: &str,
+) -> Result<(Vec<MaybeOwnedRow<'static>>, HashMap<String, VariablePosition>), PipelineExecutionError> {
     let snapshot = Arc::new(context.storage.clone().open_snapshot_read());
     let match_ = typeql::parse_query(query).unwrap().into_pipeline();
     let pipeline = context

--- a/executor/tests/execute_function.rs
+++ b/executor/tests/execute_function.rs
@@ -4,7 +4,10 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
+use std::collections::HashMap;
 use std::sync::Arc;
+use answer::variable_value::VariableValue;
+use compiler::VariablePosition;
 
 use concept::{thing::thing_manager::ThingManager, type_::type_manager::TypeManager};
 use encoding::graph::definition::definition_key_generator::DefinitionKeyGenerator;
@@ -56,7 +59,7 @@ fn setup_common(schema: &str) -> Context {
     Context { _tmp_dir, storage, type_manager, function_manager, query_manager, thing_manager }
 }
 
-fn run_read_query(context: &Context, query: &str) -> Result<Vec<MaybeOwnedRow<'static>>, PipelineExecutionError> {
+fn run_read_query(context: &Context, query: &str) -> Result<(Vec<MaybeOwnedRow<'static>>, HashMap<String, VariablePosition>), PipelineExecutionError> {
     let snapshot = Arc::new(context.storage.clone().open_snapshot_read());
     let match_ = typeql::parse_query(query).unwrap().into_pipeline();
     let pipeline = context
@@ -69,13 +72,13 @@ fn run_read_query(context: &Context, query: &str) -> Result<Vec<MaybeOwnedRow<'s
             &match_,
         )
         .unwrap();
-
+    let rows_positions = pipeline.rows_positions().unwrap().clone();
     let (mut iterator, _) = pipeline.into_rows_iterator(ExecutionInterrupt::new_uninterruptible()).unwrap();
 
-    let rows: Result<Vec<MaybeOwnedRow<'static>>, PipelineExecutionError> =
+    let result: Result<Vec<MaybeOwnedRow<'static>>, PipelineExecutionError> =
         iterator.map_static(|row| row.map(|row| row.into_owned()).map_err(|err| err.clone())).collect();
 
-    rows
+    result.map(move |rows| (rows, rows_positions))
 }
 
 #[test]
@@ -117,7 +120,7 @@ fn function_compiles() {
                 $p isa person;
                 $z in get_ages($p);
         "#;
-        let rows = run_read_query(&context, query).unwrap();
+        let (rows, _) = run_read_query(&context, query).unwrap();
         assert_eq!(rows.len(), 3);
     }
 
@@ -134,7 +137,7 @@ fn function_compiles() {
                 $p isa person;
                 $z in get_ages($p);
         "#;
-        let rows = run_read_query(&context, query).unwrap();
+        let (rows, _) = run_read_query(&context, query).unwrap();
         assert_eq!(rows.len(), 1);
     }
 
@@ -151,7 +154,7 @@ fn function_compiles() {
                 $p isa person;
                 $z in get_ages($p);
         "#;
-        let rows = run_read_query(&context, query).unwrap();
+        let (rows, _) = run_read_query(&context, query).unwrap();
         assert_eq!(rows.len(), 0);
     }
 
@@ -168,7 +171,7 @@ fn function_compiles() {
                 $p isa person;
                 $z in get_ages($p);
         "#;
-        let rows = run_read_query(&context, query).unwrap();
+        let (rows, _) = run_read_query(&context, query).unwrap();
         assert_eq!(rows.len(), 0);
     }
 
@@ -185,7 +188,7 @@ fn function_compiles() {
                 $p isa person;
                 $z in get_ages($p);
         "#;
-        let rows = run_read_query(&context, query).unwrap();
+        let (rows, _) = run_read_query(&context, query).unwrap();
         assert_eq!(rows.len(), 2);
     }
 
@@ -202,7 +205,7 @@ fn function_compiles() {
                 $p isa person;
                 $z in get_ages($p);
         "#;
-        let rows = run_read_query(&context, query).unwrap();
+        let (rows, _) = run_read_query(&context, query).unwrap();
         assert_eq!(rows.len(), 3);
     }
 
@@ -219,7 +222,7 @@ fn function_compiles() {
                 $p isa person;
                 $z in get_ages($p);
         "#;
-        let rows = run_read_query(&context, query).unwrap();
+        let (rows, _) = run_read_query(&context, query).unwrap();
         assert_eq!(rows.len(), 2);
     }
 }
@@ -267,7 +270,7 @@ fn function_binary() {
                 $name1 != $name2;
                 $same_age in same_age_check($p1, $p2);
         "#;
-        let rows = run_read_query(&context, query).unwrap();
+        let (rows, _) = run_read_query(&context, query).unwrap();
         assert_eq!(rows.len(), 2); // Symmetrically Alice & Charlie
     }
 }
@@ -323,7 +326,77 @@ fn simple_tabled() {
                 $from isa node, has name "n1";
                 $to in reachable($from);
         "#;
-        let rows = run_read_query(&context, query).unwrap();
+        let (rows, _) = run_read_query(&context, query).unwrap();
         assert_eq!(rows.len(), 2);
+    }
+}
+
+#[test]
+fn fibonacci() {
+    let custom_schema = r#"define
+        attribute number @independent, value long;
+    "#;
+    let context = setup_common(custom_schema);
+    let snapshot = context.storage.clone().open_snapshot_write();
+    let insert_query_str = r#"insert
+        $n1   1 isa number;
+        $n2   2 isa number;
+        $n3   3 isa number;
+        $n4   4 isa number;
+        $n5   5 isa number;
+        $n6   6 isa number;
+        $n7   7 isa number;
+        $n8   8 isa number;
+        $n9   9 isa number;
+        $n10 10 isa number;
+        $n11 11 isa number;
+        $n12 12 isa number;
+        $n13 13 isa number;
+        $n14 14 isa number;
+        $n15 15 isa number;
+    "#;
+    let insert_query = typeql::parse_query(insert_query_str).unwrap().into_pipeline();
+    let insert_pipeline = context
+        .query_manager
+        .prepare_write_pipeline(
+            snapshot,
+            &context.type_manager,
+            context.thing_manager.clone(),
+            &context.function_manager,
+            &insert_query,
+        )
+        .unwrap();
+    let (mut iterator, ExecutionContext { snapshot, .. }) =
+        insert_pipeline.into_rows_iterator(ExecutionInterrupt::new_uninterruptible()).unwrap();
+
+    assert_matches!(iterator.next(), Some(Ok(_)));
+    assert_matches!(iterator.next(), None);
+    let snapshot = Arc::into_inner(snapshot).unwrap();
+    snapshot.commit().unwrap();
+
+    {
+        let query = r#"
+            with
+            fun ith_fibonacci_number($i: long) -> { long }:
+            match
+                $ret isa number;
+                { $i == 0; $ret == 1; $ret isa number; } or
+                { $i == 1; $ret == 1; $ret isa number; } or
+                { $i > 1;
+                     $i1 = $i - 1;
+                     $i2 = $i - 2;
+                     $combined = ith_fibonacci_number($i1) +  ith_fibonacci_number($i2);
+                     $ret == $combined;
+                     $ret isa number;
+                };
+            return { $ret };
+
+            match
+                $f_6 = ith_fibonacci_number(6);
+        "#;
+        let (rows, positions) = run_read_query(&context, query).unwrap();
+        assert_eq!(rows.len(), 1);
+        let f_6_position = positions.get("f_6").unwrap().clone();
+        assert_eq!(rows[0].get(f_6_position).as_value().clone().unwrap_long(), 13);
     }
 }


### PR DESCRIPTION
## Release notes: product changes
Fixes a bug where the functions were passed the parameter registry of the entry pattern.

## Motivation

## Implementation
ExecutableFunction now holds its own parameter registry. PatternExecutor ensures the right one is passed.