### PR TITLE
Return query operations errors on commit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2610,6 +2610,7 @@ version = "1.0.132"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d726bfaff4b320266d395898905d0eba0345aae23b54aee3a737e260fd46db03"
 dependencies = [
+ "indexmap 2.6.0",
  "itoa",
  "memchr",
  "ryu",
@@ -2768,6 +2769,7 @@ dependencies = [
  "options",
  "primitive",
  "query",
+ "serde_json",
  "server",
  "storage",
  "test_utils",
@@ -3323,7 +3325,7 @@ checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
 [[package]]
 name = "typeql"
 version = "0.0.0"
-source = "git+https://github.com/typedb/typeql?rev=c31b226a0c04dc5276e71ec2e557deec3f61e986#c31b226a0c04dc5276e71ec2e557deec3f61e986"
+source = "git+https://github.com/typedb/typeql?rev=0be38cbab19da7d6b2549ad5aa1248fc811bc4e0#0be38cbab19da7d6b2549ad5aa1248fc811bc4e0"
 dependencies = [
  "chrono",
  "itertools 0.10.5",

--- a/common/error/Cargo.toml
+++ b/common/error/Cargo.toml
@@ -16,7 +16,7 @@ features = {}
 
 	[dependencies.typeql]
 		features = []
-		rev = "c31b226a0c04dc5276e71ec2e557deec3f61e986"
+		rev = "0be38cbab19da7d6b2549ad5aa1248fc811bc4e0"
 		git = "https://github.com/typedb/typeql"
 		default-features = false
 

--- a/common/logger/logger.rs
+++ b/common/logger/logger.rs
@@ -16,7 +16,7 @@ pub fn initialise_logging_global() {
     let filter = EnvFilter::from_default_env()
         .add_directive(LevelFilter::INFO.into())
         // .add_directive("database=trace".parse().unwrap())
-        // .add_directive("server=trace".parse().unwrap())
+        .add_directive("server=trace".parse().unwrap())
         // .add_directive("storage=trace".parse().unwrap())
         // useful for debugging what tonic is doing:
         .add_directive("tonic=trace".parse().unwrap());

--- a/common/logger/logger.rs
+++ b/common/logger/logger.rs
@@ -16,7 +16,7 @@ pub fn initialise_logging_global() {
     let filter = EnvFilter::from_default_env()
         .add_directive(LevelFilter::INFO.into())
         // .add_directive("database=trace".parse().unwrap())
-        .add_directive("server=trace".parse().unwrap())
+        // .add_directive("server=trace".parse().unwrap())
         // .add_directive("storage=trace".parse().unwrap())
         // useful for debugging what tonic is doing:
         .add_directive("tonic=trace".parse().unwrap());

--- a/common/structural_equality/Cargo.toml
+++ b/common/structural_equality/Cargo.toml
@@ -21,7 +21,7 @@ features = {}
 
 	[dependencies.typeql]
 		features = []
-		rev = "c31b226a0c04dc5276e71ec2e557deec3f61e986"
+		rev = "0be38cbab19da7d6b2549ad5aa1248fc811bc4e0"
 		git = "https://github.com/typedb/typeql"
 		default-features = false
 

--- a/compiler/Cargo.toml
+++ b/compiler/Cargo.toml
@@ -43,7 +43,7 @@ features = {}
 
 	[dependencies.typeql]
 		features = []
-		rev = "c31b226a0c04dc5276e71ec2e557deec3f61e986"
+		rev = "0be38cbab19da7d6b2549ad5aa1248fc811bc4e0"
 		git = "https://github.com/typedb/typeql"
 		default-features = false
 

--- a/database/Cargo.toml
+++ b/database/Cargo.toml
@@ -83,7 +83,7 @@ features = {}
 
 	[dependencies.typeql]
 		features = []
-		rev = "c31b226a0c04dc5276e71ec2e557deec3f61e986"
+		rev = "0be38cbab19da7d6b2549ad5aa1248fc811bc4e0"
 		git = "https://github.com/typedb/typeql"
 		default-features = false
 

--- a/executor/Cargo.toml
+++ b/executor/Cargo.toml
@@ -108,7 +108,7 @@ features = {}
 
 	[dependencies.typeql]
 		features = []
-		rev = "c31b226a0c04dc5276e71ec2e557deec3f61e986"
+		rev = "0be38cbab19da7d6b2549ad5aa1248fc811bc4e0"
 		git = "https://github.com/typedb/typeql"
 		default-features = false
 

--- a/function/Cargo.toml
+++ b/function/Cargo.toml
@@ -93,7 +93,7 @@ features = {}
 
 	[dependencies.typeql]
 		features = []
-		rev = "c31b226a0c04dc5276e71ec2e557deec3f61e986"
+		rev = "0be38cbab19da7d6b2549ad5aa1248fc811bc4e0"
 		git = "https://github.com/typedb/typeql"
 		default-features = false
 

--- a/ir/Cargo.toml
+++ b/ir/Cargo.toml
@@ -83,7 +83,7 @@ features = {}
 
 	[dependencies.typeql]
 		features = []
-		rev = "c31b226a0c04dc5276e71ec2e557deec3f61e986"
+		rev = "0be38cbab19da7d6b2549ad5aa1248fc811bc4e0"
 		git = "https://github.com/typedb/typeql"
 		default-features = false
 

--- a/query/Cargo.toml
+++ b/query/Cargo.toml
@@ -93,7 +93,7 @@ features = {}
 
 	[dependencies.typeql]
 		features = []
-		rev = "c31b226a0c04dc5276e71ec2e557deec3f61e986"
+		rev = "0be38cbab19da7d6b2549ad5aa1248fc811bc4e0"
 		git = "https://github.com/typedb/typeql"
 		default-features = false
 

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -71,7 +71,7 @@ features = {}
 
 	[dependencies.typeql]
 		features = []
-		rev = "c31b226a0c04dc5276e71ec2e557deec3f61e986"
+		rev = "0be38cbab19da7d6b2549ad5aa1248fc811bc4e0"
 		git = "https://github.com/typedb/typeql"
 		default-features = false
 

--- a/server/service/transaction_service.rs
+++ b/server/service/transaction_service.rs
@@ -308,17 +308,6 @@ impl TransactionService {
                 for request in message.reqs {
                     let request_id = Uuid::from_slice(&request.req_id).unwrap();
                     let metadata = request.metadata;
-                    match &request.req {
-                        None => {}
-                        Some(req) => match req {
-                            typedb_protocol::transaction::req::Req::OpenReq(_) => event!(Level::TRACE, "OpenReq"),
-                            typedb_protocol::transaction::req::Req::QueryReq(_) => event!(Level::TRACE, "QueryReq"),
-                            typedb_protocol::transaction::req::Req::StreamReq(_) => event!(Level::TRACE, "StreamReq"),
-                            typedb_protocol::transaction::req::Req::CommitReq(_) => event!(Level::TRACE, "CommitReq"),
-                            typedb_protocol::transaction::req::Req::RollbackReq(_) => event!(Level::TRACE, "RollbackReq"),
-                            typedb_protocol::transaction::req::Req::CloseReq(_) => event!(Level::TRACE, "CloseReq"),
-                        }
-                    }
                     match request.req {
                         None => {
                             return Err(ProtocolError::MissingField {

--- a/server/service/transaction_service.rs
+++ b/server/service/transaction_service.rs
@@ -275,8 +275,7 @@ impl TransactionService {
             match result {
                 Ok(Continue(())) => (),
                 Ok(Break(())) => {
-                    let self_p = format!("{self:p}");
-                    event!(Level::TRACE, self_p, "Stream ended, closing transaction service.");
+                    event!(Level::TRACE, "Stream ended, closing transaction service.");
                     self.do_close().await;
                     return;
                 }

--- a/tests/behaviour/steps/Cargo.toml
+++ b/tests/behaviour/steps/Cargo.toml
@@ -34,43 +34,13 @@ features = {}
 		version = "0.19.1"
 		default-features = false
 
-	[dependencies.query]
-		path = "../../../query"
-		features = []
-		default-features = false
-
 	[dependencies.concept]
 		path = "../../../concept"
 		features = []
 		default-features = false
 
-	[dependencies.durability]
-		path = "../../../durability"
-		features = []
-		default-features = false
-
-	[dependencies.ir]
-		path = "../../../ir"
-		features = []
-		default-features = false
-
-	[dependencies.macro_rules_attribute]
-		features = ["default"]
-		version = "0.2.0"
-		default-features = false
-
 	[dependencies.storage]
 		path = "../../../storage"
-		features = []
-		default-features = false
-
-	[dependencies.futures]
-		features = ["alloc", "async-await", "default", "executor", "futures-executor", "std", "thread-pool"]
-		version = "0.3.30"
-		default-features = false
-
-	[dependencies.encoding]
-		path = "../../../encoding"
 		features = []
 		default-features = false
 
@@ -94,11 +64,6 @@ features = {}
 		features = []
 		default-features = false
 
-	[dependencies.answer]
-		path = "../../../answer"
-		features = []
-		default-features = false
-
 	[dependencies.executor]
 		path = "../../../executor"
 		features = []
@@ -116,7 +81,7 @@ features = {}
 
 	[dependencies.typeql]
 		features = []
-		rev = "c31b226a0c04dc5276e71ec2e557deec3f61e986"
+		rev = "0be38cbab19da7d6b2549ad5aa1248fc811bc4e0"
 		git = "https://github.com/typedb/typeql"
 		default-features = false
 
@@ -125,9 +90,49 @@ features = {}
 		features = []
 		default-features = false
 
+	[dependencies.query]
+		path = "../../../query"
+		features = []
+		default-features = false
+
+	[dependencies.durability]
+		path = "../../../durability"
+		features = []
+		default-features = false
+
+	[dependencies.ir]
+		path = "../../../ir"
+		features = []
+		default-features = false
+
+	[dependencies.macro_rules_attribute]
+		features = ["default"]
+		version = "0.2.0"
+		default-features = false
+
+	[dependencies.futures]
+		features = ["alloc", "async-await", "default", "executor", "futures-executor", "std", "thread-pool"]
+		version = "0.3.30"
+		default-features = false
+
+	[dependencies.encoding]
+		path = "../../../encoding"
+		features = []
+		default-features = false
+
+	[dependencies.answer]
+		path = "../../../answer"
+		features = []
+		default-features = false
+
 	[dependencies.chrono]
 		features = ["alloc", "android-tzdata", "clock", "default", "iana-time-zone", "js-sys", "now", "oldtime", "serde", "std", "wasm-bindgen", "wasmbind", "winapi", "windows-targets"]
 		version = "0.4.38"
+		default-features = false
+
+	[dependencies.serde_json]
+		features = ["alloc", "default", "indexmap", "preserve_order", "raw_value", "std"]
+		version = "1.0.128"
 		default-features = false
 
 	[dependencies.lending_iterator]


### PR DESCRIPTION
## Release notes: product changes
We return errors from the awaited operations on `commit` as the commit error. It can be useful if you want to run a number of queries from your TypeDB Driver like:
```rust
let queries = [........];
let mut promises = vec![];
for query in queries {
    promises.push(transaction.query(query));
}

let result = transaction.commit().await;
println!("Commit result will contain the unresolved query's error: {}", result.unwrap_err());
```

## Motivation

## Implementation
I haven't created an additional wrapping error saying "Failed to commit because an operation failed: ....`: it's sufficient and simple now (from my perspective). But if it's needed, I can add it.