### PR TITLE
Disable variables of category value being narrow-able to attribute

### DIFF
--- a/compiler/annotation/type_seeder.rs
+++ b/compiler/annotation/type_seeder.rs
@@ -334,6 +334,7 @@ impl<'this, Snapshot: ReadableSnapshot> TypeGraphSeedingContext<'this, Snapshot>
             VariableCategory::ObjectList | VariableCategory::Object => (true, true, false, false),
             VariableCategory::AttributeList | VariableCategory::Attribute => (false, false, true, false),
             VariableCategory::ValueList | VariableCategory::Value => (false, false, true, false),
+            VariableCategory::AttributeOrValue => unreachable!("Insufficiently bound variable!"),
         };
         let mut annotations = BTreeSet::new();
 

--- a/compiler/executable/match_/planner/plan.rs
+++ b/compiler/executable/match_/planner/plan.rs
@@ -282,6 +282,9 @@ impl<'a> ConjunctionPlanBuilder<'a> {
                 | VariableCategory::ThingList
                 | VariableCategory::AttributeList
                 | VariableCategory::ValueList => todo!("list variable planning"),
+                VariableCategory::AttributeOrValue => {
+                    unreachable!("Insufficiently bound variable should have been flagged earlier")
+                }
             }
         }
 
@@ -306,6 +309,9 @@ impl<'a> ConjunctionPlanBuilder<'a> {
                 | VariableCategory::ThingList
                 | VariableCategory::AttributeList
                 | VariableCategory::ValueList => todo!("list variable planning"),
+                VariableCategory::AttributeOrValue => {
+                    unreachable!("Insufficiently bound variable would have been flagged earlier")
+                }
             }
         }
     }

--- a/ir/pattern/constraint.rs
+++ b/ir/pattern/constraint.rs
@@ -253,17 +253,12 @@ impl<'cx, 'reg> ConstraintsBuilder<'cx, 'reg> {
 
         if let Some(lhs) = lhs_var {
             debug_assert!(self.context.is_variable_available(self.constraints.scope, lhs));
-            self.context.set_variable_category(lhs, VariableCategory::Value, comparison.clone().into())?;
+            self.context.set_variable_category(lhs, VariableCategory::AttributeOrValue, comparison.clone().into())?;
         }
-
         if let Some(rhs) = rhs_var {
             debug_assert!(self.context.is_variable_available(self.constraints.scope, rhs));
-            self.context.set_variable_category(rhs, VariableCategory::Value, comparison.clone().into())?;
+            self.context.set_variable_category(rhs, VariableCategory::AttributeOrValue, comparison.clone().into())?;
         }
-
-        // TODO The above lines were the two lines below
-        // self.context.set_variable_category(lhs, VariableCategory::AttributeOrValue, comparison.clone().into())?;
-        // self.context.set_variable_category(rhs, VariableCategory::AttributeOrValue, comparison.clone().into())?;
 
         let as_ref = self.constraints.add_constraint(comparison);
         Ok(as_ref.as_comparison().unwrap())

--- a/ir/pattern/variable_category.rs
+++ b/ir/pattern/variable_category.rs
@@ -57,7 +57,6 @@ impl VariableCategory {
             (_, Self::Object) | (Self::Object, _) => None,
 
             (Self::Attribute, Self::Attribute) => Some(Self::Attribute),
-            (Self::Value, Self::Attribute) | (Self::Attribute, Self::Value) => Some(Self::Attribute),
             (_, Self::Attribute) | (Self::Attribute, _) => None,
 
             (Self::Value, Self::Value) => Some(Self::Value),

--- a/ir/pattern/variable_category.rs
+++ b/ir/pattern/variable_category.rs
@@ -50,7 +50,6 @@ impl VariableCategory {
             (Self::Thing, Self::Thing) => Some(Self::Thing),
             (Self::Thing, Self::Object) | (Self::Object, Self::Thing) => Some(Self::Object),
             (Self::Thing, Self::Attribute) | (Self::Attribute, Self::Thing) => Some(Self::Attribute),
-            (Self::Thing, Self::Value) | (Self::Value, Self::Thing) => Some(Self::Attribute),
             (_, Self::Thing) | (Self::Thing, _) => None,
 
             (Self::Object, Self::Object) => Some(Self::Object),

--- a/ir/pattern/variable_category.rs
+++ b/ir/pattern/variable_category.rs
@@ -16,6 +16,7 @@ pub enum VariableCategory {
     Thing,
     Object,
 
+    AttributeOrValue,
     Attribute,
     Value,
 
@@ -49,11 +50,19 @@ impl VariableCategory {
 
             (Self::Thing, Self::Thing) => Some(Self::Thing),
             (Self::Thing, Self::Object) | (Self::Object, Self::Thing) => Some(Self::Object),
+            (Self::Thing, Self::AttributeOrValue) | (Self::AttributeOrValue, Self::Thing) => Some(Self::Attribute),
             (Self::Thing, Self::Attribute) | (Self::Attribute, Self::Thing) => Some(Self::Attribute),
             (_, Self::Thing) | (Self::Thing, _) => None,
 
             (Self::Object, Self::Object) => Some(Self::Object),
             (_, Self::Object) | (Self::Object, _) => None,
+
+            (Self::AttributeOrValue, Self::AttributeOrValue) => Some(Self::AttributeOrValue),
+            (Self::AttributeOrValue, Self::Attribute) | (Self::Attribute, Self::AttributeOrValue) => {
+                Some(Self::Attribute)
+            }
+            (Self::AttributeOrValue, Self::Value) | (Self::Value, Self::AttributeOrValue) => Some(Self::Value),
+            (Self::AttributeOrValue, _) | (_, Self::AttributeOrValue) => None,
 
             (Self::Attribute, Self::Attribute) => Some(Self::Attribute),
             (_, Self::Attribute) | (Self::Attribute, _) => None,

--- a/ir/pipeline/block.rs
+++ b/ir/pipeline/block.rs
@@ -106,9 +106,11 @@ fn validate_conjunction(
     conjunction: &Conjunction,
     variable_registry: &VariableRegistry,
 ) -> Result<(), Box<RepresentationError>> {
-    let unbound = conjunction
-        .referenced_variables()
-        .find(|&variable| variable_registry.get_variable_category(variable).is_none());
+    let unbound =
+        conjunction.referenced_variables().find(|&variable| match variable_registry.get_variable_category(variable) {
+            Some(VariableCategory::AttributeOrValue) | None => true,
+            _ => false,
+        });
     match unbound {
         Some(variable) => Err(Box::new(RepresentationError::UnboundVariable {
             variable: variable_registry.get_variable_name(variable).cloned().unwrap_or(String::new()),


### PR DESCRIPTION
## Release notes: product changes
Disable variables of category value being narrowed to attribute
```
$name = "some name"; $person has name == $name; # Fine
$name == "some name"; $person has name $name; # Also Fine
$name = "some name"; $person has name $name; # Disallowed
```

## Motivation

## Implementation
