### PR TITLE
Guarantee transaction causality

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3422,7 +3422,7 @@ checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
 [[package]]
 name = "typeql"
 version = "0.0.0"
-source = "git+https://github.com/typedb/typeql?rev=a839354d9633794d989fc15b3e41bb85e202f761#a839354d9633794d989fc15b3e41bb85e202f761"
+source = "git+https://github.com/typedb/typeql?rev=7b5404c7f098dcea34bfdaaee384abfe8ecf90d1#7b5404c7f098dcea34bfdaaee384abfe8ecf90d1"
 dependencies = [
  "chrono",
  "itertools 0.10.5",

--- a/common/error/Cargo.toml
+++ b/common/error/Cargo.toml
@@ -16,7 +16,7 @@ features = {}
 
 	[dependencies.typeql]
 		features = []
-		rev = "a839354d9633794d989fc15b3e41bb85e202f761"
+		rev = "7b5404c7f098dcea34bfdaaee384abfe8ecf90d1"
 		git = "https://github.com/typedb/typeql"
 		default-features = false
 

--- a/common/structural_equality/Cargo.toml
+++ b/common/structural_equality/Cargo.toml
@@ -21,7 +21,7 @@ features = {}
 
 	[dependencies.typeql]
 		features = []
-		rev = "a839354d9633794d989fc15b3e41bb85e202f761"
+		rev = "7b5404c7f098dcea34bfdaaee384abfe8ecf90d1"
 		git = "https://github.com/typedb/typeql"
 		default-features = false
 

--- a/compiler/Cargo.toml
+++ b/compiler/Cargo.toml
@@ -43,7 +43,7 @@ features = {}
 
 	[dependencies.typeql]
 		features = []
-		rev = "a839354d9633794d989fc15b3e41bb85e202f761"
+		rev = "7b5404c7f098dcea34bfdaaee384abfe8ecf90d1"
 		git = "https://github.com/typedb/typeql"
 		default-features = false
 

--- a/compiler/annotation/type_seeder.rs
+++ b/compiler/annotation/type_seeder.rs
@@ -99,8 +99,7 @@ impl<'this, Snapshot: ReadableSnapshot> TypeGraphSeedingContext<'this, Snapshot>
             .flat_map(|constraint| constraint.vertices())
             .filter(|vertex| !vertex.is_parameter())
             .unique()
-            .all(|vertex| vertex.is_parameter() ||  graph.vertices.contains_key(vertex))
-        );
+            .all(|vertex| vertex.is_parameter() || graph.vertices.contains_key(vertex)));
 
         Ok(graph)
     }

--- a/compiler/executable/match_/planner/vertex/mod.rs
+++ b/compiler/executable/match_/planner/vertex/mod.rs
@@ -184,12 +184,7 @@ impl ElementCost {
 }
 
 pub(super) trait Costed {
-    fn cost(
-        &self,
-        inputs: &[VertexId],
-        sort_variable: Option<VariableVertexId>,
-        graph: &Graph<'_>,
-    ) -> ElementCost;
+    fn cost(&self, inputs: &[VertexId], sort_variable: Option<VariableVertexId>, graph: &Graph<'_>) -> ElementCost;
 }
 
 impl Costed for PlannerVertex<'_> {

--- a/concept/benches/bench_thing_write.rs
+++ b/concept/benches/bench_thing_write.rs
@@ -114,7 +114,7 @@ fn criterion_benchmark(c: &mut Criterion) {
         let definition_key_generator = Arc::new(DefinitionKeyGenerator::new());
         let type_vertex_generator = Arc::new(TypeVertexGenerator::new());
         let thing_vertex_generator = Arc::new(ThingVertexGenerator::new());
-        let schema_cache = Arc::new(TypeCache::new(storage.clone(), storage.read_watermark()).unwrap());
+        let schema_cache = Arc::new(TypeCache::new(storage.clone(), storage.snapshot_watermark()).unwrap());
         let mut statistics = Statistics::new(DurabilitySequenceNumber::MIN);
         statistics.may_synchronise(&storage).unwrap();
         let statistics = Arc::new(statistics);

--- a/concept/thing/statistics.rs
+++ b/concept/thing/statistics.rs
@@ -9,31 +9,30 @@ use std::{
     ops::Bound,
 };
 
-use serde::{Deserialize, Serialize};
-
 use bytes::Bytes;
 use durability::DurabilityRecordType;
 use encoding::graph::{
     thing::{
         edge::{ThingEdgeHas, ThingEdgeLinks, ThingEdgeRolePlayerIndex},
-        ThingVertex,
         vertex_attribute::AttributeVertex,
         vertex_object::ObjectVertex,
+        ThingVertex,
     },
     type_::vertex::{PrefixedTypeVertexEncoding, TypeID, TypeIDUInt, TypeVertexEncoding},
     Typed,
 };
 use error::typedb_error;
 use resource::constants::database::STATISTICS_DURABLE_WRITE_CHANGE_PERCENT;
+use serde::{Deserialize, Serialize};
 use storage::{
     durability_client::{DurabilityClient, DurabilityClientError, DurabilityRecord, UnsequencedDurabilityRecord},
     isolation_manager::CommitType,
     iterator::MVCCReadError,
     key_value::StorageKeyReference,
-    MVCCStorage,
     recovery::commit_recovery::{load_commit_data_from, RecoveryCommitStatus, StorageRecoveryError},
     sequence_number::SequenceNumber,
     snapshot::{buffer::OperationsBuffer, write::Write},
+    MVCCStorage,
 };
 
 use crate::{
@@ -156,7 +155,9 @@ impl Statistics {
         self.update_writes(&data_commits, storage).map_err(|err| DataRead { source: err })?;
 
         let change_since_last_durable_write = self.total_count as f64 - self.last_durable_write_total_count as f64;
-        if change_since_last_durable_write.abs() / self.last_durable_write_total_count as f64 > STATISTICS_DURABLE_WRITE_CHANGE_PERCENT {
+        if change_since_last_durable_write.abs() / self.last_durable_write_total_count as f64
+            > STATISTICS_DURABLE_WRITE_CHANGE_PERCENT
+        {
             self.durably_write(storage)?;
         }
 
@@ -579,8 +580,8 @@ mod serialise {
     use serde::{
         de,
         de::{MapAccess, SeqAccess, Visitor},
-        Deserialize,
-        Deserializer, ser::SerializeStruct, Serialize, Serializer,
+        ser::SerializeStruct,
+        Deserialize, Deserializer, Serialize, Serializer,
     };
 
     use crate::{
@@ -644,7 +645,7 @@ mod serialise {
             match self {
                 Field::StatisticsVersion => "StatisticsVersion",
                 Field::OpenSequenceNumber => "OpenSequenceNumber",
-                Field::LastDurableWriteTotalCount=> "LastDurableWriteTotalCount",
+                Field::LastDurableWriteTotalCount => "LastDurableWriteTotalCount",
                 Field::TotalCount => "TotalCount",
                 Field::TotalThingCount => "TotalThingCount",
                 Field::TotalEntityCount => "TotalEntityCount",
@@ -842,7 +843,8 @@ mod serialise {
                     let statistics_version = seq.next_element()?.ok_or_else(|| de::Error::invalid_length(0, &self))?;
                     let open_sequence_number =
                         seq.next_element()?.ok_or_else(|| de::Error::invalid_length(1, &self))?;
-                    let last_durable_write_total_count = seq.next_element()?.ok_or_else(|| de::Error::invalid_length(2, &self))?;
+                    let last_durable_write_total_count =
+                        seq.next_element()?.ok_or_else(|| de::Error::invalid_length(2, &self))?;
                     let total_count = seq.next_element()?.ok_or_else(|| de::Error::invalid_length(3, &self))?;
                     let total_thing_count = seq.next_element()?.ok_or_else(|| de::Error::invalid_length(4, &self))?;
                     let total_entity_count = seq.next_element()?.ok_or_else(|| de::Error::invalid_length(5, &self))?;
@@ -1180,7 +1182,7 @@ mod serialise {
                         encoding_version: statistics_version
                             .ok_or_else(|| de::Error::missing_field(Field::StatisticsVersion.name()))?,
                         sequence_number: open_sequence_number
-                            .ok_or_else(|| de::Error::missing_field(Field::OpenSequenceNumber.name()))?, 
+                            .ok_or_else(|| de::Error::missing_field(Field::OpenSequenceNumber.name()))?,
                         last_durable_write_total_count: last_durable_write_total_count
                             .ok_or_else(|| de::Error::missing_field(Field::LastDurableWriteTotalCount.name()))?,
                         total_count: total_count.ok_or_else(|| de::Error::missing_field(Field::TotalCount.name()))?,

--- a/concept/thing/statistics.rs
+++ b/concept/thing/statistics.rs
@@ -9,29 +9,31 @@ use std::{
     ops::Bound,
 };
 
+use serde::{Deserialize, Serialize};
+
 use bytes::Bytes;
 use durability::DurabilityRecordType;
 use encoding::graph::{
     thing::{
         edge::{ThingEdgeHas, ThingEdgeLinks, ThingEdgeRolePlayerIndex},
+        ThingVertex,
         vertex_attribute::AttributeVertex,
         vertex_object::ObjectVertex,
-        ThingVertex,
     },
     type_::vertex::{PrefixedTypeVertexEncoding, TypeID, TypeIDUInt, TypeVertexEncoding},
     Typed,
 };
 use error::typedb_error;
-use serde::{Deserialize, Serialize};
+use resource::constants::database::STATISTICS_DURABLE_WRITE_CHANGE_PERCENT;
 use storage::{
     durability_client::{DurabilityClient, DurabilityClientError, DurabilityRecord, UnsequencedDurabilityRecord},
     isolation_manager::CommitType,
     iterator::MVCCReadError,
     key_value::StorageKeyReference,
+    MVCCStorage,
     recovery::commit_recovery::{load_commit_data_from, RecoveryCommitStatus, StorageRecoveryError},
     sequence_number::SequenceNumber,
     snapshot::{buffer::OperationsBuffer, write::Write},
-    MVCCStorage,
 };
 
 use crate::{
@@ -51,6 +53,7 @@ type StatisticsEncodingVersion = u64;
 pub struct Statistics {
     encoding_version: StatisticsEncodingVersion,
     pub sequence_number: SequenceNumber,
+    pub last_durable_write_total_count: u64,
 
     pub total_count: u64,
 
@@ -87,6 +90,7 @@ impl Statistics {
         Statistics {
             encoding_version: Self::ENCODING_VERSION,
             sequence_number,
+            last_durable_write_total_count: 0,
             total_count: 0,
             total_thing_count: 0,
             total_entity_count: 0,
@@ -150,12 +154,19 @@ impl Statistics {
         }
 
         self.update_writes(&data_commits, storage).map_err(|err| DataRead { source: err })?;
+
+        let change_since_last_durable_write = self.total_count as f64 - self.last_durable_write_total_count as f64;
+        if change_since_last_durable_write.abs() / self.last_durable_write_total_count as f64 > STATISTICS_DURABLE_WRITE_CHANGE_PERCENT {
+            self.durably_write(storage)?;
+        }
+
         Ok(())
     }
 
     pub fn durably_write(&mut self, storage: &MVCCStorage<impl DurabilityClient>) -> Result<(), StatisticsError> {
         use StatisticsError::DurablyWrite;
         storage.durability().unsequenced_write(self).map_err(|err| DurablyWrite { typedb_source: err })?;
+        self.last_durable_write_total_count = self.total_count;
         Ok(())
     }
 
@@ -568,8 +579,8 @@ mod serialise {
     use serde::{
         de,
         de::{MapAccess, SeqAccess, Visitor},
-        ser::SerializeStruct,
-        Deserialize, Deserializer, Serialize, Serializer,
+        Deserialize,
+        Deserializer, ser::SerializeStruct, Serialize, Serializer,
     };
 
     use crate::{
@@ -583,6 +594,7 @@ mod serialise {
     enum Field {
         StatisticsVersion,
         OpenSequenceNumber,
+        LastDurableWriteTotalCount,
         TotalCount,
         TotalThingCount,
         TotalEntityCount,
@@ -604,9 +616,10 @@ mod serialise {
     }
 
     impl Field {
-        const NAMES: [&'static str; 20] = [
+        const NAMES: [&'static str; 21] = [
             Self::StatisticsVersion.name(),
             Self::OpenSequenceNumber.name(),
+            Self::LastDurableWriteTotalCount.name(),
             Self::TotalCount.name(),
             Self::TotalThingCount.name(),
             Self::TotalEntityCount.name(),
@@ -631,6 +644,7 @@ mod serialise {
             match self {
                 Field::StatisticsVersion => "StatisticsVersion",
                 Field::OpenSequenceNumber => "OpenSequenceNumber",
+                Field::LastDurableWriteTotalCount=> "LastDurableWriteTotalCount",
                 Field::TotalCount => "TotalCount",
                 Field::TotalThingCount => "TotalThingCount",
                 Field::TotalEntityCount => "TotalEntityCount",
@@ -656,6 +670,7 @@ mod serialise {
             match string {
                 "StatisticsVersion" => Some(Field::StatisticsVersion),
                 "OpenSequenceNumber" => Some(Field::OpenSequenceNumber),
+                "LastDurableWriteTotalCount" => Some(Field::LastDurableWriteTotalCount),
                 "TotalCount" => Some(Field::TotalCount),
                 "TotalThingCount" => Some(Field::TotalThingCount),
                 "TotalEntityCount" => Some(Field::TotalEntityCount),
@@ -688,6 +703,7 @@ mod serialise {
             state.serialize_field(Field::StatisticsVersion.name(), &self.encoding_version)?;
 
             state.serialize_field(Field::OpenSequenceNumber.name(), &self.sequence_number)?;
+            state.serialize_field(Field::LastDurableWriteTotalCount.name(), &self.last_durable_write_total_count)?;
 
             state.serialize_field(Field::TotalCount.name(), &self.total_count)?;
             state.serialize_field(Field::TotalThingCount.name(), &self.total_thing_count)?;
@@ -826,47 +842,48 @@ mod serialise {
                     let statistics_version = seq.next_element()?.ok_or_else(|| de::Error::invalid_length(0, &self))?;
                     let open_sequence_number =
                         seq.next_element()?.ok_or_else(|| de::Error::invalid_length(1, &self))?;
-                    let total_count = seq.next_element()?.ok_or_else(|| de::Error::invalid_length(2, &self))?;
-                    let total_thing_count = seq.next_element()?.ok_or_else(|| de::Error::invalid_length(3, &self))?;
-                    let total_entity_count = seq.next_element()?.ok_or_else(|| de::Error::invalid_length(4, &self))?;
+                    let last_durable_write_total_count = seq.next_element()?.ok_or_else(|| de::Error::invalid_length(2, &self))?;
+                    let total_count = seq.next_element()?.ok_or_else(|| de::Error::invalid_length(3, &self))?;
+                    let total_thing_count = seq.next_element()?.ok_or_else(|| de::Error::invalid_length(4, &self))?;
+                    let total_entity_count = seq.next_element()?.ok_or_else(|| de::Error::invalid_length(5, &self))?;
                     let total_relation_count =
-                        seq.next_element()?.ok_or_else(|| de::Error::invalid_length(5, &self))?;
-                    let total_attribute_count =
                         seq.next_element()?.ok_or_else(|| de::Error::invalid_length(6, &self))?;
-                    let total_role_count = seq.next_element()?.ok_or_else(|| de::Error::invalid_length(7, &self))?;
-                    let total_has_count = seq.next_element()?.ok_or_else(|| de::Error::invalid_length(8, &self))?;
+                    let total_attribute_count =
+                        seq.next_element()?.ok_or_else(|| de::Error::invalid_length(7, &self))?;
+                    let total_role_count = seq.next_element()?.ok_or_else(|| de::Error::invalid_length(8, &self))?;
+                    let total_has_count = seq.next_element()?.ok_or_else(|| de::Error::invalid_length(9, &self))?;
                     let encoded_entity_counts =
-                        seq.next_element()?.ok_or_else(|| de::Error::invalid_length(9, &self))?;
+                        seq.next_element()?.ok_or_else(|| de::Error::invalid_length(10, &self))?;
                     let entity_counts = into_entity_map(encoded_entity_counts);
                     let encoded_relation_counts =
-                        seq.next_element()?.ok_or_else(|| de::Error::invalid_length(10, &self))?;
+                        seq.next_element()?.ok_or_else(|| de::Error::invalid_length(11, &self))?;
                     let relation_counts = into_relation_map(encoded_relation_counts);
                     let encoded_attribute_counts =
-                        seq.next_element()?.ok_or_else(|| de::Error::invalid_length(11, &self))?;
+                        seq.next_element()?.ok_or_else(|| de::Error::invalid_length(12, &self))?;
                     let attribute_counts = into_attribute_map(encoded_attribute_counts);
                     let encoded_role_counts =
-                        seq.next_element()?.ok_or_else(|| de::Error::invalid_length(12, &self))?;
+                        seq.next_element()?.ok_or_else(|| de::Error::invalid_length(13, &self))?;
                     let role_counts = into_role_map(encoded_role_counts);
                     let encoded_has_attribute_counts: HashMap<SerialisableType, HashMap<SerialisableType, u64>> =
-                        seq.next_element()?.ok_or_else(|| de::Error::invalid_length(13, &self))?;
+                        seq.next_element()?.ok_or_else(|| de::Error::invalid_length(14, &self))?;
                     let has_attribute_counts = encoded_has_attribute_counts
                         .into_iter()
                         .map(|(type_1, map)| (type_1.into_object_type(), into_attribute_map(map)))
                         .collect();
                     let encoded_attribute_owner_counts: HashMap<SerialisableType, HashMap<SerialisableType, u64>> =
-                        seq.next_element()?.ok_or_else(|| de::Error::invalid_length(14, &self))?;
+                        seq.next_element()?.ok_or_else(|| de::Error::invalid_length(15, &self))?;
                     let attribute_owner_counts = encoded_attribute_owner_counts
                         .into_iter()
                         .map(|(type_1, map)| (type_1.into_attribute_type(), into_object_map(map)))
                         .collect();
                     let encoded_role_player_counts: HashMap<SerialisableType, HashMap<SerialisableType, u64>> =
-                        seq.next_element()?.ok_or_else(|| de::Error::invalid_length(15, &self))?;
+                        seq.next_element()?.ok_or_else(|| de::Error::invalid_length(16, &self))?;
                     let role_player_counts = encoded_role_player_counts
                         .into_iter()
                         .map(|(type_1, map)| (type_1.into_object_type(), into_role_map(map)))
                         .collect();
                     let encoded_relation_role_counts: HashMap<SerialisableType, HashMap<SerialisableType, u64>> =
-                        seq.next_element()?.ok_or_else(|| de::Error::invalid_length(16, &self))?;
+                        seq.next_element()?.ok_or_else(|| de::Error::invalid_length(17, &self))?;
                     let relation_role_counts = encoded_relation_role_counts
                         .into_iter()
                         .map(|(type_1, map)| (type_1.into_relation_type(), into_role_map(map)))
@@ -874,7 +891,7 @@ mod serialise {
                     let encoded_relation_role_player_counts: HashMap<
                         SerialisableType,
                         HashMap<SerialisableType, HashMap<SerialisableType, u64>>,
-                    > = seq.next_element()?.ok_or_else(|| de::Error::invalid_length(17, &self))?;
+                    > = seq.next_element()?.ok_or_else(|| de::Error::invalid_length(18, &self))?;
                     let relation_role_player_counts = encoded_relation_role_player_counts
                         .into_iter()
                         .map(|(type_1, map)| {
@@ -889,7 +906,7 @@ mod serialise {
                     let encoded_player_role_relation_counts: HashMap<
                         SerialisableType,
                         HashMap<SerialisableType, HashMap<SerialisableType, u64>>,
-                    > = seq.next_element()?.ok_or_else(|| de::Error::invalid_length(18, &self))?;
+                    > = seq.next_element()?.ok_or_else(|| de::Error::invalid_length(19, &self))?;
                     let player_role_relation_counts = encoded_player_role_relation_counts
                         .into_iter()
                         .map(|(type_1, map)| {
@@ -902,7 +919,7 @@ mod serialise {
                         })
                         .collect();
                     let encoded_links_index_counts: HashMap<SerialisableType, HashMap<SerialisableType, u64>> =
-                        seq.next_element()?.ok_or_else(|| de::Error::invalid_length(19, &self))?;
+                        seq.next_element()?.ok_or_else(|| de::Error::invalid_length(20, &self))?;
                     let links_index_counts = encoded_links_index_counts
                         .into_iter()
                         .map(|(type_1, map)| (type_1.into_object_type(), into_object_map(map)))
@@ -910,6 +927,7 @@ mod serialise {
                     Ok(Statistics {
                         encoding_version: statistics_version,
                         sequence_number: open_sequence_number,
+                        last_durable_write_total_count,
                         total_count,
                         total_thing_count,
                         total_entity_count,
@@ -937,6 +955,7 @@ mod serialise {
                 {
                     let mut statistics_version = None;
                     let mut open_sequence_number = None;
+                    let mut last_durable_write_total_count = None;
                     let mut total_count = None;
                     let mut total_thing_count = None;
                     let mut total_entity_count = None;
@@ -968,6 +987,12 @@ mod serialise {
                                     return Err(de::Error::duplicate_field(Field::OpenSequenceNumber.name()));
                                 }
                                 open_sequence_number = Some(map.next_value()?);
+                            }
+                            Field::LastDurableWriteTotalCount => {
+                                if total_count.is_some() {
+                                    return Err(de::Error::duplicate_field(Field::LastDurableWriteTotalCount.name()));
+                                }
+                                last_durable_write_total_count = Some(map.next_value()?);
                             }
                             Field::TotalCount => {
                                 if total_count.is_some() {
@@ -1155,7 +1180,9 @@ mod serialise {
                         encoding_version: statistics_version
                             .ok_or_else(|| de::Error::missing_field(Field::StatisticsVersion.name()))?,
                         sequence_number: open_sequence_number
-                            .ok_or_else(|| de::Error::missing_field(Field::OpenSequenceNumber.name()))?,
+                            .ok_or_else(|| de::Error::missing_field(Field::OpenSequenceNumber.name()))?, 
+                        last_durable_write_total_count: last_durable_write_total_count
+                            .ok_or_else(|| de::Error::missing_field(Field::LastDurableWriteTotalCount.name()))?,
                         total_count: total_count.ok_or_else(|| de::Error::missing_field(Field::TotalCount.name()))?,
                         total_thing_count: total_thing_count
                             .ok_or_else(|| de::Error::missing_field(Field::TotalThingCount.name()))?,

--- a/concept/thing/statistics.rs
+++ b/concept/thing/statistics.rs
@@ -111,7 +111,7 @@ impl Statistics {
     pub fn may_synchronise(&mut self, storage: &MVCCStorage<impl DurabilityClient>) -> Result<(), StatisticsError> {
         use StatisticsError::{DataRead, ReloadCommitData};
 
-        let storage_watermark = storage.read_watermark();
+        let storage_watermark = storage.snapshot_watermark();
         debug_assert!(self.sequence_number <= storage_watermark);
         if self.sequence_number == storage_watermark {
             return Ok(());

--- a/database/Cargo.toml
+++ b/database/Cargo.toml
@@ -88,7 +88,7 @@ features = {}
 
 	[dependencies.typeql]
 		features = []
-		rev = "a839354d9633794d989fc15b3e41bb85e202f761"
+		rev = "7b5404c7f098dcea34bfdaaee384abfe8ecf90d1"
 		git = "https://github.com/typedb/typeql"
 		default-features = false
 

--- a/database/database.rs
+++ b/database/database.rs
@@ -235,7 +235,7 @@ impl Database<WALClient> {
         let type_vertex_generator = Arc::new(TypeVertexGenerator::new());
         let thing_vertex_generator =
             Arc::new(ThingVertexGenerator::load(storage.clone()).map_err(|err| Encoding { source: err })?);
-        let thing_statistics = Arc::new(Statistics::new(storage.read_watermark()));
+        let thing_statistics = Arc::new(Statistics::new(storage.snapshot_watermark()));
 
         let type_cache = Arc::new(
             TypeCache::new(storage.clone(), SequenceNumber::MIN)
@@ -419,7 +419,7 @@ impl Database<WALClient> {
         }
 
         let thing_statistics = Arc::get_mut(&mut locked_schema.thing_statistics).unwrap();
-        thing_statistics.reset(self.storage.read_watermark());
+        thing_statistics.reset(self.storage.snapshot_watermark());
 
         self.query_cache.force_reset(0);
 

--- a/database/database.rs
+++ b/database/database.rs
@@ -435,7 +435,7 @@ fn make_update_statistics_fn(
     query_cache: Arc<QueryCache>,
 ) -> impl Fn() {
     move || {
-        if storage.read_watermark() > (*schema).read().unwrap().thing_statistics.sequence_number {
+        if storage.snapshot_watermark() > (*schema).read().unwrap().thing_statistics.sequence_number {
             let _schema_txn_guard = schema_txn_lock.read().unwrap(); // prevent Schema txns from opening during statistics update
             let mut thing_statistics = (*schema.read().unwrap().thing_statistics).clone();
             thing_statistics.may_synchronise(&storage).ok();

--- a/encoding/graph/thing/vertex_attribute.rs
+++ b/encoding/graph/thing/vertex_attribute.rs
@@ -22,8 +22,7 @@ use crate::{
         type_::vertex::TypeID,
         Typed,
     },
-    layout::prefix::Prefix,
-    layout::prefix::PrefixID,
+    layout::prefix::{Prefix, PrefixID},
     value::{
         boolean_bytes::BooleanBytes,
         date_bytes::DateBytes,

--- a/executor/Cargo.toml
+++ b/executor/Cargo.toml
@@ -108,7 +108,7 @@ features = {}
 
 	[dependencies.typeql]
 		features = []
-		rev = "a839354d9633794d989fc15b3e41bb85e202f761"
+		rev = "7b5404c7f098dcea34bfdaaee384abfe8ecf90d1"
 		git = "https://github.com/typedb/typeql"
 		default-features = false
 

--- a/function/Cargo.toml
+++ b/function/Cargo.toml
@@ -93,7 +93,7 @@ features = {}
 
 	[dependencies.typeql]
 		features = []
-		rev = "a839354d9633794d989fc15b3e41bb85e202f761"
+		rev = "7b5404c7f098dcea34bfdaaee384abfe8ecf90d1"
 		git = "https://github.com/typedb/typeql"
 		default-features = false
 

--- a/ir/Cargo.toml
+++ b/ir/Cargo.toml
@@ -88,7 +88,7 @@ features = {}
 
 	[dependencies.typeql]
 		features = []
-		rev = "a839354d9633794d989fc15b3e41bb85e202f761"
+		rev = "7b5404c7f098dcea34bfdaaee384abfe8ecf90d1"
 		git = "https://github.com/typedb/typeql"
 		default-features = false
 

--- a/query/Cargo.toml
+++ b/query/Cargo.toml
@@ -118,7 +118,7 @@ features = {}
 
 	[dependencies.typeql]
 		features = []
-		rev = "a839354d9633794d989fc15b3e41bb85e202f761"
+		rev = "7b5404c7f098dcea34bfdaaee384abfe8ecf90d1"
 		git = "https://github.com/typedb/typeql"
 		default-features = false
 

--- a/query/benches/bench_insert_queries.rs
+++ b/query/benches/bench_insert_queries.rs
@@ -145,7 +145,7 @@ fn criterion_benchmark(c: &mut Criterion) {
 
     let (_tmp_dir, mut storage) = create_core_storage();
     setup_database(&mut storage);
-    let (type_manager, thing_manager) = load_managers(storage.clone(), Some(storage.read_watermark()));
+    let (type_manager, thing_manager) = load_managers(storage.clone(), Some(storage.snapshot_watermark()));
     let query_manager = QueryManager::new(Some(Arc::new(QueryCache::new(0))));
 
     group.bench_function("insert_queries", |b| {

--- a/query/benches/bench_insert_queries_multithreaded.rs
+++ b/query/benches/bench_insert_queries_multithreaded.rs
@@ -135,7 +135,7 @@ fn multi_threaded_inserts() {
 
     let (_tmp_dir, mut storage) = create_core_storage();
     setup_database(&mut storage);
-    let (type_manager, thing_manager) = load_managers(storage.clone(), Some(storage.read_watermark()));
+    let (type_manager, thing_manager) = load_managers(storage.clone(), Some(storage.snapshot_watermark()));
     let query_manager = QueryManager::new(Some(Arc::new(QueryCache::new(0))));
     const NUM_THREADS: usize = 32;
     const INTERNAL_ITERS: usize = 1000;

--- a/resource/constants.rs
+++ b/resource/constants.rs
@@ -20,7 +20,7 @@ pub mod server {
 }
 
 pub mod database {
-    pub const QUERY_PLAN_CACHE_FLUSH_STATISTICS_CHANGE_PERCENT: f64 = 0.1;
+    pub const QUERY_PLAN_CACHE_FLUSH_STATISTICS_CHANGE_PERCENT: f64 = 0.05;
     pub const QUERY_PLAN_CACHE_SIZE: u64 = 100;
 }
 

--- a/resource/constants.rs
+++ b/resource/constants.rs
@@ -36,7 +36,7 @@ pub mod snapshot {
 pub mod storage {
     pub const TIMELINE_WINDOW_SIZE: usize = 100;
     pub const WAL_SYNC_INTERVAL_MICROSECONDS: u64 = 1000;
-    pub const WATERMARK_WAIT_INTERVAL_MICROSECONDS: u64 = 100;
+    pub const WATERMARK_WAIT_INTERVAL_MICROSECONDS: u64 = 50;
 }
 
 pub mod encoding {

--- a/resource/constants.rs
+++ b/resource/constants.rs
@@ -36,6 +36,7 @@ pub mod snapshot {
 pub mod storage {
     pub const TIMELINE_WINDOW_SIZE: usize = 100;
     pub const WAL_SYNC_INTERVAL_MICROSECONDS: u64 = 1000;
+    pub const WATERMARK_WAIT_INTERVAL_MICROSECONDS: u64 = 100;
 }
 
 pub mod encoding {

--- a/resource/constants.rs
+++ b/resource/constants.rs
@@ -22,6 +22,7 @@ pub mod server {
 pub mod database {
     pub const QUERY_PLAN_CACHE_FLUSH_STATISTICS_CHANGE_PERCENT: f64 = 0.05;
     pub const QUERY_PLAN_CACHE_SIZE: u64 = 100;
+    pub const STATISTICS_DURABLE_WRITE_CHANGE_PERCENT: f64 = 0.05;
 }
 
 pub mod traversal {

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -71,7 +71,7 @@ features = {}
 
 	[dependencies.typeql]
 		features = []
-		rev = "a839354d9633794d989fc15b3e41bb85e202f761"
+		rev = "7b5404c7f098dcea34bfdaaee384abfe8ecf90d1"
 		git = "https://github.com/typedb/typeql"
 		default-features = false
 

--- a/storage/isolation_manager.rs
+++ b/storage/isolation_manager.rs
@@ -53,7 +53,7 @@ impl IsolationManager {
         IsolationManager {
             initial_sequence_number: next_sequence_number,
             timeline: Timeline::new(next_sequence_number),
-            highest_validated_sequence_number: AtomicU64::new(next_sequence_number.number() - 1)
+            highest_validated_sequence_number: AtomicU64::new(next_sequence_number.number() - 1),
         }
     }
 
@@ -246,7 +246,7 @@ impl IsolationManager {
     pub(crate) fn watermark(&self) -> SequenceNumber {
         self.timeline.watermark()
     }
-    
+
     pub(crate) fn highest_validated_sequence_number(&self) -> SequenceNumber {
         SequenceNumber::new(self.highest_validated_sequence_number.load(Ordering::SeqCst))
     }
@@ -377,10 +377,7 @@ impl Timeline {
     // The whole of the timeline uses the underlying u64
     fn new(next_sequence_number: SequenceNumber) -> Timeline {
         let windows = VecDeque::from([Arc::new(TimelineWindow::new(next_sequence_number))]);
-        Timeline {
-            windows: RwLock::new(windows),
-            watermark: AtomicU64::new(next_sequence_number.number() - 1),
-        }
+        Timeline { windows: RwLock::new(windows), watermark: AtomicU64::new(next_sequence_number.number() - 1) }
     }
 
     fn may_free_windows(&self) {

--- a/storage/storage.rs
+++ b/storage/storage.rs
@@ -169,7 +169,7 @@ impl<Durability> MVCCStorage<Durability> {
 
     pub fn open_snapshot_write(self: Arc<Self>) -> WriteSnapshot<Durability> {
         // guarantee external consistency: we always await the latest snapshots to finish
-        let possible_sequence_number = self.isolation_manager.highest_possible_watermark();
+        let possible_sequence_number = self.isolation_manager.highest_validated_sequence_number();
         let mut open_sequence_number = self.snapshot_watermark();
         while open_sequence_number < possible_sequence_number {
             sleep(Duration::from_micros(WATERMARK_WAIT_INTERVAL_MICROSECONDS));
@@ -188,7 +188,7 @@ impl<Durability> MVCCStorage<Durability> {
 
     pub fn open_snapshot_read(self: Arc<Self>) -> ReadSnapshot<Durability> {
         // guarantee external consistency: we always await the latest snapshots to finish
-        let possible_sequence_number = self.isolation_manager.highest_possible_watermark();
+        let possible_sequence_number = self.isolation_manager.highest_validated_sequence_number();
         let mut open_sequence_number = self.snapshot_watermark();
         while open_sequence_number < possible_sequence_number {
             sleep(Duration::from_micros(WATERMARK_WAIT_INTERVAL_MICROSECONDS));
@@ -206,7 +206,7 @@ impl<Durability> MVCCStorage<Durability> {
 
     pub fn open_snapshot_schema(self: Arc<Self>) -> SchemaSnapshot<Durability> {
         // guarantee external consistency: we always await the latest snapshots to finish
-        let possible_sequence_number = self.isolation_manager.highest_possible_watermark();
+        let possible_sequence_number = self.isolation_manager.highest_validated_sequence_number();
         let mut open_sequence_number = self.snapshot_watermark();
         while open_sequence_number < possible_sequence_number {
             sleep(Duration::from_micros(WATERMARK_WAIT_INTERVAL_MICROSECONDS));

--- a/storage/storage.rs
+++ b/storage/storage.rs
@@ -200,6 +200,8 @@ impl<Durability> MVCCStorage<Durability> {
     }
 
     fn wait_for_watermark(&self, target: SequenceNumber) -> SequenceNumber {
+        // We can alternatively also block commits from returning until the watermark rises
+        // See detailed analysis at https://github.com/typedb/typedb/pull/7254/
         let mut watermark = self.snapshot_watermark();
         while watermark < target{
             sleep(Duration::from_micros(WATERMARK_WAIT_INTERVAL_MICROSECONDS));

--- a/storage/storage.rs
+++ b/storage/storage.rs
@@ -13,9 +13,9 @@ use std::{
     fs, io,
     path::{Path, PathBuf},
     sync::{atomic::Ordering, Arc},
+    thread::sleep,
+    time::Duration,
 };
-use std::thread::sleep;
-use std::time::Duration;
 
 use ::error::typedb_error;
 use bytes::{byte_array::ByteArray, byte_reference::ByteReference, Bytes};
@@ -24,8 +24,7 @@ use iterator::MVCCReadError;
 use keyspace::KeyspaceDeleteError;
 use lending_iterator::LendingIterator;
 use logger::{error, result::ResultExt};
-use resource::constants::snapshot::BUFFER_VALUE_INLINE;
-use resource::constants::storage::WATERMARK_WAIT_INTERVAL_MICROSECONDS;
+use resource::constants::{snapshot::BUFFER_VALUE_INLINE, storage::WATERMARK_WAIT_INTERVAL_MICROSECONDS};
 
 use crate::{
     durability_client::{DurabilityClient, DurabilityClientError},
@@ -203,7 +202,7 @@ impl<Durability> MVCCStorage<Durability> {
         // We can alternatively also block commits from returning until the watermark rises
         // See detailed analysis at https://github.com/typedb/typedb/pull/7254/
         let mut watermark = self.snapshot_watermark();
-        while watermark < target{
+        while watermark < target {
             sleep(Duration::from_micros(WATERMARK_WAIT_INTERVAL_MICROSECONDS));
             watermark = self.snapshot_watermark();
         }

--- a/storage/storage.rs
+++ b/storage/storage.rs
@@ -180,7 +180,7 @@ impl<Durability> MVCCStorage<Durability> {
 
     pub fn open_snapshot_write_at(self: Arc<Self>, sequence_number: SequenceNumber) -> WriteSnapshot<Durability> {
         // guarantee external consistency: await this sequence number to be behind the watermark
-        while sequence_number < self.snapshot_watermark() {
+        while self.snapshot_watermark() < sequence_number {
             sleep(Duration::from_micros(WATERMARK_WAIT_INTERVAL_MICROSECONDS));
         }
         WriteSnapshot::new(self, sequence_number)
@@ -198,7 +198,7 @@ impl<Durability> MVCCStorage<Durability> {
     }
 
     pub fn open_snapshot_read_at(self: Arc<Self>, sequence_number: SequenceNumber) -> ReadSnapshot<Durability> {
-        while sequence_number < self.snapshot_watermark() {
+        while self.snapshot_watermark() < sequence_number{
             sleep(Duration::from_micros(WATERMARK_WAIT_INTERVAL_MICROSECONDS));
         }
         ReadSnapshot::new(self, sequence_number)

--- a/storage/tests/test_isolation.rs
+++ b/storage/tests/test_isolation.rs
@@ -612,7 +612,7 @@ fn isolation_manager_reads_evicted_from_disk() {
     let mut snapshot0 = storage.clone().open_snapshot_write();
     snapshot0.put_val(key_1.clone().into_owned_array(), value_1.clone());
     snapshot0.commit().unwrap();
-    let watermark_after_0 = storage.read_watermark();
+    let watermark_after_0 = storage.snapshot_watermark();
 
     let mut snapshot1 = storage.clone().open_snapshot_write();
     snapshot1.delete(key_1.clone().into_owned_array());
@@ -664,12 +664,12 @@ fn isolation_manager_correctly_recovers_from_disk() {
         let mut snapshot = storage.clone().open_snapshot_write();
         snapshot.put_val(key_1.clone().into_owned_array(), value_1.clone());
         snapshot.commit().unwrap();
-        storage.clone().read_watermark()
+        storage.clone().snapshot_watermark()
     };
 
     {
         // TODO: Find a way to make commits crash before they're committed
         let storage = load_storage::<TestKeyspaceSet>(&storage_path, WAL::load(&storage_path).unwrap(), None).unwrap();
-        assert_eq!(watermark_after_one_commit, storage.read_watermark());
+        assert_eq!(watermark_after_one_commit, storage.snapshot_watermark());
     };
 }

--- a/storage/tests/test_mvcc.rs
+++ b/storage/tests/test_mvcc.rs
@@ -46,13 +46,13 @@ fn test_commit_increments_watermark() {
     init_logging();
     let storage_path = create_tmp_dir();
     let storage = create_storage::<TestKeyspaceSet>(&storage_path).unwrap();
-    let wm_initial = storage.read_watermark();
+    let wm_initial = storage.snapshot_watermark();
     let mut snapshot_0 = storage.clone().open_snapshot_write();
     let key_1 = StorageKeyArray::new(Keyspace, ByteArray::copy(&KEY_1));
     snapshot_0.put_val(key_1.clone(), ByteArray::copy(&VALUE_1));
     snapshot_0.commit().unwrap();
 
-    assert_eq!(wm_initial.number() + 1, storage.read_watermark().number());
+    assert_eq!(wm_initial.number() + 1, storage.snapshot_watermark().number());
 }
 
 #[test]
@@ -68,7 +68,7 @@ fn test_reading_snapshots() {
     snapshot_write_0.put_val(StorageKeyArray::new(Keyspace, ByteArray::copy(&KEY_1)), ByteArray::copy(&VALUE_0));
     snapshot_write_0.commit().unwrap();
 
-    let watermark_0 = storage.read_watermark();
+    let watermark_0 = storage.snapshot_watermark();
 
     let snapshot_read_0 = storage.clone().open_snapshot_read();
     assert_eq!(*snapshot_read_0.get::<128>(key_1.as_reference()).unwrap().unwrap(), VALUE_0);
@@ -110,7 +110,7 @@ fn test_conflicting_update_fails() {
     snapshot_write_0.put_val(key_1.clone().into_owned_array(), ByteArray::copy(&VALUE_0));
     snapshot_write_0.commit().unwrap();
 
-    let watermark_after_initial_write = storage.read_watermark();
+    let watermark_after_initial_write = storage.snapshot_watermark();
 
     {
         let mut snapshot_write_11 = storage.clone().open_snapshot_write();
@@ -143,7 +143,7 @@ fn test_open_snapshot_write_at() {
     let key_1: &StorageKey<'_, 48> =
         &StorageKey::Reference(StorageKeyReference::new(Keyspace, ByteReference::new(&KEY_1)));
 
-    let watermark_init = storage.read_watermark();
+    let watermark_init = storage.snapshot_watermark();
 
     let mut snapshot_write_0 = storage.clone().open_snapshot_write();
     snapshot_write_0.put_val(StorageKeyArray::new(Keyspace, ByteArray::copy(&KEY_1)), ByteArray::copy(&VALUE_0));

--- a/storage/tests/test_recovery.rs
+++ b/storage/tests/test_recovery.rs
@@ -34,14 +34,14 @@ fn wal_and_checkpoint_ok() {
         snapshot.put(key_world.clone());
         snapshot.commit().unwrap();
 
-        (checkpoint_storage(&storage), storage.read_watermark())
+        (checkpoint_storage(&storage), storage.snapshot_watermark())
     };
 
     {
         let storage =
             load_storage::<TestKeyspaceSet>(&storage_path, WAL::load(&storage_path).unwrap(), Some(checkpoint))
                 .unwrap();
-        assert_eq!(watermark, storage.read_watermark());
+        assert_eq!(watermark, storage.snapshot_watermark());
         let snapshot = storage.open_snapshot_read();
         assert!(snapshot.get_mapped(StorageKeyReference::from(&key_hello), |_| true).unwrap().is_some());
     };
@@ -76,12 +76,12 @@ fn wal_and_no_checkpoint_ok() {
         snapshot.put(key_world.clone());
         snapshot.commit().unwrap();
 
-        storage.read_watermark()
+        storage.snapshot_watermark()
     };
 
     {
         let storage = load_storage::<TestKeyspaceSet>(&storage_path, WAL::load(&storage_path).unwrap(), None).unwrap();
-        assert_eq!(watermark, storage.read_watermark());
+        assert_eq!(watermark, storage.snapshot_watermark());
         let snapshot = storage.open_snapshot_read();
         assert!(snapshot.get_mapped(StorageKeyReference::from(&key_hello), |_| true).unwrap().is_some());
     }

--- a/tests/behaviour/steps/Cargo.toml
+++ b/tests/behaviour/steps/Cargo.toml
@@ -81,7 +81,7 @@ features = {}
 
 	[dependencies.typeql]
 		features = []
-		rev = "a839354d9633794d989fc15b3e41bb85e202f761"
+		rev = "7b5404c7f098dcea34bfdaaee384abfe8ecf90d1"
 		git = "https://github.com/typedb/typeql"
 		default-features = false
 


### PR DESCRIPTION
## Release notes: product changes

Under concurrent write workloads, causality can appear to be violated. For example:

```
- Open tx1, tx2
- start tx1 commit (validation begins)
- start tx2 commit (validation begins and ends, no conflict with tx1!)
- open tx3
- end tx1 commit (validation finishes)
```
When we open `tx3`, we end up with a snapshot that is actually from _before_ `tx1`, even though `tx2` has committed - because we don't know the status of `tx1` yet, and in our current simplified model, transaction are assigned a linear commit order decided at WAL write time, the read watermark remains before `tx1` until it finishes validating.

In this scenario, a client that commits a transaction can actually end up opening the next transaction snapshot _before_ the last commit that successfully returned.

After this change, when opening a transaction, TypeDB wait until the currently pending transactions all finish, guaranteeing we see the latest possible data version. The assumption is that 1) validation in general is a small amount of time and 2) is fully concurrent, so the wait time should be very small, and only occur under large concurrently committing transactions.

## Motivation

TypeDB by default should guarantee causality across transactions. In particular, when one client/driver submits and successfully commits a transaction, they should always read their own preceding writes.

## Implementation

We add a busy wait loop (with 100 microsecond sleeps) at snapshot open, that waits until the storage watermark rises to at least the latest pending sequence number.


## Analysis and cost

Short of changing TypeDB's logically-sequential transaction model, we have two alternatives to guarantee causality

1) on commit, we wait until all preceding commits finish validation and the watermark rises past the current commit sequence number.
2) on open, we take the latest committed sequence number, and wait for the watermark to rise until that point, before opening the transaction

Option 1) implies that all write transactions, even ones that don't interact at all, are essentially queued behind the slowest concurrent validating commit (let's say this takes `t` time). It also means that the network latency of responding to the user can't be used to hide this slow committer - we can't respond until `t` elapses. So let's say every write transaction takes on average `w` time, we now have write transactions that can take around `w + t`.

Option 2) implies that not just all write transactions, but also all read transactions, have to wait some amount of time before opening. Similarly to above, we could hit a case where there is a validating commit that finishes after `t` time - but this is paid on transaction open, not commit. As a result, write transactions still take `w + t` time and also read transactions (avg duratino `r`) also take `r + t` time, which is strictly worse.

One optimisation for 2), say 2a) is to have the drivers hold onto the last commit sequence number they saw, so opening a new transaction can open the current watermark as long as it is a newer version that the last commit number. A new connection would fall back to waiting for the currently last pending commit to finish, then proceed. However, this can still lead to unexpected behaviour:
```
- driver 1 opens tx1 @ 0, tx2 @0
- commit tx1 (assigned 1), which is a slow commit taking T time and doesn't return yet (watermark = 0)
- commit tx2 (assigned 2), which is a fast commit, and returns. Driver 1 receives that the latest sequence number is 2. (watermark = 0)
- open a new driver 2, open tx3 and tx4, which waits for watermark to rise to 2, and opens both (watermark = 2)
- commit tx3 (assigned 3), which is a slow commit taking T2 time, and doesn't return yet (watermark = 2)
- commit tx4 (assigned 4), which is a fast commit and returns. Driver 2 receives that the latest sequence number is 4. (watermark = 2)

- Driver 1 opens a new transaction tx5, which must open on a version higher than 2, which is fine, so opens at 2. 
```

Here the apparent causality violation comes from receiving a confirmed commit at 4 in the same program, but not seeing that data from the other driver opening a transaction.

A third option would combine some properties of both variants, option 3). Here, we allow the user to open a transaction any time, and take the currently highest committed sequence number and record this in the transaction, and respond to the driver that the transaction is open. Any subsequent request would pay the network latency again! If by the time any query arrives from the driver to the server, and the watermark has not risen yet to the recorded sequence number, we block the query until it does. This gives us the nice property that we leverage network latency to hide the time of the slowest commit validation `T` (benefit of option 1), while not sequentialising write transactions (benefit of option 2) and also never violating causality in any case (risk of option 2a).

This PR does not implement option 3), though it is likely the best compromise we can reach for the time being, only implementing option 2) until we can benchmark the consequences in a stable fashion.
