### PR TITLE
Bugfix: do not reuse cartesian product iterators between inputs

### DIFF
--- a/executor/read/immediate_executor.rs
+++ b/executor/read/immediate_executor.rs
@@ -491,7 +491,7 @@ impl CartesianIterator {
                         let next_value_cmp = iter
                             .advance_until_index_is(iter.first_unbound_index(), source_intersection_value)
                             .map_err(|err| ReadExecutionError::ConceptRead { source: err })?;
-                        debug_assert!(next_value_cmp.is_some() && next_value_cmp.unwrap().is_eq());
+                        debug_assert_eq!(next_value_cmp, Some(std::cmp::Ordering::Equal));
                         iter
                     }
                 };

--- a/executor/read/immediate_executor.rs
+++ b/executor/read/immediate_executor.rs
@@ -242,6 +242,7 @@ impl IntersectionExecutor {
                     return Ok(true);
                 } else {
                     self.iterators.clear();
+                    self.cartesian_iterator.clear();
                     let _ = self.input.as_mut().unwrap().next().unwrap().map_err(|err| err.clone());
                     if self.input.as_mut().unwrap().peek().is_some() {
                         self.may_create_intersection_iterators(context)?;
@@ -453,6 +454,10 @@ impl CartesianIterator {
 
     fn is_active(&self) -> bool {
         self.is_active
+    }
+
+    fn clear(&mut self) {
+        self.iterators.iter_mut().for_each(|iter| drop(iter.take()));
     }
 
     fn activate(


### PR DESCRIPTION
## Release notes: product changes

We can't reuse the iterators created from the previous input row, as they would iterate over different tuples. Now, when we take a new input, we reset the cartesian iterators.

## Motivation

## Implementation
