### PR TITLE
Introduce naive retries for suspended function calls

### DIFF
--- a/executor/match_executor.rs
+++ b/executor/match_executor.rs
@@ -18,7 +18,7 @@ use crate::{
     error::ReadExecutionError,
     pipeline::stage::ExecutionContext,
     read::{
-        pattern_executor::PatternExecutor, tabled_functions::TabledFunctions, SuspendPoint,
+        pattern_executor::PatternExecutor, tabled_functions::TabledFunctions, QueryPatternSuspensions,
         TODO_REMOVE_create_executors_for_match,
     },
     row::MaybeOwnedRow,
@@ -29,7 +29,8 @@ pub struct MatchExecutor {
     entry: PatternExecutor,
     input: Option<MaybeOwnedRow<'static>>,
     tabled_functions: TabledFunctions,
-    suspend_points: Vec<SuspendPoint>,
+    suspensions: QueryPatternSuspensions,
+    last_seen_table_size: usize,
 }
 
 impl MatchExecutor {
@@ -49,7 +50,8 @@ impl MatchExecutor {
             )?,
             tabled_functions: TabledFunctions::new(function_registry),
             input: Some(input.into_owned()),
-            suspend_points: Vec::new(),
+            suspensions: QueryPatternSuspensions::new(),
+            last_seen_table_size: 0,
         })
     }
 
@@ -70,12 +72,36 @@ impl MatchExecutor {
     ) -> Result<Option<FixedBatch>, Box<ReadExecutionError>> {
         if let Some(input) = self.input.take() {
             self.entry.prepare(FixedBatch::from(input.into_owned()));
+            self.last_seen_table_size = 0;
         }
         let batch =
-            self.entry.compute_next_batch(context, interrupt, &mut self.tabled_functions, &mut self.suspend_points)?;
-        if batch.is_none() && !self.suspend_points.is_empty() {
-            self.suspend_points.clear(); // I had an infinite collection, so I don't want to risk it.
-            Err(Box::new(ReadExecutionError::UnimplementedCyclicFunctions {}))
+            self.entry.compute_next_batch(context, interrupt, &mut self.tabled_functions, &mut self.suspensions)?;
+        debug_assert!(self.suspensions.current_depth() == 0);
+        if batch.is_none() && !self.suspensions.is_empty() {
+            let mut return_batch = batch;
+            // TODO: We do it all the restoring here, but we should probably be doing it elsewhere. Maybe pattern_executor::execute_tabled_call
+            //  when the function returns None, AND it's possibly the head of a cycle.
+            while return_batch.is_none() && !self.suspensions.is_empty() {
+                self.last_seen_table_size = self.tabled_functions.total_table_size();
+                for function_state in self.tabled_functions.iterate_states() {
+                    let mut guard = function_state.executor_state.try_lock().unwrap();
+                    guard.prepare_to_retry_suspended();
+                }
+                // And on the entry
+                self.suspensions.prepare_restoring_from_suspending();
+                self.entry.prepare_to_restore_from_suspension(0);
+
+                return_batch = self.entry.compute_next_batch(
+                    context,
+                    interrupt,
+                    &mut self.tabled_functions,
+                    &mut self.suspensions,
+                )?;
+                if return_batch.is_none() && self.last_seen_table_size == self.tabled_functions.total_table_size() {
+                    return Ok(None);
+                }
+            }
+            Ok(return_batch)
         } else {
             Ok(batch)
         }

--- a/executor/read/control_instruction.rs
+++ b/executor/read/control_instruction.rs
@@ -22,6 +22,10 @@ pub(super) struct PatternStart {
     pub(super) input_batch: FixedBatch,
 }
 
+pub(super) struct RestoreSuspension {
+    pub(super) depth: usize,
+}
+
 pub(super) struct ExecuteImmediate {
     pub(super) index: ExecutorIndex,
 }
@@ -78,6 +82,7 @@ pub(super) struct Yield {
 
 pub(super) enum ControlInstruction {
     PatternStart(PatternStart),
+    RestoreSuspension(RestoreSuspension),
 
     ExecuteImmediate(ExecuteImmediate),
 

--- a/executor/read/control_instruction.rs
+++ b/executor/read/control_instruction.rs
@@ -4,10 +4,6 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-use std::sync::Arc;
-
-use ir::pipeline::ParameterRegistry;
-
 use crate::{
     batch::{FixedBatch, FixedBatchRowIterator},
     read::{
@@ -43,7 +39,6 @@ pub(super) struct ExecuteStreamModifier {
 
 pub(super) struct ExecuteInlinedFunction {
     pub(super) index: ExecutorIndex,
-    pub(super) parameters_override: Arc<ParameterRegistry>, // TODO: Get this straight from the executor?
     pub(super) input: MaybeOwnedRow<'static>,
 }
 

--- a/executor/read/mod.rs
+++ b/executor/read/mod.rs
@@ -17,6 +17,7 @@ use crate::{
     read::{
         pattern_executor::{BranchIndex, ExecutorIndex, PatternExecutor},
         step_executor::create_executors_for_pipeline_stages,
+        tabled_call_executor::TabledCallExecutor,
         tabled_functions::TableIndex,
     },
     row::MaybeOwnedRow,
@@ -61,35 +62,105 @@ pub(super) fn create_executors_for_pipeline(
     Ok(PatternExecutor::new(executors))
 }
 
-pub(crate) enum SuspendPoint {
-    TabledCall(TabledCallSuspension),
-    Nested(NestedSuspension),
+#[derive(Debug)]
+pub(crate) enum PatternSuspension {
+    AtTabledCall(TabledCallSuspension),
+    AtNestedPattern(NestedPatternSuspension),
 }
 
-impl SuspendPoint {
-    fn new_tabled_call(
-        executor_index: ExecutorIndex,
-        next_table_row: TableIndex,
-        input_row: MaybeOwnedRow<'static>,
-    ) -> Self {
-        Self::TabledCall(TabledCallSuspension { executor_index, next_table_row, input_row })
-    }
-
-    fn new_nested(executor_index: ExecutorIndex, branch_index: BranchIndex, input_row: MaybeOwnedRow<'static>) -> Self {
-        Self::Nested(NestedSuspension { executor_index, branch_index, input_row })
+impl PatternSuspension {
+    fn depth(&self) -> usize {
+        match self {
+            PatternSuspension::AtTabledCall(tabled_call) => tabled_call.depth,
+            PatternSuspension::AtNestedPattern(nested) => nested.depth,
+        }
     }
 }
 
 #[derive(Debug)]
 pub(super) struct TabledCallSuspension {
     pub(crate) executor_index: ExecutorIndex,
+    pub(crate) depth: usize,
     pub(crate) input_row: MaybeOwnedRow<'static>,
     pub(crate) next_table_row: TableIndex,
 }
 
 #[derive(Debug)]
-pub(super) struct NestedSuspension {
+pub(super) struct NestedPatternSuspension {
     pub(crate) executor_index: ExecutorIndex,
+    pub(crate) depth: usize,
     pub(crate) branch_index: BranchIndex,
     pub(crate) input_row: MaybeOwnedRow<'static>,
+}
+
+#[derive(Debug)]
+pub(super) struct QueryPatternSuspensions {
+    current_depth: usize,
+    suspending_patterns_tree: Vec<PatternSuspension>,
+    restoring_patterns_tree: Vec<PatternSuspension>, //Peekable<std::vec::IntoIter<SuspendPoint>>,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+struct SuspensionCount(usize);
+
+impl QueryPatternSuspensions {
+    pub(crate) fn new() -> Self {
+        Self { current_depth: 0, suspending_patterns_tree: Vec::new(), restoring_patterns_tree: Vec::new() }
+    }
+
+    pub(super) fn prepare_restoring_from_suspending(&mut self) {
+        debug_assert!(self.restoring_patterns_tree.is_empty());
+        self.restoring_patterns_tree.clear();
+        std::mem::swap(&mut self.restoring_patterns_tree, &mut self.suspending_patterns_tree);
+    }
+
+    pub(crate) fn is_empty(&self) -> bool {
+        self.suspending_patterns_tree.is_empty()
+    }
+
+    pub(crate) fn current_depth(&self) -> usize {
+        self.current_depth
+    }
+
+    fn record_nested_pattern_entry(&mut self) -> SuspensionCount {
+        self.current_depth += 1;
+        SuspensionCount(self.suspending_patterns_tree.len())
+    }
+
+    fn record_nested_pattern_exit(&mut self) -> SuspensionCount {
+        self.current_depth -= 1;
+        SuspensionCount(self.suspending_patterns_tree.len())
+    }
+
+    fn push_nested(
+        &mut self,
+        executor_index: ExecutorIndex,
+        branch_index: BranchIndex,
+        input_row: MaybeOwnedRow<'static>,
+    ) {
+        self.suspending_patterns_tree.push(PatternSuspension::AtNestedPattern(NestedPatternSuspension {
+            depth: self.current_depth,
+            executor_index,
+            branch_index,
+            input_row,
+        }))
+    }
+
+    fn push_tabled_call(&mut self, executor_index: ExecutorIndex, tabled_call_executor: &TabledCallExecutor) {
+        self.suspending_patterns_tree
+            .push(tabled_call_executor.create_suspension_at(executor_index, self.current_depth))
+    }
+
+    fn next_restore_point_at_current_depth(&mut self) -> Option<PatternSuspension> {
+        let has_next = if let Some(point) = self.restoring_patterns_tree.last() {
+            point.depth() == self.current_depth
+        } else {
+            false
+        };
+        if has_next {
+            self.restoring_patterns_tree.pop()
+        } else {
+            None
+        }
+    }
 }

--- a/executor/read/pattern_executor.rs
+++ b/executor/read/pattern_executor.rs
@@ -18,7 +18,7 @@ use crate::{
         control_instruction::{
             CollectingStage, ControlInstruction, ExecuteDisjunction, ExecuteImmediate, ExecuteInlinedFunction,
             ExecuteNegation, ExecuteStreamModifier, MapRowBatchToRowForNested, PatternStart, ReshapeForReturn,
-            StreamCollected, TabledCall, Yield,
+            RestoreSuspension, StreamCollected, TabledCall, Yield,
         },
         nested_pattern_executor::{Disjunction, InlinedFunction, Negation, NestedPatternExecutor},
         step_executor::StepExecutors,
@@ -27,7 +27,7 @@ use crate::{
         },
         tabled_call_executor::TabledCallResult,
         tabled_functions::{TabledFunctionPatternExecutorState, TabledFunctions},
-        SuspendPoint,
+        NestedPatternSuspension, PatternSuspension, QueryPatternSuspensions, TabledCallSuspension,
     },
     row::MaybeOwnedRow,
     ExecutionInterrupt,
@@ -55,14 +55,22 @@ impl PatternExecutor {
         PatternExecutor { executors, control_stack: Vec::new() }
     }
 
+    pub(crate) fn has_empty_control_stack(&self) -> bool {
+        self.control_stack.is_empty()
+    }
+
     pub(crate) fn compute_next_batch(
         &mut self,
         context: &ExecutionContext<impl ReadableSnapshot + 'static>,
         interrupt: &mut ExecutionInterrupt,
         tabled_functions: &mut TabledFunctions,
-        suspend_points: &mut Vec<SuspendPoint>,
+        suspensions: &mut QueryPatternSuspensions,
     ) -> Result<Option<FixedBatch>, ReadExecutionError> {
-        self.batch_continue(context, interrupt, tabled_functions, suspend_points)
+        let _suspension_count_before = suspensions.record_nested_pattern_entry();
+        let result = self.batch_continue(context, interrupt, tabled_functions, suspensions);
+        let _suspension_count_after = suspensions.record_nested_pattern_exit();
+        // debug_assert!(state_after == state_before); // TODO: Enable once we figure out retries at the calls. // As long as compute_next_batch is only called for the entry.
+        result
     }
 
     pub(crate) fn prepare(&mut self, input_batch: FixedBatch) {
@@ -71,7 +79,13 @@ impl PatternExecutor {
         self.control_stack.push(ControlInstruction::PatternStart(PatternStart { input_batch }));
     }
 
-    pub(super) fn reset(&mut self) {
+    pub(crate) fn prepare_to_restore_from_suspension(&mut self, depth: usize) {
+        debug_assert!(self.control_stack.is_empty());
+        self.reset();
+        self.control_stack.push(ControlInstruction::RestoreSuspension(RestoreSuspension { depth: depth + 1 }));
+    }
+
+    pub(crate) fn reset(&mut self) {
         self.control_stack.clear();
     }
 
@@ -80,8 +94,11 @@ impl PatternExecutor {
         context: &ExecutionContext<impl ReadableSnapshot + 'static>,
         interrupt: &mut ExecutionInterrupt,
         tabled_functions: &mut TabledFunctions,
-        suspend_point_accumulator: &mut Vec<SuspendPoint>,
+        suspensions: &mut QueryPatternSuspensions,
     ) -> Result<Option<FixedBatch>, ReadExecutionError> {
+        // TODO: In debug mode, this function has a frame of ~60k, causing an overflow at ~10 frames
+        //  In release mode, the frame is ~10x smaller, allowing ~100 frames.
+        //  We could switch to iteration & handle the stack ourselves: StackFrame { pattern_executor, return_address }
         // debug_assert!(self.control_stack.len() > 0);
         while self.control_stack.last().is_some() {
             let Self { control_stack, executors } = self;
@@ -93,6 +110,71 @@ impl PatternExecutor {
             match control_stack.pop().unwrap() {
                 ControlInstruction::PatternStart(PatternStart { input_batch }) => {
                     self.push_next_instruction(context, ExecutorIndex(0), input_batch)?;
+                }
+                ControlInstruction::RestoreSuspension(RestoreSuspension { depth }) => {
+                    debug_assert!(depth == suspensions.current_depth()); // Smell. The depth in the step is redundant
+                    if let Some(point) = suspensions.next_restore_point_at_current_depth() {
+                        control_stack.push(ControlInstruction::RestoreSuspension(RestoreSuspension { depth }));
+                        match point {
+                            PatternSuspension::AtTabledCall(suspended_call) => {
+                                let TabledCallSuspension { executor_index, next_table_row, input_row, .. } =
+                                    suspended_call;
+                                let executor = executors[executor_index.0].unwrap_tabled_call();
+                                executor.restore_from_suspension(input_row, next_table_row);
+                                control_stack
+                                    .push(ControlInstruction::ExecuteTabledCall(TabledCall { index: executor_index }))
+                            }
+                            PatternSuspension::AtNestedPattern(suspended_nested) => {
+                                let NestedPatternSuspension { executor_index, input_row, branch_index, depth } =
+                                    suspended_nested;
+                                if let StepExecutors::Nested(nested) = &mut executors[executor_index.0] {
+                                    match nested {
+                                        NestedPatternExecutor::Negation(_) => {
+                                            unreachable!("Stratification must have been violated")
+                                        }
+                                        NestedPatternExecutor::Disjunction(disjunction) => {
+                                            disjunction.branches[branch_index.0]
+                                                .prepare_to_restore_from_suspension(depth);
+                                            control_stack.push(ControlInstruction::ExecuteDisjunction(
+                                                ExecuteDisjunction {
+                                                    index: executor_index,
+                                                    branch_index,
+                                                    input: input_row.into_owned(),
+                                                },
+                                            ))
+                                        }
+                                        NestedPatternExecutor::InlinedFunction(inlined) => {
+                                            inlined.inner.prepare_to_restore_from_suspension(depth);
+                                            control_stack.push(ControlInstruction::ExecuteInlinedFunction(
+                                                ExecuteInlinedFunction {
+                                                    index: executor_index,
+                                                    input: input_row.into_owned(),
+                                                    parameters_override: inlined.parameter_registry.clone(),
+                                                },
+                                            ))
+                                        }
+                                    }
+                                } else if let StepExecutors::StreamModifier(StreamModifierExecutor::Distinct {
+                                    inner,
+                                    output_width,
+                                }) = &mut executors[executor_index.0]
+                                {
+                                    inner.prepare_to_restore_from_suspension(depth);
+                                    control_stack.push(ControlInstruction::ExecuteStreamModifier(
+                                        ExecuteStreamModifier {
+                                            index: executor_index,
+                                            mapper: StreamModifierResultMapper::Distinct(DistinctMapper::new(
+                                                *output_width,
+                                            )),
+                                            input: input_row.into_owned(),
+                                        },
+                                    ))
+                                } else {
+                                    todo!("Any other modifier should be illegal")
+                                }
+                            }
+                        }
+                    }
                 }
                 ControlInstruction::ExecuteImmediate(ExecuteImmediate { index }) => {
                     let executor = executors[index.0].unwrap_immediate();
@@ -115,20 +197,31 @@ impl PatternExecutor {
                     else {
                         unreachable!();
                     };
-                    let mut fresh_suspend_points = Vec::new();
-                    match inner.batch_continue(context, interrupt, tabled_functions, &mut fresh_suspend_points)? {
+                    let mut negation_suspensions = QueryPatternSuspensions::new();
+                    negation_suspensions.record_nested_pattern_entry();
+                    match inner.batch_continue(context, interrupt, tabled_functions, &mut negation_suspensions)? {
                         None => {
                             self.push_next_instruction(context, index.next(), FixedBatch::from(input.as_reference()))?
                         }
                         Some(_) => inner.reset(), // fail
                     };
-                    if !fresh_suspend_points.is_empty() {
-                        // TODO: This goes away because we can always retry here.
-                        suspend_point_accumulator.push(SuspendPoint::new_nested(
-                            index,
-                            BranchIndex(0),
-                            input.clone().into_owned(),
-                        ));
+                    negation_suspensions.record_nested_pattern_exit();
+                    if !negation_suspensions.is_empty() {
+                        // todo!("A negated pattern encountered a cycle (lasso). Retries aren't done at the right place yet. - The results may be unsound.")
+                        for function_state in tabled_functions.iterate_states() {
+                            let mut guard = function_state.executor_state.try_lock().unwrap();
+                            if guard.pattern_executor.has_empty_control_stack() {
+                                guard.prepare_to_retry_suspended();
+                            }
+                            negation_suspensions.prepare_restoring_from_suspending();
+                            // Re-borrow inner to keep borrow-checker happy.
+                            let StepExecutors::Nested(NestedPatternExecutor::Negation(Negation { inner })) =
+                                &mut self.executors[index.0]
+                            else {
+                                unreachable!();
+                            };
+                            inner.prepare_to_restore_from_suspension(0);
+                        }
                     }
                 }
                 ControlInstruction::ExecuteDisjunction(ExecuteDisjunction { index, branch_index, input }) => {
@@ -137,11 +230,10 @@ impl PatternExecutor {
                         unreachable!();
                     };
                     let branch = &mut disjunction.branches[branch_index.0];
-                    let suspend_point_len_before = suspend_point_accumulator.len();
-                    let batch_opt =
-                        branch.batch_continue(context, interrupt, tabled_functions, suspend_point_accumulator)?;
-                    if suspend_point_accumulator.len() != suspend_point_len_before {
-                        suspend_point_accumulator.push(SuspendPoint::new_nested(index, branch_index, input.clone()))
+                    let suspension_count_before = suspensions.record_nested_pattern_entry();
+                    let batch_opt = branch.batch_continue(&context, interrupt, tabled_functions, suspensions)?;
+                    if suspensions.record_nested_pattern_exit() != suspension_count_before {
+                        suspensions.push_nested(index, branch_index, input.clone());
                     }
                     if let Some(unmapped) = batch_opt {
                         let mapped = disjunction.map_output(unmapped);
@@ -162,15 +254,15 @@ impl PatternExecutor {
                     else {
                         unreachable!();
                     };
-                    let suspend_point_len_before = suspend_point_accumulator.len();
+                    let suspension_count_before = suspensions.record_nested_pattern_entry();
                     let unmapped_opt = executor.inner.batch_continue(
                         &context.clone_with_replaced_parameters(parameters_override.clone()),
                         interrupt,
                         tabled_functions,
-                        suspend_point_accumulator,
+                        suspensions,
                     )?;
-                    if suspend_point_accumulator.len() != suspend_point_len_before {
-                        suspend_point_accumulator.push(SuspendPoint::new_nested(index, BranchIndex(0), input.clone()))
+                    if suspensions.record_nested_pattern_exit() != suspension_count_before {
+                        suspensions.push_nested(index, BranchIndex(0), input.clone());
                     }
                     if let Some(unmapped) = unmapped_opt {
                         let mapped = executor.map_output(input.as_reference(), unmapped);
@@ -184,11 +276,10 @@ impl PatternExecutor {
                 }
                 ControlInstruction::ExecuteStreamModifier(ExecuteStreamModifier { index, mut mapper, input }) => {
                     let inner = &mut executors[index.0].unwrap_stream_modifier().get_inner();
-                    let suspend_point_len_before = suspend_point_accumulator.len();
-                    let unmapped =
-                        inner.batch_continue(context, interrupt, tabled_functions, suspend_point_accumulator)?;
-                    if suspend_point_accumulator.len() != suspend_point_len_before {
-                        suspend_point_accumulator.push(SuspendPoint::new_nested(index, BranchIndex(0), input.clone()))
+                    let suspension_count_before = suspensions.record_nested_pattern_entry();
+                    let unmapped = inner.batch_continue(&context, interrupt, tabled_functions, suspensions)?;
+                    if suspensions.record_nested_pattern_exit() != suspension_count_before {
+                        suspensions.push_nested(index, BranchIndex(0), input.clone());
                     }
                     let (must_retry, mapped) = mapper.map_output(unmapped).into_parts();
                     if must_retry {
@@ -205,12 +296,11 @@ impl PatternExecutor {
                     }
                 }
                 ControlInstruction::ExecuteTabledCall(TabledCall { index }) => {
-                    self.execute_tabled_call(context, interrupt, tabled_functions, suspend_point_accumulator, index)?;
+                    self.execute_tabled_call(context, interrupt, tabled_functions, suspensions, index)?;
                 }
                 ControlInstruction::CollectingStage(CollectingStage { index }) => {
-                    let (pattern, collector) = executors[index.0].unwrap_collecting_stage().to_parts_mut();
-                    // Distinct isn't a collecting stage. We should use fresh suspend_point_accumulators here.
-                    match pattern.batch_continue(context, interrupt, tabled_functions, suspend_point_accumulator)? {
+                    let (pattern, mut collector) = executors[index.0].unwrap_collecting_stage().to_parts_mut();
+                    match pattern.batch_continue(context, interrupt, tabled_functions, suspensions)? {
                         Some(batch) => {
                             collector.accept(context, batch);
                             self.control_stack.push(ControlInstruction::CollectingStage(CollectingStage { index }))
@@ -259,6 +349,9 @@ impl PatternExecutor {
         next_executor_index: ExecutorIndex,
         batch: FixedBatch,
     ) -> Result<(), ReadExecutionError> {
+        if batch.is_empty() {
+            return Ok(());
+        }
         if next_executor_index.0 >= self.executors.len() {
             self.control_stack.push(ControlInstruction::Yield(Yield { batch }));
         } else {
@@ -371,7 +464,7 @@ impl PatternExecutor {
         context: &ExecutionContext<impl ReadableSnapshot + 'static>,
         interrupt: &mut ExecutionInterrupt,
         tabled_functions: &mut TabledFunctions,
-        suspend_point_accumulator: &mut Vec<SuspendPoint>,
+        query_suspensions: &mut QueryPatternSuspensions,
         index: ExecutorIndex,
     ) -> Result<(), ReadExecutionError> {
         let executor = self.executors[index.0].unwrap_tabled_call();
@@ -380,26 +473,32 @@ impl PatternExecutor {
         let found = match executor.try_read_next_batch(&function_state) {
             TabledCallResult::RetrievedFromTable(batch) => Some(batch),
             TabledCallResult::Suspend => {
-                suspend_point_accumulator.push(executor.create_suspend_point_for(index));
+                query_suspensions.push_tabled_call(index, executor);
                 None
             }
             TabledCallResult::MustExecutePattern(mut pattern_state_mutex_guard) => {
-                let TabledFunctionPatternExecutorState { pattern_executor, suspend_points, parameters } =
-                    pattern_state_mutex_guard.deref_mut();
+                let TabledFunctionPatternExecutorState {
+                    pattern_executor,
+                    suspensions: function_suspensions,
+                    parameters,
+                } = pattern_state_mutex_guard.deref_mut();
                 let context_with_function_parameters =
                     ExecutionContext::new(context.snapshot.clone(), context.thing_manager.clone(), parameters.clone());
+                let _suspension_count_before = function_suspensions.record_nested_pattern_entry();
                 let batch_opt = pattern_executor.batch_continue(
                     &context_with_function_parameters,
                     interrupt,
                     tabled_functions,
-                    suspend_points,
+                    function_suspensions,
                 )?;
+                let suspension_count_after = function_suspensions.record_nested_pattern_exit();
                 if let Some(batch) = batch_opt {
                     let deduplicated_batch = executor.add_batch_to_table(&function_state, batch);
                     Some(deduplicated_batch)
                 } else {
-                    if !suspend_points.is_empty() {
-                        suspend_point_accumulator.push(executor.create_suspend_point_for(index))
+                    if suspension_count_after.0 > 0 {
+                        // TODO: Consider retrying here. For now, just record a suspension point for ourselves.
+                        query_suspensions.push_tabled_call(index, executor);
                     }
                     None
                 }
@@ -409,8 +508,6 @@ impl PatternExecutor {
             self.control_stack.push(ControlInstruction::ExecuteTabledCall(TabledCall { index }));
             let mapped = executor.map_output(batch);
             self.push_next_instruction(context, index.next(), mapped)?;
-        } else {
-            // TODO: This looks like the place to consider a retry?
         }
         Ok(())
     }

--- a/executor/read/tabled_call_executor.rs
+++ b/executor/read/tabled_call_executor.rs
@@ -17,7 +17,7 @@ use crate::{
         pattern_executor::ExecutorIndex,
         tabled_call_executor::TabledCallResult::Suspend,
         tabled_functions::{CallKey, TableIndex, TabledFunctionPatternExecutorState, TabledFunctionState},
-        SuspendPoint, TabledCallSuspension,
+        PatternSuspension, TabledCallSuspension,
     },
     row::MaybeOwnedRow,
 };
@@ -53,12 +53,19 @@ impl TabledCallExecutor {
     }
 
     pub(crate) fn prepare(&mut self, input: MaybeOwnedRow<'static>) {
+        self.prepare_impl(input, TableIndex(0))
+    }
+
+    pub(crate) fn restore_from_suspension(&mut self, input: MaybeOwnedRow<'static>, next_table_index: TableIndex) {
+        self.prepare_impl(input, next_table_index);
+    }
+    pub fn prepare_impl(&mut self, input: MaybeOwnedRow<'static>, next_table_row: TableIndex) {
         let arguments = MaybeOwnedRow::new_owned(
             self.argument_positions.iter().map(|pos| input.get(pos.clone()).to_owned()).collect(),
             input.multiplicity(),
         );
         let call_key = CallKey { function_id: self.function_id.clone(), arguments };
-        self.active_executor = Some(TabledCallExecutorState { call_key, input, next_table_row: TableIndex(0) });
+        self.active_executor = Some(TabledCallExecutorState { call_key, input, next_table_row });
     }
 
     pub(crate) fn active_call_key(&self) -> Option<&CallKey> {
@@ -82,9 +89,10 @@ impl TabledCallExecutor {
         output_batch
     }
 
-    pub(crate) fn create_suspend_point_for(&self, executor_index: ExecutorIndex) -> SuspendPoint {
-        SuspendPoint::TabledCall(TabledCallSuspension {
+    pub(crate) fn create_suspension_at(&self, executor_index: ExecutorIndex, depth: usize) -> PatternSuspension {
+        PatternSuspension::AtTabledCall(TabledCallSuspension {
             executor_index,
+            depth,
             input_row: self.active_executor.as_ref().unwrap().input.clone().into_owned(),
             next_table_row: self.active_executor.as_ref().unwrap().next_table_row,
         })

--- a/executor/read/tabled_functions.rs
+++ b/executor/read/tabled_functions.rs
@@ -18,7 +18,7 @@ use crate::{
     batch::FixedBatch,
     error::ReadExecutionError,
     pipeline::stage::ExecutionContext,
-    read::{pattern_executor::PatternExecutor, step_executor::create_executors_for_function, SuspendPoint},
+    read::{pattern_executor::PatternExecutor, step_executor::create_executors_for_function, QueryPatternSuspensions},
     row::MaybeOwnedRow,
 };
 
@@ -63,6 +63,14 @@ impl TabledFunctions {
         }
         Ok(self.state.get(call_key).unwrap().clone())
     }
+
+    pub(crate) fn iterate_states(&self) -> impl Iterator<Item = Arc<TabledFunctionState>> + '_ {
+        self.state.values().cloned()
+    }
+
+    pub(crate) fn total_table_size(&self) -> usize {
+        self.state.values().map(|state| state.table.read().unwrap().answers.len()).sum()
+    }
 }
 
 pub(crate) struct TabledFunctionState {
@@ -72,9 +80,20 @@ pub(crate) struct TabledFunctionState {
 }
 
 pub(crate) struct TabledFunctionPatternExecutorState {
-    pub(crate) suspend_points: Vec<SuspendPoint>,
+    pub(crate) suspensions: QueryPatternSuspensions,
     pub(crate) pattern_executor: PatternExecutor,
     pub(crate) parameters: Arc<ParameterRegistry>,
+}
+
+impl TabledFunctionPatternExecutorState {
+    pub(crate) fn prepare_to_retry_suspended(&mut self) {
+        debug_assert!(self.pattern_executor.has_empty_control_stack());
+        self.pattern_executor.reset();
+        if !self.suspensions.is_empty() {
+            self.suspensions.prepare_restoring_from_suspending();
+            self.pattern_executor.prepare_to_restore_from_suspension(0);
+        }
+    }
 }
 
 impl TabledFunctionState {
@@ -89,7 +108,7 @@ impl TabledFunctionState {
             table: RwLock::new(AnswerTable { answers: Vec::new(), width: answer_width }),
             executor_state: Mutex::new(TabledFunctionPatternExecutorState {
                 pattern_executor,
-                suspend_points: Vec::new(),
+                suspensions: QueryPatternSuspensions::new(),
                 parameters,
             }),
         }
@@ -115,6 +134,7 @@ pub(crate) struct AnswerTable {
     // TODO: use a better data-structure. XSB has an "answer-trie" though a LinkedHashSet might do.
     answers: Vec<MaybeOwnedRow<'static>>,
     width: u32,
+    // TODO: We need to be able to record the fact that a table is DONE
 }
 
 impl AnswerTable {

--- a/executor/tests/BUILD
+++ b/executor/tests/BUILD
@@ -93,6 +93,7 @@ rust_test(
     name = "test_functions",
     crate_root = "execute_function.rs",
     srcs = ["execute_function.rs"],
+    env = {"RUST_MIN_STACK": "40960000"},
     deps = deps + [
         "//function",
         "//query:query",

--- a/executor/tests/execute_function.rs
+++ b/executor/tests/execute_function.rs
@@ -18,7 +18,7 @@ use function::function_manager::FunctionManager;
 use lending_iterator::LendingIterator;
 use query::query_manager::QueryManager;
 use storage::{durability_client::WALClient, snapshot::CommittableSnapshot, MVCCStorage};
-use test_utils::{assert_matches, TempDir};
+use test_utils::TempDir;
 use test_utils_concept::{load_managers, setup_concept_storage};
 use test_utils_encoding::create_core_storage;
 
@@ -39,6 +39,54 @@ const COMMON_SCHEMA: &str = r#"
         entity organisation plays membership:group;
         relation membership relates member, relates group;
     "#;
+
+const REACHABILITY_DATA: &str = r#"
+insert
+        # Chain
+        $c1 isa node, has name "c1";
+        $c2 isa node, has name "c2";
+        $c3 isa node, has name "c3";
+
+        (from: $c1, to: $c2) isa edge;
+        (from: $c2, to: $c3) isa edge;
+
+        # Tree
+        $t1 isa node, has name "t1";
+        $t2 isa node, has name "t2";
+        $t3 isa node, has name "t3";
+        $t4 isa node, has name "t4";
+        $t5 isa node, has name "t5";
+        $t6 isa node, has name "t6";
+        $t7 isa node, has name "t7";
+
+        (from: $t1, to: $t2) isa edge; (from: $t1, to: $t3) isa edge;
+        (from: $t2, to: $t4) isa edge; (from: $t2, to: $t5) isa edge;
+        (from: $t3, to: $t6) isa edge; (from: $t3, to: $t7) isa edge;
+
+        # Figure of 8? or of an ant.
+        #    (e1)->-.  .-(e3)->-.  .->-(e5)->-.
+        #           (e2)        (e4)          (e6)
+        #    (e9)-<-'  '-<-(e8)-'  '-<-(e7)-<-'
+
+        $e1 isa node, has name "e1";
+        $e2 isa node, has name "e2";
+        $e3 isa node, has name "e3";
+        $e4 isa node, has name "e4";
+        $e5 isa node, has name "e5";
+        $e6 isa node, has name "e6";
+        $e7 isa node, has name "e7";
+        $e8 isa node, has name "e8";
+        $e9 isa node, has name "e9";
+
+        (from: $e1, to: $e2) isa edge; (from: $e2, to: $e3) isa edge;
+        (from: $e3, to: $e4) isa edge; (from: $e4, to: $e5) isa edge;
+
+        (from: $e5, to: $e6) isa edge; (from: $e6, to: $e7) isa edge;
+
+        (from: $e7, to: $e4) isa edge; (from: $e4, to: $e8) isa edge;
+        (from: $e8, to: $e2) isa edge; (from: $e2, to: $e9) isa edge;
+"#;
+
 fn setup_common(schema: &str) -> Context {
     let (_tmp_dir, mut storage) = create_core_storage();
     setup_concept_storage(&mut storage);
@@ -82,31 +130,40 @@ fn run_read_query(
     result.map(move |rows| (rows, rows_positions))
 }
 
-#[test]
-fn function_compiles() {
-    let context = setup_common(COMMON_SCHEMA);
+fn run_write_query(
+    context: &Context,
+    query: &str,
+) -> Result<(Vec<MaybeOwnedRow<'static>>, HashMap<String, VariablePosition>), Box<PipelineExecutionError>> {
     let snapshot = context.storage.clone().open_snapshot_write();
-    let insert_query_str = r#"insert
-        $p1 isa person, has name "Alice", has age 1, has age 5;
-        $p2 isa person, has name "Bob", has age 2;"#;
-    let insert_query = typeql::parse_query(insert_query_str).unwrap().into_pipeline();
-    let insert_pipeline = context
+    let query_as_pipeline = typeql::parse_query(query).unwrap().into_pipeline();
+    let pipeline = context
         .query_manager
         .prepare_write_pipeline(
             snapshot,
             &context.type_manager,
             context.thing_manager.clone(),
             &context.function_manager,
-            &insert_query,
+            &query_as_pipeline,
         )
         .unwrap();
+    let rows_positions = pipeline.rows_positions().unwrap().clone();
     let (mut iterator, ExecutionContext { snapshot, .. }) =
-        insert_pipeline.into_rows_iterator(ExecutionInterrupt::new_uninterruptible()).unwrap();
-
-    assert_matches!(iterator.next(), Some(Ok(_)));
-    assert_matches!(iterator.next(), None);
+        pipeline.into_rows_iterator(ExecutionInterrupt::new_uninterruptible()).unwrap();
     let snapshot = Arc::into_inner(snapshot).unwrap();
+    let result: Result<Vec<MaybeOwnedRow<'static>>, Box<PipelineExecutionError>> =
+        iterator.map_static(|row| row.map(|row| row.into_owned()).map_err(|err| err.clone())).collect();
     snapshot.commit().unwrap();
+    result.map(move |rows| (rows, rows_positions))
+}
+
+#[test]
+fn function_compiles() {
+    let context = setup_common(COMMON_SCHEMA);
+    let insert_query_str = r#"insert
+        $p1 isa person, has name "Alice", has age 1, has age 5;
+        $p2 isa person, has name "Bob", has age 2;"#;
+    let (rows, _positions) = run_write_query(&context, insert_query_str).unwrap();
+    assert_eq!(1, rows.len());
 
     {
         let query = r#"
@@ -231,30 +288,14 @@ fn function_compiles() {
 #[test]
 fn function_binary() {
     let context = setup_common(COMMON_SCHEMA);
-    let snapshot = context.storage.clone().open_snapshot_write();
     let insert_query_str = r#"insert
         $p1 isa person, has name "Alice", has age 1, has age 5;
         $p2 isa person, has name "Bob", has age 2;
         $p3 isa person, has name "Chris", has age 5;
         "#;
-    let insert_query = typeql::parse_query(insert_query_str).unwrap().into_pipeline();
-    let insert_pipeline = context
-        .query_manager
-        .prepare_write_pipeline(
-            snapshot,
-            &context.type_manager,
-            context.thing_manager.clone(),
-            &context.function_manager,
-            &insert_query,
-        )
-        .unwrap();
-    let (mut iterator, ExecutionContext { snapshot, .. }) =
-        insert_pipeline.into_rows_iterator(ExecutionInterrupt::new_uninterruptible()).unwrap();
 
-    assert_matches!(iterator.next(), Some(Ok(_)));
-    assert_matches!(iterator.next(), None);
-    let snapshot = Arc::into_inner(snapshot).unwrap();
-    snapshot.commit().unwrap();
+    let (rows, _positions) = run_write_query(&context, insert_query_str).unwrap();
+    assert_eq!(1, rows.len());
 
     {
         let query = r#"
@@ -276,46 +317,18 @@ fn function_binary() {
     }
 }
 
-#[ignore] // TODO
 #[test]
-fn simple_tabled() {
+fn quadratic_reachability_in_tree() {
     let custom_schema = r#"define
         attribute name value string;
         entity node, owns name @card(0..), plays edge:from, plays edge:to;
         relation edge, relates from, relates to;
     "#;
     let context = setup_common(custom_schema);
-    let snapshot = context.storage.clone().open_snapshot_write();
-    let insert_query_str = r#"insert
-        $n1 isa node, has name "n1";
-        $n2 isa node, has name "n2";
-        $n3 isa node, has name "n3";
 
-        (from: $n1, to: $n2) isa edge;
-        (from: $n2, to: $n3) isa edge;
-    "#;
-    let insert_query = typeql::parse_query(insert_query_str).unwrap().into_pipeline();
-    let insert_pipeline = context
-        .query_manager
-        .prepare_write_pipeline(
-            snapshot,
-            &context.type_manager,
-            context.thing_manager.clone(),
-            &context.function_manager,
-            &insert_query,
-        )
-        .unwrap();
-    let (mut iterator, ExecutionContext { snapshot, .. }) =
-        insert_pipeline.into_rows_iterator(ExecutionInterrupt::new_uninterruptible()).unwrap();
-
-    assert_matches!(iterator.next(), Some(Ok(_)));
-    assert_matches!(iterator.next(), None);
-    let snapshot = Arc::into_inner(snapshot).unwrap();
-    snapshot.commit().unwrap();
-
-    {
-        // quadratic tabling reachability.
-        let query = r#"
+    let (rows, _positions) = run_write_query(&context, REACHABILITY_DATA).unwrap();
+    assert_eq!(1, rows.len());
+    let query_template = r#"
             with
             fun reachable($from: node) -> { node }:
             match
@@ -325,23 +338,119 @@ fn simple_tabled() {
             return { $return-me };
 
             match
-                $from isa node, has name "n1";
+                $from isa node, has name "<<NODE_NAME>>";
                 $to in reachable($from);
         "#;
-        let (rows, _) = run_read_query(&context, query).unwrap();
+    let placeholder_start_node = "<<NODE_NAME>>";
+    {
+        // Chain
+        let query = query_template.replace(placeholder_start_node, "c1");
+        let (rows, _) = run_read_query(&context, query.as_str()).unwrap();
         assert_eq!(rows.len(), 2);
+
+        let query = query_template.replace(placeholder_start_node, "c2");
+        let (rows, _) = run_read_query(&context, query.as_str()).unwrap();
+        assert_eq!(rows.len(), 1);
+    }
+
+    {
+        // tree
+        let query = query_template.replace(placeholder_start_node, "t1");
+        let (rows, _) = run_read_query(&context, query.as_str()).unwrap();
+        assert_eq!(6, rows.len());
+
+        let query = query_template.replace(placeholder_start_node, "t2");
+        let (rows, _) = run_read_query(&context, query.as_str()).unwrap();
+        assert_eq!(2, rows.len());
+    }
+
+    {
+        // ant
+        let query = query_template.replace(placeholder_start_node, "e1");
+        let (rows, _) = run_read_query(&context, query.as_str()).unwrap();
+        assert_eq!(8, rows.len()); // all except e1
+
+        let query = query_template.replace(placeholder_start_node, "e9");
+        let (rows, _) = run_read_query(&context, query.as_str()).unwrap();
+        assert_eq!(0, rows.len()); // none
+
+        let query = query_template.replace(placeholder_start_node, "e2");
+        let (rows, _) = run_read_query(&context, query.as_str()).unwrap();
+        assert_eq!(8, rows.len()); // all except e1. e2 should be reachable from itself
     }
 }
 
-#[ignore] // TODO
+#[test]
+fn linear_reachability_in_tree() {
+    let custom_schema = r#"define
+        attribute name value string;
+        entity node, owns name @card(0..), plays edge:from, plays edge:to;
+        relation edge, relates from, relates to;
+    "#;
+    let context = setup_common(custom_schema);
+    let (rows, _positions) = run_write_query(&context, REACHABILITY_DATA).unwrap();
+    assert_eq!(1, rows.len());
+
+    let placeholder_start_node = "<<NODE_NAME>>";
+    let query_template = r#"
+            with
+            fun reachable($from: node) -> { node }:
+            match
+                $return-me has name $name;
+                { $middle in reachable($from); (from: $middle, to: $indirect) isa edge; $indirect has name $name; } or
+                { (from: $from, to: $direct) isa edge; $direct has name $name; }; # Do we have is yet?
+            return { $return-me };
+
+            match
+                $from isa node, has name "<<NODE_NAME>>";
+                $to in reachable($from);
+        "#;
+
+    {
+        // Chain
+        let query = query_template.replace(placeholder_start_node, "c1");
+        let (rows, _) = run_read_query(&context, query.as_str()).unwrap();
+        assert_eq!(rows.len(), 2);
+
+        let query = query_template.replace(placeholder_start_node, "c2");
+        let (rows, _) = run_read_query(&context, query.as_str()).unwrap();
+        assert_eq!(rows.len(), 1);
+    }
+
+    {
+        // tree
+        let query = query_template.replace(placeholder_start_node, "t1");
+        let (rows, _) = run_read_query(&context, query.as_str()).unwrap();
+        assert_eq!(6, rows.len());
+
+        let query = query_template.replace(placeholder_start_node, "t2");
+        let (rows, _) = run_read_query(&context, query.as_str()).unwrap();
+        assert_eq!(2, rows.len());
+    }
+
+    {
+        // // ant
+        let query = query_template.replace(placeholder_start_node, "e1");
+        let (rows, _) = run_read_query(&context, query.as_str()).unwrap();
+        assert_eq!(8, rows.len()); // all except e1
+
+        let query = query_template.replace(placeholder_start_node, "e9");
+        let (rows, _) = run_read_query(&context, query.as_str()).unwrap();
+        assert_eq!(0, rows.len()); // none
+
+        let query = query_template.replace(placeholder_start_node, "e2");
+        let (rows, _) = run_read_query(&context, query.as_str()).unwrap();
+        assert_eq!(8, rows.len()); // all except e1. e2 should be reachable from itself
+    }
+}
+
 #[test]
 fn fibonacci() {
     let custom_schema = r#"define
         attribute number @independent, value long;
     "#;
     let context = setup_common(custom_schema);
-    let snapshot = context.storage.clone().open_snapshot_write();
-    let insert_query_str = r#"insert
+    let insert_query = r#"insert
         $n1   1 isa number;
         $n2   2 isa number;
         $n3   3 isa number;
@@ -358,24 +467,8 @@ fn fibonacci() {
         $n14 14 isa number;
         $n15 15 isa number;
     "#;
-    let insert_query = typeql::parse_query(insert_query_str).unwrap().into_pipeline();
-    let insert_pipeline = context
-        .query_manager
-        .prepare_write_pipeline(
-            snapshot,
-            &context.type_manager,
-            context.thing_manager.clone(),
-            &context.function_manager,
-            &insert_query,
-        )
-        .unwrap();
-    let (mut iterator, ExecutionContext { snapshot, .. }) =
-        insert_pipeline.into_rows_iterator(ExecutionInterrupt::new_uninterruptible()).unwrap();
-
-    assert_matches!(iterator.next(), Some(Ok(_)));
-    assert_matches!(iterator.next(), None);
-    let snapshot = Arc::into_inner(snapshot).unwrap();
-    snapshot.commit().unwrap();
+    let (rows, _positions) = run_write_query(&context, insert_query).unwrap();
+    assert_eq!(1, rows.len());
 
     {
         let query = r#"

--- a/executor/tests/execute_function.rs
+++ b/executor/tests/execute_function.rs
@@ -317,6 +317,7 @@ fn function_binary() {
     }
 }
 
+#[ignore] // TODO: Re-enable when the CONSTANT_CONCEPT_LIMIT assert is fixed
 #[test]
 fn quadratic_reachability_in_tree() {
     let custom_schema = r#"define
@@ -380,6 +381,7 @@ fn quadratic_reachability_in_tree() {
     }
 }
 
+#[ignore] // TODO: Re-enable when the CONSTANT_CONCEPT_LIMIT assert is fixed
 #[test]
 fn linear_reachability_in_tree() {
     let custom_schema = r#"define


### PR DESCRIPTION
## Release notes: product changes
Introduces retries for suspended function calls. 
Functions may suspend to break cycles of recursion. Restoring suspend points is essential to completeness of recursive functions, and thus correctness of negations which call them.

## Motivation
Towards complete fixpoint computation.

## Implementation
* Introduces a SuspendPointContext to abstract away some of the logic.
* Introduces retries at the entry point and at each negation.