### PR TITLE
Optimise has comparators and implement Executable Display

### DIFF
--- a/compiler/executable/match_/instructions/mod.rs
+++ b/compiler/executable/match_/instructions/mod.rs
@@ -6,18 +6,22 @@
 
 #![allow(clippy::large_enum_variant)]
 
-use std::{collections::{HashMap, HashSet}, fmt, ops::Deref};
-use std::fmt::{Debug, Display, Formatter};
 use std::{
+    collections::{HashMap, HashSet},
+    fmt,
+    fmt::{Debug, Display, Formatter},
+    ops::Deref,
     sync::Arc,
 };
+use std::collections::BTreeSet;
 
-use answer::{variable::Variable, Type};
+use itertools::Itertools;
+
+use answer::{Type, variable::Variable};
 use ir::pattern::{
     constraint::{Comparator, Comparison, Constraint, ExpressionBinding, FunctionCallBinding, Is, IsaKind, SubKind},
     IrID, ParameterID, Vertex,
 };
-use itertools::Itertools;
 
 use crate::{
     annotation::type_annotations::TypeAnnotations, executable::match_::planner::match_executable::InstructionAPI,
@@ -399,14 +403,14 @@ impl<ID: IrID> Display for ConstraintInstruction<ID> {
             ConstraintInstruction::TypeList(instruction) => write!(f, "{instruction}"),
             ConstraintInstruction::Sub(instruction) => write!(f, "{instruction}"),
             ConstraintInstruction::SubReverse(instruction) => write!(f, "{instruction}"),
-            ConstraintInstruction::Owns(instruction) =>  write!(f, "{instruction}"),
+            ConstraintInstruction::Owns(instruction) => write!(f, "{instruction}"),
             ConstraintInstruction::OwnsReverse(instruction) => write!(f, "{instruction}"),
             ConstraintInstruction::Relates(instruction) => write!(f, "{instruction}"),
             ConstraintInstruction::RelatesReverse(instruction) => write!(f, "{instruction}"),
             ConstraintInstruction::Plays(instruction) => write!(f, "{instruction}"),
             ConstraintInstruction::PlaysReverse(instruction) => write!(f, "{instruction}"),
             ConstraintInstruction::Isa(instruction) => write!(f, "{instruction}"),
-            ConstraintInstruction::IsaReverse(instruction) =>  write!(f, "{instruction}"),
+            ConstraintInstruction::IsaReverse(instruction) => write!(f, "{instruction}"),
             ConstraintInstruction::Has(instruction) => write!(f, "{instruction}"),
             ConstraintInstruction::HasReverse(instruction) => write!(f, "{instruction}"),
             ConstraintInstruction::Links(instruction) => write!(f, "{instruction}"),
@@ -607,38 +611,38 @@ impl<ID: IrID> Display for CheckInstruction<ID> {
         match self {
             Self::TypeList { type_var, types } => {
                 write!(f, "{type_var} type (")?;
-                for type_ in types {
+                for type_ in types.as_ref() {
                     write!(f, "{type_}, ")?;
                 }
                 write!(f, ")")?;
-            },
+            }
             Self::Sub { sub_kind, subtype, supertype } => {
                 write!(f, "{subtype} {}{} {supertype}", typeql::token::Keyword::Sub, sub_kind)?;
-            },
+            }
             Self::Owns { owner, attribute } => {
                 write!(f, "{owner} {} {attribute}", typeql::token::Keyword::Owns)?;
-            },
+            }
             Self::Relates { relation, role_type } => {
                 write!(f, "{relation} {} {role_type}", typeql::token::Keyword::Relates)?;
-            },
+            }
             Self::Plays { player, role_type } => {
                 write!(f, "{player} {} {role_type}", typeql::token::Keyword::Plays)?;
-            },
+            }
             Self::Isa { isa_kind, type_, thing } => {
                 write!(f, "{thing} {}{} {type_}", typeql::token::Keyword::Isa, isa_kind)?;
-            },
+            }
             Self::Has { owner, attribute } => {
                 write!(f, "{owner} {} {attribute}", typeql::token::Keyword::Has)?;
-            },
+            }
             Self::Links { relation, player, role } => {
                 write!(f, "{relation} {} ({role}:{player})", typeql::token::Keyword::Links)?;
-            },
+            }
             Self::Is { lhs, rhs } => {
                 write!(f, "{lhs} {} {rhs}", typeql::token::Keyword::Is)?;
-            },
+            }
             Self::Comparison { lhs, rhs, comparator } => {
                 write!(f, "{lhs} {comparator} {rhs}")?;
-            },
+            }
         }
         write!(f, "] ")
     }

--- a/compiler/executable/match_/instructions/mod.rs
+++ b/compiler/executable/match_/instructions/mod.rs
@@ -6,9 +6,9 @@
 
 #![allow(clippy::large_enum_variant)]
 
+use std::{collections::{HashMap, HashSet}, fmt, ops::Deref};
+use std::fmt::{Debug, Display, Formatter};
 use std::{
-    collections::{BTreeSet, HashMap, HashSet},
-    ops::Deref,
     sync::Arc,
 };
 
@@ -27,7 +27,7 @@ use crate::{
 pub mod thing;
 pub mod type_;
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Ord, PartialOrd)]
 pub enum VariableMode {
     Input,
     Output,
@@ -45,6 +45,17 @@ impl VariableMode {
             Self::Count
         } else {
             Self::Check
+        }
+    }
+}
+
+impl Display for VariableMode {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            VariableMode::Input => write!(f, "input"),
+            VariableMode::Output => write!(f, "output"),
+            VariableMode::Count => write!(f, "count"),
+            VariableMode::Check => write!(f, "check"),
         }
     }
 }
@@ -94,6 +105,18 @@ impl VariableModes {
 
     pub fn none_inputs(&self) -> bool {
         self.modes.values().all(|mode| mode != &VariableMode::Input)
+    }
+}
+
+impl Display for VariableModes {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        for (key, group) in &self.modes.iter().sorted_by_key(|(_, value)| *value).group_by(|(_, value)| *value) {
+            write!(f, "{key}s=")?;
+            for (var, _) in group {
+                write!(f, "{}, ", var)?;
+            }
+        }
+        Ok(())
     }
 }
 
@@ -369,6 +392,32 @@ impl<ID: IrID + Copy> InstructionAPI<ID> for ConstraintInstruction<ID> {
     }
 }
 
+impl<ID: IrID> Display for ConstraintInstruction<ID> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ConstraintInstruction::Is(instruction) => write!(f, "{instruction}"),
+            ConstraintInstruction::TypeList(instruction) => write!(f, "{instruction}"),
+            ConstraintInstruction::Sub(instruction) => write!(f, "{instruction}"),
+            ConstraintInstruction::SubReverse(instruction) => write!(f, "{instruction}"),
+            ConstraintInstruction::Owns(instruction) =>  write!(f, "{instruction}"),
+            ConstraintInstruction::OwnsReverse(instruction) => write!(f, "{instruction}"),
+            ConstraintInstruction::Relates(instruction) => write!(f, "{instruction}"),
+            ConstraintInstruction::RelatesReverse(instruction) => write!(f, "{instruction}"),
+            ConstraintInstruction::Plays(instruction) => write!(f, "{instruction}"),
+            ConstraintInstruction::PlaysReverse(instruction) => write!(f, "{instruction}"),
+            ConstraintInstruction::Isa(instruction) => write!(f, "{instruction}"),
+            ConstraintInstruction::IsaReverse(instruction) =>  write!(f, "{instruction}"),
+            ConstraintInstruction::Has(instruction) => write!(f, "{instruction}"),
+            ConstraintInstruction::HasReverse(instruction) => write!(f, "{instruction}"),
+            ConstraintInstruction::Links(instruction) => write!(f, "{instruction}"),
+            ConstraintInstruction::LinksReverse(instruction) => write!(f, "{instruction}"),
+            ConstraintInstruction::FunctionCallBinding(instruction) => write!(f, "{instruction}"),
+            ConstraintInstruction::ComparisonCheck(instruction) => write!(f, "{instruction}"),
+            ConstraintInstruction::ExpressionBinding(instruction) => write!(f, "{instruction}"),
+        }
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct IsInstruction<ID> {
     pub is: Is<ID>,
@@ -396,6 +445,12 @@ impl<ID: IrID> IsInstruction<ID> {
             inputs: inputs.map(mapping),
             checks: checks.into_iter().map(|check| check.map(mapping)).collect(),
         }
+    }
+}
+
+impl<ID: IrID> Display for IsInstruction<ID> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{} filter {}", &self.is, DisplayVec::new(&self.checks))
     }
 }
 
@@ -482,7 +537,17 @@ impl<ID: IrID> CheckVertex<ID> {
     }
 }
 
-#[derive(Debug, Clone)]
+impl<ID: IrID> Display for CheckVertex<ID> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            CheckVertex::Variable(var) => write!(f, "{var}"),
+            CheckVertex::Type(type_) => write!(f, "{type_}"),
+            CheckVertex::Parameter(param) => write!(f, "{param}"),
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
 pub enum CheckInstruction<ID> {
     TypeList { type_var: ID, types: Arc<BTreeSet<Type>> },
 
@@ -536,6 +601,49 @@ impl<ID: IrID> CheckInstruction<ID> {
     }
 }
 
+impl<ID: IrID> Display for CheckInstruction<ID> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "Check[")?;
+        match self {
+            Self::TypeList { type_var, types } => {
+                write!(f, "{type_var} type (")?;
+                for type_ in types {
+                    write!(f, "{type_}, ")?;
+                }
+                write!(f, ")")?;
+            },
+            Self::Sub { sub_kind, subtype, supertype } => {
+                write!(f, "{subtype} {}{} {supertype}", typeql::token::Keyword::Sub, sub_kind)?;
+            },
+            Self::Owns { owner, attribute } => {
+                write!(f, "{owner} {} {attribute}", typeql::token::Keyword::Owns)?;
+            },
+            Self::Relates { relation, role_type } => {
+                write!(f, "{relation} {} {role_type}", typeql::token::Keyword::Relates)?;
+            },
+            Self::Plays { player, role_type } => {
+                write!(f, "{player} {} {role_type}", typeql::token::Keyword::Plays)?;
+            },
+            Self::Isa { isa_kind, type_, thing } => {
+                write!(f, "{thing} {}{} {type_}", typeql::token::Keyword::Isa, isa_kind)?;
+            },
+            Self::Has { owner, attribute } => {
+                write!(f, "{owner} {} {attribute}", typeql::token::Keyword::Has)?;
+            },
+            Self::Links { relation, player, role } => {
+                write!(f, "{relation} {} ({role}:{player})", typeql::token::Keyword::Links)?;
+            },
+            Self::Is { lhs, rhs } => {
+                write!(f, "{lhs} {} {rhs}", typeql::token::Keyword::Is)?;
+            },
+            Self::Comparison { lhs, rhs, comparator } => {
+                write!(f, "{lhs} {comparator} {rhs}")?;
+            },
+        }
+        write!(f, "] ")
+    }
+}
+
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub enum Inputs<ID> {
     None([ID; 0]),
@@ -566,5 +674,29 @@ impl<ID> Deref for Inputs<ID> {
             Inputs::Single(ids) => ids,
             Inputs::Dual(ids) => ids,
         }
+    }
+}
+
+struct DisplayVec<'a, T: Display> {
+    vec: &'a Vec<T>,
+}
+
+impl<'a, T: Display> DisplayVec<'a, T> {
+    fn new(vec: &'a Vec<T>) -> Self {
+        Self { vec }
+    }
+}
+
+impl<'a, T: Display> Display for DisplayVec<'a, T> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(f, "[")?;
+        for (i, element) in self.vec.iter().enumerate() {
+            if i != self.vec.len() - 1 {
+                write!(f, "{}, ", element)?;
+            } else {
+                write!(f, "{}", element)?;
+            }
+        }
+        write!(f, "]")
     }
 }

--- a/compiler/executable/match_/instructions/thing.rs
+++ b/compiler/executable/match_/instructions/thing.rs
@@ -6,11 +6,11 @@
 
 use std::{
     collections::{BTreeMap, BTreeSet, HashMap},
+    fmt::{Display, Formatter},
     sync::Arc,
 };
-use std::fmt::{Display, Formatter};
 
-use answer::{Type, variable::Variable};
+use answer::{variable::Variable, Type};
 use ir::pattern::{
     constraint::{Has, Isa, Links},
     IrID,
@@ -18,9 +18,8 @@ use ir::pattern::{
 
 use crate::{
     annotation::type_annotations::TypeAnnotations,
-    executable::match_::instructions::{CheckInstruction, Inputs},
+    executable::match_::instructions::{CheckInstruction, DisplayVec, Inputs},
 };
-use crate::executable::match_::instructions::DisplayVec;
 
 #[derive(Debug, Clone)]
 pub struct IsaInstruction<ID> {

--- a/compiler/executable/match_/instructions/thing.rs
+++ b/compiler/executable/match_/instructions/thing.rs
@@ -8,8 +8,9 @@ use std::{
     collections::{BTreeMap, BTreeSet, HashMap},
     sync::Arc,
 };
+use std::fmt::{Display, Formatter};
 
-use answer::{variable::Variable, variable_value::VariableValue, Type};
+use answer::{Type, variable::Variable};
 use ir::pattern::{
     constraint::{Has, Isa, Links},
     IrID,
@@ -19,36 +20,7 @@ use crate::{
     annotation::type_annotations::TypeAnnotations,
     executable::match_::instructions::{CheckInstruction, Inputs},
 };
-
-#[derive(Debug, Clone)]
-pub struct ConstantInstruction<ID> {
-    pub value: VariableValue<'static>,
-    pub var: ID,
-    pub checks: Vec<CheckInstruction<ID>>,
-}
-
-impl ConstantInstruction<Variable> {
-    pub fn new(value: VariableValue<'static>, var: Variable) -> Self {
-        Self { value, var, checks: Vec::new() }
-    }
-}
-
-impl<ID> ConstantInstruction<ID> {
-    pub(crate) fn add_check(&mut self, check: CheckInstruction<ID>) {
-        self.checks.push(check)
-    }
-}
-
-impl<ID: IrID> ConstantInstruction<ID> {
-    pub fn map<T: IrID>(self, mapping: &HashMap<ID, T>) -> ConstantInstruction<T> {
-        let Self { value, var, checks } = self;
-        ConstantInstruction {
-            value,
-            var: mapping[&var],
-            checks: checks.into_iter().map(|check| check.map(mapping)).collect(),
-        }
-    }
-}
+use crate::executable::match_::instructions::DisplayVec;
 
 #[derive(Debug, Clone)]
 pub struct IsaInstruction<ID> {
@@ -84,6 +56,12 @@ impl<ID: IrID> IsaInstruction<ID> {
     }
 }
 
+impl<ID: IrID> Display for IsaInstruction<ID> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "[{}] filter {}", &self.isa, DisplayVec::new(&self.checks))
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct IsaReverseInstruction<ID> {
     pub isa: Isa<ID>,
@@ -115,6 +93,12 @@ impl<ID: IrID> IsaReverseInstruction<ID> {
             type_to_instance_types,
             checks: checks.into_iter().map(|check| check.map(mapping)).collect(),
         }
+    }
+}
+
+impl<ID: IrID> Display for IsaReverseInstruction<ID> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "Reverse[{}] filter {}", &self.isa, DisplayVec::new(&self.checks))
     }
 }
 
@@ -164,6 +148,12 @@ impl<ID: IrID> HasInstruction<ID> {
     }
 }
 
+impl<ID: IrID> Display for HasInstruction<ID> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "[{}] filter {}", &self.has, DisplayVec::new(&self.checks))
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct HasReverseInstruction<ID> {
     pub has: Has<ID>,
@@ -206,6 +196,12 @@ impl<ID: IrID> HasReverseInstruction<ID> {
             owner_types,
             checks: checks.into_iter().map(|check| check.map(mapping)).collect(),
         }
+    }
+}
+
+impl<ID: IrID> Display for HasReverseInstruction<ID> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "Reverse[{}] filter {}", &self.has, DisplayVec::new(&self.checks))
     }
 }
 
@@ -262,6 +258,12 @@ impl<ID: IrID> LinksInstruction<ID> {
     }
 }
 
+impl<ID: IrID> Display for LinksInstruction<ID> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "[{}] filter {}", &self.links, DisplayVec::new(&self.checks))
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct LinksReverseInstruction<ID> {
     pub links: Links<ID>,
@@ -312,5 +314,11 @@ impl<ID: IrID> LinksReverseInstruction<ID> {
             relation_types,
             checks: checks.into_iter().map(|check| check.map(mapping)).collect(),
         }
+    }
+}
+
+impl<ID: IrID> Display for LinksReverseInstruction<ID> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "Reverse[{}] filter {}", &self.links, DisplayVec::new(&self.checks))
     }
 }

--- a/compiler/executable/match_/instructions/type_.rs
+++ b/compiler/executable/match_/instructions/type_.rs
@@ -8,6 +8,8 @@ use std::{
     collections::{BTreeMap, BTreeSet, HashMap},
     sync::Arc,
 };
+use std::fmt::{Display, Formatter};
+use itertools::Itertools;
 
 use answer::{variable::Variable, Type};
 use ir::pattern::{
@@ -19,6 +21,7 @@ use crate::{
     annotation::type_annotations::TypeAnnotations,
     executable::match_::instructions::{CheckInstruction, Inputs},
 };
+use crate::executable::match_::instructions::IsInstruction;
 
 #[derive(Debug, Clone)]
 pub struct TypeListInstruction<ID> {
@@ -51,6 +54,17 @@ impl<ID: IrID> TypeListInstruction<ID> {
             types,
             checks: checks.into_iter().map(|check| check.map(mapping)).collect(),
         }
+    }
+}
+
+impl<ID: IrID> Display for TypeListInstruction<ID> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "[{} type ", self.type_var)?;
+        write!(f, "(")?;
+        for type_ in self.types.iter().sorted() {
+            write!(f, "{type_}")?;
+        }
+        write!(f, ")] filter {:?}", &self.checks)
     }
 }
 
@@ -99,6 +113,12 @@ impl<ID: IrID> SubInstruction<ID> {
     }
 }
 
+impl<ID: IrID> Display for SubInstruction<ID> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "[{}] filter {:?}", &self.sub, &self.checks)
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct SubReverseInstruction<ID> {
     pub sub: Sub<ID>,
@@ -141,6 +161,12 @@ impl<ID: IrID> SubReverseInstruction<ID> {
             subtypes,
             checks: checks.into_iter().map(|check| check.map(mapping)).collect(),
         }
+    }
+}
+
+impl<ID: IrID> Display for SubReverseInstruction<ID> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "Reverse[{}] filter {:?}", &self.sub, &self.checks)
     }
 }
 
@@ -189,6 +215,12 @@ impl<ID: IrID> OwnsInstruction<ID> {
     }
 }
 
+impl<ID: IrID> Display for OwnsInstruction<ID> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "[{}] filter {:?}", &self.owns, &self.checks)
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct OwnsReverseInstruction<ID> {
     pub owns: Owns<ID>,
@@ -231,6 +263,12 @@ impl<ID: IrID> OwnsReverseInstruction<ID> {
             owner_types,
             checks: checks.into_iter().map(|check| check.map(mapping)).collect(),
         }
+    }
+}
+
+impl<ID: IrID> Display for OwnsReverseInstruction<ID> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "Reverse[{}] filter {:?}", &self.owns, &self.checks)
     }
 }
 
@@ -280,6 +318,12 @@ impl<ID: IrID> RelatesInstruction<ID> {
     }
 }
 
+impl<ID: IrID> Display for RelatesInstruction<ID> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "[{}] filter {:?}", &self.relates, &self.checks)
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct RelatesReverseInstruction<ID> {
     pub relates: Relates<ID>,
@@ -323,6 +367,12 @@ impl<ID: IrID> RelatesReverseInstruction<ID> {
             relation_types,
             checks: checks.into_iter().map(|check| check.map(mapping)).collect(),
         }
+    }
+}
+
+impl<ID: IrID> Display for RelatesReverseInstruction<ID> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "Reverse[{}] filter {:?}", &self.relates, &self.checks)
     }
 }
 
@@ -372,6 +422,12 @@ impl<ID: IrID> PlaysInstruction<ID> {
     }
 }
 
+impl<ID: IrID> Display for PlaysInstruction<ID> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "[{}] filter {:?}", &self.plays, &self.checks)
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct PlaysReverseInstruction<ID> {
     pub plays: Plays<ID>,
@@ -415,5 +471,11 @@ impl<ID: IrID> PlaysReverseInstruction<ID> {
             player_types,
             checks: checks.into_iter().map(|check| check.map(mapping)).collect(),
         }
+    }
+}
+
+impl<ID: IrID> Display for PlaysReverseInstruction<ID> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "Reverse[{}] filter {:?}", &self.plays, &self.checks)
     }
 }

--- a/compiler/executable/match_/instructions/type_.rs
+++ b/compiler/executable/match_/instructions/type_.rs
@@ -6,22 +6,21 @@
 
 use std::{
     collections::{BTreeMap, BTreeSet, HashMap},
+    fmt::{Display, Formatter},
     sync::Arc,
 };
-use std::fmt::{Display, Formatter};
-use itertools::Itertools;
 
 use answer::{variable::Variable, Type};
 use ir::pattern::{
     constraint::{Owns, Plays, Relates, Sub},
     IrID,
 };
+use itertools::Itertools;
 
 use crate::{
     annotation::type_annotations::TypeAnnotations,
-    executable::match_::instructions::{CheckInstruction, Inputs},
+    executable::match_::instructions::{CheckInstruction, Inputs, IsInstruction},
 };
-use crate::executable::match_::instructions::IsInstruction;
 
 #[derive(Debug, Clone)]
 pub struct TypeListInstruction<ID> {

--- a/compiler/executable/match_/planner/match_executable.rs
+++ b/compiler/executable/match_/planner/match_executable.rs
@@ -8,6 +8,7 @@ use std::{
     collections::{HashMap, HashSet},
     slice,
 };
+use std::fmt::{Display, Formatter, write};
 
 use answer::variable::Variable;
 use ir::{
@@ -51,6 +52,16 @@ impl MatchExecutable {
 
     pub fn variable_positions_index(&self) -> &[Variable] {
         &self.variable_positions_index
+    }
+}
+
+impl Display for MatchExecutable {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "Match executable plan:")?;
+        for (i, step) in self.steps().iter().enumerate() {
+            write!(f, "\n  {i}: {step}")?;
+        }
+        Ok(())
     }
 }
 
@@ -107,6 +118,21 @@ impl ExecutionStep {
     }
 }
 
+impl Display for ExecutionStep {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ExecutionStep::Intersection(step) => write!(f, "Sorted, {step}"),
+            ExecutionStep::UnsortedJoin(step) => write!(f, "Unsorted, {step}"),
+            ExecutionStep::Assignment(step) =>write!(f, "Assign, {step}"),
+            ExecutionStep::Check(step) => write!(f, "Check, {step}"),
+            ExecutionStep::Disjunction(step) =>write!(f, "Disjunction, {step}"),
+            ExecutionStep::Negation(step) => write!(f, "Negation, {step}"),
+            ExecutionStep::Optional(step) => write!(f, "Optional, {step}"),
+            ExecutionStep::FunctionCall(step) =>write!(f, "FunctionCall, {step}"),
+        }
+    }
+}
+
 #[derive(Clone, Debug)]
 pub struct IntersectionStep {
     pub sort_variable: ExecutorVariable,
@@ -159,6 +185,16 @@ impl IntersectionStep {
 
     fn output_width(&self) -> u32 {
         self.output_width
+    }
+}
+
+impl Display for IntersectionStep {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "inputs={:?}, output_size={}, sort_by={}", &self.input_variables, self.output_width, self.sort_variable)?;
+        for (instruction, modes) in &self.instructions {
+            write!(f, "\n      {instruction} with ({modes})")?;
+        }
+        Ok(())
     }
 }
 
@@ -221,6 +257,15 @@ impl UnsortedJoinStep {
     }
 }
 
+impl Display for UnsortedJoinStep {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "inputs={:?}, output_size={:?}", &self.input_variables, self.output_width)?;
+        write!(f, "\n      {}", &self.iterate_instruction)?;
+        // TODO: do we need these at all?
+        write!(f, "\n      {:?}", &self.check_instructions)
+    }
+}
+
 #[derive(Clone, Debug)]
 pub struct AssignmentStep {
     pub expression: ExecutableExpression<VariablePosition>,
@@ -253,6 +298,14 @@ impl AssignmentStep {
     }
 }
 
+impl Display for AssignmentStep {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "inputs={:?}, output_size={}", &self.input_positions, self.output_width)?;
+        // TODO: Display expression
+        write!(f, "\n      {:?}", &self.expression)
+    }
+}
+
 #[derive(Clone, Debug)]
 pub struct CheckStep {
     pub check_instructions: Vec<CheckInstruction<ExecutorVariable>>,
@@ -274,6 +327,15 @@ impl CheckStep {
     }
 }
 
+impl Display for CheckStep {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        for check in &self.check_instructions {
+            write!(f, "\n      {}", check)?;
+        }
+        Ok(())
+    }
+}
+
 #[derive(Clone, Debug)]
 pub struct DisjunctionStep {
     pub branches: Vec<MatchExecutable>,
@@ -288,6 +350,18 @@ impl DisjunctionStep {
 
     pub fn output_width(&self) -> u32 {
         self.output_width
+    }
+}
+
+impl Display for DisjunctionStep {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "output_size={}", self.output_width)?;
+        for branch in &self.branches {
+            write!(f, "\n      --- Start branch ---")?;
+            write!(f, "{}", branch)?;
+            write!(f, "\n      --- End branch ---")?;
+        }
+        Ok(())
     }
 }
 
@@ -308,6 +382,27 @@ impl NegationStep {
     }
 }
 
+impl Display for NegationStep {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "\n      --- Start negation ---")?;
+        write!(f, "\n {}", &self.negation)?;
+        write!(f, "\n      --- End negation ---")
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct OptionalStep {
+    pub optional: MatchExecutable,
+}
+
+impl Display for OptionalStep {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "\n      --- Start negation ---")?;
+        write!(f, "\n {}", &self.optional)?;
+        write!(f, "\n      --- End negation ---")
+    }
+}
+
 #[derive(Clone, Debug)]
 pub struct FunctionCallStep {
     // TODO: Deduplication, selection counting etc.
@@ -323,9 +418,17 @@ impl FunctionCallStep {
     }
 }
 
-#[derive(Clone, Debug)]
-pub struct OptionalStep {
-    pub optional: MatchExecutable,
+impl Display for FunctionCallStep {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "fn_id={}, assigned={:?}, arguments={:?}, output_size={}\n",
+            self.function_id,
+            &self.assigned,
+            &self.arguments,
+            self.output_width
+        )
+    }
 }
 
 pub trait InstructionAPI<ID: IrID> {

--- a/compiler/executable/match_/planner/match_executable.rs
+++ b/compiler/executable/match_/planner/match_executable.rs
@@ -6,9 +6,9 @@
 
 use std::{
     collections::{HashMap, HashSet},
+    fmt::{write, Display, Formatter},
     slice,
 };
-use std::fmt::{Display, Formatter, write};
 
 use answer::variable::Variable;
 use ir::{
@@ -123,12 +123,12 @@ impl Display for ExecutionStep {
         match self {
             ExecutionStep::Intersection(step) => write!(f, "Sorted, {step}"),
             ExecutionStep::UnsortedJoin(step) => write!(f, "Unsorted, {step}"),
-            ExecutionStep::Assignment(step) =>write!(f, "Assign, {step}"),
+            ExecutionStep::Assignment(step) => write!(f, "Assign, {step}"),
             ExecutionStep::Check(step) => write!(f, "Check, {step}"),
-            ExecutionStep::Disjunction(step) =>write!(f, "Disjunction, {step}"),
+            ExecutionStep::Disjunction(step) => write!(f, "Disjunction, {step}"),
             ExecutionStep::Negation(step) => write!(f, "Negation, {step}"),
             ExecutionStep::Optional(step) => write!(f, "Optional, {step}"),
-            ExecutionStep::FunctionCall(step) =>write!(f, "FunctionCall, {step}"),
+            ExecutionStep::FunctionCall(step) => write!(f, "FunctionCall, {step}"),
         }
     }
 }
@@ -190,7 +190,11 @@ impl IntersectionStep {
 
 impl Display for IntersectionStep {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        write!(f, "inputs={:?}, output_size={}, sort_by={}", &self.input_variables, self.output_width, self.sort_variable)?;
+        write!(
+            f,
+            "inputs={:?}, output_size={}, sort_by={}",
+            &self.input_variables, self.output_width, self.sort_variable
+        )?;
         for (instruction, modes) in &self.instructions {
             write!(f, "\n      {instruction} with ({modes})")?;
         }
@@ -423,10 +427,7 @@ impl Display for FunctionCallStep {
         write!(
             f,
             "fn_id={}, assigned={:?}, arguments={:?}, output_size={}\n",
-            self.function_id,
-            &self.assigned,
-            &self.arguments,
-            self.output_width
+            self.function_id, &self.assigned, &self.arguments, self.output_width
         )
     }
 }

--- a/compiler/executable/match_/planner/mod.rs
+++ b/compiler/executable/match_/planner/mod.rs
@@ -406,7 +406,7 @@ impl MatchExecutableBuilder {
     fn register_internal(&mut self, var: Variable) {
         if let hash_map::Entry::Vacant(entry) = self.index.entry(var) {
             entry.insert(ExecutorVariable::Internal(var));
-            self.reverse_index.insert(ExecutorVariable::Internal(var), var);
+            self.reverse_index.insert(ExecutorVariable::new_internal(var), var);
         }
     }
 

--- a/compiler/executable/match_/planner/plan.rs
+++ b/compiler/executable/match_/planner/plan.rs
@@ -550,21 +550,17 @@ impl<'a> ConjunctionPlanBuilder<'a> {
         }
 
         while !open_set.is_empty() {
-            println!("Picking next element...");
             let (next, _cost) = open_set
                 .iter()
                 .filter(|&&elem| self.graph.elements[&elem].is_valid(elem, &ordering, &self.graph))
                 .map(|&elem| {
                     let cost = self.calculate_marginal_cost(&ordering, elem, intersection_variable);
-                    let graph_element = &self.graph.elements[&elem];
-                    println!("Marginal cost for {:?} is {:?}", graph_element, cost);
-                    (elem, self.calculate_marginal_cost(&ordering, elem, intersection_variable))
+                    // useful when debugging
+                    let _graph_element = &self.graph.elements[&elem];
+                    (elem, cost)
                 })
                 .min_by(|(_, lhs_cost), (_, rhs_cost)| lhs_cost.total_cmp(rhs_cost))
                 .unwrap();
-            let elem = &self.graph.elements[&next];
-            println!("Chose {:?}", elem);
-
             let element = &self.graph.elements[&next];
 
             if element.is_variable() {

--- a/compiler/executable/match_/planner/plan.rs
+++ b/compiler/executable/match_/planner/plan.rs
@@ -550,12 +550,20 @@ impl<'a> ConjunctionPlanBuilder<'a> {
         }
 
         while !open_set.is_empty() {
+            println!("Picking next element...");
             let (next, _cost) = open_set
                 .iter()
                 .filter(|&&elem| self.graph.elements[&elem].is_valid(elem, &ordering, &self.graph))
-                .map(|&elem| (elem, self.calculate_marginal_cost(&ordering, elem, intersection_variable)))
+                .map(|&elem| {
+                    let cost = self.calculate_marginal_cost(&ordering, elem, intersection_variable);
+                    let graph_element = &self.graph.elements[&elem];
+                    println!("Marginal cost for {:?} is {:?}", graph_element, cost);
+                    (elem, self.calculate_marginal_cost(&ordering, elem, intersection_variable))
+                })
                 .min_by(|(_, lhs_cost), (_, rhs_cost)| lhs_cost.total_cmp(rhs_cost))
                 .unwrap();
+            let elem = &self.graph.elements[&next];
+            println!("Chose {:?}", elem);
 
             let element = &self.graph.elements[&next];
 
@@ -622,7 +630,7 @@ impl<'a> ConjunctionPlanBuilder<'a> {
                 let intersection_variable = ordering.get(i + 1).and_then(|vertex| vertex.as_variable_id());
                 self.graph.elements[idx].cost(&ordering[..i], intersection_variable, &self.graph)
             })
-            .fold(ElementCost::FREE_BRANCH_1, |acc, e| acc.chain(e));
+            .fold(ElementCost::MEM_SIMPLE_BRANCH_1, |acc, e| acc.chain(e));
 
         let Self { shared_variables, graph, type_annotations, statistics: _ } = self;
 

--- a/compiler/executable/match_/planner/vertex/constraint.rs
+++ b/compiler/executable/match_/planner/vertex/constraint.rs
@@ -255,7 +255,11 @@ impl<'a> IsaPlanner<'a> {
 
     fn expected_output_size(&self, graph: &Graph<'_>, inputs: &[VertexId]) -> f64 {
         let thing = graph.elements()[&VertexId::Variable(self.thing)].as_variable().unwrap();
-        self.unrestricted_expected_size * thing.selectivity(inputs)
+        let thing_selectivity = thing.selectivity(inputs);
+        f64::max(
+            self.unrestricted_expected_size * thing_selectivity,
+            VariableVertex::OUTPUT_SIZE_MIN
+        )
     }
 }
 

--- a/compiler/executable/match_/planner/vertex/constraint.rs
+++ b/compiler/executable/match_/planner/vertex/constraint.rs
@@ -28,6 +28,7 @@ use crate::{
         },
     },
 };
+use crate::executable::match_::planner::vertex::variable::VariableVertex;
 
 #[derive(Clone, Debug)]
 pub(crate) enum ConstraintVertex<'a> {
@@ -208,7 +209,7 @@ impl<'a> TypeListPlanner<'a> {
 
 impl Costed for TypeListPlanner<'_> {
     fn cost(&self, _: &[VertexId], _intersection: Option<VariableVertexId>, _: &Graph<'_>) -> ElementCost {
-        ElementCost::free_with_branching(self.types.len() as f64)
+        ElementCost::in_mem_complex_with_branching(self.types.len() as f64)
     }
 }
 
@@ -392,7 +393,8 @@ impl<'a> HasPlanner<'a> {
     fn expected_output_size(&self, graph: &Graph<'_>, inputs: &[VertexId]) -> f64 {
         // get selectivity of attribute and multiply it by the expected size based on types
         let attribute = &graph.elements()[&VertexId::Variable(self.attribute)].as_variable().unwrap();
-        self.unbound_typed_expected_size * attribute.selectivity(inputs)
+        let expected_size = self.unbound_typed_expected_size * attribute.selectivity(inputs);
+        f64::max(expected_size, VariableVertex::OUTPUT_SIZE_MIN)
     }
 }
 
@@ -541,7 +543,10 @@ impl<'a> LinksPlanner<'a> {
     }
 
     fn unbound_expected_scan_size(&self, graph: &Graph<'_>) -> f64 {
-        f64::min(self.unbound_expected_scan_size_canonical(graph), self.unbound_expected_scan_size_reverse(graph))
+        f64::max(
+            f64::min(self.unbound_expected_scan_size_canonical(graph), self.unbound_expected_scan_size_reverse(graph)),
+            VariableVertex::OUTPUT_SIZE_MIN
+        )
     }
 
     fn unbound_expected_scan_size_canonical(&self, graph: &Graph<'_>) -> f64 {
@@ -558,7 +563,10 @@ impl<'a> LinksPlanner<'a> {
         // get selectivity of attribute and multiply it by the expected size based on types
         let player = &graph.elements()[&VertexId::Variable(self.player)].as_variable().unwrap();
         let relation = &graph.elements()[&VertexId::Variable(self.relation)].as_variable().unwrap();
-        self.unbound_typed_expected_size * player.selectivity(inputs) * relation.selectivity(inputs)
+        f64::max(
+            self.unbound_typed_expected_size * player.selectivity(inputs) * relation.selectivity(inputs),
+            VariableVertex::OUTPUT_SIZE_MIN
+        )
     }
 }
 
@@ -639,7 +647,7 @@ impl<'a> SubPlanner<'a> {
 
 impl Costed for SubPlanner<'_> {
     fn cost(&self, _: &[VertexId], _intersection: Option<VariableVertexId>, _: &Graph<'_>) -> ElementCost {
-        ElementCost::free_with_branching(1.0) // TODO branching
+        ElementCost::in_mem_complex_with_branching(1.0) // TODO branching
     }
 }
 
@@ -674,7 +682,7 @@ impl<'a> OwnsPlanner<'a> {
 
 impl Costed for OwnsPlanner<'_> {
     fn cost(&self, _: &[VertexId], _intersection: Option<VariableVertexId>, _: &Graph<'_>) -> ElementCost {
-        ElementCost::free_with_branching(1.0) // TODO branching
+        ElementCost::in_mem_complex_with_branching(1.0) // TODO branching
     }
 }
 
@@ -709,7 +717,7 @@ impl<'a> RelatesPlanner<'a> {
 
 impl Costed for RelatesPlanner<'_> {
     fn cost(&self, _: &[VertexId], _intersection: Option<VariableVertexId>, _: &Graph<'_>) -> ElementCost {
-        ElementCost::free_with_branching(1.0) // TODO branching
+        ElementCost::in_mem_complex_with_branching(1.0) // TODO branching
     }
 }
 
@@ -744,6 +752,6 @@ impl<'a> PlaysPlanner<'a> {
 
 impl Costed for PlaysPlanner<'_> {
     fn cost(&self, _: &[VertexId], _intersection: Option<VariableVertexId>, _: &Graph<'_>) -> ElementCost {
-        ElementCost::free_with_branching(1.0) // TODO branching
+        ElementCost::in_mem_complex_with_branching(1.0) // TODO branching
     }
 }

--- a/compiler/executable/match_/planner/vertex/mod.rs
+++ b/compiler/executable/match_/planner/vertex/mod.rs
@@ -130,11 +130,18 @@ pub(crate) struct ElementCost {
 }
 
 impl ElementCost {
+    const IN_MEM_COST_SIMPLE: f64 = 0.01;
+    const IN_MEM_COST_COMPLEX: f64 = ElementCost::IN_MEM_COST_SIMPLE * 2.0;
     pub const EMPTY: Self = Self { per_input: 0.0, per_output: 0.0, branching_factor: 0.0 };
-    pub const FREE_BRANCH_1: Self = Self { per_input: 0.0, per_output: 0.0, branching_factor: 1.0 };
+    pub const MEM_SIMPLE_BRANCH_1: Self = Self { per_input: ElementCost::IN_MEM_COST_SIMPLE, per_output: ElementCost::IN_MEM_COST_SIMPLE, branching_factor: 1.0 };
+    pub const MEM_COMPLEX_BRANCH_1: Self = Self { per_input: ElementCost::IN_MEM_COST_COMPLEX, per_output: ElementCost::IN_MEM_COST_COMPLEX, branching_factor: 1.0 };
 
-    fn free_with_branching(branching_factor: f64) -> Self {
-        Self { per_input: 0.0, per_output: 0.0, branching_factor }
+    fn in_mem_complex_with_branching(branching_factor: f64) -> Self {
+        Self { per_input: ElementCost::IN_MEM_COST_COMPLEX, per_output: ElementCost::IN_MEM_COST_COMPLEX, branching_factor }
+    }
+    
+    fn in_mem_simple_with_branching(branching_factor: f64) -> Self {
+        Self { per_input: ElementCost::IN_MEM_COST_SIMPLE, per_output: ElementCost::IN_MEM_COST_SIMPLE, branching_factor }
     }
 
     pub(crate) fn chain(self, other: Self) -> Self {
@@ -229,7 +236,7 @@ impl<'a> ExpressionPlanner<'a> {
         inputs: Vec<VariableVertexId>,
         output: VariableVertexId,
     ) -> Self {
-        let cost = ElementCost::FREE_BRANCH_1;
+        let cost = ElementCost::MEM_COMPLEX_BRANCH_1;
         Self { inputs, output, cost, expression }
     }
 
@@ -311,7 +318,7 @@ impl<'a> IsPlanner<'a> {
 
 impl Costed for IsPlanner<'_> {
     fn cost(&self, _: &[VertexId], _: Option<VariableVertexId>, _: &Graph<'_>) -> ElementCost {
-        ElementCost::FREE_BRANCH_1
+        ElementCost::MEM_SIMPLE_BRANCH_1
     }
 }
 
@@ -361,7 +368,7 @@ impl<'a> ComparisonPlanner<'a> {
 
 impl Costed for ComparisonPlanner<'_> {
     fn cost(&self, _: &[VertexId], _intersection: Option<VariableVertexId>, _: &Graph<'_>) -> ElementCost {
-        ElementCost::FREE_BRANCH_1
+        ElementCost::MEM_SIMPLE_BRANCH_1
     }
 }
 

--- a/compiler/lib.rs
+++ b/compiler/lib.rs
@@ -8,6 +8,7 @@
 #![allow(clippy::result_large_err)]
 
 use std::fmt;
+use std::fmt::Formatter;
 
 use answer::variable::Variable;
 use ir::pattern::IrID;
@@ -23,7 +24,7 @@ macro_rules! filter_variants {
 }
 pub(crate) use filter_variants;
 
-#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash, PartialOrd, Ord)]
+#[derive(Copy, Clone, Eq, PartialEq, Hash, PartialOrd, Ord)]
 pub enum ExecutorVariable {
     RowPosition(VariablePosition),
     Internal(Variable),
@@ -69,8 +70,17 @@ impl ExecutorVariable {
     }
 }
 
-impl fmt::Display for ExecutorVariable {
+impl fmt::Debug for ExecutorVariable {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            ExecutorVariable::RowPosition(position) => write!(f, "{position}"),
+            ExecutorVariable::Internal(var) => write!(f, "__{var}__")
+        }
+    }
+}
+
+impl fmt::Display for ExecutorVariable {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         fmt::Debug::fmt(self, f)
     }
 }
@@ -94,7 +104,7 @@ impl VariablePosition {
 
 impl fmt::Debug for VariablePosition {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "P_{}", self.position)
+        write!(f, "p{}", self.position)
     }
 }
 

--- a/compiler/lib.rs
+++ b/compiler/lib.rs
@@ -7,8 +7,7 @@
 #![deny(elided_lifetimes_in_paths)]
 #![allow(clippy::result_large_err)]
 
-use std::fmt;
-use std::fmt::Formatter;
+use std::{fmt, fmt::Formatter};
 
 use answer::variable::Variable;
 use ir::pattern::IrID;
@@ -74,7 +73,7 @@ impl fmt::Debug for ExecutorVariable {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             ExecutorVariable::RowPosition(position) => write!(f, "{position}"),
-            ExecutorVariable::Internal(var) => write!(f, "__{var}__")
+            ExecutorVariable::Internal(var) => write!(f, "__{var}__"),
         }
     }
 }

--- a/concept/thing/statistics.rs
+++ b/concept/thing/statistics.rs
@@ -143,8 +143,6 @@ impl Statistics {
                         self.update_writes(&commits, storage).map_err(|err| DataRead { source: err })?;
                     }
                 }
-            } else {
-                unreachable!("Only open validated records as snapshots.")
             }
         }
 

--- a/concept/thing/thing_manager.rs
+++ b/concept/thing/thing_manager.rs
@@ -379,19 +379,19 @@ impl ThingManager {
         if matches!(range.start_bound(), Bound::Unbounded) && matches!(range.end_bound(), Bound::Unbounded) {
             return self.get_attributes_in(snapshot, attribute_type);
         }
-        let Some(attribute_value_type) = attribute_type.get_value_type_without_source(snapshot, self.type_manager())? else {
-            return Ok(AttributeIterator::new_empty())
+        let Some(attribute_value_type) = attribute_type.get_value_type_without_source(snapshot, self.type_manager())?
+        else {
+            return Ok(AttributeIterator::new_empty());
         };
 
-        let Some((range_start, range_end)) = Self::get_value_range(
-            attribute_value_type,
-            range,
-            |value| AttributeVertex::build_prefix_for_value(
+        let Some((range_start, range_end)) = Self::get_value_range(attribute_value_type, range, |value| {
+            AttributeVertex::build_prefix_for_value(
                 attribute_type.vertex().type_id_(),
                 value,
                 self.vertex_generator.hasher(),
             )
-        )? else {
+        })?
+        else {
             return Ok(AttributeIterator::new_empty());
         };
         let key_range_start = match range_start {
@@ -453,7 +453,7 @@ impl ThingManager {
         range: &impl RangeBounds<Value<'a>>,
         prefix_constructor: PrefixFn,
     ) -> Result<Option<(Bound<Key>, Bound<Key>)>, ConceptReadError>
-        where
+    where
         PrefixFn: for<'b> Fn(Value<'b>) -> Key,
     {
         fn get_value_type(bound: Bound<&Value<'_>>) -> Option<ValueType> {
@@ -467,7 +467,7 @@ impl ThingManager {
         debug_assert!(start_value_type == end_value_type || start_value_type.is_none() || end_value_type.is_none());
         let range_value_type = start_value_type.unwrap_or_else(|| end_value_type.unwrap());
         if !range_value_type.is_approximately_castable_to(&expected_value_type) {
-            return Ok(None)
+            return Ok(None);
         }
         let value_type = expected_value_type;
 
@@ -478,11 +478,6 @@ impl ThingManager {
                 value.as_reference()
             };
             prefix_constructor(value)
-            // AttributeVertex::build_prefix_for_value(
-            //     attribute_type.vertex().type_id_(),
-            //     value,
-            //     self.vertex_generator.hasher(),
-            // )
         });
         let range_end = range.end_bound().map(|value| {
             let value = if value_type != range_value_type {
@@ -490,11 +485,6 @@ impl ThingManager {
             } else {
                 value.as_reference()
             };
-            // AttributeVertex::build_prefix_for_value(
-            //     attribute_type.vertex().type_id_(),
-            //     value,
-            //     self.vertex_generator.hasher(),
-            // )
             prefix_constructor(value)
         });
         Ok(Some((range_start, range_end)))
@@ -595,24 +585,20 @@ impl ThingManager {
         if matches!(range.start_bound(), Bound::Unbounded) && matches!(range.end_bound(), Bound::Unbounded) {
             return self.get_has_reverse(snapshot, attribute_type);
         }
-        let Some(attribute_value_type) = attribute_type.get_value_type_without_source(snapshot, self.type_manager())? else {
-            return Ok(HasReverseIterator::new_empty())
+        let Some(attribute_value_type) = attribute_type.get_value_type_without_source(snapshot, self.type_manager())?
+        else {
+            return Ok(HasReverseIterator::new_empty());
         };
 
-        let Some((range_start, range_end)) = Self::get_value_range(
-            attribute_value_type,
-            range,
-            |value| {
-                let attribute_vertex_prefix = AttributeVertex::build_prefix_for_value(
-                    attribute_type.vertex().type_id_(),
-                    value,
-                    self.vertex_generator.hasher(),
-                );
-                ThingEdgeHasReverse::prefix_from_attribute_vertex_prefix(
-                    attribute_vertex_prefix.as_reference().byte_ref()
-                )
-            }
-        )? else {
+        let Some((range_start, range_end)) = Self::get_value_range(attribute_value_type, range, |value| {
+            let attribute_vertex_prefix = AttributeVertex::build_prefix_for_value(
+                attribute_type.vertex().type_id_(),
+                value,
+                self.vertex_generator.hasher(),
+            );
+            ThingEdgeHasReverse::prefix_from_attribute_vertex_prefix(attribute_vertex_prefix.as_reference().byte_ref())
+        })?
+        else {
             return Ok(HasReverseIterator::new_empty());
         };
 
@@ -621,7 +607,7 @@ impl ThingManager {
             Bound::Excluded(start) => RangeStart::Exclusive(start),
             Bound::Unbounded => RangeStart::Inclusive(
                 ThingEdgeHasReverse::prefix_from_attribute_type(attribute_type.vertex().type_id_())
-                    .resize_to::<{ThingEdgeHasReverse::LENGTH_BOUND_PREFIX_FROM}>()
+                    .resize_to::<{ ThingEdgeHasReverse::LENGTH_BOUND_PREFIX_FROM }>(),
             ),
         };
         let key_range_end = match range_end {
@@ -633,7 +619,9 @@ impl ThingManager {
                 let mut array = prefix.into_bytes().into_array();
                 array.increment().unwrap();
                 let prefix_key = StorageKey::Array(StorageKeyArray::new_raw(keyspace, array));
-                RangeEnd::EndPrefixExclusive(prefix_key.resize_to::<{ThingEdgeHasReverse::LENGTH_BOUND_PREFIX_FROM}>())
+                RangeEnd::EndPrefixExclusive(
+                    prefix_key.resize_to::<{ ThingEdgeHasReverse::LENGTH_BOUND_PREFIX_FROM }>(),
+                )
             }
         };
         let key_range = if ThingEdgeHasReverse::FIXED_WIDTH_ENCODING {

--- a/database/database.rs
+++ b/database/database.rs
@@ -197,6 +197,8 @@ impl<D> Database<D> {
 }
 
 impl Database<WALClient> {
+    const STATISTICS_UPDATE_INTERVAL: Duration = Duration::from_millis(100);
+    
     pub fn open(path: &Path) -> Result<Database<WALClient>, DatabaseOpenError> {
         use DatabaseOpenError::InvalidUnicodeName;
 
@@ -210,7 +212,6 @@ impl Database<WALClient> {
         }
     }
 
-    const STATISTICS_UPDATE_INTERVAL: Duration = Duration::from_secs(1);
 
     fn create(path: &Path, name: impl AsRef<str>) -> Result<Database<WALClient>, DatabaseOpenError> {
         use DatabaseOpenError::{

--- a/database/database.rs
+++ b/database/database.rs
@@ -210,7 +210,7 @@ impl Database<WALClient> {
         }
     }
 
-    const STATISTICS_UPDATE_INTERVAL: Duration = Duration::from_secs(60);
+    const STATISTICS_UPDATE_INTERVAL: Duration = Duration::from_secs(1);
 
     fn create(path: &Path, name: impl AsRef<str>) -> Result<Database<WALClient>, DatabaseOpenError> {
         use DatabaseOpenError::{

--- a/encoding/graph/thing/edge.rs
+++ b/encoding/graph/thing/edge.rs
@@ -228,10 +228,11 @@ impl<'a> ThingEdgeHasReverse<'a> {
         bytes.bytes_mut()[from_prefix_end..from_type_id_end].copy_from_slice(&from_type_id.bytes());
         StorageKey::new_owned(EncodingKeyspace::Data, bytes)
     }
-
+    
     pub fn prefix_from_attribute_vertex_prefix(
         attribute_vertex_prefix: ByteReference<'_>,
     ) -> StorageKey<'static, { ThingEdgeHasReverse::LENGTH_BOUND_PREFIX_FROM }> {
+        debug_assert!(attribute_vertex_prefix.bytes()[AttributeVertex::RANGE_PREFIX] == AttributeVertex::PREFIX.prefix_id().bytes);
         let mut bytes = ByteArray::zeros(Self::RANGE_PREFIX.end + attribute_vertex_prefix.length());
         bytes.bytes_mut()[Self::RANGE_PREFIX].copy_from_slice(&Self::PREFIX.prefix_id().bytes());
         bytes.bytes_mut()[Self::RANGE_PREFIX.end..Self::RANGE_PREFIX.end + attribute_vertex_prefix.length()]

--- a/encoding/graph/thing/edge.rs
+++ b/encoding/graph/thing/edge.rs
@@ -228,11 +228,13 @@ impl<'a> ThingEdgeHasReverse<'a> {
         bytes.bytes_mut()[from_prefix_end..from_type_id_end].copy_from_slice(&from_type_id.bytes());
         StorageKey::new_owned(EncodingKeyspace::Data, bytes)
     }
-    
+
     pub fn prefix_from_attribute_vertex_prefix(
         attribute_vertex_prefix: ByteReference<'_>,
     ) -> StorageKey<'static, { ThingEdgeHasReverse::LENGTH_BOUND_PREFIX_FROM }> {
-        debug_assert!(attribute_vertex_prefix.bytes()[AttributeVertex::RANGE_PREFIX] == AttributeVertex::PREFIX.prefix_id().bytes);
+        debug_assert!(
+            attribute_vertex_prefix.bytes()[AttributeVertex::RANGE_PREFIX] == AttributeVertex::PREFIX.prefix_id().bytes
+        );
         let mut bytes = ByteArray::zeros(Self::RANGE_PREFIX.end + attribute_vertex_prefix.length());
         bytes.bytes_mut()[Self::RANGE_PREFIX].copy_from_slice(&Self::PREFIX.prefix_id().bytes());
         bytes.bytes_mut()[Self::RANGE_PREFIX.end..Self::RANGE_PREFIX.end + attribute_vertex_prefix.length()]

--- a/executor/instruction/has_executor.rs
+++ b/executor/instruction/has_executor.rs
@@ -176,9 +176,6 @@ impl HasExecutor {
             }
             BinaryIterateMode::UnboundInverted => {
                 debug_assert!(self.owner_cache.is_some());
-
-                // TODO: inject value range into thing manager calls
-                
                 if let Some([owner]) = self.owner_cache.as_deref() {
                     // no heap allocs needed if there is only 1 iterator
                     let iterator = owner.get_has_types_range_unordered(

--- a/executor/instruction/has_executor.rs
+++ b/executor/instruction/has_executor.rs
@@ -177,6 +177,8 @@ impl HasExecutor {
             BinaryIterateMode::UnboundInverted => {
                 debug_assert!(self.owner_cache.is_some());
 
+                // TODO: inject value range into thing manager calls
+                
                 if let Some([owner]) = self.owner_cache.as_deref() {
                     // no heap allocs needed if there is only 1 iterator
                     let iterator = owner.get_has_types_range_unordered(

--- a/executor/instruction/has_executor.rs
+++ b/executor/instruction/has_executor.rs
@@ -223,6 +223,7 @@ impl HasExecutor {
             BinaryIterateMode::BoundFrom => {
                 let owner = self.has.owner().as_variable().unwrap().as_position().unwrap();
                 debug_assert!(row.len() > owner.as_usize());
+                // TODO: inject value ranges
                 let iterator = match row.get(owner) {
                     VariableValue::Thing(Thing::Entity(entity)) => entity.get_has_types_range_unordered(
                         snapshot,

--- a/executor/instruction/isa_executor.rs
+++ b/executor/instruction/isa_executor.rs
@@ -257,11 +257,11 @@ pub(super) fn instances_of_all_types_chained<'a>(
     // Since the object types are sorted, and instance ordering follows matches type ordering, we have instance-sorting here
     let object_iter: MultipleTypeIsaObjectIterator = AsLendingIterator::new(object_iters).flatten();
 
-    // TODO: don't unwrap inside the operators
     let type_manager = thing_manager.type_manager();
     let attribute_iters: Vec<_> = attribute_types
         .into_iter()
-        .filter(|(type_, _)| type_.as_attribute_type().get_value_type(snapshot, type_manager).unwrap().is_some())
+        // TODO: we shouldn't really filter out errors here, but presumably a ConceptReadError will crop up elsewhere too if it happens here
+        .filter(|(type_, _)| type_.as_attribute_type().get_value_type(snapshot, type_manager).is_ok_and(|vt| vt.is_some()))
         .map(|(type_, types)| {
             let returned_types = if matches!(isa_kind, IsaKind::Subtype) { types.clone() } else { vec![type_.clone()] };
             Ok(with_types(

--- a/executor/instruction/isa_executor.rs
+++ b/executor/instruction/isa_executor.rs
@@ -261,7 +261,9 @@ pub(super) fn instances_of_all_types_chained<'a>(
     let attribute_iters: Vec<_> = attribute_types
         .into_iter()
         // TODO: we shouldn't really filter out errors here, but presumably a ConceptReadError will crop up elsewhere too if it happens here
-        .filter(|(type_, _)| type_.as_attribute_type().get_value_type(snapshot, type_manager).is_ok_and(|vt| vt.is_some()))
+        .filter(|(type_, _)| {
+            type_.as_attribute_type().get_value_type(snapshot, type_manager).is_ok_and(|vt| vt.is_some())
+        })
         .map(|(type_, types)| {
             let returned_types = if matches!(isa_kind, IsaKind::Subtype) { types.clone() } else { vec![type_.clone()] };
             Ok(with_types(

--- a/executor/instruction/mod.rs
+++ b/executor/instruction/mod.rs
@@ -244,7 +244,7 @@ impl BinaryIterateMode {
         }
     }
 
-    pub(crate) fn is_inverted(&self) -> bool {
+    pub(crate) fn is_unbound_inverted(&self) -> bool {
         self == &Self::UnboundInverted
     }
 }

--- a/executor/match_executor.rs
+++ b/executor/match_executor.rs
@@ -40,7 +40,6 @@ impl MatchExecutor {
         input: MaybeOwnedRow<'_>,
         function_registry: Arc<ExecutableFunctionRegistry>,
     ) -> Result<Self, ConceptReadError> {
-        println!("{}", match_executable);
         Ok(Self {
             entry: TODO_REMOVE_create_executors_for_match(
                 snapshot,

--- a/executor/match_executor.rs
+++ b/executor/match_executor.rs
@@ -40,6 +40,7 @@ impl MatchExecutor {
         input: MaybeOwnedRow<'_>,
         function_registry: Arc<ExecutableFunctionRegistry>,
     ) -> Result<Self, ConceptReadError> {
+        println!("{}", match_executable);
         Ok(Self {
             entry: TODO_REMOVE_create_executors_for_match(
                 snapshot,

--- a/ir/pattern/constraint.rs
+++ b/ir/pattern/constraint.rs
@@ -5,6 +5,7 @@
  */
 
 use std::{collections::HashMap, fmt, ops::Deref};
+use std::fmt::{Display, Formatter};
 
 use answer::variable::Variable;
 use itertools::Itertools;
@@ -878,6 +879,16 @@ impl From<typeql::statement::type_::SubKind> for SubKind {
     }
 }
 
+impl Display for SubKind {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Exact => write!(f, "!"),
+            // This is not a great Display implementation since there is no symbol to read this variant
+            Self::Subtype => write!(f, ""),
+        }
+    }
+}
+
 #[derive(Debug, Clone, Eq, PartialEq, Hash)]
 pub struct Sub<ID> {
     kind: SubKind,
@@ -1055,6 +1066,16 @@ impl From<typeql::statement::thing::isa::IsaKind> for IsaKind {
         match kind {
             typeql::statement::thing::isa::IsaKind::Exact => Self::Exact,
             typeql::statement::thing::isa::IsaKind::Subtype => Self::Subtype,
+        }
+    }
+}
+
+impl Display for IsaKind {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Exact => write!(f, "!"),
+            // This is not a great Display implementation since there is no symbol to read this variant
+            Self::Subtype => write!(f, ""),
         }
     }
 }
@@ -1335,6 +1356,21 @@ impl From<typeql::token::Comparator> for Comparator {
             typeql::token::Comparator::Lte => Self::LessOrEqual,
             typeql::token::Comparator::Contains => Self::Contains,
             typeql::token::Comparator::Like => Self::Like,
+        }
+    }
+}
+
+impl Display for Comparator {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Equal => write!(f, "{}", typeql::token::Comparator::Eq),
+            Self::NotEqual => write!(f, "{}", typeql::token::Comparator::Neq),
+            Self::Less => write!(f, "{}", typeql::token::Comparator::Lt),
+            Self::Greater => write!(f, "{}", typeql::token::Comparator::Gt),
+            Self::LessOrEqual => write!(f, "{}", typeql::token::Comparator::Lte),
+            Self::GreaterOrEqual => write!(f, "{}", typeql::token::Comparator::Gte),
+            Self::Like => write!(f, "{}", typeql::token::Comparator::Like),
+            Self::Contains => write!(f, "{}", typeql::token::Comparator::Contains),
         }
     }
 }

--- a/ir/pattern/constraint.rs
+++ b/ir/pattern/constraint.rs
@@ -4,8 +4,12 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-use std::{collections::HashMap, fmt, ops::Deref};
-use std::fmt::{Display, Formatter};
+use std::{
+    collections::HashMap,
+    fmt,
+    fmt::{Display, Formatter},
+    ops::Deref,
+};
 
 use answer::variable::Variable;
 use itertools::Itertools;

--- a/ir/pattern/mod.rs
+++ b/ir/pattern/mod.rs
@@ -5,6 +5,7 @@
  */
 
 use std::{collections::HashMap, fmt, hash::Hash};
+use std::fmt::Formatter;
 
 use answer::variable::Variable;
 use encoding::value::label::Label;
@@ -46,12 +47,12 @@ impl fmt::Display for ScopeId {
     }
 }
 
-pub trait IrID: Copy + fmt::Display + Hash + Eq + PartialEq + Ord + PartialOrd + 'static {}
+pub trait IrID: Copy + fmt::Display + fmt::Debug + Hash + Eq + PartialEq + Ord + PartialOrd + 'static {}
 
 impl IrID for Variable {}
 
 // TODO: rename to 'Identifier' in lieu of a better name
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub enum Vertex<ID> {
     Variable(ID),
     Label(Label<'static>),
@@ -122,24 +123,36 @@ impl<ID> From<ID> for Vertex<ID> {
     }
 }
 
-impl<ID: fmt::Display> fmt::Display for Vertex<ID> {
+impl<ID: fmt::Debug> fmt::Debug for Vertex<ID> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Self::Variable(var) => fmt::Display::fmt(var, f),
+            Self::Variable(var) => fmt::Debug::fmt(var, f),
             Self::Label(label) => write!(f, "{}", label.scoped_name().as_str()),
-            Self::Parameter(param) => fmt::Display::fmt(param, f),
+            Self::Parameter(param) => fmt::Debug::fmt(param, f),
         }
     }
 }
 
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+impl<ID: fmt::Debug> fmt::Display for Vertex<ID> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        fmt::Debug::fmt(self, f)
+    }
+}
+
+#[derive(Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct ParameterID {
     pub id: usize,
 }
 
-impl fmt::Display for ParameterID {
+impl fmt::Debug for ParameterID {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "Parameter[{}]", self.id)
+        write!(f, "Param[{}]", self.id)
+    }
+}
+
+impl fmt::Display for ParameterID {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        fmt::Debug::fmt(self, f)
     }
 }
 

--- a/ir/pattern/mod.rs
+++ b/ir/pattern/mod.rs
@@ -4,8 +4,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-use std::{collections::HashMap, fmt, hash::Hash};
-use std::fmt::Formatter;
+use std::{collections::HashMap, fmt, fmt::Formatter, hash::Hash};
 
 use answer::variable::Variable;
 use encoding::value::label::Label;

--- a/resource/constants.rs
+++ b/resource/constants.rs
@@ -18,7 +18,7 @@ pub mod server {
 }
 
 pub mod traversal {
-    pub const CONSTANT_CONCEPT_LIMIT: usize = 50;
+    pub const CONSTANT_CONCEPT_LIMIT: usize = 10;
 }
 
 pub mod snapshot {

--- a/resource/constants.rs
+++ b/resource/constants.rs
@@ -18,7 +18,7 @@ pub mod server {
 }
 
 pub mod traversal {
-    pub const CONSTANT_CONCEPT_LIMIT: usize = 5;
+    pub const CONSTANT_CONCEPT_LIMIT: usize = 50;
 }
 
 pub mod snapshot {


### PR DESCRIPTION
## Release notes: product changes

We inline comparators into `HasReverse` executors, as a continuation of #7233, which inlined comparators into `Isa` executors. Both optimisations reduce the search space by using the value ranges provided by constants in the query or previously executed query steps. We also improve the query planner's statistics and cost function.

## Motivation

Traversals can do extra work scanning ranges of data when 1) we know a range to search in eg, `$age > 18;` and 2) the data is sorted in an order that we can take advantage of.

## Implementation

- Push value ranges into `HasReverse` execution, which causes the iterators to skip data ranges that would never match the query
- Implement `Display` for `MatchExecutable`s, which allow much faster debugging of slow or incorrect queries, which may always be caused by an unusual query plan!
- Optimise the query planner statistics calculation, including making in-memory costs non-zero.
