### PR TITLE
Variable position fix

### DIFF
--- a/compiler/executable/match_/planner/mod.rs
+++ b/compiler/executable/match_/planner/mod.rs
@@ -301,7 +301,7 @@ impl MatchExecutableBuilder {
 
         if self.current.is_none() {
             self.current = Some(Box::new(StepBuilder {
-                selected_variables:  Vec::from_iter(self.current_outputs.iter().copied()),
+                selected_variables: Vec::from_iter(self.current_outputs.iter().copied()),
                 builder: StepInstructionsBuilder::Intersection(IntersectionBuilder::new()),
             }));
         }
@@ -327,7 +327,7 @@ impl MatchExecutableBuilder {
         }
         if self.current.is_none() {
             self.current = Some(Box::new(StepBuilder {
-                selected_variables:  Vec::from_iter(self.current_outputs.iter().copied()),
+                selected_variables: Vec::from_iter(self.current_outputs.iter().copied()),
                 builder: StepInstructionsBuilder::Check(CheckBuilder::default()),
             }))
         }

--- a/compiler/executable/match_/planner/plan.rs
+++ b/compiler/executable/match_/planner/plan.rs
@@ -1189,8 +1189,12 @@ impl<'a> DisjunctionPlan<'a> {
         let mut branches: Vec<_> = Vec::with_capacity(self.branches.len());
         let mut assigned_positions = assigned_positions.clone();
         for branch in &self.branches {
-            let lowered_branch =
-                branch.lower(disjunction_inputs.clone(), selected_variables.clone(), &assigned_positions, variable_registry);
+            let lowered_branch = branch.lower(
+                disjunction_inputs.clone(),
+                selected_variables.clone(),
+                &assigned_positions,
+                variable_registry,
+            );
             assigned_positions = lowered_branch.position_mapping().clone();
             branches.push(lowered_branch);
         }

--- a/compiler/executable/pipeline.rs
+++ b/compiler/executable/pipeline.rs
@@ -59,8 +59,8 @@ impl ExecutableStage {
             ExecutableStage::Insert(executable) => executable
                 .output_row_schema
                 .iter()
-                .filter_map(|opt| opt.map(|(v, _)| v))
                 .enumerate()
+                .filter_map(|(i, opt)| opt.map(|(v, _)| (i,v)))
                 .map(|(i, v)| (v, VariablePosition::new(i as u32)))
                 .collect(),
             ExecutableStage::Delete(executable) => executable

--- a/compiler/executable/pipeline.rs
+++ b/compiler/executable/pipeline.rs
@@ -60,7 +60,7 @@ impl ExecutableStage {
                 .output_row_schema
                 .iter()
                 .enumerate()
-                .filter_map(|(i, opt)| opt.map(|(v, _)| (i,v)))
+                .filter_map(|(i, opt)| opt.map(|(v, _)| (i, v)))
                 .map(|(i, v)| (v, VariablePosition::new(i as u32)))
                 .collect(),
             ExecutableStage::Delete(executable) => executable


### PR DESCRIPTION
Variable positions in inserts were filtered before they were enumerated, which meant that variable position number were passed along incorrectly.