### PR TITLE
Green match BDD redux

### DIFF
--- a/.factory/automation.yml
+++ b/.factory/automation.yml
@@ -70,12 +70,12 @@ build:
       command: |
         bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
         bazel test //tests/behaviour/concept/... --test_output=errors
-#    test-behaviour-query-read:
-#      image: vaticle-ubuntu-22.04
-#      dependencies: [build]
-#      command: |
-#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-#        bazel test //tests/behaviour/query/language:test_match --test_output=streamed
+    test-behaviour-query-read:
+      image: vaticle-ubuntu-22.04
+      dependencies: [build]
+      command: |
+        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+        bazel test //tests/behaviour/query/language:test_match --test_output=streamed
 #        bazel test //tests/behaviour/query/language:test_expressions --test_output=streamed
 #        bazel test //tests/behaviour/query/language:test_modifiers --test_output=streamed
 #        bazel test //tests/behaviour/query/language:test_get --test_output=streamed

--- a/common/lending_iterator/lending_iterator.rs
+++ b/common/lending_iterator/lending_iterator.rs
@@ -6,10 +6,10 @@
 
 use std::{borrow::Borrow, cmp::Ordering, marker::PhantomData, mem::transmute};
 
-use adaptors::Inspect;
-
 use crate::{
-    adaptors::{Chain, Filter, FilterMap, FlatMap, Flatten, Map, RepeatEach, TakeWhile, TryFilter, TryFlatMap, Zip},
+    adaptors::{
+        Chain, Filter, FilterMap, FlatMap, Flatten, Inspect, Map, RepeatEach, TakeWhile, TryFilter, TryFlatMap, Zip,
+    },
     higher_order::{AdHocHkt, FnHktHelper, FnMutHktHelper, Hkt},
 };
 

--- a/common/lending_iterator/lending_iterator.rs
+++ b/common/lending_iterator/lending_iterator.rs
@@ -6,6 +6,8 @@
 
 use std::{borrow::Borrow, cmp::Ordering, marker::PhantomData, mem::transmute};
 
+use adaptors::Inspect;
+
 use crate::{
     adaptors::{Chain, Filter, FilterMap, FlatMap, Flatten, Map, RepeatEach, TakeWhile, TryFilter, TryFlatMap, Zip},
     higher_order::{AdHocHkt, FnHktHelper, FnMutHktHelper, Hkt},
@@ -68,6 +70,14 @@ pub trait LendingIterator: 'static {
         P: FnMut(&Self::Item<'_>) -> bool,
     {
         TakeWhile::new(self, pred)
+    }
+
+    fn inspect<F>(self, f: F) -> Inspect<Self, F>
+    where
+        Self: Sized,
+        F: FnMut(&Self::Item<'_>) + 'static,
+    {
+        Inspect::new(self, f)
     }
 
     fn map<B, F>(self, mapper: F) -> Map<Self, F, B>

--- a/compiler/executable/match_/planner/mod.rs
+++ b/compiler/executable/match_/planner/mod.rs
@@ -396,7 +396,13 @@ impl MatchExecutableBuilder {
             .into_iter()
             .map(|builder| builder.finish(&self.index, &named_variables, variable_registry.clone()))
             .collect();
-        let variable_positions_index = self.reverse_index.iter().sorted_by_key(|(&k, _)| k).map(|(_, &v)| v).collect();
+        let variable_positions_index = self
+            .reverse_index
+            .iter()
+            .filter(|(&var, _)| var.is_output())
+            .sorted_by_key(|(&k, _)| k)
+            .map(|(_, &v)| v)
+            .collect();
         MatchExecutable::new(
             steps,
             self.index.into_iter().filter_map(|(var, id)| Some((var, id.as_position()?))).collect(),

--- a/compiler/executable/match_/planner/plan.rs
+++ b/compiler/executable/match_/planner/plan.rs
@@ -537,10 +537,6 @@ impl<'a> ConjunctionPlanBuilder<'a> {
                 .min_by(|(_, lhs_cost), (_, rhs_cost)| lhs_cost.total_cmp(rhs_cost))
                 .unwrap();
 
-            if intersection_variable == next.as_variable_id() {
-                intersection_variable = None;
-            }
-
             let element = &self.graph.elements[&next];
 
             if element.is_variable() {

--- a/compiler/executable/match_/planner/plan.rs
+++ b/compiler/executable/match_/planner/plan.rs
@@ -542,11 +542,20 @@ impl<'a> ConjunctionPlanBuilder<'a> {
             if element.is_variable() {
                 commit_variables!();
             } else if element.is_constraint() {
-                match element.variables().filter(|var| produced_at_this_stage.contains(var)).exactly_one() {
-                    Ok(var) if (intersection_variable.is_none() || intersection_variable == Some(var)) => {
-                        intersection_variable = Some(var)
+                if let Ok(var) = element.variables().filter(|var| produced_at_this_stage.contains(var)).exactly_one() {
+                    let prev = &self.graph.elements[ordering.last().unwrap()];
+                    let next_constraint = &element.as_constraint().unwrap();
+                    let prev_constraint = &prev.as_constraint().unwrap();
+                    if next_constraint.can_sort_on(var)
+                        && prev_constraint.can_sort_on(var)
+                        && (intersection_variable == Some(var) || intersection_variable.is_none())
+                    {
+                        intersection_variable = Some(var);
+                    } else {
+                        commit_variables!()
                     }
-                    _ => commit_variables!(),
+                } else {
+                    commit_variables!()
                 }
 
                 produced_at_this_stage

--- a/compiler/executable/match_/planner/vertex/constraint.rs
+++ b/compiler/executable/match_/planner/vertex/constraint.rs
@@ -70,6 +70,13 @@ impl ConstraintVertex<'_> {
             Self::Plays(inner) => Box::new(inner.variables()),
         }
     }
+
+    pub(crate) fn can_sort_on(&self, var: VariableVertexId) -> bool {
+        match self {
+            Self::Links(inner) => inner.relation == var || inner.player == var,
+            _ => self.variables().contains(&var),
+        }
+    }
 }
 
 impl Costed for ConstraintVertex<'_> {

--- a/compiler/executable/match_/planner/vertex/mod.rs
+++ b/compiler/executable/match_/planner/vertex/mod.rs
@@ -106,7 +106,14 @@ impl PlannerVertex<'_> {
 
     pub(super) fn as_variable_mut(&mut self) -> Option<&mut VariableVertex> {
         match self {
-            Self::Variable(v) => Some(v),
+            Self::Variable(var) => Some(var),
+            _ => None,
+        }
+    }
+
+    pub(super) fn as_constraint(&self) -> Option<&ConstraintVertex<'_>> {
+        match self {
+            Self::Constraint(constraint) => Some(constraint),
             _ => None,
         }
     }

--- a/executor/instruction/has_executor.rs
+++ b/executor/instruction/has_executor.rs
@@ -99,10 +99,9 @@ impl HasExecutor {
         let owner = has.owner().as_variable().unwrap();
         let attribute = has.attribute().as_variable().unwrap();
 
-        let output_tuple_positions = if iterate_mode.is_inverted() {
-            TuplePositions::Pair([Some(attribute), Some(owner)])
-        } else {
-            TuplePositions::Pair([Some(owner), Some(attribute)])
+        let output_tuple_positions = match iterate_mode {
+            BinaryIterateMode::Unbound => TuplePositions::Pair([Some(owner), Some(attribute)]),
+            _ => TuplePositions::Pair([Some(attribute), Some(owner)]),
         };
 
         let checker = Checker::<(Has<'_>, _)>::new(
@@ -234,7 +233,7 @@ impl HasExecutor {
                 };
                 let as_tuples: HasBoundedSortedAttribute = iterator
                     .try_filter::<_, HasFilterFn, (Has<'_>, _), _>(filter_for_row)
-                    .map::<Result<Tuple<'_>, _>, _>(has_to_tuple_owner_attribute);
+                    .map::<Result<Tuple<'_>, _>, _>(has_to_tuple_attribute_owner);
                 Ok(TupleIterator::HasBounded(SortedTupleIterator::new(
                     as_tuples,
                     self.tuple_positions.clone(),

--- a/executor/instruction/has_reverse_executor.rs
+++ b/executor/instruction/has_reverse_executor.rs
@@ -73,10 +73,9 @@ impl HasReverseExecutor {
         let owner = has.owner().as_variable().unwrap();
         let attribute = has.attribute().as_variable().unwrap();
 
-        let output_tuple_positions = if iterate_mode.is_inverted() {
-            TuplePositions::Pair([Some(owner), Some(attribute)])
-        } else {
-            TuplePositions::Pair([Some(attribute), Some(owner)])
+        let output_tuple_positions = match iterate_mode {
+            BinaryIterateMode::Unbound => TuplePositions::Pair([Some(attribute), Some(owner)]),
+            _ => TuplePositions::Pair([Some(owner), Some(attribute)]),
         };
 
         let checker = Checker::<(Has<'_>, _)>::new(
@@ -201,7 +200,7 @@ impl HasReverseExecutor {
                 );
                 let filtered = iterator.try_filter::<_, HasFilterFn, (Has<'_>, _), _>(filter_for_row);
                 let as_tuples: HasReverseBoundedSortedOwner =
-                    filtered.map::<Result<Tuple<'_>, _>, _>(has_to_tuple_attribute_owner);
+                    filtered.map::<Result<Tuple<'_>, _>, _>(has_to_tuple_owner_attribute);
                 Ok(TupleIterator::HasReverseBounded(SortedTupleIterator::new(
                     as_tuples,
                     self.tuple_positions.clone(),

--- a/executor/instruction/isa_executor.rs
+++ b/executor/instruction/isa_executor.rs
@@ -139,10 +139,9 @@ impl IsaExecutor {
         let thing = isa.thing().as_variable();
         let type_ = isa.type_().as_variable();
 
-        let output_tuple_positions = if iterate_mode.is_inverted() {
-            TuplePositions::Pair([type_, thing])
-        } else {
-            TuplePositions::Pair([thing, type_])
+        let output_tuple_positions = match iterate_mode {
+            BinaryIterateMode::Unbound => TuplePositions::Pair([thing, type_]),
+            _ => TuplePositions::Pair([type_, thing]),
         };
 
         let checker = Checker::<(Thing<'_>, Type)>::new(
@@ -233,7 +232,7 @@ impl IsaExecutor {
                 };
                 let as_tuples: IsaBoundedSortedType = with_types(lending_iterator::once(Ok(thing)), types)
                     .try_filter::<_, IsaFilterFn, (Thing<'_>, Type), _>(filter_for_row)
-                    .map(isa_to_tuple_thing_type);
+                    .map(isa_to_tuple_type_thing);
                 Ok(TupleIterator::IsaBounded(SortedTupleIterator::new(
                     as_tuples,
                     self.tuple_positions.clone(),

--- a/executor/instruction/isa_reverse_executor.rs
+++ b/executor/instruction/isa_reverse_executor.rs
@@ -92,10 +92,9 @@ impl IsaReverseExecutor {
         let thing = isa.thing().as_variable();
         let type_ = isa.type_().as_variable();
 
-        let output_tuple_positions = if iterate_mode.is_inverted() {
-            TuplePositions::Pair([thing, type_])
-        } else {
-            TuplePositions::Pair([type_, thing])
+        let output_tuple_positions = match iterate_mode {
+            BinaryIterateMode::Unbound => TuplePositions::Pair([type_, thing]),
+            _ => TuplePositions::Pair([thing, type_]),
         };
 
         let checker = Checker::<(Thing<'_>, Type)>::new(
@@ -195,7 +194,7 @@ impl IsaReverseExecutor {
                             Err(err) => Err(err.clone()),
                         },
                     ))
-                    .map(isa_to_tuple_type_thing);
+                    .map(isa_to_tuple_thing_type);
                 Ok(TupleIterator::IsaReverseBounded(SortedTupleIterator::new(
                     as_tuples,
                     self.tuple_positions.clone(),

--- a/executor/instruction/links_executor.rs
+++ b/executor/instruction/links_executor.rs
@@ -253,7 +253,7 @@ impl LinksExecutor {
                 };
                 let as_tuples: LinksBoundedRelationSortedPlayer = iterator
                     .try_filter::<_, LinksFilterFn, (Relation<'_>, RolePlayer<'_>, _), _>(filter_for_row)
-                    .map(links_to_tuple_relation_player_role);
+                    .map(links_to_tuple_player_relation_role);
                 Ok(TupleIterator::LinksBoundedRelation(SortedTupleIterator::new(
                     as_tuples,
                     self.tuple_positions.clone(),

--- a/executor/instruction/links_executor.rs
+++ b/executor/instruction/links_executor.rs
@@ -32,8 +32,8 @@ use crate::{
     instruction::{
         iterator::{SortedTupleIterator, TupleIterator},
         tuple::{
-            links_to_tuple_player_relation_role, links_to_tuple_relation_player_role, LinksToTupleFn, Tuple,
-            TuplePositions, TupleResult,
+            links_to_tuple_player_relation_role, links_to_tuple_relation_player_role,
+            links_to_tuple_role_relation_player, LinksToTupleFn, Tuple, TuplePositions, TupleResult,
         },
         Checker, FilterFn, TernaryIterateMode, VariableModes,
     },
@@ -108,10 +108,15 @@ impl LinksExecutor {
         let player = links.player().as_variable().unwrap();
         let role_type = links.role_type().as_variable().unwrap();
 
-        let output_tuple_positions = if iterate_mode == TernaryIterateMode::UnboundInverted {
-            TuplePositions::Triple([Some(player), Some(relation), Some(role_type)])
-        } else {
-            TuplePositions::Triple([Some(relation), Some(player), Some(role_type)])
+        let output_tuple_positions = match iterate_mode {
+            TernaryIterateMode::Unbound => TuplePositions::Triple([Some(relation), Some(player), Some(role_type)]),
+            TernaryIterateMode::UnboundInverted => {
+                TuplePositions::Triple([Some(player), Some(relation), Some(role_type)])
+            }
+            TernaryIterateMode::BoundFrom => TuplePositions::Triple([Some(player), Some(relation), Some(role_type)]),
+            TernaryIterateMode::BoundFromBoundTo => {
+                TuplePositions::Triple([Some(role_type), Some(relation), Some(player)])
+            }
         };
 
         let checker = Checker::<(Relation<'_>, RolePlayer<'_>, _)>::new(
@@ -266,7 +271,7 @@ impl LinksExecutor {
                 let iterator = thing_manager.get_links_by_relation_and_player(snapshot, relation, player);
                 let as_tuples: LinksBoundedRelationSortedPlayer = iterator
                     .try_filter::<_, LinksFilterFn, (Relation<'_>, RolePlayer<'_>, _), _>(filter_for_row)
-                    .map(links_to_tuple_relation_player_role);
+                    .map(links_to_tuple_role_relation_player);
                 Ok(TupleIterator::LinksBoundedRelationPlayer(SortedTupleIterator::new(
                     as_tuples,
                     self.tuple_positions.clone(),

--- a/executor/instruction/plays_reverse_executor.rs
+++ b/executor/instruction/plays_reverse_executor.rs
@@ -23,7 +23,7 @@ use crate::{
     instruction::{
         iterator::{SortedTupleIterator, TupleIterator},
         plays_executor::{PlaysFilterFn, PlaysTupleIterator, EXTRACT_PLAYER, EXTRACT_ROLE},
-        tuple::{plays_to_tuple_role_player, TuplePositions},
+        tuple::{plays_to_tuple_player_role, plays_to_tuple_role_player, TuplePositions},
         BinaryIterateMode, Checker, VariableModes,
     },
     pipeline::stage::ExecutionContext,
@@ -81,10 +81,9 @@ impl PlaysReverseExecutor {
         let player = plays.player().as_variable();
         let role_type = plays.role_type().as_variable();
 
-        let output_tuple_positions = if iterate_mode.is_inverted() {
-            TuplePositions::Pair([player, role_type])
-        } else {
-            TuplePositions::Pair([role_type, player])
+        let output_tuple_positions = match iterate_mode {
+            BinaryIterateMode::Unbound => TuplePositions::Pair([role_type, player]),
+            _ => TuplePositions::Pair([player, role_type]),
         };
 
         let checker = Checker::<AsHkt![Plays<'_>]>::new(
@@ -158,7 +157,7 @@ impl PlaysReverseExecutor {
                 let as_tuples: PlaysReverseBoundedSortedPlayer =
                     AsNarrowingIterator::<_, Result<Plays<'_>, _>>::new(iterator)
                         .try_filter::<_, PlaysFilterFn, Plays<'_>, _>(filter_for_row)
-                        .map(plays_to_tuple_role_player);
+                        .map(plays_to_tuple_player_role);
                 Ok(TupleIterator::PlaysReverseBounded(SortedTupleIterator::new(
                     as_tuples,
                     self.tuple_positions.clone(),

--- a/executor/instruction/tuple.rs
+++ b/executor/instruction/tuple.rs
@@ -286,3 +286,16 @@ pub(crate) fn links_to_tuple_player_relation_role<'a>(
         VariableValue::Type(role_type.into()),
     ]))
 }
+
+pub(crate) fn links_to_tuple_role_relation_player<'a>(
+    result: Result<(Relation<'a>, RolePlayer<'a>, u64), ConceptReadError>,
+) -> TupleResult<'a> {
+    let (rel, rp, _count) = result?;
+    let role_type = rp.role_type();
+    Ok(Tuple::Triple([
+        VariableValue::Type(role_type.into()),
+        VariableValue::Thing(rel.into()),
+        VariableValue::Thing(rp.into_player().into()),
+    ]))
+}
+

--- a/executor/instruction/tuple.rs
+++ b/executor/instruction/tuple.rs
@@ -298,4 +298,3 @@ pub(crate) fn links_to_tuple_role_relation_player<'a>(
         VariableValue::Thing(rp.into_player().into()),
     ]))
 }
-

--- a/executor/read/immediate_executor.rs
+++ b/executor/read/immediate_executor.rs
@@ -4,20 +4,14 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-use std::{
-    cmp::Ordering,
-    collections::{hash_set, HashMap, HashSet},
-    sync::Arc,
-};
+use std::{cmp::Ordering, collections::HashMap, sync::Arc};
 
 use answer::variable_value::VariableValue;
 use compiler::{
     annotation::expression::compiled_expression::ExecutableExpression,
     executable::match_::{
         instructions::{CheckInstruction, ConstraintInstruction, VariableModes},
-        planner::match_executable::{
-            AssignmentStep, CheckStep, ExecutionStep, IntersectionStep, MatchExecutable, UnsortedJoinStep,
-        },
+        planner::match_executable::{AssignmentStep, CheckStep, IntersectionStep, UnsortedJoinStep},
     },
     ExecutorVariable, VariablePosition,
 };
@@ -30,7 +24,6 @@ use crate::{
     batch::{FixedBatch, FixedBatchRowIterator},
     error::ReadExecutionError,
     instruction::{iterator::TupleIterator, Checker, InstructionExecutor},
-    match_executor::MatchExecutor,
     pipeline::stage::ExecutionContext,
     read::{
         expression_executor::{evaluate_expression, ExpressionValue},
@@ -187,7 +180,7 @@ impl IntersectionExecutor {
     fn batch_continue(
         &mut self,
         context: &ExecutionContext<impl ReadableSnapshot + 'static>,
-        interrupt: &mut ExecutionInterrupt,
+        _interrupt: &mut ExecutionInterrupt,
     ) -> Result<Option<FixedBatch>, ReadExecutionError> {
         debug_assert!(self.output.is_none());
         self.may_compute_next_batch(context)?;
@@ -395,7 +388,7 @@ impl IntersectionExecutor {
 
         let input_row = self.input.as_mut().unwrap().peek().unwrap().as_ref().map_err(|&err| err.clone())?;
         for &position in &self.outputs_selected {
-            if position.as_usize() < input_row.len() {
+            if position.as_usize() < input_row.len() && !input_row.get(position).is_empty() {
                 row.set(position, input_row.get(position).clone().into_owned())
             }
         }


### PR DESCRIPTION
## Release notes: product changes

We resolve the remaining flaky failures in match BDDs.

## Motivation

## Implementation

- ensure sort variable for the sorted tuple iterator always comes first,
- fix incorrect tuple positioning in some executors,
- disallow intersection over unsorted executors in planner.