### PR TITLE
Is constraint

### DIFF
--- a/answer/variable_value.rs
+++ b/answer/variable_value.rs
@@ -11,6 +11,7 @@ use std::{
 };
 
 use encoding::value::value::Value;
+use lending_iterator::higher_order::Hkt;
 
 use crate::{Thing, Type};
 
@@ -101,7 +102,11 @@ impl<'a> VariableValue<'a> {
     }
 }
 
-impl<'a> PartialOrd for VariableValue<'a> {
+impl Hkt for VariableValue<'static> {
+    type HktSelf<'a> = VariableValue<'a>;
+}
+
+impl PartialOrd for VariableValue<'_> {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
         match (self, other) {
             (Self::Type(self_type), Self::Type(other_type)) => self_type.partial_cmp(other_type),
@@ -112,7 +117,7 @@ impl<'a> PartialOrd for VariableValue<'a> {
     }
 }
 
-impl<'a> Display for VariableValue<'a> {
+impl Display for VariableValue<'_> {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
             VariableValue::Empty => write!(f, "[None]"),

--- a/common/lending_iterator/higher_order.rs
+++ b/common/lending_iterator/higher_order.rs
@@ -61,10 +61,10 @@ impl<B> Hkt for AdHocHkt<B> {
 
 #[macro_export]
 macro_rules! AsHkt {
-    {$($path_element:ident)::+ <'_ $(, $generic_param:tt)*> } => { $($path_element)::+<'static $(, $generic_param)*> };
-    {<$ty:ty as $trait:ty>::$($path_element:ident)::+ <'_ $(, $generic_param:tt)*> } => {
+    { $($path_element:ident)::+ <'_ $(, $generic_param:tt)*> } => { $($path_element)::+<'static $(, $generic_param)*> };
+    { <$ty:ty as $trait:ty>::$($path_element:ident)::+ <'_ $(, $generic_param:tt)*> } => {
         <$ty as $trait>::$($path_element)::+<'static $(, $generic_param)*>
     };
-    {& mut $ty:ty  } => {&'static mut $ty};
-    {& $ty:ty  } => {&'static $ty};
+    { & mut $ty:ty } => {&'static mut $ty};
+    { & $ty:ty } => {&'static $ty};
 }

--- a/compiler/annotation/fetch.rs
+++ b/compiler/annotation/fetch.rs
@@ -174,7 +174,7 @@ fn annotate_some(
     match some {
         FetchSome::SingleVar(var) => Ok(AnnotatedFetchSome::SingleVar(var)),
         FetchSome::SingleAttribute(FetchSingleAttribute { variable, attribute }) => {
-            let variable_name = variable_registry.get_variable_name(&variable).unwrap();
+            let variable_name = variable_registry.get_variable_name(variable).unwrap();
             let attribute_type = type_manager
                 .get_attribute_type(snapshot, &Label::build(&attribute))
                 .map_err(|err| AnnotationError::ConceptRead { source: err })?
@@ -239,7 +239,7 @@ fn annotate_some(
             Ok(AnnotatedFetchSome::ListSubFetch(annotated_sub_fetch?))
         }
         FetchSome::ListAttributesAsList(FetchListAttributeAsList { variable, attribute }) => {
-            let variable_name = variable_registry.get_variable_name(&variable).unwrap();
+            let variable_name = variable_registry.get_variable_name(variable).unwrap();
             let attribute_type = type_manager
                 .get_attribute_type(snapshot, &Label::build(&attribute))
                 .map_err(|err| AnnotationError::ConceptRead { source: err })?

--- a/compiler/annotation/type_inference.rs
+++ b/compiler/annotation/type_inference.rs
@@ -110,7 +110,7 @@ pub mod tests {
         let type_player_1 = Type::Relation(RelationType::build_from_type_id(TypeID::build(2)));
 
         let mut translation_context = TranslationContext::new();
-        let dummy = Block::builder(translation_context.new_block_builder_context()).finish();
+        let dummy = Block::builder(translation_context.new_block_builder_context()).finish().unwrap();
         let constraint1 = Constraint::Links(Links::new(var_relation, var_player, var_role_type));
         let constraint2 = Constraint::Links(Links::new(var_relation, var_player, var_role_type));
         let nested1 = TypeInferenceGraph {
@@ -218,7 +218,7 @@ pub mod tests {
         assert_eq!(expected_annotations.vertex_annotations(), type_annotations.vertex_annotations());
         assert_eq!(expected_annotations.constraint_annotations(), type_annotations.constraint_annotations());
     }
-    //
+
     #[test]
     fn test_functions() {
         let (_tmp_dir, storage) = setup_storage();
@@ -228,7 +228,7 @@ pub mod tests {
             setup_types(storage.clone().open_snapshot_write(), &type_manager, &thing_manager);
         let object_types = [type_animal.clone(), type_cat.clone(), type_dog.clone(), type_fears.clone()];
 
-        let (with_no_cache, with_local_cache, with_schema_cache) = [
+        let (with_no_cache, with_local_cache, _with_schema_cache) = [
             FunctionID::Preamble(0),
             FunctionID::Preamble(0),
             FunctionID::Schema(DefinitionKey::build(Prefix::DefinitionFunction, DefinitionID::build(0))),
@@ -244,7 +244,7 @@ pub mod tests {
             f_conjunction.constraints_mut().add_label(f_var_animal_type, LABEL_CAT.clone()).unwrap();
             f_conjunction.constraints_mut().add_isa(IsaKind::Subtype, f_var_animal, f_var_animal_type.into()).unwrap();
             f_conjunction.constraints_mut().add_has(f_var_animal, f_var_name).unwrap();
-            let function_block = builder.finish();
+            let function_block = builder.finish().unwrap();
             let f_ir = Function::new(
                 "fn_test",
                 function_context,
@@ -271,7 +271,7 @@ pub mod tests {
                 .constraints_mut()
                 .add_function_binding(vec![var_animal], &callee_signature, vec![], "test_fn")
                 .unwrap();
-            let entry = builder.finish();
+            let entry = builder.finish().unwrap();
             (entry, entry_context, f_ir)
         })
         .collect_tuple()
@@ -450,7 +450,7 @@ pub mod tests {
             conjunction.constraints_mut().add_label(var_name_type, LABEL_NAME.clone()).unwrap();
             conjunction.constraints_mut().add_has(var_animal, var_name).unwrap();
 
-            let block = builder.finish();
+            let block = builder.finish().unwrap();
             let constraints = block.conjunction().constraints();
             let graph = compute_type_inference_graph(
                 &snapshot,
@@ -519,7 +519,7 @@ pub mod tests {
             conjunction.constraints_mut().add_label(var_name_type, LABEL_CATNAME.clone()).unwrap();
             conjunction.constraints_mut().add_has(var_animal, var_name).unwrap();
 
-            let block = builder.finish();
+            let block = builder.finish().unwrap();
 
             let constraints = block.conjunction().constraints();
             let graph = compute_type_inference_graph(
@@ -588,7 +588,7 @@ pub mod tests {
             conjunction.constraints_mut().add_label(var_name_type, LABEL_DOGNAME.clone()).unwrap();
             conjunction.constraints_mut().add_has(var_animal, var_name).unwrap();
 
-            let block = builder.finish();
+            let block = builder.finish().unwrap();
             let err = compute_type_inference_graph(
                 &snapshot,
                 &block,
@@ -623,7 +623,7 @@ pub mod tests {
             conjunction.constraints_mut().add_label(var_name_type, LABEL_NAME.clone()).unwrap();
             conjunction.constraints_mut().add_has(var_animal, var_name).unwrap();
 
-            let block = builder.finish();
+            let block = builder.finish().unwrap();
             let constraints = block.conjunction().constraints();
             let graph = compute_type_inference_graph(
                 &snapshot,
@@ -725,7 +725,7 @@ pub mod tests {
 
         let (b1_var_animal_type, b2_var_animal_type) = (b1_var_animal_type, b2_var_animal_type);
 
-        let block = builder.finish();
+        let block = builder.finish().unwrap();
 
         let snapshot = storage.clone().open_snapshot_write();
         let graph = compute_type_inference_graph(
@@ -845,7 +845,7 @@ pub mod tests {
 
         conjunction.constraints_mut().add_has(var_animal, var_name).unwrap();
 
-        let block = builder.finish();
+        let block = builder.finish().unwrap();
         let conjunction = block.conjunction();
         let constraints = conjunction.constraints();
         let graph = compute_type_inference_graph(
@@ -938,7 +938,7 @@ pub mod tests {
             .unwrap();
         conjunction.constraints_mut().add_label(var_role_is_feared_type, LABEL_IS_FEARED.clone()).unwrap();
 
-        let block = builder.finish();
+        let block = builder.finish().unwrap();
 
         let conjunction = block.conjunction();
 
@@ -1053,7 +1053,7 @@ pub mod tests {
             conjunction.constraints_mut().add_isa(IsaKind::Exact, var_name, var_owned_type.into()).unwrap();
             conjunction.constraints_mut().add_owns(var_animal_type.into(), var_owned_type.into()).unwrap();
 
-            let block = builder.finish();
+            let block = builder.finish().unwrap();
             let constraints = block.conjunction().constraints();
             let graph = compute_type_inference_graph(
                 &snapshot,
@@ -1121,7 +1121,7 @@ pub mod tests {
             conjunction.constraints_mut().add_label(var_name_type, LABEL_CATNAME.clone()).unwrap();
             conjunction.constraints_mut().add_owns(var_owner_type.into(), var_name_type.into()).unwrap();
 
-            let block = builder.finish();
+            let block = builder.finish().unwrap();
 
             let constraints = block.conjunction().constraints();
             let graph = compute_type_inference_graph(
@@ -1189,7 +1189,7 @@ pub mod tests {
             conjunction.constraints_mut().add_label(var_name_type, LABEL_DOGNAME.clone()).unwrap();
             conjunction.constraints_mut().add_owns(var_animal_type.into(), var_name_type.into()).unwrap();
 
-            let block = builder.finish();
+            let block = builder.finish().unwrap();
             let constraints = block.conjunction().constraints();
             // We manually compute the graph so we can confirm it decays to empty annotations everywhere
             let mut graph = TypeGraphSeedingContext::new(
@@ -1243,7 +1243,7 @@ pub mod tests {
             conjunction.constraints_mut().add_isa(IsaKind::Exact, var_name, var_name_type.into()).unwrap();
             conjunction.constraints_mut().add_owns(var_animal_type.into(), var_name_type.into()).unwrap();
 
-            let block = builder.finish();
+            let block = builder.finish().unwrap();
             let constraints = block.conjunction().constraints();
             let graph = compute_type_inference_graph(
                 &snapshot,
@@ -1332,7 +1332,7 @@ pub mod tests {
             conjunction.constraints_mut().add_isa(IsaKind::Subtype, var_name, Vertex::Label(LABEL_NAME)).unwrap();
             conjunction.constraints_mut().add_has(var_animal, var_name).unwrap();
 
-            let block = builder.finish();
+            let block = builder.finish().unwrap();
             let constraints = block.conjunction().constraints();
             let graph = compute_type_inference_graph(
                 &snapshot,
@@ -1396,7 +1396,7 @@ pub mod tests {
             conjunction.constraints_mut().add_isa(IsaKind::Subtype, var_name, Vertex::Label(LABEL_CATNAME)).unwrap();
             conjunction.constraints_mut().add_has(var_animal, var_name).unwrap();
 
-            let block = builder.finish();
+            let block = builder.finish().unwrap();
 
             let constraints = block.conjunction().constraints();
             let graph = compute_type_inference_graph(
@@ -1458,7 +1458,7 @@ pub mod tests {
             conjunction.constraints_mut().add_isa(IsaKind::Subtype, var_name, Vertex::Label(LABEL_DOGNAME)).unwrap();
             conjunction.constraints_mut().add_has(var_animal, var_name).unwrap();
 
-            let block = builder.finish();
+            let block = builder.finish().unwrap();
             let err = compute_type_inference_graph(
                 &snapshot,
                 &block,
@@ -1487,7 +1487,7 @@ pub mod tests {
             conjunction.constraints_mut().add_isa(IsaKind::Subtype, var_name, Vertex::Label(LABEL_NAME)).unwrap();
             conjunction.constraints_mut().add_has(var_animal, var_name).unwrap();
 
-            let block = builder.finish();
+            let block = builder.finish().unwrap();
             let constraints = block.conjunction().constraints();
             let graph = compute_type_inference_graph(
                 &snapshot,

--- a/compiler/executable/delete/executable.rs
+++ b/compiler/executable/delete/executable.rs
@@ -78,6 +78,7 @@ pub fn compile(
             | Constraint::Relates(_)
             | Constraint::Plays(_)
             | Constraint::ExpressionBinding(_)
+            | Constraint::Is(_)
             | Constraint::Comparison(_)
             | Constraint::Sub(_)
             | Constraint::FunctionCallBinding(_) => {

--- a/compiler/executable/insert/type_check.rs
+++ b/compiler/executable/insert/type_check.rs
@@ -61,6 +61,7 @@ pub fn check_annotations(
             | Constraint::Sub(_)
             | Constraint::ExpressionBinding(_)
             | Constraint::FunctionCallBinding(_)
+            | Constraint::Is(_)
             | Constraint::Comparison(_)
             | Constraint::Owns(_)
             | Constraint::Relates(_)

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -21,8 +21,8 @@ def vaticle_dependencies():
 def vaticle_typeql():
     git_repository(
         name = "vaticle_typeql",
-        remote = "https://github.com/dmitrii-ubskii/typeql",
-        commit = "eb7ea8e99824e2836c998e85e1280a3e43a4edd3",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typeql
+        remote = "https://github.com/typedb/typeql",
+        commit = "9441e3d1472316b3efcd195aab79b0eee6a96572",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typeql
     )
 
 def vaticle_typedb_common():
@@ -42,6 +42,6 @@ def vaticle_typedb_protocol():
 def vaticle_typedb_behaviour():
     git_repository(
         name = "vaticle_typedb_behaviour",
-        remote = "https://github.com/dmitrii-ubskii/typedb-behaviour",
-        commit = "bf03461ebd0aed20e4239168ee7ac05f79b39528",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_behaviour
+        remote = "https://github.com/typedb/typedb-behaviour",
+        commit = "bcc49a3ffd8305f844922a2b36e6f705d9a437de",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_behaviour
     )

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -21,8 +21,8 @@ def vaticle_dependencies():
 def vaticle_typeql():
     git_repository(
         name = "vaticle_typeql",
-        remote = "https://github.com/typedb/typeql",
-        commit = "08439833aa7ddeacad96476e567c184cc3fadda4",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typeql
+        remote = "https://github.com/dmitrii-ubskii/typeql",
+        commit = "eb7ea8e99824e2836c998e85e1280a3e43a4edd3",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typeql
     )
 
 def vaticle_typedb_common():
@@ -42,6 +42,6 @@ def vaticle_typedb_protocol():
 def vaticle_typedb_behaviour():
     git_repository(
         name = "vaticle_typedb_behaviour",
-        remote = "https://github.com/typedb/typedb-behaviour",
-        commit = "4b4afc1cb17dd501e69e582e920bd4d10f0f4ba4",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_behaviour
+        remote = "https://github.com/dmitrii-ubskii/typedb-behaviour",
+        commit = "bf03461ebd0aed20e4239168ee7ac05f79b39528",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_behaviour
     )

--- a/executor/instruction/is_executor.rs
+++ b/executor/instruction/is_executor.rs
@@ -1,0 +1,108 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+use std::collections::HashMap;
+
+use answer::variable_value::VariableValue;
+use compiler::{
+    executable::match_::instructions::{Inputs, IsInstruction},
+    ExecutorVariable, VariablePosition,
+};
+use concept::error::ConceptReadError;
+use ir::pattern::constraint::Is;
+use lending_iterator::{
+    adaptors::{Map, TryFilter},
+    AsHkt, LendingIterator,
+};
+use storage::snapshot::ReadableSnapshot;
+
+use super::tuple::Tuple;
+use crate::{
+    instruction::{
+        iterator::{SortedTupleIterator, TupleIterator},
+        tuple::{TuplePositions, TupleResult},
+        Checker, FilterFn, VariableModes,
+    },
+    pipeline::stage::ExecutionContext,
+    row::MaybeOwnedRow,
+};
+
+pub(crate) struct IsExecutor {
+    is: Is<ExecutorVariable>,
+    input: VariablePosition,
+    variable_modes: VariableModes,
+    tuple_positions: TuplePositions,
+    checker: Checker<AsHkt![VariableValue<'_>]>,
+}
+
+pub(crate) type IsToTupleFn = for<'a> fn(Result<VariableValue<'a>, ConceptReadError>) -> TupleResult<'a>;
+
+pub(super) type IsTupleIterator<I> = Map<
+    TryFilter<I, Box<IsFilterFn>, AsHkt![VariableValue<'_>], ConceptReadError>,
+    IsToTupleFn,
+    AsHkt![TupleResult<'_>],
+>;
+
+pub(super) type IsFilterFn = FilterFn<AsHkt![VariableValue<'_>]>;
+
+pub(crate) type IsIterator =
+    IsTupleIterator<lending_iterator::Once<Result<AsHkt![VariableValue<'_>], ConceptReadError>>>;
+
+type IsVariableValueExtractor = for<'a, 'b> fn(&'a VariableValue<'b>) -> VariableValue<'a>;
+
+pub(super) const EXTRACT_LHS: IsVariableValueExtractor = |lhs| lhs.as_reference();
+pub(super) const EXTRACT_RHS: IsVariableValueExtractor = |rhs| rhs.as_reference();
+
+fn is_to_tuple(result: Result<VariableValue<'_>, ConceptReadError>) -> TupleResult<'_> {
+    match result {
+        Ok(value) => Ok(Tuple::Pair([value.clone(), value])),
+        Err(err) => Err(err),
+    }
+}
+
+impl IsExecutor {
+    pub(crate) fn new(
+        is: IsInstruction<ExecutorVariable>,
+        variable_modes: VariableModes,
+        _sort_by: ExecutorVariable,
+    ) -> Self {
+        let IsInstruction { is, inputs, checks } = is;
+
+        let lhs = is.lhs().as_variable().unwrap();
+        let rhs = is.rhs().as_variable().unwrap();
+
+        let output_tuple_positions = TuplePositions::Pair([Some(lhs), Some(rhs)]);
+
+        let checker =
+            Checker::<VariableValue<'_>>::new(checks, HashMap::from_iter([(lhs, EXTRACT_LHS), (rhs, EXTRACT_RHS)]));
+
+        let Inputs::Single([ExecutorVariable::RowPosition(input)]) = inputs else {
+            unreachable!("expected single input for IsExecutor ({inputs:?})")
+        };
+
+        Self { is, input, variable_modes, tuple_positions: output_tuple_positions, checker }
+    }
+
+    pub(crate) fn get_iterator(
+        &self,
+        context: &ExecutionContext<impl ReadableSnapshot + 'static>,
+        row: MaybeOwnedRow<'_>,
+    ) -> Result<TupleIterator, ConceptReadError> {
+        let filter_for_row: Box<IsFilterFn> = self.checker.filter_for_row(context, &row);
+        let input: VariableValue<'static> = row.get(self.input).clone().into_owned();
+
+        fn as_tuples<T: for<'a> LendingIterator<Item<'a> = Result<VariableValue<'a>, ConceptReadError>>>(
+            it: T,
+        ) -> Map<T, IsToTupleFn, AsHkt![TupleResult<'_>]> {
+            it.map::<TupleResult<'_>, IsToTupleFn>(is_to_tuple)
+        }
+
+        let iterator = lending_iterator::once(Ok(input));
+        let as_tuples = as_tuples(iterator.try_filter::<_, IsFilterFn, VariableValue<'_>, _>(filter_for_row));
+
+        Ok(TupleIterator::Is(SortedTupleIterator::new(as_tuples, self.tuple_positions.clone(), &self.variable_modes)))
+    }
+}

--- a/executor/instruction/iterator.rs
+++ b/executor/instruction/iterator.rs
@@ -25,6 +25,7 @@ use crate::{
             HasReverseBoundedSortedOwner, HasReverseUnboundedSortedAttribute, HasReverseUnboundedSortedOwnerMerged,
             HasReverseUnboundedSortedOwnerSingle,
         },
+        is_executor::IsIterator,
         isa_executor::{
             IsaBoundedSortedType, IsaUnboundedSortedThingMerged, IsaUnboundedSortedThingSingle,
             IsaUnboundedSortedTypeMerged, IsaUnboundedSortedTypeSingle,
@@ -98,6 +99,7 @@ macro_rules! dispatch_tuple_iterator {
 dispatch_tuple_iterator! {
 #[allow(clippy::large_enum_variant)]
 pub(crate) enum TupleIterator {
+    Is(SortedTupleIterator<IsIterator>),
     Type(SortedTupleIterator<TypeIterator>),
 
     SubUnbounded(SortedTupleIterator<SubUnboundedSortedSub>),

--- a/executor/tests/compile_execute.rs
+++ b/executor/tests/compile_execute.rs
@@ -22,10 +22,7 @@ use concept::{
     type_::type_manager::TypeManager,
 };
 use executor::{
-    match_executor::MatchExecutor,
-    pipeline::stage::{ExecutionContext, StageAPI},
-    row::MaybeOwnedRow,
-    ExecutionInterrupt,
+    match_executor::MatchExecutor, pipeline::stage::ExecutionContext, row::MaybeOwnedRow, ExecutionInterrupt,
 };
 use function::function_manager::FunctionManager;
 use ir::{
@@ -97,7 +94,7 @@ fn test_has_planning_traversal() {
     let empty_function_index = HashMapFunctionSignatureIndex::empty();
     let mut translation_context = TranslationContext::new();
     let builder = translate_match(&mut translation_context, &empty_function_index, &match_).unwrap();
-    let block = builder.finish();
+    let block = builder.finish().unwrap();
 
     // Executor
     let snapshot = Arc::new(storage.clone().open_snapshot_read());
@@ -179,7 +176,7 @@ fn test_expression_planning_traversal() {
     let empty_function_index = HashMapFunctionSignatureIndex::empty();
     let mut translation_context = TranslationContext::new();
     let builder = translate_match(&mut translation_context, &empty_function_index, &match_).unwrap();
-    let block = builder.finish();
+    let block = builder.finish().unwrap();
 
     // Executor
     let snapshot = Arc::new(storage.clone().open_snapshot_read());
@@ -271,7 +268,7 @@ fn test_links_planning_traversal() {
     let empty_function_index = HashMapFunctionSignatureIndex::empty();
     let mut translation_context = TranslationContext::new();
     let builder = translate_match(&mut translation_context, &empty_function_index, &match_).unwrap();
-    let block = builder.finish();
+    let block = builder.finish().unwrap();
 
     // Executor
     let snapshot = Arc::new(storage.clone().open_snapshot_read());
@@ -359,7 +356,7 @@ fn test_links_intersection() {
     let empty_function_index = HashMapFunctionSignatureIndex::empty();
     let mut translation_context = TranslationContext::new();
     let builder = translate_match(&mut translation_context, &empty_function_index, &match_).unwrap();
-    let block = builder.finish();
+    let block = builder.finish().unwrap();
 
     // Executor
     let snapshot = Arc::new(storage.clone().open_snapshot_read());
@@ -438,7 +435,7 @@ fn test_negation_planning_traversal() {
     let empty_function_index = HashMapFunctionSignatureIndex::empty();
     let mut translation_context = TranslationContext::new();
     let builder = translate_match(&mut translation_context, &empty_function_index, &match_).unwrap();
-    let block = builder.finish();
+    let block = builder.finish().unwrap();
 
     // Executor
     let snapshot = Arc::new(storage.clone().open_snapshot_read());
@@ -538,7 +535,7 @@ fn test_forall_planning_traversal() {
     let empty_function_index = HashMapFunctionSignatureIndex::empty();
     let mut translation_context = TranslationContext::new();
     let builder = translate_match(&mut translation_context, &empty_function_index, &match_).unwrap();
-    let block = builder.finish();
+    let block = builder.finish().unwrap();
 
     // Executor
     let snapshot = Arc::new(storage.clone().open_snapshot_read());
@@ -624,7 +621,7 @@ fn test_named_var_select() {
     let empty_function_index = HashMapFunctionSignatureIndex::empty();
     let mut translation_context = TranslationContext::new();
     let builder = translate_match(&mut translation_context, &empty_function_index, &match_).unwrap();
-    let block = builder.finish();
+    let block = builder.finish().unwrap();
 
     // Executor
     let snapshot = Arc::new(storage.clone().open_snapshot_read());
@@ -710,7 +707,7 @@ fn test_disjunction_planning_traversal() {
     let empty_function_index = HashMapFunctionSignatureIndex::empty();
     let mut translation_context = TranslationContext::new();
     let builder = translate_match(&mut translation_context, &empty_function_index, &match_).unwrap();
-    let block = builder.finish();
+    let block = builder.finish().unwrap();
 
     // Executor
     let snapshot = Arc::new(storage.clone().open_snapshot_read());
@@ -800,7 +797,7 @@ fn test_disjunction_planning_nested_negations() {
     let empty_function_index = HashMapFunctionSignatureIndex::empty();
     let mut translation_context = TranslationContext::new();
     let builder = translate_match(&mut translation_context, &empty_function_index, &match_).unwrap();
-    let block = builder.finish();
+    let block = builder.finish().unwrap();
 
     // Executor
     let snapshot = Arc::new(storage.clone().open_snapshot_read());

--- a/executor/tests/execute_comparison_check.rs
+++ b/executor/tests/execute_comparison_check.rs
@@ -92,7 +92,7 @@ fn attribute_equality() {
         conjunction.constraints_mut().add_isa(IsaKind::Subtype, var_age_b, var_age_type_b.into()).unwrap().clone();
     conjunction.constraints_mut().add_label(var_age_type_a, AGE_LABEL.clone()).unwrap();
     conjunction.constraints_mut().add_label(var_age_type_b, AGE_LABEL.clone()).unwrap();
-    let entry = builder.finish();
+    let entry = builder.finish().unwrap();
 
     let snapshot = storage.clone().open_snapshot_read();
     let (type_manager, thing_manager) = load_managers(storage.clone(), None);

--- a/executor/tests/execute_expression.rs
+++ b/executor/tests/execute_expression.rs
@@ -52,7 +52,7 @@ fn compile_expression_via_match(
     let mut translation_context = TranslationContext::new();
     if let Stage::Match(match_) = typeql::parse_query(query.as_str()).unwrap().into_pipeline().stages.first().unwrap() {
         let block =
-            translate_match(&mut translation_context, &HashMapFunctionSignatureIndex::empty(), match_)?.finish();
+            translate_match(&mut translation_context, &HashMapFunctionSignatureIndex::empty(), match_)?.finish()?;
         let variable_mapping = variable_types
             .keys()
             .map(|name| ((*name).to_owned(), translation_context.get_variable(*name).unwrap()))

--- a/executor/tests/execute_expression.rs
+++ b/executor/tests/execute_expression.rs
@@ -55,7 +55,7 @@ fn compile_expression_via_match(
             translate_match(&mut translation_context, &HashMapFunctionSignatureIndex::empty(), match_)?.finish()?;
         let variable_mapping = variable_types
             .keys()
-            .map(|name| ((*name).to_owned(), translation_context.get_variable(*name).unwrap()))
+            .map(|&name| (name.to_owned(), translation_context.get_variable(name).unwrap()))
             .collect::<HashMap<_, _>>();
         let variable_types_mapped = variable_types
             .into_iter()
@@ -174,6 +174,7 @@ fn test_ops_long_double() {
             let result = evaluate_expression(&expr, HashMap::new(), &params).unwrap();
             assert_eq!(as_value!(result), Value::Double(16.0));
         }
+
         {
             let (_, expr, params) = compile_expression_via_match("12.0e0 - 4.0e0", HashMap::new()).unwrap();
             let result = evaluate_expression(&expr, HashMap::new(), &params).unwrap();

--- a/executor/tests/execute_function.rs
+++ b/executor/tests/execute_function.rs
@@ -6,7 +6,6 @@
 
 use std::{collections::HashMap, sync::Arc};
 
-use answer::variable_value::VariableValue;
 use compiler::VariablePosition;
 use concept::{thing::thing_manager::ThingManager, type_::type_manager::TypeManager};
 use encoding::graph::definition::definition_key_generator::DefinitionKeyGenerator;
@@ -75,7 +74,7 @@ fn run_read_query(
         )
         .unwrap();
     let rows_positions = pipeline.rows_positions().unwrap().clone();
-    let (mut iterator, _) = pipeline.into_rows_iterator(ExecutionInterrupt::new_uninterruptible()).unwrap();
+    let (iterator, _) = pipeline.into_rows_iterator(ExecutionInterrupt::new_uninterruptible()).unwrap();
 
     let result: Result<Vec<MaybeOwnedRow<'static>>, PipelineExecutionError> =
         iterator.map_static(|row| row.map(|row| row.into_owned()).map_err(|err| err.clone())).collect();

--- a/executor/tests/execute_function.rs
+++ b/executor/tests/execute_function.rs
@@ -334,7 +334,7 @@ fn simple_tabled() {
     }
 }
 
-#[ignore]  // TODO
+#[ignore] // TODO
 #[test]
 fn fibonacci() {
     let custom_schema = r#"define

--- a/executor/tests/execute_has.rs
+++ b/executor/tests/execute_has.rs
@@ -137,7 +137,7 @@ fn traverse_has_unbounded_sorted_from() {
     conjunction.constraints_mut().add_isa(IsaKind::Subtype, var_age, var_age_type.into()).unwrap();
     conjunction.constraints_mut().add_label(var_person_type, PERSON_LABEL.clone()).unwrap();
     conjunction.constraints_mut().add_label(var_age_type, AGE_LABEL.clone()).unwrap();
-    let entry = builder.finish();
+    let entry = builder.finish().unwrap();
 
     let snapshot = storage.clone().open_snapshot_read();
     let (type_manager, thing_manager) = load_managers(storage.clone(), None);
@@ -239,7 +239,7 @@ fn traverse_has_bounded_sorted_from_chain_intersect() {
     conjunction.constraints_mut().add_label(var_name_type, NAME_LABEL.clone()).unwrap();
 
     let snapshot = storage.clone().open_snapshot_read();
-    let entry = builder.finish();
+    let entry = builder.finish().unwrap();
     let variable_registry = &translation_context.variable_registry;
     let previous_stage_variable_annotations = &BTreeMap::new();
     let annotated_schema_functions = &IndexedAnnotatedFunctions::empty();
@@ -352,7 +352,7 @@ fn traverse_has_unbounded_sorted_from_intersect() {
     conjunction.constraints_mut().add_label(var_age_type, AGE_LABEL.clone()).unwrap();
     conjunction.constraints_mut().add_label(var_name_type, NAME_LABEL.clone()).unwrap();
 
-    let entry = builder.finish();
+    let entry = builder.finish().unwrap();
 
     let snapshot: ReadSnapshot<WALClient> = storage.clone().open_snapshot_read();
     let (type_manager, thing_manager) = load_managers(storage.clone(), None);
@@ -446,7 +446,7 @@ fn traverse_has_unbounded_sorted_to_merged() {
     let has_attribute = conjunction.constraints_mut().add_has(var_person, var_attribute).unwrap().clone();
     conjunction.constraints_mut().add_isa(IsaKind::Subtype, var_person, var_person_type.into()).unwrap();
     conjunction.constraints_mut().add_label(var_person_type, PERSON_LABEL.clone()).unwrap();
-    let entry = builder.finish();
+    let entry = builder.finish().unwrap();
 
     let snapshot: ReadSnapshot<WALClient> = storage.clone().open_snapshot_read();
     let (type_manager, thing_manager) = load_managers(storage.clone(), None);
@@ -555,7 +555,7 @@ fn traverse_has_reverse_unbounded_sorted_from() {
     conjunction.constraints_mut().add_label(var_person_type, PERSON_LABEL.clone()).unwrap();
     conjunction.constraints_mut().add_label(var_age_type, AGE_LABEL.clone()).unwrap();
 
-    let entry = builder.finish();
+    let entry = builder.finish().unwrap();
 
     let snapshot: ReadSnapshot<WALClient> = storage.clone().open_snapshot_read();
     let (type_manager, thing_manager) = load_managers(storage.clone(), None);

--- a/executor/tests/execute_isa.rs
+++ b/executor/tests/execute_isa.rs
@@ -90,7 +90,7 @@ fn traverse_isa_unbounded_sorted_thing() {
     // add all constraints to make type inference return correct types, though we only plan Has's
     let isa = conjunction.constraints_mut().add_isa(IsaKind::Subtype, var_dog, var_dog_type.into()).unwrap().clone();
     conjunction.constraints_mut().add_label(var_dog_type, DOG_LABEL.clone()).unwrap();
-    let entry = builder.finish();
+    let entry = builder.finish().unwrap();
 
     let snapshot = storage.clone().open_snapshot_read();
     let (type_manager, thing_manager) = load_managers(storage.clone(), None);
@@ -175,7 +175,7 @@ fn traverse_isa_unbounded_sorted_type() {
     // add all constraints to make type inference return correct types, though we only plan Has's
     let isa = conjunction.constraints_mut().add_isa(IsaKind::Subtype, var_dog, var_dog_type.into()).unwrap().clone();
     conjunction.constraints_mut().add_label(var_dog_type, DOG_LABEL.clone()).unwrap();
-    let entry = builder.finish();
+    let entry = builder.finish().unwrap();
 
     let snapshot = storage.clone().open_snapshot_read();
     let (type_manager, thing_manager) = load_managers(storage.clone(), None);
@@ -263,7 +263,7 @@ fn traverse_isa_bounded_thing() {
         conjunction.constraints_mut().add_isa(IsaKind::Exact, var_thing, var_type_from.into()).unwrap().clone();
     let isa_to_type =
         conjunction.constraints_mut().add_isa(IsaKind::Subtype, var_thing, var_type_to.into()).unwrap().clone();
-    let entry = builder.finish();
+    let entry = builder.finish().unwrap();
 
     let snapshot = storage.clone().open_snapshot_read();
     let (type_manager, thing_manager) = load_managers(storage.clone(), None);
@@ -365,7 +365,7 @@ fn traverse_isa_reverse_unbounded_sorted_thing() {
     // add all constraints to make type inference return correct types, though we only plan Has's
     let isa = conjunction.constraints_mut().add_isa(IsaKind::Subtype, var_dog, var_dog_type.into()).unwrap().clone();
     conjunction.constraints_mut().add_label(var_dog_type, DOG_LABEL.clone()).unwrap();
-    let entry = builder.finish();
+    let entry = builder.finish().unwrap();
 
     let snapshot = storage.clone().open_snapshot_read();
     let (type_manager, thing_manager) = load_managers(storage.clone(), None);
@@ -452,7 +452,7 @@ fn traverse_isa_reverse_unbounded_sorted_type() {
     // add all constraints to make type inference return correct types, though we only plan Has's
     let isa = conjunction.constraints_mut().add_isa(IsaKind::Subtype, var_dog, var_dog_type.into()).unwrap().clone();
     conjunction.constraints_mut().add_label(var_dog_type, DOG_LABEL.clone()).unwrap();
-    let entry = builder.finish();
+    let entry = builder.finish().unwrap();
 
     let snapshot = storage.clone().open_snapshot_read();
     let (type_manager, thing_manager) = load_managers(storage.clone(), None);
@@ -542,7 +542,7 @@ fn traverse_isa_reverse_bounded_type_exact() {
         conjunction.constraints_mut().add_isa(IsaKind::Exact, var_thing_from, var_type.into()).unwrap().clone();
     let isa_to_thing =
         conjunction.constraints_mut().add_isa(IsaKind::Exact, var_thing_to, var_type.into()).unwrap().clone();
-    let entry = builder.finish();
+    let entry = builder.finish().unwrap();
 
     let snapshot = storage.clone().open_snapshot_read();
     let (type_manager, thing_manager) = load_managers(storage.clone(), None);
@@ -647,7 +647,7 @@ fn traverse_isa_reverse_bounded_type_subtype() {
         conjunction.constraints_mut().add_isa(IsaKind::Subtype, var_thing_from, var_type.into()).unwrap().clone();
     let isa_to_thing =
         conjunction.constraints_mut().add_isa(IsaKind::Subtype, var_thing_to, var_type.into()).unwrap().clone();
-    let entry = builder.finish();
+    let entry = builder.finish().unwrap();
 
     let snapshot = storage.clone().open_snapshot_read();
     let (type_manager, thing_manager) = load_managers(storage.clone(), None);
@@ -749,7 +749,7 @@ fn traverse_isa_reverse_fixed_type_exact() {
     // add all constraints to make type inference return correct types, though we only plan Has's
     let isa =
         conjunction.constraints_mut().add_isa(IsaKind::Exact, var_thing, Vertex::Label(ANIMAL_LABEL)).unwrap().clone();
-    let entry = builder.finish();
+    let entry = builder.finish().unwrap();
 
     let snapshot = storage.clone().open_snapshot_read();
     let (type_manager, thing_manager) = load_managers(storage.clone(), None);
@@ -839,7 +839,7 @@ fn traverse_isa_reverse_fixed_type_subtype() {
         .add_isa(IsaKind::Subtype, var_thing, Vertex::Label(ANIMAL_LABEL))
         .unwrap()
         .clone();
-    let entry = builder.finish();
+    let entry = builder.finish().unwrap();
 
     let snapshot = storage.clone().open_snapshot_read();
     let (type_manager, thing_manager) = load_managers(storage.clone(), None);

--- a/executor/tests/execute_links.rs
+++ b/executor/tests/execute_links.rs
@@ -210,7 +210,7 @@ fn traverse_links_unbounded_sorted_from() {
     conjunction.constraints_mut().add_label(var_membership_member_type, MEMBERSHIP_MEMBER_LABEL.clone()).unwrap();
     conjunction.constraints_mut().add_label(var_membership_group_type, MEMBERSHIP_GROUP_LABEL.clone()).unwrap();
 
-    let entry = builder.finish();
+    let entry = builder.finish().unwrap();
     let snapshot = storage.clone().open_snapshot_read();
     let (type_manager, thing_manager) = load_managers(storage.clone(), None);
     let variable_registry = &translation_context.variable_registry;
@@ -328,7 +328,7 @@ fn traverse_links_unbounded_sorted_to() {
     conjunction.constraints_mut().add_label(var_membership_type, MEMBERSHIP_LABEL.clone()).unwrap();
     conjunction.constraints_mut().add_label(var_membership_member_type, MEMBERSHIP_MEMBER_LABEL.clone()).unwrap();
 
-    let entry = builder.finish();
+    let entry = builder.finish().unwrap();
     let snapshot = storage.clone().open_snapshot_read();
     let (type_manager, thing_manager) = load_managers(storage.clone(), None);
     let variable_registry = &translation_context.variable_registry;
@@ -435,7 +435,7 @@ fn traverse_links_bounded_relation() {
     conjunction.constraints_mut().add_label(var_membership_type, MEMBERSHIP_LABEL.clone()).unwrap();
     conjunction.constraints_mut().add_label(var_membership_member_type, MEMBERSHIP_MEMBER_LABEL.clone()).unwrap();
 
-    let entry = builder.finish();
+    let entry = builder.finish().unwrap();
 
     let snapshot = storage.clone().open_snapshot_read();
     let (type_manager, thing_manager) = load_managers(storage.clone(), None);
@@ -556,7 +556,7 @@ fn traverse_links_bounded_relation_player() {
     conjunction.constraints_mut().add_label(var_membership_type, MEMBERSHIP_LABEL.clone()).unwrap();
     conjunction.constraints_mut().add_label(var_membership_member_type, MEMBERSHIP_MEMBER_LABEL.clone()).unwrap();
 
-    let entry = builder.finish();
+    let entry = builder.finish().unwrap();
 
     let snapshot = storage.clone().open_snapshot_read();
     let (type_manager, thing_manager) = load_managers(storage.clone(), None);
@@ -684,7 +684,7 @@ fn traverse_links_reverse_unbounded_sorted_from() {
     conjunction.constraints_mut().add_label(var_membership_type, MEMBERSHIP_LABEL.clone()).unwrap();
     conjunction.constraints_mut().add_label(var_membership_member_type, MEMBERSHIP_MEMBER_LABEL.clone()).unwrap();
 
-    let entry = builder.finish();
+    let entry = builder.finish().unwrap();
 
     let snapshot = Arc::new(storage.clone().open_snapshot_read());
     let (type_manager, thing_manager) = load_managers(storage.clone(), None);
@@ -789,7 +789,7 @@ fn traverse_links_reverse_unbounded_sorted_to() {
     conjunction.constraints_mut().add_label(var_membership_type, MEMBERSHIP_LABEL.clone()).unwrap();
     conjunction.constraints_mut().add_label(var_membership_member_type, MEMBERSHIP_MEMBER_LABEL.clone()).unwrap();
 
-    let entry = builder.finish();
+    let entry = builder.finish().unwrap();
 
     let snapshot = Arc::new(storage.clone().open_snapshot_read());
     let (type_manager, thing_manager) = load_managers(storage.clone(), None);
@@ -895,7 +895,7 @@ fn traverse_links_reverse_bounded_player() {
     conjunction.constraints_mut().add_label(var_membership_type, MEMBERSHIP_LABEL.clone()).unwrap();
     conjunction.constraints_mut().add_label(var_membership_member_type, MEMBERSHIP_MEMBER_LABEL.clone()).unwrap();
 
-    let entry = builder.finish();
+    let entry = builder.finish().unwrap();
 
     let snapshot = storage.clone().open_snapshot_read();
     let (type_manager, thing_manager) = load_managers(storage.clone(), None);
@@ -1016,7 +1016,7 @@ fn traverse_links_reverse_bounded_player_relation() {
     conjunction.constraints_mut().add_label(var_membership_type, MEMBERSHIP_LABEL.clone()).unwrap();
     conjunction.constraints_mut().add_label(var_membership_member_type, MEMBERSHIP_MEMBER_LABEL.clone()).unwrap();
 
-    let entry = builder.finish();
+    let entry = builder.finish().unwrap();
 
     let snapshot = storage.clone().open_snapshot_read();
     let (type_manager, thing_manager) = load_managers(storage.clone(), None);

--- a/executor/tests/execute_select.rs
+++ b/executor/tests/execute_select.rs
@@ -163,7 +163,7 @@ fn anonymous_vars_not_enumerated_or_counted() {
     conjunction.constraints_mut().add_isa(IsaKind::Subtype, var_person, var_person_type.into()).unwrap();
     conjunction.constraints_mut().add_isa(IsaKind::Subtype, var_attribute, var_attribute_type.into()).unwrap();
     conjunction.constraints_mut().add_label(var_person_type, PERSON_LABEL.clone()).unwrap();
-    let entry = builder.finish();
+    let entry = builder.finish().unwrap();
 
     let entry_annotations = {
         let snapshot: ReadSnapshot<WALClient> = storage.clone().open_snapshot_read();
@@ -263,7 +263,7 @@ fn unselected_named_vars_counted() {
     conjunction.constraints_mut().add_isa(IsaKind::Subtype, var_person, var_person_type.into()).unwrap();
     conjunction.constraints_mut().add_isa(IsaKind::Subtype, var_attribute, var_attribute_type.into()).unwrap();
     conjunction.constraints_mut().add_label(var_person_type, PERSON_LABEL.clone()).unwrap();
-    let entry = builder.finish();
+    let entry = builder.finish().unwrap();
 
     let entry_annotations = {
         let snapshot: ReadSnapshot<WALClient> = storage.clone().open_snapshot_read();
@@ -375,7 +375,7 @@ fn cartesian_named_counted_checked() {
     conjunction.constraints_mut().add_label(var_name_type, NAME_LABEL.clone()).unwrap();
     conjunction.constraints_mut().add_label(var_age_type, AGE_LABEL.clone()).unwrap();
     conjunction.constraints_mut().add_label(var_email_type, EMAIL_LABEL.clone()).unwrap();
-    let entry = builder.finish();
+    let entry = builder.finish().unwrap();
 
     let entry_annotations = {
         let snapshot: ReadSnapshot<WALClient> = storage.clone().open_snapshot_read();

--- a/executor/tests/writes.rs
+++ b/executor/tests/writes.rs
@@ -229,7 +229,8 @@ fn execute_delete<Snapshot: WritableSnapshot + 'static>(
             &typeql_match,
         )
         .unwrap()
-        .finish();
+        .finish()
+        .unwrap();
         let variable_registry = &translation_context.variable_registry;
         let previous_stage_variable_annotations = &BTreeMap::new();
         let annotated_schema_functions = &IndexedAnnotatedFunctions::empty();

--- a/ir/lib.rs
+++ b/ir/lib.rs
@@ -169,6 +169,11 @@ typedb_error!(
             "Fetch clauses must be the final clause in a query pipeline.\nSource:\n{declaration}",
             declaration: typeql::query::stage::Stage
         ),
+        UnboundVariable(
+            25,
+            "Invalid query containing unbound concept variable {variable}",
+            variable: String
+        ),
     }
 );
 

--- a/ir/pattern/constraint.rs
+++ b/ir/pattern/constraint.rs
@@ -310,8 +310,12 @@ impl<'cx, 'reg> ConstraintsBuilder<'cx, 'reg> {
         debug_assert!(self.context.is_variable_available(self.constraints.scope, variable));
         let binding = ExpressionBinding::new(variable, expression);
         binding.validate(self.context).map_err(|source| RepresentationError::ExpressionDefinitionError { source })?;
-        // WARNING: we can't set a variable category here, since we don't know if the expression will produce a
-        //          Value, a ValueList, or a ThingList! We will know this at compilation time
+
+        let binding = Constraint::from(binding);
+        // WARNING: we don't know if the expression will produce a Value, a ValueList, or a ThingList! We will know this at compilation time
+        // assume Value for now
+        self.context.set_variable_category(variable, VariableCategory::Value, binding.clone())?;
+
         let as_ref = self.constraints.add_constraint(binding);
         Ok(as_ref.as_expression_binding().unwrap())
     }

--- a/ir/pipeline/mod.rs
+++ b/ir/pipeline/mod.rs
@@ -191,8 +191,8 @@ impl VariableRegistry {
         &self.variable_names
     }
 
-    pub fn get_variable_name(&self, variable: &Variable) -> Option<&String> {
-        self.variable_names.get(variable)
+    pub fn get_variable_name(&self, variable: Variable) -> Option<&String> {
+        self.variable_names.get(&variable)
     }
 
     pub fn get_variable_category(&self, variable: Variable) -> Option<VariableCategory> {

--- a/ir/tests/pattern.rs
+++ b/ir/tests/pattern.rs
@@ -23,7 +23,11 @@ fn build_conjunction_constraints() {
     eprintln!("{:#}\n", match_); // TODO
     eprintln!(
         "{}\n",
-        translate_match(&mut TranslationContext::new(), &empty_function_index, match_).unwrap().finish().conjunction()
+        translate_match(&mut TranslationContext::new(), &empty_function_index, match_)
+            .unwrap()
+            .finish()
+            .unwrap()
+            .conjunction()
     );
 
     let query = "match
@@ -38,7 +42,11 @@ fn build_conjunction_constraints() {
     eprintln!("{:#}\n", match_); // TODO
     eprintln!(
         "{}\n",
-        translate_match(&mut TranslationContext::new(), &empty_function_index, match_).unwrap().finish().conjunction()
+        translate_match(&mut TranslationContext::new(), &empty_function_index, match_)
+            .unwrap()
+            .finish()
+            .unwrap()
+            .conjunction()
     );
 
     let query = "match
@@ -55,7 +63,11 @@ fn build_conjunction_constraints() {
     eprintln!("{:#}\n", match_); // TODO
     eprintln!(
         "{}\n",
-        translate_match(&mut TranslationContext::new(), &empty_function_index, match_).unwrap().finish().conjunction()
+        translate_match(&mut TranslationContext::new(), &empty_function_index, match_)
+            .unwrap()
+            .finish()
+            .unwrap()
+            .conjunction()
     );
 
     // let mut block = FunctionalBlock::new();
@@ -120,7 +132,10 @@ fn variable_category_narrowing() {
     eprintln!("{}\n", match_); // TODO
     eprintln!("{:#}\n", match_); // TODO
     let mut context = TranslationContext::new();
-    eprintln!("{}\n", translate_match(&mut context, &empty_function_index, match_).unwrap().finish().conjunction());
+    eprintln!(
+        "{}\n",
+        translate_match(&mut context, &empty_function_index, match_).unwrap().finish().unwrap().conjunction()
+    );
 
     // let mut block = FunctionalBlock::new();
     // let conjunction = block.conjunction_mut();

--- a/ir/tests/pipeline.rs
+++ b/ir/tests/pipeline.rs
@@ -73,7 +73,7 @@ fn build_with_functions() {
         .constraints_mut()
         .add_function_binding(vec![var_count, var_mean], &function_signature, vec![var_person], "test_fn")
         .unwrap();
-    let block = builder.finish();
+    let block = builder.finish().unwrap();
     println!("{}", block.conjunction());
 
     // TODO: incomplete, since we don't have the called function IR

--- a/ir/translation/constraints.rs
+++ b/ir/translation/constraints.rs
@@ -9,7 +9,8 @@ use encoding::value::label::Label;
 use typeql::{
     expression::{FunctionCall, FunctionName},
     statement::{
-        comparison::ComparisonStatement, thing::AttributeComparisonStatement, Assignment, AssignmentPattern, InIterable,
+        comparison::ComparisonStatement, thing::AttributeComparisonStatement, Assignment, AssignmentPattern,
+        InIterable, Is,
     },
     token::Kind,
     type_::NamedType,
@@ -37,7 +38,11 @@ pub(super) fn add_statement(
 ) -> Result<(), RepresentationError> {
     let constraints = &mut conjunction.constraints_mut();
     match stmt {
-        typeql::Statement::Is(_) => todo!(),
+        typeql::Statement::Is(Is { lhs, rhs, .. }) => {
+            let lhs = register_typeql_var(constraints, lhs)?;
+            let rhs = register_typeql_var(constraints, rhs)?;
+            constraints.add_is(lhs, rhs)?;
+        }
         typeql::Statement::InIterable(InIterable { lhs, rhs, .. }) => {
             let assigned = assignment_typeql_vars_to_variables(constraints, lhs)?;
             add_typeql_iterable_binding(function_index, constraints, assigned, rhs)?

--- a/ir/translation/expression.rs
+++ b/ir/translation/expression.rs
@@ -220,7 +220,7 @@ pub mod tests {
     fn parse_query_get_match(context: &mut TranslationContext, query_str: &str) -> Result<Block, RepresentationError> {
         let mut query = typeql::parse_query(query_str).unwrap().into_pipeline();
         let match_ = query.stages.remove(0).into_match();
-        translate_match(context, &HashMapFunctionSignatureIndex::empty(), &match_).map(|builder| builder.finish())
+        translate_match(context, &HashMapFunctionSignatureIndex::empty(), &match_).and_then(|builder| builder.finish())
     }
 
     #[test]

--- a/ir/translation/literal.rs
+++ b/ir/translation/literal.rs
@@ -263,7 +263,8 @@ pub mod tests {
             typeql::parse_query(query.as_str()).unwrap().into_pipeline().stages.first().unwrap()
         {
             let mut context = TranslationContext::new();
-            let block = translate_match(&mut context, &HashMapFunctionSignatureIndex::empty(), match_)?.finish();
+            let block =
+                translate_match(&mut context, &HashMapFunctionSignatureIndex::empty(), match_)?.finish().unwrap();
             let x = block.conjunction().constraints()[0].as_expression_binding().unwrap().expression().get_root();
             match *x {
                 Expression::Constant(id) => Ok(context.parameters.value_unchecked(id).to_owned()),

--- a/ir/translation/mod.rs
+++ b/ir/translation/mod.rs
@@ -78,7 +78,7 @@ impl TranslationContext {
             is_optional,
             reducer,
         );
-        self.visible_variables.insert(name.to_owned(), variable.clone());
+        self.visible_variables.insert(name.to_owned(), variable);
         variable
     }
 

--- a/ir/translation/pipeline.rs
+++ b/ir/translation/pipeline.rs
@@ -147,7 +147,7 @@ fn translate_stage(
 ) -> Result<Either<TranslatedStage, FetchObject>, RepresentationError> {
     match typeql_stage {
         TypeQLStage::Match(match_) => translate_match(translation_context, all_function_signatures, match_)
-            .map(|builder| Either::First(TranslatedStage::Match { block: builder.finish() })),
+            .and_then(|builder| Ok(Either::First(TranslatedStage::Match { block: builder.finish()? }))),
         TypeQLStage::Insert(insert) => {
             translate_insert(translation_context, insert).map(|block| Either::First(TranslatedStage::Insert { block }))
         }

--- a/ir/translation/writes.rs
+++ b/ir/translation/writes.rs
@@ -25,7 +25,7 @@ pub fn translate_insert(
     for statement in &insert.statements {
         add_statement(&function_index, &mut builder.conjunction_mut(), statement)?;
     }
-    Ok(builder.finish())
+    builder.finish()
 }
 
 pub fn translate_delete(
@@ -53,5 +53,5 @@ pub fn translate_delete(
             }
         }
     }
-    Ok((builder.finish(), deleted_concepts))
+    Ok((builder.finish()?, deleted_concepts))
 }


### PR DESCRIPTION
## Release notes: product changes

We implement the `is` constraint support in queries:

```php
match
    $x isa company;
    $y isa person;
    $z isa person;
    not { $y is $z; };  # <---
    $r1 isa employment, links ($x, $y);
    $r2 isa employment, links ($x, $z);
    select $x, $y, $z;
```

## Motivation

## Implementation
