### PR TITLE
Carry correct types into type list executor

### DIFF
--- a/compiler/executable/match_/instructions/mod.rs
+++ b/compiler/executable/match_/instructions/mod.rs
@@ -7,8 +7,9 @@
 #![allow(clippy::large_enum_variant)]
 
 use std::{
-    collections::{HashMap, HashSet},
+    collections::{BTreeSet, HashMap, HashSet},
     ops::Deref,
+    sync::Arc,
 };
 
 use answer::{variable::Variable, Type};
@@ -483,7 +484,7 @@ impl<ID: IrID> CheckVertex<ID> {
 
 #[derive(Debug, Clone)]
 pub enum CheckInstruction<ID> {
-    TypeList { type_var: ID, types: Vec<Type> },
+    TypeList { type_var: ID, types: Arc<BTreeSet<Type>> },
 
     Sub { sub_kind: SubKind, subtype: CheckVertex<ID>, supertype: CheckVertex<ID> },
     Owns { owner: CheckVertex<ID>, attribute: CheckVertex<ID> },

--- a/compiler/executable/match_/instructions/type_.rs
+++ b/compiler/executable/match_/instructions/type_.rs
@@ -12,7 +12,7 @@ use std::{
 use answer::{variable::Variable, Type};
 use ir::pattern::{
     constraint::{Owns, Plays, Relates, Sub},
-    IrID, 
+    IrID,
 };
 
 use crate::{
@@ -23,13 +23,13 @@ use crate::{
 #[derive(Debug, Clone)]
 pub struct TypeListInstruction<ID> {
     pub type_var: ID,
-    types: BTreeSet<Type>,
+    types: Arc<BTreeSet<Type>>,
     pub checks: Vec<CheckInstruction<ID>>,
 }
 
 impl TypeListInstruction<Variable> {
-    pub(crate) fn new(type_var: Variable, types: Vec<Type>) -> Self {
-        Self { type_var, types: BTreeSet::from_iter(types), checks: Vec::new() }
+    pub(crate) fn new(type_var: Variable, types: Arc<BTreeSet<Type>>) -> Self {
+        Self { type_var, types, checks: Vec::new() }
     }
 }
 

--- a/compiler/executable/match_/instructions/type_.rs
+++ b/compiler/executable/match_/instructions/type_.rs
@@ -12,7 +12,7 @@ use std::{
 use answer::{variable::Variable, Type};
 use ir::pattern::{
     constraint::{Owns, Plays, Relates, Sub},
-    IrID, Vertex,
+    IrID, 
 };
 
 use crate::{

--- a/compiler/executable/match_/instructions/type_.rs
+++ b/compiler/executable/match_/instructions/type_.rs
@@ -23,14 +23,13 @@ use crate::{
 #[derive(Debug, Clone)]
 pub struct TypeListInstruction<ID> {
     pub type_var: ID,
-    types: Arc<BTreeSet<Type>>,
+    types: BTreeSet<Type>,
     pub checks: Vec<CheckInstruction<ID>>,
 }
 
 impl TypeListInstruction<Variable> {
-    pub(crate) fn new(type_var: Variable, type_annotations: &TypeAnnotations) -> Self {
-        let types = type_annotations.vertex_annotations_of(&Vertex::Variable(type_var)).unwrap().clone();
-        Self { type_var, types, checks: Vec::new() }
+    pub(crate) fn new(type_var: Variable, types: Vec<Type>) -> Self {
+        Self { type_var, types: BTreeSet::from_iter(types), checks: Vec::new() }
     }
 }
 

--- a/compiler/executable/match_/planner/mod.rs
+++ b/compiler/executable/match_/planner/mod.rs
@@ -19,7 +19,6 @@ use crate::{
     executable::match_::{
         instructions::{CheckInstruction, ConstraintInstruction},
         planner::{
-            function_plan::ExecutableFunctionRegistry,
             match_executable::{
                 AssignmentStep, CheckStep, DisjunctionStep, ExecutionStep, FunctionCallStep, IntersectionStep,
                 MatchExecutable, NegationStep,

--- a/compiler/executable/match_/planner/plan.rs
+++ b/compiler/executable/match_/planner/plan.rs
@@ -979,7 +979,7 @@ impl ConjunctionPlan<'_> {
         match constraint {
             ConstraintVertex::TypeList(type_list) => {
                 let var = type_list.constraint().var();
-                let instruction = type_list.lower(self.type_annotations);
+                let instruction = type_list.lower();
                 match_builder.push_instruction(var, instruction);
             }
 

--- a/compiler/executable/match_/planner/vertex/constraint.rs
+++ b/compiler/executable/match_/planner/vertex/constraint.rs
@@ -214,7 +214,7 @@ impl<'a> TypeListPlanner<'a> {
 
     pub(crate) fn lower(&self, type_annotations: &TypeAnnotations) -> ConstraintInstruction<Variable> {
         let var = self.constraint.var();
-        ConstraintInstruction::TypeList(TypeListInstruction::new(var, type_annotations))
+        ConstraintInstruction::TypeList(TypeListInstruction::new(var, self.types.clone()))
     }
 
     pub(crate) fn lower_check(&self) -> CheckInstruction<Variable> {

--- a/compiler/executable/match_/planner/vertex/constraint.rs
+++ b/compiler/executable/match_/planner/vertex/constraint.rs
@@ -212,7 +212,7 @@ impl<'a> TypeListPlanner<'a> {
         &self.constraint
     }
 
-    pub(crate) fn lower(&self, type_annotations: &TypeAnnotations) -> ConstraintInstruction<Variable> {
+    pub(crate) fn lower(&self) -> ConstraintInstruction<Variable> {
         let var = self.constraint.var();
         ConstraintInstruction::TypeList(TypeListInstruction::new(var, self.types.clone()))
     }

--- a/compiler/executable/match_/planner/vertex/constraint.rs
+++ b/compiler/executable/match_/planner/vertex/constraint.rs
@@ -4,7 +4,11 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-use std::{collections::HashMap, fmt, iter};
+use std::{
+    collections::{BTreeSet, HashMap},
+    fmt, iter,
+    sync::Arc,
+};
 
 use answer::{variable::Variable, Type};
 use concept::thing::statistics::Statistics;
@@ -122,7 +126,7 @@ impl<'a> TypeListConstraint<'a> {
 pub(crate) struct TypeListPlanner<'a> {
     constraint: TypeListConstraint<'a>,
     var: VariableVertexId,
-    types: Vec<Type>,
+    types: Arc<BTreeSet<Type>>,
 }
 
 impl<'a> fmt::Debug for TypeListPlanner<'a> {
@@ -141,12 +145,7 @@ impl<'a> TypeListPlanner<'a> {
         variable_index: &HashMap<Variable, VariableVertexId>,
         type_annotations: &TypeAnnotations,
     ) -> Self {
-        let types = type_annotations
-            .vertex_annotations_of(label.type_label())
-            .into_iter()
-            .flat_map(|annos| annos.iter())
-            .cloned()
-            .collect();
+        let types = type_annotations.vertex_annotations_of(label.type_label()).cloned().unwrap_or_default();
         Self {
             constraint: TypeListConstraint::Label(label),
             var: variable_index[&label.type_().as_variable().unwrap()],
@@ -159,12 +158,7 @@ impl<'a> TypeListPlanner<'a> {
         variable_index: &HashMap<Variable, VariableVertexId>,
         type_annotations: &TypeAnnotations,
     ) -> Self {
-        let types = type_annotations
-            .vertex_annotations_of(role_name.type_())
-            .into_iter()
-            .flat_map(|annos| annos.iter())
-            .cloned()
-            .collect();
+        let types = type_annotations.vertex_annotations_of(role_name.type_()).cloned().unwrap_or_default();
         Self {
             constraint: TypeListConstraint::RoleName(role_name),
             var: variable_index[&role_name.type_().as_variable().unwrap()],
@@ -177,12 +171,7 @@ impl<'a> TypeListPlanner<'a> {
         variable_index: &HashMap<Variable, VariableVertexId>,
         type_annotations: &TypeAnnotations,
     ) -> Self {
-        let types = type_annotations
-            .vertex_annotations_of(kind.type_())
-            .into_iter()
-            .flat_map(|annos| annos.iter())
-            .cloned()
-            .collect();
+        let types = type_annotations.vertex_annotations_of(kind.type_()).cloned().unwrap_or_default();
         Self {
             constraint: TypeListConstraint::Kind(kind),
             var: variable_index[&kind.type_().as_variable().unwrap()],
@@ -195,12 +184,7 @@ impl<'a> TypeListPlanner<'a> {
         variable_index: &HashMap<Variable, VariableVertexId>,
         type_annotations: &TypeAnnotations,
     ) -> Self {
-        let types = type_annotations
-            .vertex_annotations_of(value.attribute_type())
-            .into_iter()
-            .flat_map(|annos| annos.iter())
-            .cloned()
-            .collect();
+        let types = type_annotations.vertex_annotations_of(value.attribute_type()).cloned().unwrap_or_default();
         Self {
             constraint: TypeListConstraint::Value(value),
             var: variable_index[&value.attribute_type().as_variable().unwrap()],

--- a/compiler/executable/match_/planner/vertex/variable.rs
+++ b/compiler/executable/match_/planner/vertex/variable.rs
@@ -9,13 +9,12 @@ use std::{collections::HashSet, fmt};
 use answer::variable::Variable;
 use concept::thing::statistics::Statistics;
 use ir::pattern::Vertex;
-use itertools::{chain, Itertools};
 
 use crate::{
     annotation::type_annotations::TypeAnnotations,
     executable::match_::planner::{
         plan::{Graph, PatternVertexId, VariableVertexId, VertexId},
-        vertex::{Costed, ElementCost, Input, PlannerVertex},
+        vertex::{Costed, ElementCost, Input},
     },
 };
 

--- a/executor/error.rs
+++ b/executor/error.rs
@@ -7,9 +7,8 @@
 use compiler::annotation::expression::instructions::ExpressionEvaluationError;
 use concept::error::ConceptReadError;
 use error::typedb_error;
-use ir::pipeline::function_signature::FunctionID;
 
-use crate::{row::MaybeOwnedRow, InterruptType};
+use crate::InterruptType;
 
 typedb_error!(
     pub ReadExecutionError(component = "Read execution", prefix = "REX") {

--- a/executor/instruction/isa_executor.rs
+++ b/executor/instruction/isa_executor.rs
@@ -17,17 +17,9 @@ use concept::{
         object::Object,
         relation::Relation,
         thing_manager::ThingManager,
-        ThingAPI,
     },
 };
-use encoding::{
-    graph::{
-        thing::{vertex_attribute::AttributeVertex, ThingVertex},
-        type_::vertex::TypeVertexEncoding,
-        Typed,
-    },
-    value::value::Value,
-};
+use encoding::value::value::Value;
 use ir::pattern::{
     constraint::{Isa, IsaKind},
     Vertex,

--- a/executor/instruction/isa_reverse_executor.rs
+++ b/executor/instruction/isa_reverse_executor.rs
@@ -4,12 +4,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-use std::{
-    collections::{BTreeMap, BTreeSet},
-    iter, option,
-    sync::Arc,
-    vec,
-};
+use std::{collections::BTreeMap, iter, option, sync::Arc, vec};
 
 use answer::{Thing, Type};
 use compiler::{executable::match_::instructions::thing::IsaReverseInstruction, ExecutorVariable};
@@ -22,12 +17,7 @@ use concept::{
         thing_manager::ThingManager,
     },
 };
-use encoding::graph::{
-    thing::{vertex_attribute::AttributeVertex, ThingVertex},
-    type_::vertex::TypeVertexEncoding,
-    Typed,
-};
-use ir::pattern::constraint::{Isa, IsaKind, SubKind};
+use ir::pattern::constraint::{Isa, IsaKind};
 use itertools::Itertools;
 use lending_iterator::{
     adaptors::{Chain, Flatten, Map, Zip},
@@ -40,7 +30,6 @@ use crate::{
     instruction::{
         isa_executor::{IsaFilterFn, IsaTupleIterator, SingleTypeIsaIterator, EXTRACT_THING, EXTRACT_TYPE},
         iterator::{SortedTupleIterator, TupleIterator},
-        sub_reverse_executor::get_subtypes,
         tuple::{isa_to_tuple_thing_type, isa_to_tuple_type_thing, TuplePositions},
         type_from_row_or_annotations, BinaryIterateMode, Checker, VariableModes, TYPES_EMPTY,
     },

--- a/executor/instruction/mod.rs
+++ b/executor/instruction/mod.rs
@@ -4,12 +4,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-use std::{
-    collections::HashMap,
-    fmt,
-    marker::PhantomData,
-    ops::{Bound, RangeBounds},
-};
+use std::{collections::HashMap, fmt, marker::PhantomData, ops::Bound};
 
 use answer::{variable_value::VariableValue, Thing, Type};
 use compiler::{
@@ -27,14 +22,13 @@ use encoding::value::{value::Value, ValueEncodable};
 use ir::{
     pattern::{
         constraint::{Comparator, IsaKind, SubKind},
-        ParameterID, Vertex,
+        Vertex,
     },
     pipeline::ParameterRegistry,
 };
 use itertools::Itertools;
 use lending_iterator::higher_order::{FnHktHelper, Hkt};
 use storage::snapshot::ReadableSnapshot;
-use tracing::field::debug;
 
 use crate::{
     instruction::{


### PR DESCRIPTION
## Release notes: product changes

In cases where the list of types is dependent on the context (e.g. `{$t label T;} or {$t label U;};`, the type list executor (role name, explicit label, or kind) should only be producing the types in the list defined by the constraint. That was handled correctly when the type constraint was used as a post-check, but incorrectly during direct execution.

## Motivation

## Implementation
