### PR TITLE
Decimal to double cast

### DIFF
--- a/compiler/annotation/expression/block_compiler.rs
+++ b/compiler/annotation/expression/block_compiler.rs
@@ -80,16 +80,9 @@ pub fn compile_expressions<'block, Snapshot: ReadableSnapshot>(
             ExpressionValueType::List(_) => VariableCategory::ValueList,
         };
         let existing_category = variable_registry.get_variable_category(var);
-        if existing_category.is_none() {
-            let source = Constraint::ExpressionBinding((*expression_index.get(&var).unwrap()).clone());
-            variable_registry.set_assigned_value_variable_category(var, category, source).unwrap();
-        } else if Some(category) != existing_category {
-            Err(ExpressionCompileError::DerivedConflictingVariableCategory {
-                variable_name: variable_registry.variable_names().get(&var).unwrap().clone(),
-                derived_category: category,
-                existing_category: existing_category.unwrap(),
-            })?;
-        }
+        let source = Constraint::ExpressionBinding((*expression_index.get(&var).unwrap()).clone());
+        variable_registry.set_assigned_value_variable_category(var, category, source)
+            .map_err(|source| { ExpressionCompileError::Representation { source } })?;
     }
     Ok(compiled_expressions)
 }

--- a/compiler/annotation/expression/expression_compiler.rs
+++ b/compiler/annotation/expression/expression_compiler.rs
@@ -34,12 +34,13 @@ use crate::annotation::expression::{
     },
     ExpressionCompileError,
 };
+use crate::annotation::expression::instructions::load_cast::{CastLeftDecimalToDouble, CastRightDecimalToDouble};
 
 pub struct ExpressionCompilationContext<'this> {
     expression_tree: &'this ExpressionTree<Variable>,
     variable_value_categories: &'this HashMap<Variable, ExpressionValueType>,
     parameters: &'this ParameterRegistry,
-    type_stack: Vec<ExpressionValueType>,
+    pub type_stack: Vec<ExpressionValueType>,
 
     instructions: Vec<ExpressionOpCode>,
     variable_stack: Vec<Variable>,
@@ -238,6 +239,11 @@ impl<'this> ExpressionCompilationContext<'this> {
                 CastRightLongToDouble::validate_and_append(self)?;
                 self.compile_op_double_double(op)?;
             }
+            ValueTypeCategory::Decimal => {
+                // The right needs to be cast
+                CastRightDecimalToDouble::validate_and_append(self)?;
+                self.compile_op_double_double(op)?;
+            }
             ValueTypeCategory::Double => {
                 self.compile_op_double_double(op)?;
             }
@@ -253,11 +259,19 @@ impl<'this> ExpressionCompilationContext<'this> {
     fn compile_op_decimal(&mut self, op: Operator, right: &Expression<Variable>) -> Result<(), ExpressionCompileError> {
         self.compile_recursive(right)?;
         let right_category = self.peek_type_single()?.category();
-        Err(ExpressionCompileError::UnsupportedOperandsForOperation {
-            op,
-            left_category: ValueTypeCategory::Decimal,
-            right_category,
-        })
+        match right_category {
+            ValueTypeCategory::Double => {
+                // The left needs to be cast
+                CastLeftDecimalToDouble::validate_and_append(self)?;
+                self.compile_op_double_double(op)?;
+            }
+            _ => Err(ExpressionCompileError::UnsupportedOperandsForOperation {
+                op,
+                left_category: ValueTypeCategory::Decimal,
+                right_category,
+            })?,
+        }
+        Ok(())
     }
 
     fn compile_op_string(&mut self, op: Operator, right: &Expression<Variable>) -> Result<(), ExpressionCompileError> {

--- a/compiler/annotation/expression/expression_compiler.rs
+++ b/compiler/annotation/expression/expression_compiler.rs
@@ -40,7 +40,7 @@ pub struct ExpressionCompilationContext<'this> {
     expression_tree: &'this ExpressionTree<Variable>,
     variable_value_categories: &'this HashMap<Variable, ExpressionValueType>,
     parameters: &'this ParameterRegistry,
-    pub type_stack: Vec<ExpressionValueType>,
+    type_stack: Vec<ExpressionValueType>,
 
     instructions: Vec<ExpressionOpCode>,
     variable_stack: Vec<Variable>,

--- a/compiler/annotation/expression/instructions/load_cast.rs
+++ b/compiler/annotation/expression/instructions/load_cast.rs
@@ -112,7 +112,6 @@ impl<From: NativeValueConvertible, To: ImplicitCast<From>> CompilableExpression 
     }
 
     fn validate_and_append(builder: &mut ExpressionCompilationContext<'_>) -> Result<(), ExpressionCompileError> {
-        dbg!(&builder.type_stack);
         let right_before = builder.pop_type_single()?.category();
         if right_before != From::VALUE_TYPE_CATEGORY {
             Err(ExpressionCompileError::InternalUnexpectedValueType)?;

--- a/compiler/annotation/expression/instructions/op_codes.rs
+++ b/compiler/annotation/expression/instructions/op_codes.rs
@@ -20,6 +20,10 @@ pub enum ExpressionOpCode {
     CastLeftLongToDouble,
     CastRightLongToDouble,
 
+    CastUnaryDecimalToDouble,
+    CastLeftDecimalToDouble,
+    CastRightDecimalToDouble,
+
     // Operators
     OpLongAddLong,
     OpDoubleAddDouble,

--- a/compiler/annotation/expression/mod.rs
+++ b/compiler/annotation/expression/mod.rs
@@ -12,6 +12,7 @@ use std::{
 use concept::error::ConceptReadError;
 use encoding::value::value_type::ValueTypeCategory;
 use ir::pattern::{expression::Operator, variable_category::VariableCategory};
+use ir::RepresentationError;
 
 pub mod block_compiler;
 pub mod compiled_expression;
@@ -60,6 +61,7 @@ pub enum ExpressionCompileError {
         derived_category: VariableCategory,
         existing_category: VariableCategory,
     },
+    Representation { source: RepresentationError },
 }
 
 impl Display for ExpressionCompileError {
@@ -72,6 +74,7 @@ impl Error for ExpressionCompileError {
     fn source(&self) -> Option<&(dyn Error + 'static)> {
         match self {
             Self::ConceptRead { source, .. } => Some(source),
+            Self::Representation { source } =>  None,
             Self::InternalStackWasEmpty
             | Self::InternalUnexpectedValueType
             | Self::UnsupportedOperandsForOperation { .. }

--- a/compiler/annotation/expression/mod.rs
+++ b/compiler/annotation/expression/mod.rs
@@ -74,7 +74,6 @@ impl Error for ExpressionCompileError {
     fn source(&self) -> Option<&(dyn Error + 'static)> {
         match self {
             Self::ConceptRead { source, .. } => Some(source),
-            Self::Representation { source } =>  None,
             Self::InternalStackWasEmpty
             | Self::InternalUnexpectedValueType
             | Self::UnsupportedOperandsForOperation { .. }
@@ -85,6 +84,7 @@ impl Error for ExpressionCompileError {
             | Self::VariableHasNoValueType { .. }
             | Self::VariableMustBeValueOrAttribute { .. }
             | Self::DerivedConflictingVariableCategory { .. }
+            | Self::Representation { .. }
             | Self::UnsupportedArgumentsForBuiltin
             | Self::ListIndexMustBeLong
             | Self::HeterogenousValuesInList

--- a/executor/read/expression_executor.rs
+++ b/executor/read/expression_executor.rs
@@ -22,6 +22,9 @@ use compiler::annotation::expression::{
         ExpressionEvaluationError,
     },
 };
+use compiler::annotation::expression::instructions::load_cast::CastUnaryDecimalToDouble;
+use compiler::annotation::expression::instructions::load_cast::CastLeftDecimalToDouble;
+use compiler::annotation::expression::instructions::load_cast::CastRightDecimalToDouble;
 use encoding::value::value::{NativeValueConvertible, Value};
 use ir::{pattern::ParameterID, pipeline::ParameterRegistry};
 use storage::snapshot::ReadableSnapshot;
@@ -153,6 +156,10 @@ fn evaluate_instruction(
         ExpressionOpCode::CastUnaryLongToDouble => CastUnaryLongToDouble::evaluate(state),
         ExpressionOpCode::CastLeftLongToDouble => CastLeftLongToDouble::evaluate(state),
         ExpressionOpCode::CastRightLongToDouble => CastRightLongToDouble::evaluate(state),
+
+        ExpressionOpCode::CastUnaryDecimalToDouble => CastUnaryDecimalToDouble::evaluate(state),
+        ExpressionOpCode::CastLeftDecimalToDouble => CastLeftDecimalToDouble::evaluate(state),
+        ExpressionOpCode::CastRightDecimalToDouble => CastRightDecimalToDouble::evaluate(state),
 
         ExpressionOpCode::OpLongAddLong => operators::OpLongAddLong::evaluate(state),
         ExpressionOpCode::OpLongSubtractLong => operators::OpLongSubtractLong::evaluate(state),


### PR DESCRIPTION
## Release notes: product changes

We can now use decimals in double expressions.

## Motivation

We allow implicit casting of `long -> decimal -> double` in TypeQL

## Implementation

Added casts in compiler.


