### PR TITLE
Use type inference in sub constraints

### DIFF
--- a/compiler/executable/match_/instructions/mod.rs
+++ b/compiler/executable/match_/instructions/mod.rs
@@ -7,21 +7,19 @@
 #![allow(clippy::large_enum_variant)]
 
 use std::{
-    collections::{HashMap, HashSet},
+    collections::{BTreeSet, HashMap, HashSet},
     fmt,
     fmt::{Debug, Display, Formatter},
     ops::Deref,
     sync::Arc,
 };
-use std::collections::BTreeSet;
 
-use itertools::Itertools;
-
-use answer::{Type, variable::Variable};
+use answer::{variable::Variable, Type};
 use ir::pattern::{
     constraint::{Comparator, Comparison, Constraint, ExpressionBinding, FunctionCallBinding, Is, IsaKind, SubKind},
     IrID, ParameterID, Vertex,
 };
+use itertools::Itertools;
 
 use crate::{
     annotation::type_annotations::TypeAnnotations, executable::match_::planner::match_executable::InstructionAPI,

--- a/compiler/executable/match_/instructions/type_.rs
+++ b/compiler/executable/match_/instructions/type_.rs
@@ -19,7 +19,7 @@ use itertools::Itertools;
 
 use crate::{
     annotation::type_annotations::TypeAnnotations,
-    executable::match_::instructions::{CheckInstruction, Inputs, IsInstruction},
+    executable::match_::instructions::{CheckInstruction, Inputs},
 };
 
 #[derive(Debug, Clone)]

--- a/compiler/executable/match_/planner/vertex/constraint.rs
+++ b/compiler/executable/match_/planner/vertex/constraint.rs
@@ -12,7 +12,7 @@ use std::{
 
 use answer::{variable::Variable, Type};
 use concept::thing::statistics::Statistics;
-use ir::pattern::constraint::{Has, Isa, Kind, Label, Links, Owns, Plays, Relates, RoleName, Sub, SubKind, Value};
+use ir::pattern::constraint::{Has, Isa, Kind, Label, Links, Owns, Plays, Relates, RoleName, Sub, Value};
 use itertools::Itertools;
 
 use crate::{

--- a/compiler/executable/match_/planner/vertex/constraint.rs
+++ b/compiler/executable/match_/planner/vertex/constraint.rs
@@ -22,13 +22,12 @@ use crate::{
         planner::{
             plan::{Graph, VariableVertexId, VertexId},
             vertex::{
-                instance_count, Costed, Direction, ElementCost, Input, ADVANCE_ITERATOR_RELATIVE_COST,
-                OPEN_ITERATOR_RELATIVE_COST,
+                instance_count, variable::VariableVertex, Costed, Direction, ElementCost, Input,
+                ADVANCE_ITERATOR_RELATIVE_COST, OPEN_ITERATOR_RELATIVE_COST,
             },
         },
     },
 };
-use crate::executable::match_::planner::vertex::variable::VariableVertex;
 
 #[derive(Clone, Debug)]
 pub(crate) enum ConstraintVertex<'a> {
@@ -256,10 +255,7 @@ impl<'a> IsaPlanner<'a> {
     fn expected_output_size(&self, graph: &Graph<'_>, inputs: &[VertexId]) -> f64 {
         let thing = graph.elements()[&VertexId::Variable(self.thing)].as_variable().unwrap();
         let thing_selectivity = thing.selectivity(inputs);
-        f64::max(
-            self.unrestricted_expected_size * thing_selectivity,
-            VariableVertex::OUTPUT_SIZE_MIN
-        )
+        f64::max(self.unrestricted_expected_size * thing_selectivity, VariableVertex::OUTPUT_SIZE_MIN)
     }
 }
 
@@ -549,7 +545,7 @@ impl<'a> LinksPlanner<'a> {
     fn unbound_expected_scan_size(&self, graph: &Graph<'_>) -> f64 {
         f64::max(
             f64::min(self.unbound_expected_scan_size_canonical(graph), self.unbound_expected_scan_size_reverse(graph)),
-            VariableVertex::OUTPUT_SIZE_MIN
+            VariableVertex::OUTPUT_SIZE_MIN,
         )
     }
 
@@ -569,7 +565,7 @@ impl<'a> LinksPlanner<'a> {
         let relation = &graph.elements()[&VertexId::Variable(self.relation)].as_variable().unwrap();
         f64::max(
             self.unbound_typed_expected_size * player.selectivity(inputs) * relation.selectivity(inputs),
-            VariableVertex::OUTPUT_SIZE_MIN
+            VariableVertex::OUTPUT_SIZE_MIN,
         )
     }
 }

--- a/compiler/executable/match_/planner/vertex/constraint.rs
+++ b/compiler/executable/match_/planner/vertex/constraint.rs
@@ -617,7 +617,6 @@ pub(crate) struct SubPlanner<'a> {
     sub: &'a Sub<Variable>,
     type_: Input,
     supertype: Input,
-    kind: SubKind,
     unbound_direction: Direction,
 }
 
@@ -631,7 +630,6 @@ impl<'a> SubPlanner<'a> {
             sub,
             type_: Input::from_vertex(sub.subtype(), variable_index),
             supertype: Input::from_vertex(sub.supertype(), variable_index),
-            kind: sub.sub_kind(),
             unbound_direction: Direction::Reverse,
         }
     }

--- a/compiler/executable/match_/planner/vertex/mod.rs
+++ b/compiler/executable/match_/planner/vertex/mod.rs
@@ -133,15 +133,31 @@ impl ElementCost {
     const IN_MEM_COST_SIMPLE: f64 = 0.01;
     const IN_MEM_COST_COMPLEX: f64 = ElementCost::IN_MEM_COST_SIMPLE * 2.0;
     pub const EMPTY: Self = Self { per_input: 0.0, per_output: 0.0, branching_factor: 0.0 };
-    pub const MEM_SIMPLE_BRANCH_1: Self = Self { per_input: ElementCost::IN_MEM_COST_SIMPLE, per_output: ElementCost::IN_MEM_COST_SIMPLE, branching_factor: 1.0 };
-    pub const MEM_COMPLEX_BRANCH_1: Self = Self { per_input: ElementCost::IN_MEM_COST_COMPLEX, per_output: ElementCost::IN_MEM_COST_COMPLEX, branching_factor: 1.0 };
+    pub const MEM_SIMPLE_BRANCH_1: Self = Self {
+        per_input: ElementCost::IN_MEM_COST_SIMPLE,
+        per_output: ElementCost::IN_MEM_COST_SIMPLE,
+        branching_factor: 1.0,
+    };
+    pub const MEM_COMPLEX_BRANCH_1: Self = Self {
+        per_input: ElementCost::IN_MEM_COST_COMPLEX,
+        per_output: ElementCost::IN_MEM_COST_COMPLEX,
+        branching_factor: 1.0,
+    };
 
     fn in_mem_complex_with_branching(branching_factor: f64) -> Self {
-        Self { per_input: ElementCost::IN_MEM_COST_COMPLEX, per_output: ElementCost::IN_MEM_COST_COMPLEX, branching_factor }
+        Self {
+            per_input: ElementCost::IN_MEM_COST_COMPLEX,
+            per_output: ElementCost::IN_MEM_COST_COMPLEX,
+            branching_factor,
+        }
     }
-    
+
     fn in_mem_simple_with_branching(branching_factor: f64) -> Self {
-        Self { per_input: ElementCost::IN_MEM_COST_SIMPLE, per_output: ElementCost::IN_MEM_COST_SIMPLE, branching_factor }
+        Self {
+            per_input: ElementCost::IN_MEM_COST_SIMPLE,
+            per_output: ElementCost::IN_MEM_COST_SIMPLE,
+            branching_factor,
+        }
     }
 
     pub(crate) fn chain(self, other: Self) -> Self {

--- a/compiler/executable/match_/planner/vertex/variable.rs
+++ b/compiler/executable/match_/planner/vertex/variable.rs
@@ -4,8 +4,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-use std::{collections::HashSet, fmt};
-use std::cmp::min;
+use std::{cmp::min, collections::HashSet, fmt};
 
 use answer::variable::Variable;
 use concept::thing::statistics::Statistics;
@@ -314,7 +313,11 @@ impl ThingPlanner {
     fn selectivity(&self, inputs: &[VertexId]) -> f64 {
         // decrease selectivity whenever we have any matching restrictions
         let bias: f64 = 2.0;
-        let selectivity = if self.restriction_exact.iter().any(|restriction| is_input_available(&Input::Variable(*restriction), inputs)) {
+        let selectivity = if self
+            .restriction_exact
+            .iter()
+            .any(|restriction| is_input_available(&Input::Variable(*restriction), inputs))
+        {
             // exactly 1 of the full set is selected
             1.0 / (self.unrestricted_expected_size * bias)
         } else {

--- a/database/database.rs
+++ b/database/database.rs
@@ -198,7 +198,7 @@ impl<D> Database<D> {
 
 impl Database<WALClient> {
     const STATISTICS_UPDATE_INTERVAL: Duration = Duration::from_millis(100);
-    
+
     pub fn open(path: &Path) -> Result<Database<WALClient>, DatabaseOpenError> {
         use DatabaseOpenError::InvalidUnicodeName;
 
@@ -211,7 +211,6 @@ impl Database<WALClient> {
             Self::create(path, name)
         }
     }
-
 
     fn create(path: &Path, name: impl AsRef<str>) -> Result<Database<WALClient>, DatabaseOpenError> {
         use DatabaseOpenError::{

--- a/executor/instruction/mod.rs
+++ b/executor/instruction/mod.rs
@@ -495,7 +495,7 @@ impl<T: Hkt> Checker<T> {
                                     thing_manager.type_manager(),
                                 ),
                                 SubKind::Exact => subtype.as_type().is_direct_subtype_of(
-                                    subtype.as_type(),
+                                    supertype.as_type(),
                                     &*snapshot,
                                     thing_manager.type_manager(),
                                 ),

--- a/executor/read/nested_pattern_executor.rs
+++ b/executor/read/nested_pattern_executor.rs
@@ -54,10 +54,7 @@ impl InlinedFunction {
                 output_row.copy_from_row(input.as_reference());
                 output_row.copy_mapped(
                     returned_row.as_reference(),
-                    self.return_mapping
-                        .iter()
-                        .enumerate()
-                        .map(|(src, &dst)| (VariablePosition::new(src as u32), dst)),
+                    self.return_mapping.iter().enumerate().map(|(src, &dst)| (VariablePosition::new(src as u32), dst)),
                 );
             });
         }

--- a/executor/read/nested_pattern_executor.rs
+++ b/executor/read/nested_pattern_executor.rs
@@ -26,7 +26,7 @@ impl Disjunction {
         let mut uniform_batch = FixedBatch::new(self.output_width);
         unmapped.into_iter().for_each(|row| {
             uniform_batch.append(|mut output_row| {
-                output_row.copy_mapped(row, self.selected_variables.iter().map(|pos| (pos.clone(), pos.clone())));
+                output_row.copy_mapped(row, self.selected_variables.iter().map(|&pos| (pos, pos)));
             })
         });
         uniform_batch
@@ -57,7 +57,7 @@ impl InlinedFunction {
                     self.return_mapping
                         .iter()
                         .enumerate()
-                        .map(|(src, dst)| (VariablePosition::new(src as u32), dst.clone())),
+                        .map(|(src, &dst)| (VariablePosition::new(src as u32), dst)),
                 );
             });
         }


### PR DESCRIPTION
## Release notes: product changes

Previously we would use concept API to determine super / subtypes when executing as `sub` instruction. However, that work has already been done during type inference, so it is cheaper and more correct to reuse that work.

## Motivation

## Implementation
