### PR TITLE
Fix outputs from earlier disjunction branches affecting later branches

### DIFF
--- a/compiler/executable/match_/planner/mod.rs
+++ b/compiler/executable/match_/planner/mod.rs
@@ -59,7 +59,12 @@ pub fn compile(
         expressions,
         statistics,
     )
-    .lower(variable_registry.variable_names().keys().copied(), &assigned_identities, &variable_registry)
+    .lower(
+        variable_registry.variable_names().keys().copied(),
+        &assigned_identities,
+        &input_variables.keys().copied().collect(),
+        &variable_registry,
+    )
     .finish(variable_registry)
 }
 
@@ -252,9 +257,13 @@ struct MatchExecutableBuilder {
 }
 
 impl MatchExecutableBuilder {
-    fn new(assigned_positions: &HashMap<Variable, ExecutorVariable>, selected_variables: Vec<Variable>) -> Self {
+    fn new(
+        assigned_positions: &HashMap<Variable, ExecutorVariable>,
+        selected_variables: Vec<Variable>,
+        input_variables: &Vec<Variable>,
+    ) -> Self {
         let index = assigned_positions.clone();
-        let current_outputs = index.keys().copied().collect();
+        let current_outputs = input_variables.clone();
         let reverse_index = index.iter().map(|(&var, &pos)| (pos, var)).collect();
         let next_position = assigned_positions
             .values()

--- a/compiler/executable/match_/planner/plan.rs
+++ b/compiler/executable/match_/planner/plan.rs
@@ -836,7 +836,7 @@ impl ConjunctionPlan<'_> {
                 let negation = negation.plan().lower(
                     match_builder.current_outputs.iter().copied(),
                     match_builder.position_mapping(),
-                    &match_builder.current_outputs,
+                    &match_builder.position_mapping().keys().copied().collect(),
                     variable_registry,
                 );
                 let variable_positions = negation.index.clone(); // FIXME needless clone

--- a/compiler/executable/match_/planner/plan.rs
+++ b/compiler/executable/match_/planner/plan.rs
@@ -1148,7 +1148,7 @@ impl<'a> DisjunctionPlanBuilder<'a> {
         let branches =
             self.branches.into_iter().map(|branch| branch.with_inputs(input_variables.clone()).plan()).collect_vec();
         let cost = branches.iter().map(ConjunctionPlan::cost).fold(ElementCost::EMPTY, ElementCost::combine_parallel);
-        dbg!(DisjunctionPlan { branches, _cost: cost })
+        DisjunctionPlan { branches, _cost: cost }
     }
 }
 


### PR DESCRIPTION
## Release notes: product changes
Fixes outputs from earlier disjunction branches affecting later branches

## Motivation

## Implementation
Disjunctions can't just re-use `assigned_positions` as input variables. `MatchExecutableBuilder` now takes an explicit input_variables argument to support this.
