### PR TITLE
Introducing TypeDB Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 [![Discord](https://img.shields.io/discord/665254494820368395?color=7389D8&label=discord&logo=discord&logoColor=ffffff)](https://typedb.com/discord)
 [![Discussion Forum](https://img.shields.io/badge/discourse-forum-blue.svg)](https://forum.typedb.com)
 [![Hosted By: Cloudsmith](https://img.shields.io/badge/OSS%20hosting%20by-cloudsmith-blue?logo=cloudsmith&style=flat)](https://cloudsmith.com)
+[![Gurubase](https://img.shields.io/badge/Gurubase-Ask%20TypeDB%20Guru-006BFF)](https://gurubase.io/g/typedb)
 
 # Introducing TypeDB
 


### PR DESCRIPTION
Hello team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [TypeDB Guru](https://gurubase.io/g/typedb) to Gurubase. TypeDB Guru uses the data from this repo and data from the [docs](https://typedb.com/docs) to answer questions by leveraging the LLM.

In this PR, I showcased the "TypeDB Guru", which highlights that TypeDB now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable TypeDB Guru in Gurubase, just let me know that's totally fine.
