### PR TITLE
Ensure sorted join executor respects selected outputs

### DIFF
--- a/executor/lib.rs
+++ b/executor/lib.rs
@@ -29,6 +29,7 @@ pub mod write;
 
 // TODO: use a bit-vec, since we have a continuously allocated range of positions
 // ---> for now, using a byte vec, which is 8x wasteful and on the heap!
+#[derive(Clone, Debug)]
 pub(crate) struct SelectedPositions {
     selected: Vec<VariablePosition>,
 }

--- a/executor/lib.rs
+++ b/executor/lib.rs
@@ -29,7 +29,7 @@ pub mod write;
 
 // TODO: use a bit-vec, since we have a continuously allocated range of positions
 // ---> for now, using a byte vec, which is 8x wasteful and on the heap!
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 pub(crate) struct SelectedPositions {
     selected: Vec<VariablePosition>,
 }

--- a/executor/read/step_executor.rs
+++ b/executor/read/step_executor.rs
@@ -4,7 +4,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-use std::{collections::HashSet, sync::Arc};
+use std::sync::Arc;
 
 use compiler::{
     executable::{


### PR DESCRIPTION
## Release notes: product changes

Before this change, an intersection executor (which is used for any number of sorted iterators, not necessarily a join) would write into the output row all items in the constituent executors, so long as they have a row position assigned. That would happen even if those values were not selected for future steps, which prevented deduplication of answers from being handled correctly.

## Motivation

## Implementation
