### PR TITLE
Query execution analyser

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -536,7 +536,6 @@ dependencies = [
  "error",
  "ir",
  "itertools 0.10.5",
- "log",
  "storage",
  "test_utils",
  "typeql",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -536,6 +536,7 @@ dependencies = [
  "error",
  "ir",
  "itertools 0.10.5",
+ "log",
  "storage",
  "test_utils",
  "typeql",

--- a/answer/variable.rs
+++ b/answer/variable.rs
@@ -18,7 +18,7 @@ impl Variable {
     pub fn new(id: u16) -> Self {
         Self { id: VariableId { id }, anonymous: false }
     }
-    
+
     pub fn new_anonymous(id: u16) -> Self {
         Self { id: VariableId { id }, anonymous: true }
     }
@@ -50,10 +50,7 @@ impl fmt::Display for VariableId {
 
 impl StructuralEquality for Variable {
     fn hash(&self) -> u64 {
-        ordered_hash_combine(
-            self.anonymous as u64,
-            self.id.id as u64
-        )
+        ordered_hash_combine(self.anonymous as u64, self.id.id as u64)
     }
 
     fn equals(&self, other: &Self) -> bool {

--- a/common/logger/logger.rs
+++ b/common/logger/logger.rs
@@ -18,8 +18,10 @@ pub fn initialise_logging_global() {
         // .add_directive("database=trace".parse().unwrap())
         // .add_directive("server=trace".parse().unwrap())
         // .add_directive("storage=trace".parse().unwrap())
+        .add_directive("executor=trace".parse().unwrap())
         // useful for debugging what tonic is doing:
-        .add_directive("tonic=trace".parse().unwrap());
+        // .add_directive("tonic=trace".parse().unwrap());
+    ;
 
     let subscriber = SubscriberBuilder::default().with_max_level(Level::TRACE).with_env_filter(filter).finish();
     tracing::subscriber::set_global_default(subscriber).unwrap()

--- a/common/logger/logger.rs
+++ b/common/logger/logger.rs
@@ -18,7 +18,7 @@ pub fn initialise_logging_global() {
         // .add_directive("database=trace".parse().unwrap())
         // .add_directive("server=trace".parse().unwrap())
         // .add_directive("storage=trace".parse().unwrap())
-        .add_directive("executor=trace".parse().unwrap())
+        // .add_directive("executor=trace".parse().unwrap())
         // useful for debugging what tonic is doing:
         // .add_directive("tonic=trace".parse().unwrap());
     ;

--- a/common/structural_equality/structural_equality.rs
+++ b/common/structural_equality/structural_equality.rs
@@ -5,11 +5,10 @@
  */
 
 use std::{
-    collections::{BTreeMap, HashSet},
+    collections::{BTreeMap, HashMap, HashSet},
     hash::{DefaultHasher, Hash, Hasher},
     mem::Discriminant,
 };
-use std::collections::HashMap;
 
 mod typeql_structural_equality;
 
@@ -151,9 +150,9 @@ impl<K: StructuralEquality + Hash, V: StructuralEquality> StructuralEquality for
             return false;
         }
 
-        self.iter().all(|(key, value)| other.iter().any(|(other_key, other_value)| {
-            key.equals(other_key) && value.equals(other_value)
-        }))
+        self.iter().all(|(key, value)| {
+            other.iter().any(|(other_key, other_value)| key.equals(other_key) && value.equals(other_value))
+        })
     }
 }
 

--- a/compiler/Cargo.toml
+++ b/compiler/Cargo.toml
@@ -24,9 +24,6 @@ features = {}
 		features = []
 		default-features = false
 
-[dependencies]
-log = "0.4.22"
-
 [dependencies.answer]
 		path = "../answer"
 		features = []

--- a/compiler/Cargo.toml
+++ b/compiler/Cargo.toml
@@ -24,7 +24,9 @@ features = {}
 		features = []
 		default-features = false
 
-[dependencies.answer]
+[dependencies]
+
+	[dependencies.answer]
 		path = "../answer"
 		features = []
 		default-features = false

--- a/compiler/Cargo.toml
+++ b/compiler/Cargo.toml
@@ -25,8 +25,9 @@ features = {}
 		default-features = false
 
 [dependencies]
+log = "0.4.22"
 
-	[dependencies.answer]
+[dependencies.answer]
 		path = "../answer"
 		features = []
 		default-features = false

--- a/compiler/annotation/fetch.rs
+++ b/compiler/annotation/fetch.rs
@@ -10,11 +10,7 @@ use std::{
 };
 
 use answer::{variable::Variable, Type};
-use concept::type_::{
-    attribute_type::AttributeType,
-    type_manager::TypeManager,
-     OwnerAPI, TypeAPI,
-};
+use concept::type_::{attribute_type::AttributeType, type_manager::TypeManager, OwnerAPI, TypeAPI};
 use encoding::{graph::type_::Kind, value::label::Label};
 use ir::{
     pattern::ParameterID,

--- a/compiler/executable/delete/executable.rs
+++ b/compiler/executable/delete/executable.rs
@@ -17,10 +17,10 @@ use crate::{
         insert::{
             executable::collect_role_type_bindings, get_thing_source, ThingSource, TypeSource, WriteCompilationError,
         },
+        next_executable_id,
     },
     VariablePosition,
 };
-use crate::executable::next_executable_id;
 
 #[derive(Debug)]
 pub struct DeleteExecutable {

--- a/compiler/executable/delete/executable.rs
+++ b/compiler/executable/delete/executable.rs
@@ -13,16 +13,18 @@ use ir::pattern::{constraint::Constraint, Vertex};
 use crate::{
     annotation::type_annotations::TypeAnnotations,
     executable::{
-        delete::instructions::{ConnectionInstruction, Has, RolePlayer, ThingInstruction},
+        delete::instructions::{ConnectionInstruction, Has, Links, ThingInstruction},
         insert::{
             executable::collect_role_type_bindings, get_thing_source, ThingSource, TypeSource, WriteCompilationError,
         },
     },
     VariablePosition,
 };
+use crate::executable::next_executable_id;
 
 #[derive(Debug)]
 pub struct DeleteExecutable {
+    pub executable_id: u64,
     pub concept_instructions: Vec<ThingInstruction>,
     pub connection_instructions: Vec<ConnectionInstruction>,
     pub output_row_schema: Vec<Option<Variable>>,
@@ -69,7 +71,7 @@ pub fn compile(
                     Vertex::Label(_) => unreachable!("expected role name, found label in a `links` constraint"),
                     Vertex::Parameter(_) => unreachable!(),
                 };
-                connection_deletes.push(ConnectionInstruction::RolePlayer(RolePlayer { relation, player, role }));
+                connection_deletes.push(ConnectionInstruction::Links(Links { relation, player, role }));
             }
             | Constraint::Isa(_)
             | Constraint::Kind(_)
@@ -120,6 +122,7 @@ pub fn compile(
     }
 
     Ok(DeleteExecutable {
+        executable_id: next_executable_id(),
         connection_instructions: connection_deletes,
         concept_instructions: concept_deletes,
         output_row_schema,

--- a/compiler/executable/delete/instructions.rs
+++ b/compiler/executable/delete/instructions.rs
@@ -4,17 +4,33 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
+use std::fmt::{Display, Formatter};
 use crate::executable::insert::{ThingSource, TypeSource};
 
 #[derive(Debug)]
 pub enum ConnectionInstruction {
     Has(Has),               // TODO: Ordering
-    RolePlayer(RolePlayer), // TODO: Ordering
+    Links(Links),           // TODO: Ordering
+}
+
+impl Display for ConnectionInstruction {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ConnectionInstruction::Has(_) => write!(f, "has"),
+            ConnectionInstruction::Links(_) => write!(f, "links"),
+        }
+    }
 }
 
 #[derive(Debug)]
 pub struct ThingInstruction {
     pub thing: ThingSource,
+}
+
+impl Display for ThingInstruction {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "instance")
+    }
 }
 
 #[derive(Debug)]
@@ -24,7 +40,7 @@ pub struct Has {
 }
 
 #[derive(Debug)]
-pub struct RolePlayer {
+pub struct Links {
     pub relation: ThingSource,
     pub player: ThingSource,
     pub role: TypeSource,

--- a/compiler/executable/delete/instructions.rs
+++ b/compiler/executable/delete/instructions.rs
@@ -5,12 +5,13 @@
  */
 
 use std::fmt::{Display, Formatter};
+
 use crate::executable::insert::{ThingSource, TypeSource};
 
 #[derive(Debug)]
 pub enum ConnectionInstruction {
-    Has(Has),               // TODO: Ordering
-    Links(Links),           // TODO: Ordering
+    Has(Has),     // TODO: Ordering
+    Links(Links), // TODO: Ordering
 }
 
 impl Display for ConnectionInstruction {

--- a/compiler/executable/fetch/executable.rs
+++ b/compiler/executable/fetch/executable.rs
@@ -135,7 +135,6 @@ fn compile_some(
                 stages,
                 Some(fetch),
                 &input_variables,
-                false,
             )
             .map_err(|err| FetchCompilationError::SubFetchCompilation { typedb_source: Box::new(err) })?;
             let input_position_remapping = input_variables

--- a/compiler/executable/fetch/executable.rs
+++ b/compiler/executable/fetch/executable.rs
@@ -16,12 +16,12 @@ use crate::{
     executable::{
         function::{compile_function, ExecutableFunction, FunctionTablingType},
         match_::planner::function_plan::ExecutableFunctionRegistry,
+        next_executable_id,
         pipeline::{compile_stages_and_fetch, ExecutableStage},
         ExecutableCompilationError,
     },
     VariablePosition,
 };
-use crate::executable::next_executable_id;
 
 #[derive(Debug)]
 pub struct ExecutableFetch {
@@ -31,10 +31,7 @@ pub struct ExecutableFetch {
 
 impl ExecutableFetch {
     fn new(object_instruction: FetchObjectInstruction) -> Self {
-        Self {
-            executable_id: next_executable_id(),
-            object_instruction
-        }
+        Self { executable_id: next_executable_id(), object_instruction }
     }
 }
 

--- a/compiler/executable/fetch/executable.rs
+++ b/compiler/executable/fetch/executable.rs
@@ -21,10 +21,21 @@ use crate::{
     },
     VariablePosition,
 };
+use crate::executable::next_executable_id;
 
 #[derive(Debug)]
 pub struct ExecutableFetch {
+    pub executable_id: u64,
     pub object_instruction: FetchObjectInstruction,
+}
+
+impl ExecutableFetch {
+    fn new(object_instruction: FetchObjectInstruction) -> Self {
+        Self {
+            executable_id: next_executable_id(),
+            object_instruction
+        }
+    }
 }
 
 #[derive(Debug)]
@@ -62,7 +73,7 @@ pub fn compile_fetch(
     variable_positions: &HashMap<Variable, VariablePosition>,
 ) -> Result<ExecutableFetch, FetchCompilationError> {
     let compiled = compile_object(statistics, available_functions, fetch.object, variable_positions)?;
-    Ok(ExecutableFetch { object_instruction: compiled })
+    Ok(ExecutableFetch::new(compiled))
 }
 
 fn compile_object(

--- a/compiler/executable/fetch/executable.rs
+++ b/compiler/executable/fetch/executable.rs
@@ -135,6 +135,7 @@ fn compile_some(
                 stages,
                 Some(fetch),
                 &input_variables,
+                false,
             )
             .map_err(|err| FetchCompilationError::SubFetchCompilation { typedb_source: Box::new(err) })?;
             let input_position_remapping = input_variables

--- a/compiler/executable/function.rs
+++ b/compiler/executable/function.rs
@@ -24,13 +24,13 @@ use crate::{
     },
     executable::{
         match_::planner::function_plan::ExecutableFunctionRegistry,
+        next_executable_id,
         pipeline::{compile_pipeline_stages, ExecutableStage},
-        reduce::{ReduceRowsExecutable},
+        reduce::ReduceRowsExecutable,
         ExecutableCompilationError,
     },
     VariablePosition,
 };
-use crate::executable::next_executable_id;
 
 #[derive(Debug, Clone)]
 pub struct ExecutableFunction {
@@ -71,7 +71,6 @@ pub(crate) fn compile_function(
         stages,
         arguments.into_iter(),
         &return_.referenced_variables(),
-        false,
     )?;
 
     let returns = compile_return_operation(&executable_stages, return_)?;

--- a/compiler/executable/function.rs
+++ b/compiler/executable/function.rs
@@ -30,9 +30,11 @@ use crate::{
     },
     VariablePosition,
 };
+use crate::executable::next_executable_id;
 
 #[derive(Debug, Clone)]
 pub struct ExecutableFunction {
+    pub executable_id: u64,
     pub executable_stages: Vec<ExecutableStage>,
     pub argument_positions: HashMap<Variable, VariablePosition>,
     pub returns: ExecutableReturn,
@@ -69,10 +71,12 @@ pub(crate) fn compile_function(
         stages,
         arguments.into_iter(),
         &return_.referenced_variables(),
+        false,
     )?;
 
     let returns = compile_return_operation(&executable_stages, return_)?;
     Ok(ExecutableFunction {
+        executable_id: next_executable_id(),
         executable_stages,
         argument_positions,
         returns,

--- a/compiler/executable/insert/executable.rs
+++ b/compiler/executable/insert/executable.rs
@@ -6,11 +6,10 @@
 
 use std::collections::{HashMap, HashSet};
 
-use itertools::Itertools;
-
 use answer::variable::Variable;
 use encoding::graph::type_::Kind;
 use ir::pattern::{constraint::Constraint, expression::Expression, ParameterID, Vertex};
+use itertools::Itertools;
 
 use crate::{
     annotation::type_annotations::TypeAnnotations,

--- a/compiler/executable/insert/executable.rs
+++ b/compiler/executable/insert/executable.rs
@@ -15,14 +15,16 @@ use crate::{
     annotation::type_annotations::TypeAnnotations,
     executable::insert::{
         get_kinds_from_annotations, get_thing_source,
-        instructions::{ConceptInstruction, ConnectionInstruction, Has, PutAttribute, PutObject, RolePlayer},
+        instructions::{ConceptInstruction, ConnectionInstruction, Has, PutAttribute, PutObject, Links},
         ThingSource, TypeSource, ValueSource, VariableSource, WriteCompilationError,
     },
     filter_variants, VariablePosition,
 };
+use crate::executable::next_executable_id;
 
 #[derive(Debug)]
 pub struct InsertExecutable {
+    pub executable_id: u64,
     pub concept_instructions: Vec<ConceptInstruction>,
     pub connection_instructions: Vec<ConnectionInstruction>,
     pub output_row_schema: Vec<Option<(Variable, VariableSource)>>,
@@ -59,6 +61,7 @@ pub fn compile(
     });
 
     Ok(InsertExecutable {
+        executable_id: next_executable_id(),
         concept_instructions: concept_inserts,
         connection_instructions: connection_inserts,
         output_row_schema,
@@ -188,7 +191,7 @@ fn add_role_players(
             }
             (Some(_), Some(_)) => unreachable!(),
         };
-        instructions.push(ConnectionInstruction::RolePlayer(RolePlayer { relation, player, role }));
+        instructions.push(ConnectionInstruction::Links(Links { relation, player, role }));
     }
     Ok(())
 }

--- a/compiler/executable/insert/executable.rs
+++ b/compiler/executable/insert/executable.rs
@@ -13,14 +13,16 @@ use itertools::Itertools;
 
 use crate::{
     annotation::type_annotations::TypeAnnotations,
-    executable::insert::{
-        get_kinds_from_annotations, get_thing_source,
-        instructions::{ConceptInstruction, ConnectionInstruction, Has, PutAttribute, PutObject, Links},
-        ThingSource, TypeSource, ValueSource, VariableSource, WriteCompilationError,
+    executable::{
+        insert::{
+            get_kinds_from_annotations, get_thing_source,
+            instructions::{ConceptInstruction, ConnectionInstruction, Has, Links, PutAttribute, PutObject},
+            ThingSource, TypeSource, ValueSource, VariableSource, WriteCompilationError,
+        },
+        next_executable_id,
     },
     filter_variants, VariablePosition,
 };
-use crate::executable::next_executable_id;
 
 #[derive(Debug)]
 pub struct InsertExecutable {

--- a/compiler/executable/insert/instructions.rs
+++ b/compiler/executable/insert/instructions.rs
@@ -5,6 +5,7 @@
  */
 
 use std::fmt::{Display, Formatter};
+
 use super::{ThingSource, TypeSource, ValueSource};
 
 #[derive(Debug)]
@@ -24,7 +25,7 @@ impl Display for ConceptInstruction {
 
 #[derive(Debug)]
 pub enum ConnectionInstruction {
-    Has(Has),               // TODO: Ordering
+    Has(Has),     // TODO: Ordering
     Links(Links), // TODO: Ordering
 }
 

--- a/compiler/executable/insert/instructions.rs
+++ b/compiler/executable/insert/instructions.rs
@@ -4,6 +4,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
+use std::fmt::{Display, Formatter};
 use super::{ThingSource, TypeSource, ValueSource};
 
 #[derive(Debug)]
@@ -12,10 +13,28 @@ pub enum ConceptInstruction {
     PutAttribute(PutAttribute),
 }
 
+impl Display for ConceptInstruction {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ConceptInstruction::PutObject(_) => write!(f, "Put object"),
+            ConceptInstruction::PutAttribute(_) => write!(f, "Put attribute"),
+        }
+    }
+}
+
 #[derive(Debug)]
 pub enum ConnectionInstruction {
     Has(Has),               // TODO: Ordering
-    RolePlayer(RolePlayer), // TODO: Ordering
+    Links(Links), // TODO: Ordering
+}
+
+impl Display for ConnectionInstruction {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Has(_) => write!(f, "Put has"),
+            Self::Links(_) => write!(f, "Put links"),
+        }
+    }
 }
 
 // TODO: Move to storing the inserted thing directly into the output row
@@ -39,7 +58,7 @@ pub struct Has {
 }
 
 #[derive(Debug)]
-pub struct RolePlayer {
+pub struct Links {
     pub relation: ThingSource,
     pub player: ThingSource,
     pub role: TypeSource,

--- a/compiler/executable/match_/planner/match_executable.rs
+++ b/compiler/executable/match_/planner/match_executable.rs
@@ -24,6 +24,7 @@ use crate::{
 
 #[derive(Clone, Debug)]
 pub struct MatchExecutable {
+    executable_id: u64,
     pub(crate) steps: Vec<ExecutionStep>,
     variable_positions: HashMap<Variable, VariablePosition>,
     variable_positions_index: Vec<Variable>,
@@ -31,11 +32,16 @@ pub struct MatchExecutable {
 
 impl MatchExecutable {
     pub fn new(
+        executable_id: u64,
         steps: Vec<ExecutionStep>,
         variable_positions: HashMap<Variable, VariablePosition>,
         variable_positions_index: Vec<Variable>,
     ) -> Self {
-        Self { steps, variable_positions, variable_positions_index }
+        Self { executable_id, steps, variable_positions, variable_positions_index }
+    }
+    
+    pub fn executable_id(&self) -> u64 {
+        self.executable_id
     }
 
     pub fn steps(&self) -> &[ExecutionStep] {

--- a/compiler/executable/match_/planner/match_executable.rs
+++ b/compiler/executable/match_/planner/match_executable.rs
@@ -39,7 +39,7 @@ impl MatchExecutable {
     ) -> Self {
         Self { executable_id, steps, variable_positions, variable_positions_index }
     }
-    
+
     pub fn executable_id(&self) -> u64 {
         self.executable_id
     }
@@ -127,14 +127,14 @@ impl ExecutionStep {
 impl Display for ExecutionStep {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
-            ExecutionStep::Intersection(step) => write!(f, "Sorted, {step}"),
-            ExecutionStep::UnsortedJoin(step) => write!(f, "Unsorted, {step}"),
-            ExecutionStep::Assignment(step) => write!(f, "Assign, {step}"),
-            ExecutionStep::Check(step) => write!(f, "Check, {step}"),
-            ExecutionStep::Disjunction(step) => write!(f, "Disjunction, {step}"),
-            ExecutionStep::Negation(step) => write!(f, "Negation, {step}"),
-            ExecutionStep::Optional(step) => write!(f, "Optional, {step}"),
-            ExecutionStep::FunctionCall(step) => write!(f, "FunctionCall, {step}"),
+            ExecutionStep::Intersection(step) => write!(f, "{step}"),
+            ExecutionStep::UnsortedJoin(step) => write!(f, "{step}"),
+            ExecutionStep::Assignment(step) => write!(f, "{step}"),
+            ExecutionStep::Check(step) => write!(f, "{step}"),
+            ExecutionStep::Disjunction(step) => write!(f, "{step}"),
+            ExecutionStep::Negation(step) => write!(f, "{step}"),
+            ExecutionStep::Optional(step) => write!(f, "{step}"),
+            ExecutionStep::FunctionCall(step) => write!(f, "{step}"),
         }
     }
 }
@@ -198,7 +198,7 @@ impl Display for IntersectionStep {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
-            "bound_vars={:?}, output_size={}, sort_by={}",
+            "Sorted Iterator Intersection [bound_vars={:?}, output_size={}, sort_by={}]",
             &self.bound_variables, self.output_width, self.sort_variable
         )?;
         for (instruction, modes) in &self.instructions {
@@ -269,7 +269,7 @@ impl UnsortedJoinStep {
 
 impl Display for UnsortedJoinStep {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        write!(f, "bound_vars={:?}, output_size={:?}", &self.bound_variables, self.output_width)?;
+        write!(f, "Unsorted Iterate [bound_vars={:?}, output_size={:?}]", &self.bound_variables, self.output_width)?;
         write!(f, "\n      {}", &self.iterate_instruction)?;
         // TODO: do we need these at all?
         write!(f, "\n      {:?}", &self.check_instructions)
@@ -310,7 +310,7 @@ impl AssignmentStep {
 
 impl Display for AssignmentStep {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        write!(f, "inputs={:?}, output_size={}", &self.input_positions, self.output_width)?;
+        write!(f, "Assignment [inputs={:?}, output_size={}]", &self.input_positions, self.output_width)?;
         // TODO: Display expression
         write!(f, "\n      {:?}", &self.expression)
     }
@@ -339,6 +339,7 @@ impl CheckStep {
 
 impl Display for CheckStep {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "Check")?;
         for check in &self.check_instructions {
             write!(f, "\n      {}", check)?;
         }
@@ -365,7 +366,7 @@ impl DisjunctionStep {
 
 impl Display for DisjunctionStep {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        write!(f, "output_size={}", self.output_width)?;
+        write!(f, "Disjunction [output_size={}]", self.output_width)?;
         for branch in &self.branches {
             write!(f, "\n      --- Start branch ---")?;
             write!(f, "{}", branch)?;
@@ -394,7 +395,8 @@ impl NegationStep {
 
 impl Display for NegationStep {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        write!(f, "\n      --- Start negation ---")?;
+        writeln!(f, "Negation")?;
+        write!(f, "      --- Start negation ---")?;
         write!(f, "\n {}", &self.negation)?;
         write!(f, "\n      --- End negation ---")
     }
@@ -407,6 +409,7 @@ pub struct OptionalStep {
 
 impl Display for OptionalStep {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        writeln!(f, "Optional")?;
         write!(f, "\n      --- Start negation ---")?;
         write!(f, "\n {}", &self.optional)?;
         write!(f, "\n      --- End negation ---")
@@ -432,7 +435,7 @@ impl Display for FunctionCallStep {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
-            "fn_id={}, assigned={:?}, arguments={:?}, output_size={}\n",
+            "Function Call [fn_id={}, assigned={:?}, arguments={:?}, output_size={}]\n",
             self.function_id, &self.assigned, &self.arguments, self.output_width
         )
     }

--- a/compiler/executable/match_/planner/mod.rs
+++ b/compiler/executable/match_/planner/mod.rs
@@ -4,14 +4,13 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-use std::{
-    collections::{hash_map, HashMap, HashSet},
-};
+use std::collections::{hash_map, HashMap, HashSet};
+
+use itertools::Itertools;
 
 use answer::variable::Variable;
 use concept::thing::statistics::Statistics;
 use ir::pipeline::{block::Block, function_signature::FunctionID, VariableRegistry};
-use itertools::Itertools;
 
 use crate::{
     annotation::{expression::compiled_expression::ExecutableExpression, type_annotations::TypeAnnotations},
@@ -27,6 +26,7 @@ use crate::{
     },
     ExecutorVariable, VariablePosition,
 };
+use crate::executable::next_executable_id;
 
 pub mod function_plan;
 pub mod match_executable;
@@ -41,6 +41,7 @@ pub fn compile(
     variable_registry: &VariableRegistry,
     expressions: &HashMap<Variable, ExecutableExpression<Variable>>,
     statistics: &Statistics,
+    log_planning: bool,
 ) -> MatchExecutable {
     let conjunction = block.conjunction();
     let block_context = block.block_context();
@@ -57,6 +58,7 @@ pub fn compile(
         &variable_registry,
         expressions,
         statistics,
+        log_planning,
     )
     .lower(input_variables.keys().copied(), selected_variables.clone(), &assigned_identities, &variable_registry)
     .finish(&variable_registry)
@@ -439,6 +441,7 @@ impl MatchExecutableBuilder {
             .map(|(_, &v)| v)
             .collect();
         MatchExecutable::new(
+            next_executable_id(),
             steps,
             self.index.into_iter().filter_map(|(var, id)| Some((var, id.as_position()?))).collect(),
             variable_positions_index,

--- a/compiler/executable/match_/planner/mod.rs
+++ b/compiler/executable/match_/planner/mod.rs
@@ -6,27 +6,28 @@
 
 use std::collections::{hash_map, HashMap, HashSet};
 
-use itertools::Itertools;
-
 use answer::variable::Variable;
 use concept::thing::statistics::Statistics;
 use ir::pipeline::{block::Block, function_signature::FunctionID, VariableRegistry};
+use itertools::Itertools;
 
 use crate::{
     annotation::{expression::compiled_expression::ExecutableExpression, type_annotations::TypeAnnotations},
-    executable::match_::{
-        instructions::{CheckInstruction, ConstraintInstruction},
-        planner::{
-            match_executable::{
-                AssignmentStep, CheckStep, DisjunctionStep, ExecutionStep, FunctionCallStep, IntersectionStep,
-                MatchExecutable, NegationStep,
+    executable::{
+        match_::{
+            instructions::{CheckInstruction, ConstraintInstruction},
+            planner::{
+                match_executable::{
+                    AssignmentStep, CheckStep, DisjunctionStep, ExecutionStep, FunctionCallStep, IntersectionStep,
+                    MatchExecutable, NegationStep,
+                },
+                plan::plan_conjunction,
             },
-            plan::plan_conjunction,
         },
+        next_executable_id,
     },
     ExecutorVariable, VariablePosition,
 };
-use crate::executable::next_executable_id;
 
 pub mod function_plan;
 pub mod match_executable;
@@ -41,7 +42,6 @@ pub fn compile(
     variable_registry: &VariableRegistry,
     expressions: &HashMap<Variable, ExecutableExpression<Variable>>,
     statistics: &Statistics,
-    log_planning: bool,
 ) -> MatchExecutable {
     let conjunction = block.conjunction();
     let block_context = block.block_context();
@@ -58,7 +58,6 @@ pub fn compile(
         &variable_registry,
         expressions,
         statistics,
-        log_planning,
     )
     .lower(input_variables.keys().copied(), selected_variables.clone(), &assigned_identities, &variable_registry)
     .finish(&variable_registry)

--- a/compiler/executable/match_/planner/plan.rs
+++ b/compiler/executable/match_/planner/plan.rs
@@ -550,7 +550,6 @@ impl<'a> ConjunctionPlanBuilder<'a> {
         }
 
         while !open_set.is_empty() {
-            println!("Choosing next plan element...");
             let (next, _cost) = open_set
                 .iter()
                 .filter(|&&elem| self.graph.elements[&elem].is_valid(elem, &ordering, &self.graph))

--- a/compiler/executable/match_/planner/plan.rs
+++ b/compiler/executable/match_/planner/plan.rs
@@ -66,7 +66,6 @@ pub(crate) fn plan_conjunction<'a>(
     variable_registry: &VariableRegistry,
     expressions: &'a HashMap<Variable, ExecutableExpression<Variable>>,
     statistics: &'a Statistics,
-    log_planning: bool,
 ) -> ConjunctionPlan<'a> {
     make_builder(
         conjunction,
@@ -77,7 +76,7 @@ pub(crate) fn plan_conjunction<'a>(
         expressions,
         statistics,
     )
-    .plan(log_planning)
+    .plan()
 }
 
 fn make_builder<'a>(
@@ -121,7 +120,7 @@ fn make_builder<'a>(
                     statistics,
                 )
                 .with_inputs(negation.conjunction().captured_variables(block_context))
-                .plan(false,),
+                .plan(),
             ),
             NestedPattern::Optional(_) => todo!(),
         }
@@ -519,7 +518,7 @@ impl<'a> ConjunctionPlanBuilder<'a> {
         }
     }
 
-    fn initialise_greedy_ordering(&self, log: bool) -> Vec<VertexId> {
+    fn initialise_greedy_ordering(&self) -> Vec<VertexId> {
         let mut open_set: HashSet<VertexId> = chain!(
             self.graph.variable_to_pattern.keys().map(|&variable_id| VertexId::Variable(variable_id)),
             self.graph.pattern_to_variable.keys().map(|&pattern_id| VertexId::Pattern(pattern_id))
@@ -559,19 +558,11 @@ impl<'a> ConjunctionPlanBuilder<'a> {
                     let cost = self.calculate_marginal_cost(&ordering, elem, intersection_variable);
                     // useful when debugging
                     let _graph_element = &self.graph.elements[&elem];
-                    
-                    if log {
-                        println!("  Choice {:?}, cost: {cost}", _graph_element);
-                    }
-                    
                     (elem, cost)
                 })
                 .min_by(|(_, lhs_cost), (_, rhs_cost)| lhs_cost.total_cmp(rhs_cost))
                 .unwrap();
             let element = &self.graph.elements[&next];
-            if log {
-                println!("--> Chose {:?}, cost: {_cost}", element);
-            }
 
             if element.is_variable() {
                 commit_variables!();
@@ -625,8 +616,8 @@ impl<'a> ConjunctionPlanBuilder<'a> {
         per_input + branching_factor * per_output
     }
 
-    pub(super) fn plan(self, log_planning: bool) -> ConjunctionPlan<'a> {
-        let ordering = self.initialise_greedy_ordering(log_planning);
+    pub(super) fn plan(self) -> ConjunctionPlan<'a> {
+        let ordering = self.initialise_greedy_ordering();
         let element_to_order = ordering.iter().copied().enumerate().map(|(order, index)| (index, order)).collect();
 
         let cost = ordering
@@ -1176,7 +1167,7 @@ impl<'a> DisjunctionPlanBuilder<'a> {
 
     fn plan(self, input_variables: impl Iterator<Item = Variable> + Clone) -> DisjunctionPlan<'a> {
         let branches =
-            self.branches.into_iter().map(|branch| branch.with_inputs(input_variables.clone()).plan(false)).collect_vec();
+            self.branches.into_iter().map(|branch| branch.with_inputs(input_variables.clone()).plan()).collect_vec();
         let cost = branches.iter().map(ConjunctionPlan::cost).fold(ElementCost::EMPTY, ElementCost::combine_parallel);
         DisjunctionPlan { branches, _cost: cost }
     }

--- a/compiler/executable/match_/planner/vertex/mod.rs
+++ b/compiler/executable/match_/planner/vertex/mod.rs
@@ -456,7 +456,7 @@ impl Costed for DisjunctionPlanner<'_> {
         self.builder()
             .branches()
             .iter()
-            .map(|branch| branch.clone().with_inputs(input_variables.clone()).plan().cost())
+            .map(|branch| branch.clone().with_inputs(input_variables.clone()).plan(false,).cost())
             .fold(ElementCost::EMPTY, ElementCost::combine_parallel)
     }
 }

--- a/compiler/executable/match_/planner/vertex/mod.rs
+++ b/compiler/executable/match_/planner/vertex/mod.rs
@@ -456,7 +456,7 @@ impl Costed for DisjunctionPlanner<'_> {
         self.builder()
             .branches()
             .iter()
-            .map(|branch| branch.clone().with_inputs(input_variables.clone()).plan(false,).cost())
+            .map(|branch| branch.clone().with_inputs(input_variables.clone()).plan().cost())
             .fold(ElementCost::EMPTY, ElementCost::combine_parallel)
     }
 }

--- a/compiler/executable/mod.rs
+++ b/compiler/executable/mod.rs
@@ -4,6 +4,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
+use std::sync::atomic::{AtomicU64, Ordering};
 use error::typedb_error;
 
 use crate::executable::{fetch::executable::FetchCompilationError, insert::WriteCompilationError};
@@ -16,6 +17,12 @@ pub mod match_;
 pub mod modifiers;
 pub mod pipeline;
 pub mod reduce;
+
+static EXECUTABLE_ID: AtomicU64 = AtomicU64::new(0);
+
+pub fn next_executable_id() -> u64 {
+    EXECUTABLE_ID.fetch_add(1, Ordering::Relaxed)
+}
 
 typedb_error!(
     pub ExecutableCompilationError(component = "Query executable", prefix = "QEE") {

--- a/compiler/executable/mod.rs
+++ b/compiler/executable/mod.rs
@@ -5,6 +5,7 @@
  */
 
 use std::sync::atomic::{AtomicU64, Ordering};
+
 use error::typedb_error;
 
 use crate::executable::{fetch::executable::FetchCompilationError, insert::WriteCompilationError};

--- a/compiler/executable/modifiers.rs
+++ b/compiler/executable/modifiers.rs
@@ -8,35 +8,91 @@ use std::collections::{HashMap, HashSet};
 
 use answer::variable::Variable;
 use ir::pipeline::modifier::SortVariable;
+use crate::executable::next_executable_id;
 
 use crate::VariablePosition;
 
 #[derive(Debug)]
 pub struct SelectExecutable {
+    pub executable_id: u64,
     pub retained_positions: HashSet<VariablePosition>,
     pub output_row_mapping: HashMap<Variable, VariablePosition>,
 }
 
+impl SelectExecutable {
+    pub(crate) fn new(retained_positions: HashSet<VariablePosition>, output_row_mapping: HashMap<Variable, VariablePosition>) -> Self {
+        Self {
+            executable_id: next_executable_id(),
+            retained_positions,
+            output_row_mapping,
+        }
+    }
+}
+
 #[derive(Debug)]
 pub struct SortExecutable {
+    pub executable_id: u64,
     pub sort_on: Vec<SortVariable>,
     pub output_row_mapping: HashMap<Variable, VariablePosition>,
 }
 
+impl SortExecutable {
+    pub(crate) fn new(sort_on: Vec<SortVariable>, output_row_mapping: HashMap<Variable, VariablePosition>) -> Self {
+        Self {
+            executable_id: next_executable_id(),
+            sort_on,
+            output_row_mapping,
+        }
+    }
+}
+
 #[derive(Debug)]
 pub struct OffsetExecutable {
+    pub executable_id: u64,
     pub offset: u64,
     pub output_row_mapping: HashMap<Variable, VariablePosition>,
 }
 
+impl OffsetExecutable {
+    pub(crate) fn new(offset: u64, output_row_mapping: HashMap<Variable, VariablePosition>) -> Self {
+        Self {
+            executable_id: next_executable_id(),
+            offset,
+            output_row_mapping,
+        }
+    }
+}
+
 #[derive(Debug)]
 pub struct LimitExecutable {
+    pub executable_id: u64,
     pub limit: u64,
     pub output_row_mapping: HashMap<Variable, VariablePosition>,
 }
 
+impl LimitExecutable {
+    pub(crate) fn new(limit: u64, output_row_mapping: HashMap<Variable, VariablePosition>) -> Self {
+        Self {
+            executable_id: next_executable_id(),
+            limit,
+            output_row_mapping,
+        }
+    }
+}
+
 #[derive(Debug)]
 pub struct RequireExecutable {
+    pub executable_id: u64,
     pub required: HashSet<VariablePosition>,
     pub output_row_mapping: HashMap<Variable, VariablePosition>,
+}
+
+impl RequireExecutable {
+    pub(crate) fn new(required: HashSet<VariablePosition>, output_row_mapping: HashMap<Variable, VariablePosition>) -> Self {
+        Self {
+            executable_id: next_executable_id(),
+            required,
+            output_row_mapping,
+        }
+    }
 }

--- a/compiler/executable/modifiers.rs
+++ b/compiler/executable/modifiers.rs
@@ -8,9 +8,8 @@ use std::collections::{HashMap, HashSet};
 
 use answer::variable::Variable;
 use ir::pipeline::modifier::SortVariable;
-use crate::executable::next_executable_id;
 
-use crate::VariablePosition;
+use crate::{executable::next_executable_id, VariablePosition};
 
 #[derive(Debug)]
 pub struct SelectExecutable {
@@ -20,12 +19,11 @@ pub struct SelectExecutable {
 }
 
 impl SelectExecutable {
-    pub(crate) fn new(retained_positions: HashSet<VariablePosition>, output_row_mapping: HashMap<Variable, VariablePosition>) -> Self {
-        Self {
-            executable_id: next_executable_id(),
-            retained_positions,
-            output_row_mapping,
-        }
+    pub(crate) fn new(
+        retained_positions: HashSet<VariablePosition>,
+        output_row_mapping: HashMap<Variable, VariablePosition>,
+    ) -> Self {
+        Self { executable_id: next_executable_id(), retained_positions, output_row_mapping }
     }
 }
 
@@ -38,11 +36,7 @@ pub struct SortExecutable {
 
 impl SortExecutable {
     pub(crate) fn new(sort_on: Vec<SortVariable>, output_row_mapping: HashMap<Variable, VariablePosition>) -> Self {
-        Self {
-            executable_id: next_executable_id(),
-            sort_on,
-            output_row_mapping,
-        }
+        Self { executable_id: next_executable_id(), sort_on, output_row_mapping }
     }
 }
 
@@ -55,11 +49,7 @@ pub struct OffsetExecutable {
 
 impl OffsetExecutable {
     pub(crate) fn new(offset: u64, output_row_mapping: HashMap<Variable, VariablePosition>) -> Self {
-        Self {
-            executable_id: next_executable_id(),
-            offset,
-            output_row_mapping,
-        }
+        Self { executable_id: next_executable_id(), offset, output_row_mapping }
     }
 }
 
@@ -72,11 +62,7 @@ pub struct LimitExecutable {
 
 impl LimitExecutable {
     pub(crate) fn new(limit: u64, output_row_mapping: HashMap<Variable, VariablePosition>) -> Self {
-        Self {
-            executable_id: next_executable_id(),
-            limit,
-            output_row_mapping,
-        }
+        Self { executable_id: next_executable_id(), limit, output_row_mapping }
     }
 }
 
@@ -88,11 +74,10 @@ pub struct RequireExecutable {
 }
 
 impl RequireExecutable {
-    pub(crate) fn new(required: HashSet<VariablePosition>, output_row_mapping: HashMap<Variable, VariablePosition>) -> Self {
-        Self {
-            executable_id: next_executable_id(),
-            required,
-            output_row_mapping,
-        }
+    pub(crate) fn new(
+        required: HashSet<VariablePosition>,
+        output_row_mapping: HashMap<Variable, VariablePosition>,
+    ) -> Self {
+        Self { executable_id: next_executable_id(), required, output_row_mapping }
     }
 }

--- a/compiler/executable/pipeline.rs
+++ b/compiler/executable/pipeline.rs
@@ -256,30 +256,24 @@ fn compile_stage(
                 retained_positions.insert(pos);
                 output_row_mapping.insert(variable, pos);
             }
-            Ok(ExecutableStage::Select(Arc::new(SelectExecutable::new(retained_positions, output_row_mapping ))))
+            Ok(ExecutableStage::Select(Arc::new(SelectExecutable::new(retained_positions, output_row_mapping))))
         }
-        AnnotatedStage::Sort(sort) => Ok(ExecutableStage::Sort(Arc::new(SortExecutable::new(
-            sort.variables.clone(),
-            input_variables.clone(),
-        )))),
-        AnnotatedStage::Offset(offset) => Ok(ExecutableStage::Offset(Arc::new(OffsetExecutable::new(
-            offset.offset(),
-            input_variables.clone(),
-        )))),
-        AnnotatedStage::Limit(limit) => Ok(ExecutableStage::Limit(Arc::new(LimitExecutable::new(
-            limit.limit(),
-            input_variables.clone(),
-        )))),
+        AnnotatedStage::Sort(sort) => {
+            Ok(ExecutableStage::Sort(Arc::new(SortExecutable::new(sort.variables.clone(), input_variables.clone()))))
+        }
+        AnnotatedStage::Offset(offset) => {
+            Ok(ExecutableStage::Offset(Arc::new(OffsetExecutable::new(offset.offset(), input_variables.clone()))))
+        }
+        AnnotatedStage::Limit(limit) => {
+            Ok(ExecutableStage::Limit(Arc::new(LimitExecutable::new(limit.limit(), input_variables.clone()))))
+        }
         AnnotatedStage::Require(require) => {
             let mut required_positions = HashSet::with_capacity(require.variables.len());
             for &variable in &require.variables {
                 let pos = input_variables[&variable];
                 required_positions.insert(pos);
             }
-            Ok(ExecutableStage::Require(Arc::new(RequireExecutable::new(
-                required_positions,
-                input_variables.clone(),
-            ))))
+            Ok(ExecutableStage::Require(Arc::new(RequireExecutable::new(required_positions, input_variables.clone()))))
         }
         AnnotatedStage::Reduce(reduce, typed_reducers) => {
             debug_assert_eq!(reduce.assigned_reductions.len(), typed_reducers.len());
@@ -298,9 +292,9 @@ fn compile_stage(
                 let reducer_on_position = reducer_on_variable.clone().map(input_variables);
                 reductions.push(reducer_on_position);
             }
-            Ok(ExecutableStage::Reduce(Arc::new(ReduceExecutable::new( 
+            Ok(ExecutableStage::Reduce(Arc::new(ReduceExecutable::new(
                 ReduceRowsExecutable { reductions, input_group_positions },
-                output_row_mapping
+                output_row_mapping,
             ))))
         }
     }

--- a/compiler/executable/pipeline.rs
+++ b/compiler/executable/pipeline.rs
@@ -256,30 +256,30 @@ fn compile_stage(
                 retained_positions.insert(pos);
                 output_row_mapping.insert(variable, pos);
             }
-            Ok(ExecutableStage::Select(Arc::new(SelectExecutable { retained_positions, output_row_mapping })))
+            Ok(ExecutableStage::Select(Arc::new(SelectExecutable::new(retained_positions, output_row_mapping ))))
         }
-        AnnotatedStage::Sort(sort) => Ok(ExecutableStage::Sort(Arc::new(SortExecutable {
-            sort_on: sort.variables.clone(),
-            output_row_mapping: input_variables.clone(),
-        }))),
-        AnnotatedStage::Offset(offset) => Ok(ExecutableStage::Offset(Arc::new(OffsetExecutable {
-            offset: offset.offset(),
-            output_row_mapping: input_variables.clone(),
-        }))),
-        AnnotatedStage::Limit(limit) => Ok(ExecutableStage::Limit(Arc::new(LimitExecutable {
-            limit: limit.limit(),
-            output_row_mapping: input_variables.clone(),
-        }))),
+        AnnotatedStage::Sort(sort) => Ok(ExecutableStage::Sort(Arc::new(SortExecutable::new(
+            sort.variables.clone(),
+            input_variables.clone(),
+        )))),
+        AnnotatedStage::Offset(offset) => Ok(ExecutableStage::Offset(Arc::new(OffsetExecutable::new(
+            offset.offset(),
+            input_variables.clone(),
+        )))),
+        AnnotatedStage::Limit(limit) => Ok(ExecutableStage::Limit(Arc::new(LimitExecutable::new(
+            limit.limit(),
+            input_variables.clone(),
+        )))),
         AnnotatedStage::Require(require) => {
             let mut required_positions = HashSet::with_capacity(require.variables.len());
             for &variable in &require.variables {
                 let pos = input_variables[&variable];
                 required_positions.insert(pos);
             }
-            Ok(ExecutableStage::Require(Arc::new(RequireExecutable {
-                required: required_positions,
-                output_row_mapping: input_variables.clone(),
-            })))
+            Ok(ExecutableStage::Require(Arc::new(RequireExecutable::new(
+                required_positions,
+                input_variables.clone(),
+            ))))
         }
         AnnotatedStage::Reduce(reduce, typed_reducers) => {
             debug_assert_eq!(reduce.assigned_reductions.len(), typed_reducers.len());
@@ -298,10 +298,10 @@ fn compile_stage(
                 let reducer_on_position = reducer_on_variable.clone().map(input_variables);
                 reductions.push(reducer_on_position);
             }
-            Ok(ExecutableStage::Reduce(Arc::new(ReduceExecutable {
-                reduce_rows_executable: Arc::new(ReduceRowsExecutable { reductions, input_group_positions }),
-                output_row_mapping,
-            })))
+            Ok(ExecutableStage::Reduce(Arc::new(ReduceExecutable::new( 
+                ReduceRowsExecutable { reductions, input_group_positions },
+                output_row_mapping
+            ))))
         }
     }
 }

--- a/compiler/executable/reduce.rs
+++ b/compiler/executable/reduce.rs
@@ -9,9 +9,8 @@ use std::{collections::HashMap, sync::Arc};
 use answer::variable::Variable;
 use encoding::value::value_type::ValueType;
 use ir::pattern::IrID;
-use crate::executable::next_executable_id;
 
-use crate::VariablePosition;
+use crate::{executable::next_executable_id, VariablePosition};
 
 #[derive(Debug, Clone)]
 pub struct ReduceExecutable {
@@ -21,11 +20,14 @@ pub struct ReduceExecutable {
 }
 
 impl ReduceExecutable {
-    pub(crate) fn new(rows_executable: ReduceRowsExecutable, output_row_mapping:  HashMap<Variable, VariablePosition>,) -> Self {
+    pub(crate) fn new(
+        rows_executable: ReduceRowsExecutable,
+        output_row_mapping: HashMap<Variable, VariablePosition>,
+    ) -> Self {
         Self {
             executable_id: next_executable_id(),
             reduce_rows_executable: Arc::new(rows_executable),
-            output_row_mapping
+            output_row_mapping,
         }
     }
 }

--- a/compiler/executable/reduce.rs
+++ b/compiler/executable/reduce.rs
@@ -9,13 +9,25 @@ use std::{collections::HashMap, sync::Arc};
 use answer::variable::Variable;
 use encoding::value::value_type::ValueType;
 use ir::pattern::IrID;
+use crate::executable::next_executable_id;
 
 use crate::VariablePosition;
 
 #[derive(Debug, Clone)]
 pub struct ReduceExecutable {
+    pub executable_id: u64,
     pub reduce_rows_executable: Arc<ReduceRowsExecutable>,
     pub output_row_mapping: HashMap<Variable, VariablePosition>, // output_row = (group_vars, reduce_outputs)
+}
+
+impl ReduceExecutable {
+    pub(crate) fn new(rows_executable: ReduceRowsExecutable, output_row_mapping:  HashMap<Variable, VariablePosition>,) -> Self {
+        Self {
+            executable_id: next_executable_id(),
+            reduce_rows_executable: Arc::new(rows_executable),
+            output_row_mapping
+        }
+    }
 }
 
 #[derive(Debug, Clone)]

--- a/concept/thing/statistics.rs
+++ b/concept/thing/statistics.rs
@@ -1156,8 +1156,7 @@ mod serialise {
                             .ok_or_else(|| de::Error::missing_field(Field::StatisticsVersion.name()))?,
                         sequence_number: open_sequence_number
                             .ok_or_else(|| de::Error::missing_field(Field::OpenSequenceNumber.name()))?,
-                        total_count: total_count 
-                            .ok_or_else(|| de::Error::missing_field(Field::TotalCount.name()))?,
+                        total_count: total_count.ok_or_else(|| de::Error::missing_field(Field::TotalCount.name()))?,
                         total_thing_count: total_thing_count
                             .ok_or_else(|| de::Error::missing_field(Field::TotalThingCount.name()))?,
                         total_entity_count: total_entity_count

--- a/database/database.rs
+++ b/database/database.rs
@@ -35,6 +35,7 @@ use encoding::{
 };
 use error::typedb_error;
 use function::{function_cache::FunctionCache, FunctionError};
+use query::query_cache::QueryCache;
 use storage::{
     durability_client::{DurabilityClient, DurabilityClientError, WALClient},
     recovery::checkpoint::{Checkpoint, CheckpointCreateError, CheckpointLoadError},
@@ -42,7 +43,6 @@ use storage::{
     MVCCStorage, StorageDeleteError, StorageOpenError, StorageResetError,
 };
 use tracing::{event, Level};
-use query::query_cache::QueryCache;
 
 use crate::{
     transaction::TransactionError,
@@ -255,7 +255,8 @@ impl Database<WALClient> {
         let schema_txn_lock = Arc::new(RwLock::default());
 
         let query_cache = Arc::new(QueryCache::new(0));
-        let update_statistics = make_update_statistics_fn(storage.clone(), schema.clone(), schema_txn_lock.clone(), query_cache.clone());
+        let update_statistics =
+            make_update_statistics_fn(storage.clone(), schema.clone(), schema_txn_lock.clone(), query_cache.clone());
 
         Ok(Database::<WALClient> {
             name: name.to_owned(),
@@ -329,7 +330,8 @@ impl Database<WALClient> {
         let schema_txn_lock = Arc::new(RwLock::default());
 
         let query_cache = Arc::new(QueryCache::new(total_count));
-        let update_statistics = make_update_statistics_fn(storage.clone(), schema.clone(), schema_txn_lock.clone(), query_cache.clone());
+        let update_statistics =
+            make_update_statistics_fn(storage.clone(), schema.clone(), schema_txn_lock.clone(), query_cache.clone());
 
         let database = Database::<WALClient> {
             name: name.to_owned(),
@@ -418,7 +420,7 @@ impl Database<WALClient> {
 
         let thing_statistics = Arc::get_mut(&mut locked_schema.thing_statistics).unwrap();
         thing_statistics.reset(self.storage.read_watermark());
-        
+
         self.query_cache.force_reset(0);
 
         self.release_schema_transaction();

--- a/database/transaction.rs
+++ b/database/transaction.rs
@@ -328,7 +328,7 @@ impl<D: DurabilityClient> TransactionSchema<D> {
             .map_err(|typedb_source| StatisticsError { typedb_source })?;
         let total_count = thing_statistics.total_count;
         schema.thing_statistics = Arc::new(thing_statistics);
-        
+
         self.database.query_cache.force_reset(total_count);
 
         *schema_commit_guard = schema;

--- a/encoding/value/value_type.rs
+++ b/encoding/value/value_type.rs
@@ -8,7 +8,7 @@ use std::{
     fmt,
     fmt::{Display, Formatter},
     mem,
-    ops::{Range},
+    ops::Range,
 };
 
 use bytes::{byte_array::ByteArray, byte_reference::ByteReference, Bytes};

--- a/executor/batch.rs
+++ b/executor/batch.rs
@@ -11,7 +11,7 @@ use std::{
 };
 
 use answer::variable_value::VariableValue;
-use itertools::{Itertools};
+use itertools::Itertools;
 use lending_iterator::LendingIterator;
 
 use crate::{

--- a/executor/instruction/function_call_binding_executor.rs
+++ b/executor/instruction/function_call_binding_executor.rs
@@ -4,9 +4,17 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
+use std::fmt::{Display, Formatter};
+
 use compiler::ExecutorVariable;
 use ir::pattern::constraint::FunctionCallBinding;
 
 pub(crate) struct FunctionCallBindingIteratorExecutor {
     function_call_binding: FunctionCallBinding<ExecutorVariable>,
+}
+
+impl Display for FunctionCallBindingIteratorExecutor {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        writeln!(f, "[{}]", &self.function_call_binding)
+    }
 }

--- a/executor/instruction/has_executor.rs
+++ b/executor/instruction/has_executor.rs
@@ -7,11 +7,11 @@
 use std::{
     cmp::Ordering,
     collections::{BTreeMap, BTreeSet, HashMap},
+    fmt::{Display, Formatter},
     sync::Arc,
 };
-use std::fmt::{Display, Formatter};
 
-use answer::{Thing, Type, variable_value::VariableValue};
+use answer::{variable_value::VariableValue, Thing, Type};
 use compiler::{executable::match_::instructions::thing::HasInstruction, ExecutorVariable};
 use concept::{
     error::ConceptReadError,
@@ -23,8 +23,8 @@ use concept::{
 };
 use lending_iterator::{
     adaptors::{Map, TryFilter},
-    AsHkt,
-    kmerge::KMergeBy, LendingIterator, Peekable,
+    kmerge::KMergeBy,
+    AsHkt, LendingIterator, Peekable,
 };
 use resource::constants::traversal::CONSTANT_CONCEPT_LIMIT;
 use storage::{
@@ -34,12 +34,12 @@ use storage::{
 
 use crate::{
     instruction::{
-        BinaryIterateMode,
-        Checker,
-        FilterFn, iterator::{SortedTupleIterator, TupleIterator}, tuple::{
+        iterator::{SortedTupleIterator, TupleIterator},
+        tuple::{
             has_to_tuple_attribute_owner, has_to_tuple_owner_attribute, HasToTupleFn, Tuple, TuplePositions,
             TupleResult,
-        }, VariableModes,
+        },
+        BinaryIterateMode, Checker, FilterFn, VariableModes,
     },
     pipeline::stage::ExecutionContext,
     row::MaybeOwnedRow,

--- a/executor/instruction/has_executor.rs
+++ b/executor/instruction/has_executor.rs
@@ -7,10 +7,11 @@
 use std::{
     cmp::Ordering,
     collections::{BTreeMap, BTreeSet, HashMap},
-    sync::{Arc, },
+    sync::Arc,
 };
+use std::fmt::{Display, Formatter};
 
-use answer::{variable_value::VariableValue, Thing, Type};
+use answer::{Thing, Type, variable_value::VariableValue};
 use compiler::{executable::match_::instructions::thing::HasInstruction, ExecutorVariable};
 use concept::{
     error::ConceptReadError,
@@ -22,8 +23,8 @@ use concept::{
 };
 use lending_iterator::{
     adaptors::{Map, TryFilter},
-    kmerge::KMergeBy,
-    AsHkt, LendingIterator, Peekable,
+    AsHkt,
+    kmerge::KMergeBy, LendingIterator, Peekable,
 };
 use resource::constants::traversal::CONSTANT_CONCEPT_LIMIT;
 use storage::{
@@ -33,12 +34,12 @@ use storage::{
 
 use crate::{
     instruction::{
-        iterator::{SortedTupleIterator, TupleIterator},
-        tuple::{
+        BinaryIterateMode,
+        Checker,
+        FilterFn, iterator::{SortedTupleIterator, TupleIterator}, tuple::{
             has_to_tuple_attribute_owner, has_to_tuple_owner_attribute, HasToTupleFn, Tuple, TuplePositions,
             TupleResult,
-        },
-        BinaryIterateMode, Checker, FilterFn, VariableModes,
+        }, VariableModes,
     },
     pipeline::stage::ExecutionContext,
     row::MaybeOwnedRow,
@@ -246,6 +247,12 @@ impl HasExecutor {
                 )))
             }
         }
+    }
+}
+
+impl Display for HasExecutor {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        writeln!(f, "[{}], mode={}", &self.has, &self.iterate_mode)
     }
 }
 

--- a/executor/instruction/has_reverse_executor.rs
+++ b/executor/instruction/has_reverse_executor.rs
@@ -6,17 +6,20 @@
 
 use std::{
     cmp::Ordering,
-    collections::{ BTreeMap, BTreeSet, Bound, HashMap},
+    collections::{Bound, BTreeMap, BTreeSet, HashMap},
     sync::{Arc, OnceLock},
     vec,
 };
+use std::fmt::{Display, Formatter};
+
+use itertools::{Itertools, MinMaxResult};
 
 use answer::Type;
 use compiler::{executable::match_::instructions::thing::HasReverseInstruction, ExecutorVariable};
 use concept::{
     error::ConceptReadError,
     thing::{
-        attribute::{Attribute, },
+        attribute::Attribute,
         has::Has,
         object::HasReverseIterator,
         thing_manager::ThingManager,
@@ -24,8 +27,7 @@ use concept::{
     type_::attribute_type::AttributeType,
 };
 use encoding::value::value::Value;
-use itertools::{Itertools, MinMaxResult};
-use lending_iterator::{adaptors::Flatten, kmerge::KMergeBy, AsHkt, AsLendingIterator, LendingIterator, Peekable};
+use lending_iterator::{adaptors::Flatten, AsHkt, AsLendingIterator, kmerge::KMergeBy, LendingIterator, Peekable};
 use resource::constants::traversal::CONSTANT_CONCEPT_LIMIT;
 use storage::{
     key_range::{KeyRange, RangeEnd, RangeStart},
@@ -34,10 +36,10 @@ use storage::{
 
 use crate::{
     instruction::{
-        has_executor::{HasFilterFn, HasOrderingFn, HasTupleIterator, EXTRACT_ATTRIBUTE, EXTRACT_OWNER},
-        iterator::{SortedTupleIterator, TupleIterator},
-        tuple::{has_to_tuple_attribute_owner, has_to_tuple_owner_attribute, Tuple, TuplePositions},
-        BinaryIterateMode, Checker, VariableModes,
+        BinaryIterateMode,
+        Checker,
+        has_executor::{EXTRACT_ATTRIBUTE, EXTRACT_OWNER, HasFilterFn, HasOrderingFn, HasTupleIterator},
+        iterator::{SortedTupleIterator, TupleIterator}, tuple::{has_to_tuple_attribute_owner, has_to_tuple_owner_attribute, Tuple, TuplePositions}, VariableModes,
     },
     pipeline::stage::ExecutionContext,
     row::MaybeOwnedRow,
@@ -249,6 +251,12 @@ impl HasReverseExecutor {
             .map(|type_| thing_manager.get_has_reverse_in_range(snapshot, type_, &attribute_values_range))
             .try_collect()?;
         Ok(AsLendingIterator::new(iterators).flatten())
+    }
+}
+impl Display for HasReverseExecutor {
+    
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        writeln!(f, "Reverse[{}], mode={}", &self.has, &self.iterate_mode)
     }
 }
 

--- a/executor/instruction/has_reverse_executor.rs
+++ b/executor/instruction/has_reverse_executor.rs
@@ -6,28 +6,22 @@
 
 use std::{
     cmp::Ordering,
-    collections::{Bound, BTreeMap, BTreeSet, HashMap},
+    collections::{BTreeMap, BTreeSet, Bound, HashMap},
+    fmt::{Display, Formatter},
     sync::{Arc, OnceLock},
     vec,
 };
-use std::fmt::{Display, Formatter};
-
-use itertools::{Itertools, MinMaxResult};
 
 use answer::Type;
 use compiler::{executable::match_::instructions::thing::HasReverseInstruction, ExecutorVariable};
 use concept::{
     error::ConceptReadError,
-    thing::{
-        attribute::Attribute,
-        has::Has,
-        object::HasReverseIterator,
-        thing_manager::ThingManager,
-    },
+    thing::{attribute::Attribute, has::Has, object::HasReverseIterator, thing_manager::ThingManager},
     type_::attribute_type::AttributeType,
 };
 use encoding::value::value::Value;
-use lending_iterator::{adaptors::Flatten, AsHkt, AsLendingIterator, kmerge::KMergeBy, LendingIterator, Peekable};
+use itertools::{Itertools, MinMaxResult};
+use lending_iterator::{adaptors::Flatten, kmerge::KMergeBy, AsHkt, AsLendingIterator, LendingIterator, Peekable};
 use resource::constants::traversal::CONSTANT_CONCEPT_LIMIT;
 use storage::{
     key_range::{KeyRange, RangeEnd, RangeStart},
@@ -36,10 +30,10 @@ use storage::{
 
 use crate::{
     instruction::{
-        BinaryIterateMode,
-        Checker,
-        has_executor::{EXTRACT_ATTRIBUTE, EXTRACT_OWNER, HasFilterFn, HasOrderingFn, HasTupleIterator},
-        iterator::{SortedTupleIterator, TupleIterator}, tuple::{has_to_tuple_attribute_owner, has_to_tuple_owner_attribute, Tuple, TuplePositions}, VariableModes,
+        has_executor::{HasFilterFn, HasOrderingFn, HasTupleIterator, EXTRACT_ATTRIBUTE, EXTRACT_OWNER},
+        iterator::{SortedTupleIterator, TupleIterator},
+        tuple::{has_to_tuple_attribute_owner, has_to_tuple_owner_attribute, Tuple, TuplePositions},
+        BinaryIterateMode, Checker, VariableModes,
     },
     pipeline::stage::ExecutionContext,
     row::MaybeOwnedRow,
@@ -254,7 +248,6 @@ impl HasReverseExecutor {
     }
 }
 impl Display for HasReverseExecutor {
-    
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         writeln!(f, "Reverse[{}], mode={}", &self.has, &self.iterate_mode)
     }

--- a/executor/instruction/is_executor.rs
+++ b/executor/instruction/is_executor.rs
@@ -4,8 +4,10 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-use std::collections::HashMap;
-use std::fmt::{Display, Formatter};
+use std::{
+    collections::HashMap,
+    fmt::{Display, Formatter},
+};
 
 use answer::variable_value::VariableValue;
 use compiler::{
@@ -20,17 +22,16 @@ use lending_iterator::{
 };
 use storage::snapshot::ReadableSnapshot;
 
+use super::tuple::Tuple;
 use crate::{
     instruction::{
-        Checker,
-        FilterFn,
-        iterator::{SortedTupleIterator, TupleIterator}, tuple::{TuplePositions, TupleResult}, VariableModes,
+        iterator::{SortedTupleIterator, TupleIterator},
+        tuple::{TuplePositions, TupleResult},
+        Checker, FilterFn, VariableModes,
     },
     pipeline::stage::ExecutionContext,
     row::MaybeOwnedRow,
 };
-
-use super::tuple::Tuple;
 
 pub(crate) struct IsExecutor {
     is: Is<ExecutorVariable>,
@@ -66,7 +67,6 @@ fn is_to_tuple(result: Result<VariableValue<'_>, Box<ConceptReadError>>) -> Tupl
 }
 
 impl IsExecutor {
-    
     pub(crate) fn new(
         is: IsInstruction<ExecutorVariable>,
         variable_modes: VariableModes,

--- a/executor/instruction/is_executor.rs
+++ b/executor/instruction/is_executor.rs
@@ -5,6 +5,7 @@
  */
 
 use std::collections::HashMap;
+use std::fmt::{Display, Formatter};
 
 use answer::variable_value::VariableValue;
 use compiler::{
@@ -19,16 +20,17 @@ use lending_iterator::{
 };
 use storage::snapshot::ReadableSnapshot;
 
-use super::tuple::Tuple;
 use crate::{
     instruction::{
-        iterator::{SortedTupleIterator, TupleIterator},
-        tuple::{TuplePositions, TupleResult},
-        Checker, FilterFn, VariableModes,
+        Checker,
+        FilterFn,
+        iterator::{SortedTupleIterator, TupleIterator}, tuple::{TuplePositions, TupleResult}, VariableModes,
     },
     pipeline::stage::ExecutionContext,
     row::MaybeOwnedRow,
 };
+
+use super::tuple::Tuple;
 
 pub(crate) struct IsExecutor {
     is: Is<ExecutorVariable>,
@@ -64,6 +66,7 @@ fn is_to_tuple(result: Result<VariableValue<'_>, Box<ConceptReadError>>) -> Tupl
 }
 
 impl IsExecutor {
+    
     pub(crate) fn new(
         is: IsInstruction<ExecutorVariable>,
         variable_modes: VariableModes,
@@ -104,5 +107,11 @@ impl IsExecutor {
         let as_tuples = as_tuples(iterator.try_filter::<_, IsFilterFn, VariableValue<'_>, _>(filter_for_row));
 
         Ok(TupleIterator::Is(SortedTupleIterator::new(as_tuples, self.tuple_positions.clone(), &self.variable_modes)))
+    }
+}
+
+impl Display for IsExecutor {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        writeln!(f, "{}, input: {}", &self.is, &self.input)
     }
 }

--- a/executor/instruction/isa_executor.rs
+++ b/executor/instruction/isa_executor.rs
@@ -5,8 +5,11 @@
  */
 
 use std::{collections::BTreeMap, iter, ops::Bound, sync::Arc, vec};
+use std::fmt::{Display, Formatter};
 
-use answer::{variable_value::VariableValue, Thing, Type};
+use itertools::Itertools;
+
+use answer::{Thing, Type, variable_value::VariableValue};
 use compiler::{executable::match_::instructions::thing::IsaInstruction, ExecutorVariable};
 use concept::{
     error::ConceptReadError,
@@ -24,7 +27,6 @@ use ir::pattern::{
     constraint::{Isa, IsaKind},
     Vertex,
 };
-use itertools::Itertools;
 use lending_iterator::{
     adaptors::{Chain, Flatten, Map, RepeatEach, TryFilter, Zip},
     AsHkt, AsLendingIterator, LendingIterator, Once,
@@ -33,9 +35,9 @@ use storage::snapshot::ReadableSnapshot;
 
 use crate::{
     instruction::{
-        iterator::{SortedTupleIterator, TupleIterator},
-        tuple::{isa_to_tuple_thing_type, isa_to_tuple_type_thing, IsaToTupleFn, TuplePositions, TupleResult},
-        BinaryIterateMode, Checker, FilterFn, VariableModes, TYPES_EMPTY,
+        BinaryIterateMode,
+        Checker,
+        FilterFn, iterator::{SortedTupleIterator, TupleIterator}, tuple::{isa_to_tuple_thing_type, isa_to_tuple_type_thing, IsaToTupleFn, TuplePositions, TupleResult}, TYPES_EMPTY, VariableModes,
     },
     pipeline::stage::ExecutionContext,
     row::MaybeOwnedRow,
@@ -219,6 +221,12 @@ impl IsaExecutor {
     }
 }
 
+impl Display for IsaExecutor {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        writeln!(f, "[{}], mode={}", &self.isa, &self.iterate_mode)
+    }
+}
+
 fn with_types<I: for<'a> LendingIterator<Item<'a> = Result<Thing<'a>, Box<ConceptReadError>>>>(
     iter: I,
     types: Vec<Type>,
@@ -281,3 +289,4 @@ pub(super) fn instances_of_all_types_chained<'a>(
     let thing_iter: MultipleTypeIsaIterator = object_iter.chain(attribute_iter);
     Ok(thing_iter)
 }
+

--- a/executor/instruction/isa_executor.rs
+++ b/executor/instruction/isa_executor.rs
@@ -4,12 +4,16 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-use std::{collections::BTreeMap, iter, ops::Bound, sync::Arc, vec};
-use std::fmt::{Display, Formatter};
+use std::{
+    collections::BTreeMap,
+    fmt::{Display, Formatter},
+    iter,
+    ops::Bound,
+    sync::Arc,
+    vec,
+};
 
-use itertools::Itertools;
-
-use answer::{Thing, Type, variable_value::VariableValue};
+use answer::{variable_value::VariableValue, Thing, Type};
 use compiler::{executable::match_::instructions::thing::IsaInstruction, ExecutorVariable};
 use concept::{
     error::ConceptReadError,
@@ -27,6 +31,7 @@ use ir::pattern::{
     constraint::{Isa, IsaKind},
     Vertex,
 };
+use itertools::Itertools;
 use lending_iterator::{
     adaptors::{Chain, Flatten, Map, RepeatEach, TryFilter, Zip},
     AsHkt, AsLendingIterator, LendingIterator, Once,
@@ -35,9 +40,9 @@ use storage::snapshot::ReadableSnapshot;
 
 use crate::{
     instruction::{
-        BinaryIterateMode,
-        Checker,
-        FilterFn, iterator::{SortedTupleIterator, TupleIterator}, tuple::{isa_to_tuple_thing_type, isa_to_tuple_type_thing, IsaToTupleFn, TuplePositions, TupleResult}, TYPES_EMPTY, VariableModes,
+        iterator::{SortedTupleIterator, TupleIterator},
+        tuple::{isa_to_tuple_thing_type, isa_to_tuple_type_thing, IsaToTupleFn, TuplePositions, TupleResult},
+        BinaryIterateMode, Checker, FilterFn, VariableModes, TYPES_EMPTY,
     },
     pipeline::stage::ExecutionContext,
     row::MaybeOwnedRow,
@@ -289,4 +294,3 @@ pub(super) fn instances_of_all_types_chained<'a>(
     let thing_iter: MultipleTypeIsaIterator = object_iter.chain(attribute_iter);
     Ok(thing_iter)
 }
-

--- a/executor/instruction/isa_reverse_executor.rs
+++ b/executor/instruction/isa_reverse_executor.rs
@@ -5,6 +5,9 @@
  */
 
 use std::{collections::BTreeMap, iter, option, sync::Arc, vec};
+use std::fmt::{Display, Formatter};
+
+use itertools::Itertools;
 
 use answer::{Thing, Type};
 use compiler::{executable::match_::instructions::thing::IsaReverseInstruction, ExecutorVariable};
@@ -18,24 +21,24 @@ use concept::{
     },
 };
 use ir::pattern::constraint::{Isa, IsaKind};
-use itertools::Itertools;
 use lending_iterator::{
     adaptors::{Chain, Flatten, Map, Zip},
     AsHkt, AsLendingIterator, LendingIterator,
 };
 use storage::snapshot::ReadableSnapshot;
 
-use super::isa_executor::{AttributeEraseFn, MapToThing, ObjectEraseFn};
 use crate::{
     instruction::{
-        isa_executor::{IsaFilterFn, IsaTupleIterator, SingleTypeIsaIterator, EXTRACT_THING, EXTRACT_TYPE},
-        iterator::{SortedTupleIterator, TupleIterator},
-        tuple::{isa_to_tuple_thing_type, isa_to_tuple_type_thing, TuplePositions},
-        type_from_row_or_annotations, BinaryIterateMode, Checker, VariableModes, TYPES_EMPTY,
+        BinaryIterateMode,
+        Checker,
+        isa_executor::{EXTRACT_THING, EXTRACT_TYPE, IsaFilterFn, IsaTupleIterator, SingleTypeIsaIterator},
+        iterator::{SortedTupleIterator, TupleIterator}, tuple::{isa_to_tuple_thing_type, isa_to_tuple_type_thing, TuplePositions}, type_from_row_or_annotations, TYPES_EMPTY, VariableModes,
     },
     pipeline::stage::ExecutionContext,
     row::MaybeOwnedRow,
 };
+
+use super::isa_executor::{AttributeEraseFn, MapToThing, ObjectEraseFn};
 
 pub(crate) struct IsaReverseExecutor {
     isa: Isa<ExecutorVariable>,
@@ -163,6 +166,12 @@ impl IsaReverseExecutor {
                 )))
             }
         }
+    }
+}
+
+impl Display for IsaReverseExecutor {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        writeln!(f, "Reverse[{}], mode={}", &self.isa, &self.iterate_mode)
     }
 }
 

--- a/executor/instruction/isa_reverse_executor.rs
+++ b/executor/instruction/isa_reverse_executor.rs
@@ -4,10 +4,13 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-use std::{collections::BTreeMap, iter, option, sync::Arc, vec};
-use std::fmt::{Display, Formatter};
-
-use itertools::Itertools;
+use std::{
+    collections::BTreeMap,
+    fmt::{Display, Formatter},
+    iter, option,
+    sync::Arc,
+    vec,
+};
 
 use answer::{Thing, Type};
 use compiler::{executable::match_::instructions::thing::IsaReverseInstruction, ExecutorVariable};
@@ -21,24 +24,24 @@ use concept::{
     },
 };
 use ir::pattern::constraint::{Isa, IsaKind};
+use itertools::Itertools;
 use lending_iterator::{
     adaptors::{Chain, Flatten, Map, Zip},
     AsHkt, AsLendingIterator, LendingIterator,
 };
 use storage::snapshot::ReadableSnapshot;
 
+use super::isa_executor::{AttributeEraseFn, MapToThing, ObjectEraseFn};
 use crate::{
     instruction::{
-        BinaryIterateMode,
-        Checker,
-        isa_executor::{EXTRACT_THING, EXTRACT_TYPE, IsaFilterFn, IsaTupleIterator, SingleTypeIsaIterator},
-        iterator::{SortedTupleIterator, TupleIterator}, tuple::{isa_to_tuple_thing_type, isa_to_tuple_type_thing, TuplePositions}, type_from_row_or_annotations, TYPES_EMPTY, VariableModes,
+        isa_executor::{IsaFilterFn, IsaTupleIterator, SingleTypeIsaIterator, EXTRACT_THING, EXTRACT_TYPE},
+        iterator::{SortedTupleIterator, TupleIterator},
+        tuple::{isa_to_tuple_thing_type, isa_to_tuple_type_thing, TuplePositions},
+        type_from_row_or_annotations, BinaryIterateMode, Checker, VariableModes, TYPES_EMPTY,
     },
     pipeline::stage::ExecutionContext,
     row::MaybeOwnedRow,
 };
-
-use super::isa_executor::{AttributeEraseFn, MapToThing, ObjectEraseFn};
 
 pub(crate) struct IsaReverseExecutor {
     isa: Isa<ExecutorVariable>,

--- a/executor/instruction/iterator.rs
+++ b/executor/instruction/iterator.rs
@@ -6,14 +6,13 @@
 
 use std::{cmp::Ordering, iter::Iterator};
 
-use itertools::zip_eq;
-
 use answer::variable_value::VariableValue;
 use compiler::{
     executable::match_::instructions::{VariableMode, VariableModes},
     ExecutorVariable, VariablePosition,
 };
 use concept::error::ConceptReadError;
+use itertools::zip_eq;
 use lending_iterator::{adaptors::Inspect, LendingIterator, Peekable};
 
 use crate::{

--- a/executor/instruction/iterator.rs
+++ b/executor/instruction/iterator.rs
@@ -6,13 +6,14 @@
 
 use std::{cmp::Ordering, iter::Iterator};
 
+use itertools::zip_eq;
+
 use answer::variable_value::VariableValue;
 use compiler::{
     executable::match_::instructions::{VariableMode, VariableModes},
     ExecutorVariable, VariablePosition,
 };
 use concept::error::ConceptReadError;
-use itertools::zip_eq;
 use lending_iterator::{adaptors::Inspect, LendingIterator, Peekable};
 
 use crate::{

--- a/executor/instruction/links_executor.rs
+++ b/executor/instruction/links_executor.rs
@@ -7,13 +7,11 @@
 use std::{
     cmp::Ordering,
     collections::{BTreeMap, BTreeSet, HashMap},
+    fmt::{Display, Formatter},
     sync::Arc,
 };
-use std::fmt::{Display, Formatter};
 
-use itertools::{Itertools, MinMaxResult};
-
-use answer::{Thing, Type, variable_value::VariableValue};
+use answer::{variable_value::VariableValue, Thing, Type};
 use compiler::{executable::match_::instructions::thing::LinksInstruction, ExecutorVariable};
 use concept::{
     error::ConceptReadError,
@@ -22,10 +20,11 @@ use concept::{
         thing_manager::ThingManager,
     },
 };
+use itertools::{Itertools, MinMaxResult};
 use lending_iterator::{
     adaptors::{Map, TryFilter},
-    AsHkt,
-    kmerge::KMergeBy, LendingIterator, Peekable,
+    kmerge::KMergeBy,
+    AsHkt, LendingIterator, Peekable,
 };
 use resource::constants::traversal::CONSTANT_CONCEPT_LIMIT;
 use storage::{
@@ -35,12 +34,12 @@ use storage::{
 
 use crate::{
     instruction::{
-        Checker,
-        FilterFn,
-        iterator::{SortedTupleIterator, TupleIterator}, TernaryIterateMode, tuple::{
+        iterator::{SortedTupleIterator, TupleIterator},
+        tuple::{
             links_to_tuple_player_relation_role, links_to_tuple_relation_player_role,
             links_to_tuple_role_relation_player, LinksToTupleFn, Tuple, TuplePositions, TupleResult,
-        }, VariableModes,
+        },
+        Checker, FilterFn, TernaryIterateMode, VariableModes,
     },
     pipeline::stage::ExecutionContext,
     row::MaybeOwnedRow,

--- a/executor/instruction/links_executor.rs
+++ b/executor/instruction/links_executor.rs
@@ -9,8 +9,11 @@ use std::{
     collections::{BTreeMap, BTreeSet, HashMap},
     sync::Arc,
 };
+use std::fmt::{Display, Formatter};
 
-use answer::{variable_value::VariableValue, Thing, Type};
+use itertools::{Itertools, MinMaxResult};
+
+use answer::{Thing, Type, variable_value::VariableValue};
 use compiler::{executable::match_::instructions::thing::LinksInstruction, ExecutorVariable};
 use concept::{
     error::ConceptReadError,
@@ -19,11 +22,10 @@ use concept::{
         thing_manager::ThingManager,
     },
 };
-use itertools::{Itertools, MinMaxResult};
 use lending_iterator::{
     adaptors::{Map, TryFilter},
-    kmerge::KMergeBy,
-    AsHkt, LendingIterator, Peekable,
+    AsHkt,
+    kmerge::KMergeBy, LendingIterator, Peekable,
 };
 use resource::constants::traversal::CONSTANT_CONCEPT_LIMIT;
 use storage::{
@@ -33,12 +35,12 @@ use storage::{
 
 use crate::{
     instruction::{
-        iterator::{SortedTupleIterator, TupleIterator},
-        tuple::{
+        Checker,
+        FilterFn,
+        iterator::{SortedTupleIterator, TupleIterator}, TernaryIterateMode, tuple::{
             links_to_tuple_player_relation_role, links_to_tuple_relation_player_role,
             links_to_tuple_role_relation_player, LinksToTupleFn, Tuple, TuplePositions, TupleResult,
-        },
-        Checker, FilterFn, TernaryIterateMode, VariableModes,
+        }, VariableModes,
     },
     pipeline::stage::ExecutionContext,
     row::MaybeOwnedRow,
@@ -288,6 +290,12 @@ impl LinksExecutor {
                 )))
             }
         }
+    }
+}
+
+impl Display for LinksExecutor {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        writeln!(f, "[{}], mode={}", &self.links, &self.iterate_mode)
     }
 }
 

--- a/executor/instruction/links_reverse_executor.rs
+++ b/executor/instruction/links_reverse_executor.rs
@@ -9,6 +9,9 @@ use std::{
     collections::{BTreeMap, BTreeSet, HashMap},
     sync::Arc,
 };
+use std::fmt::{Display, Formatter};
+
+use itertools::{Itertools, MinMaxResult};
 
 use answer::Type;
 use compiler::{executable::match_::instructions::thing::LinksReverseInstruction, ExecutorVariable};
@@ -20,8 +23,7 @@ use concept::{
         thing_manager::ThingManager,
     },
 };
-use itertools::{Itertools, MinMaxResult};
-use lending_iterator::{kmerge::KMergeBy, AsHkt, LendingIterator, Peekable};
+use lending_iterator::{AsHkt, kmerge::KMergeBy, LendingIterator, Peekable};
 use resource::constants::traversal::CONSTANT_CONCEPT_LIMIT;
 use storage::{
     key_range::{KeyRange, RangeEnd, RangeStart},
@@ -30,15 +32,15 @@ use storage::{
 
 use crate::{
     instruction::{
+        Checker,
         iterator::{SortedTupleIterator, TupleIterator},
         links_executor::{
-            LinksFilterFn, LinksOrderingFn, LinksTupleIterator, EXTRACT_PLAYER, EXTRACT_RELATION, EXTRACT_ROLE,
+            EXTRACT_PLAYER, EXTRACT_RELATION, EXTRACT_ROLE, LinksFilterFn, LinksOrderingFn, LinksTupleIterator,
         },
-        tuple::{
+        TernaryIterateMode, tuple::{
             links_to_tuple_player_relation_role, links_to_tuple_relation_player_role,
             links_to_tuple_role_relation_player, TuplePositions,
-        },
-        Checker, TernaryIterateMode, VariableModes,
+        }, VariableModes,
     },
     pipeline::stage::ExecutionContext,
     row::MaybeOwnedRow,
@@ -266,6 +268,12 @@ impl LinksReverseExecutor {
                 )))
             }
         }
+    }
+}
+
+impl Display for LinksReverseExecutor {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        writeln!(f, "Reverse[{}], mode={}", &self.links, &self.iterate_mode)
     }
 }
 

--- a/executor/instruction/links_reverse_executor.rs
+++ b/executor/instruction/links_reverse_executor.rs
@@ -7,11 +7,9 @@
 use std::{
     cmp::Ordering,
     collections::{BTreeMap, BTreeSet, HashMap},
+    fmt::{Display, Formatter},
     sync::Arc,
 };
-use std::fmt::{Display, Formatter};
-
-use itertools::{Itertools, MinMaxResult};
 
 use answer::Type;
 use compiler::{executable::match_::instructions::thing::LinksReverseInstruction, ExecutorVariable};
@@ -23,7 +21,8 @@ use concept::{
         thing_manager::ThingManager,
     },
 };
-use lending_iterator::{AsHkt, kmerge::KMergeBy, LendingIterator, Peekable};
+use itertools::{Itertools, MinMaxResult};
+use lending_iterator::{kmerge::KMergeBy, AsHkt, LendingIterator, Peekable};
 use resource::constants::traversal::CONSTANT_CONCEPT_LIMIT;
 use storage::{
     key_range::{KeyRange, RangeEnd, RangeStart},
@@ -32,15 +31,15 @@ use storage::{
 
 use crate::{
     instruction::{
-        Checker,
         iterator::{SortedTupleIterator, TupleIterator},
         links_executor::{
-            EXTRACT_PLAYER, EXTRACT_RELATION, EXTRACT_ROLE, LinksFilterFn, LinksOrderingFn, LinksTupleIterator,
+            LinksFilterFn, LinksOrderingFn, LinksTupleIterator, EXTRACT_PLAYER, EXTRACT_RELATION, EXTRACT_ROLE,
         },
-        TernaryIterateMode, tuple::{
+        tuple::{
             links_to_tuple_player_relation_role, links_to_tuple_relation_player_role,
             links_to_tuple_role_relation_player, TuplePositions,
-        }, VariableModes,
+        },
+        Checker, TernaryIterateMode, VariableModes,
     },
     pipeline::stage::ExecutionContext,
     row::MaybeOwnedRow,

--- a/executor/instruction/mod.rs
+++ b/executor/instruction/mod.rs
@@ -5,8 +5,11 @@
  */
 
 use std::{collections::HashMap, fmt, marker::PhantomData, ops::Bound};
+use std::fmt::{Display, Formatter};
 
-use answer::{variable_value::VariableValue, Thing, Type};
+use itertools::Itertools;
+
+use answer::{Thing, Type, variable_value::VariableValue};
 use compiler::{
     executable::match_::instructions::{
         CheckInstruction, CheckVertex, ConstraintInstruction, VariableMode, VariableModes,
@@ -26,7 +29,6 @@ use ir::{
     },
     pipeline::ParameterRegistry,
 };
-use itertools::Itertools;
 use lending_iterator::higher_order::{FnHktHelper, Hkt};
 use storage::snapshot::ReadableSnapshot;
 
@@ -206,6 +208,30 @@ impl InstructionExecutor {
     }
 }
 
+impl Display for InstructionExecutor {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        match self {
+            InstructionExecutor::Is(inner) => Display::fmt(inner, f),
+            InstructionExecutor::TypeList(inner) =>  Display::fmt(inner, f),
+            InstructionExecutor::Sub(inner) =>  Display::fmt(inner, f),
+            InstructionExecutor::SubReverse(inner) =>  Display::fmt(inner, f),
+            InstructionExecutor::Owns(inner) => Display::fmt(inner, f),
+            InstructionExecutor::OwnsReverse(inner) =>  Display::fmt(inner, f),
+            InstructionExecutor::Relates(inner) =>  Display::fmt(inner, f),
+            InstructionExecutor::RelatesReverse(inner) => Display::fmt(inner, f),
+            InstructionExecutor::Plays(inner) => Display::fmt(inner, f),
+            InstructionExecutor::PlaysReverse(inner) =>  Display::fmt(inner, f),
+            InstructionExecutor::Isa(inner) =>  Display::fmt(inner, f),
+            InstructionExecutor::IsaReverse(inner) =>  Display::fmt(inner, f),
+            InstructionExecutor::Has(inner) => Display::fmt(inner, f),
+            InstructionExecutor::HasReverse(inner) =>  Display::fmt(inner, f),
+            InstructionExecutor::Links(inner) => Display::fmt(inner, f),
+            InstructionExecutor::LinksReverse(inner) =>  Display::fmt(inner, f),
+            InstructionExecutor::FunctionCallBinding(inner) =>  Display::fmt(inner, f),
+        }
+    }
+}
+
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub(crate) enum BinaryIterateMode {
     // [x, y] in standard order, sorted by x, then y
@@ -246,6 +272,12 @@ impl BinaryIterateMode {
 
     pub(crate) fn is_unbound_inverted(&self) -> bool {
         self == &Self::UnboundInverted
+    }
+}
+
+impl Display for BinaryIterateMode {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        fmt::Debug::fmt(self, f)
     }
 }
 
@@ -293,6 +325,12 @@ impl TernaryIterateMode {
         } else {
             Self::Unbound
         }
+    }
+}
+
+impl Display for TernaryIterateMode {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        fmt::Debug::fmt(self, f)
     }
 }
 

--- a/executor/instruction/mod.rs
+++ b/executor/instruction/mod.rs
@@ -4,12 +4,15 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-use std::{collections::HashMap, fmt, marker::PhantomData, ops::Bound};
-use std::fmt::{Display, Formatter};
+use std::{
+    collections::HashMap,
+    fmt,
+    fmt::{Display, Formatter},
+    marker::PhantomData,
+    ops::Bound,
+};
 
-use itertools::Itertools;
-
-use answer::{Thing, Type, variable_value::VariableValue};
+use answer::{variable_value::VariableValue, Thing, Type};
 use compiler::{
     executable::match_::instructions::{
         CheckInstruction, CheckVertex, ConstraintInstruction, VariableMode, VariableModes,
@@ -29,6 +32,7 @@ use ir::{
     },
     pipeline::ParameterRegistry,
 };
+use itertools::Itertools;
 use lending_iterator::higher_order::{FnHktHelper, Hkt};
 use storage::snapshot::ReadableSnapshot;
 
@@ -212,22 +216,22 @@ impl Display for InstructionExecutor {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         match self {
             InstructionExecutor::Is(inner) => Display::fmt(inner, f),
-            InstructionExecutor::TypeList(inner) =>  Display::fmt(inner, f),
-            InstructionExecutor::Sub(inner) =>  Display::fmt(inner, f),
-            InstructionExecutor::SubReverse(inner) =>  Display::fmt(inner, f),
+            InstructionExecutor::TypeList(inner) => Display::fmt(inner, f),
+            InstructionExecutor::Sub(inner) => Display::fmt(inner, f),
+            InstructionExecutor::SubReverse(inner) => Display::fmt(inner, f),
             InstructionExecutor::Owns(inner) => Display::fmt(inner, f),
-            InstructionExecutor::OwnsReverse(inner) =>  Display::fmt(inner, f),
-            InstructionExecutor::Relates(inner) =>  Display::fmt(inner, f),
+            InstructionExecutor::OwnsReverse(inner) => Display::fmt(inner, f),
+            InstructionExecutor::Relates(inner) => Display::fmt(inner, f),
             InstructionExecutor::RelatesReverse(inner) => Display::fmt(inner, f),
             InstructionExecutor::Plays(inner) => Display::fmt(inner, f),
-            InstructionExecutor::PlaysReverse(inner) =>  Display::fmt(inner, f),
-            InstructionExecutor::Isa(inner) =>  Display::fmt(inner, f),
-            InstructionExecutor::IsaReverse(inner) =>  Display::fmt(inner, f),
+            InstructionExecutor::PlaysReverse(inner) => Display::fmt(inner, f),
+            InstructionExecutor::Isa(inner) => Display::fmt(inner, f),
+            InstructionExecutor::IsaReverse(inner) => Display::fmt(inner, f),
             InstructionExecutor::Has(inner) => Display::fmt(inner, f),
-            InstructionExecutor::HasReverse(inner) =>  Display::fmt(inner, f),
+            InstructionExecutor::HasReverse(inner) => Display::fmt(inner, f),
             InstructionExecutor::Links(inner) => Display::fmt(inner, f),
-            InstructionExecutor::LinksReverse(inner) =>  Display::fmt(inner, f),
-            InstructionExecutor::FunctionCallBinding(inner) =>  Display::fmt(inner, f),
+            InstructionExecutor::LinksReverse(inner) => Display::fmt(inner, f),
+            InstructionExecutor::FunctionCallBinding(inner) => Display::fmt(inner, f),
         }
     }
 }

--- a/executor/instruction/owns_executor.rs
+++ b/executor/instruction/owns_executor.rs
@@ -10,17 +10,19 @@ use std::{
     sync::Arc,
     vec,
 };
+use std::fmt::{Display, Formatter};
 
-use answer::{variable_value::VariableValue, Type};
+use itertools::Itertools;
+
+use answer::{Type, variable_value::VariableValue};
 use compiler::{executable::match_::instructions::type_::OwnsInstruction, ExecutorVariable};
 use concept::{
     error::ConceptReadError,
     type_::{
-        attribute_type::AttributeType, object_type::ObjectType, type_manager::TypeManager, ObjectTypeAPI,
-        OwnerAPI,
+        attribute_type::AttributeType, object_type::ObjectType, ObjectTypeAPI, OwnerAPI,
+        type_manager::TypeManager,
     },
 };
-use itertools::Itertools;
 use lending_iterator::{
     adaptors::{Map, TryFilter},
     AsHkt, AsNarrowingIterator, LendingIterator,
@@ -29,11 +31,11 @@ use storage::snapshot::ReadableSnapshot;
 
 use crate::{
     instruction::{
-        iterator::{SortedTupleIterator, TupleIterator},
-        tuple::{
+        BinaryIterateMode,
+        Checker,
+        FilterFn, iterator::{SortedTupleIterator, TupleIterator}, tuple::{
             owns_to_tuple_attribute_owner, owns_to_tuple_owner_attribute, OwnsToTupleFn, TuplePositions, TupleResult,
-        },
-        type_from_row_or_annotations, BinaryIterateMode, Checker, FilterFn, VariableModes,
+        }, type_from_row_or_annotations, VariableModes,
     },
     pipeline::stage::ExecutionContext,
     row::MaybeOwnedRow,
@@ -212,6 +214,12 @@ impl OwnsExecutor {
             .into_iter()
             .map(|attribute_type| (object_type.clone(), attribute_type))
             .collect())
+    }
+}
+
+impl Display for OwnsExecutor {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        writeln!(f, "[{}], mode={}", &self.owns, &self.iterate_mode)
     }
 }
 

--- a/executor/instruction/owns_executor.rs
+++ b/executor/instruction/owns_executor.rs
@@ -6,23 +6,21 @@
 
 use std::{
     collections::{BTreeMap, BTreeSet, HashMap},
+    fmt::{Display, Formatter},
     iter,
     sync::Arc,
     vec,
 };
-use std::fmt::{Display, Formatter};
 
-use itertools::Itertools;
-
-use answer::{Type, variable_value::VariableValue};
+use answer::{variable_value::VariableValue, Type};
 use compiler::{executable::match_::instructions::type_::OwnsInstruction, ExecutorVariable};
 use concept::{
     error::ConceptReadError,
     type_::{
-        attribute_type::AttributeType, object_type::ObjectType, ObjectTypeAPI, OwnerAPI,
-        type_manager::TypeManager,
+        attribute_type::AttributeType, object_type::ObjectType, type_manager::TypeManager, ObjectTypeAPI, OwnerAPI,
     },
 };
+use itertools::Itertools;
 use lending_iterator::{
     adaptors::{Map, TryFilter},
     AsHkt, AsNarrowingIterator, LendingIterator,
@@ -31,11 +29,11 @@ use storage::snapshot::ReadableSnapshot;
 
 use crate::{
     instruction::{
-        BinaryIterateMode,
-        Checker,
-        FilterFn, iterator::{SortedTupleIterator, TupleIterator}, tuple::{
+        iterator::{SortedTupleIterator, TupleIterator},
+        tuple::{
             owns_to_tuple_attribute_owner, owns_to_tuple_owner_attribute, OwnsToTupleFn, TuplePositions, TupleResult,
-        }, type_from_row_or_annotations, VariableModes,
+        },
+        type_from_row_or_annotations, BinaryIterateMode, Checker, FilterFn, VariableModes,
     },
     pipeline::stage::ExecutionContext,
     row::MaybeOwnedRow,

--- a/executor/instruction/owns_reverse_executor.rs
+++ b/executor/instruction/owns_reverse_executor.rs
@@ -6,31 +6,30 @@
 
 use std::{
     collections::{BTreeMap, BTreeSet, HashMap},
+    fmt::{Display, Formatter},
     iter,
     sync::Arc,
     vec,
 };
-use std::fmt::{Display, Formatter};
-
-use itertools::Itertools;
 
 use answer::Type;
 use compiler::{executable::match_::instructions::type_::OwnsReverseInstruction, ExecutorVariable};
 use concept::{
     error::ConceptReadError,
-    type_::{attribute_type::AttributeType, object_type::ObjectType, },
+    type_::{attribute_type::AttributeType, object_type::ObjectType},
 };
+use itertools::Itertools;
 use lending_iterator::{AsHkt, AsNarrowingIterator, LendingIterator};
 use storage::snapshot::ReadableSnapshot;
 
 use crate::{
     instruction::{
-        BinaryIterateMode,
-        Checker,
         iterator::{SortedTupleIterator, TupleIterator},
         owns_executor::{
-            EXTRACT_ATTRIBUTE, EXTRACT_OWNER, OwnsFilterFn, OwnsTupleIterator, OwnsVariableValueExtractor,
-        }, tuple::{owns_to_tuple_attribute_owner, owns_to_tuple_owner_attribute, TuplePositions}, type_from_row_or_annotations, VariableModes,
+            OwnsFilterFn, OwnsTupleIterator, OwnsVariableValueExtractor, EXTRACT_ATTRIBUTE, EXTRACT_OWNER,
+        },
+        tuple::{owns_to_tuple_attribute_owner, owns_to_tuple_owner_attribute, TuplePositions},
+        type_from_row_or_annotations, BinaryIterateMode, Checker, VariableModes,
     },
     pipeline::stage::ExecutionContext,
     row::MaybeOwnedRow,

--- a/executor/instruction/owns_reverse_executor.rs
+++ b/executor/instruction/owns_reverse_executor.rs
@@ -10,6 +10,9 @@ use std::{
     sync::Arc,
     vec,
 };
+use std::fmt::{Display, Formatter};
+
+use itertools::Itertools;
 
 use answer::Type;
 use compiler::{executable::match_::instructions::type_::OwnsReverseInstruction, ExecutorVariable};
@@ -17,18 +20,17 @@ use concept::{
     error::ConceptReadError,
     type_::{attribute_type::AttributeType, object_type::ObjectType, },
 };
-use itertools::Itertools;
 use lending_iterator::{AsHkt, AsNarrowingIterator, LendingIterator};
 use storage::snapshot::ReadableSnapshot;
 
 use crate::{
     instruction::{
+        BinaryIterateMode,
+        Checker,
         iterator::{SortedTupleIterator, TupleIterator},
         owns_executor::{
-            OwnsFilterFn, OwnsTupleIterator, OwnsVariableValueExtractor, EXTRACT_ATTRIBUTE, EXTRACT_OWNER,
-        },
-        tuple::{owns_to_tuple_attribute_owner, owns_to_tuple_owner_attribute, TuplePositions},
-        type_from_row_or_annotations, BinaryIterateMode, Checker, VariableModes,
+            EXTRACT_ATTRIBUTE, EXTRACT_OWNER, OwnsFilterFn, OwnsTupleIterator, OwnsVariableValueExtractor,
+        }, tuple::{owns_to_tuple_attribute_owner, owns_to_tuple_owner_attribute, TuplePositions}, type_from_row_or_annotations, VariableModes,
     },
     pipeline::stage::ExecutionContext,
     row::MaybeOwnedRow,
@@ -188,6 +190,12 @@ impl OwnsReverseExecutor {
                 )))
             }
         }
+    }
+}
+
+impl Display for OwnsReverseExecutor {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        writeln!(f, "Reverse[{}], mode={}", &self.owns, &self.iterate_mode)
     }
 }
 

--- a/executor/instruction/plays_executor.rs
+++ b/executor/instruction/plays_executor.rs
@@ -10,14 +10,16 @@ use std::{
     sync::Arc,
     vec,
 };
+use std::fmt::{Display, Formatter};
 
-use answer::{variable_value::VariableValue, Type};
+use itertools::Itertools;
+
+use answer::{Type, variable_value::VariableValue};
 use compiler::{executable::match_::instructions::type_::PlaysInstruction, ExecutorVariable};
 use concept::{
     error::ConceptReadError,
-    type_::{object_type::ObjectType, role_type::RoleType, type_manager::TypeManager, ObjectTypeAPI, PlayerAPI},
+    type_::{object_type::ObjectType, ObjectTypeAPI, PlayerAPI, role_type::RoleType, type_manager::TypeManager},
 };
-use itertools::Itertools;
 use lending_iterator::{
     adaptors::{Map, TryFilter},
     AsHkt, AsNarrowingIterator, LendingIterator,
@@ -26,9 +28,9 @@ use storage::snapshot::ReadableSnapshot;
 
 use crate::{
     instruction::{
-        iterator::{SortedTupleIterator, TupleIterator},
-        tuple::{plays_to_tuple_player_role, plays_to_tuple_role_player, PlaysToTupleFn, TuplePositions, TupleResult},
-        type_from_row_or_annotations, BinaryIterateMode, Checker, FilterFn, VariableModes,
+        BinaryIterateMode,
+        Checker,
+        FilterFn, iterator::{SortedTupleIterator, TupleIterator}, tuple::{plays_to_tuple_player_role, plays_to_tuple_role_player, PlaysToTupleFn, TuplePositions, TupleResult}, type_from_row_or_annotations, VariableModes,
     },
     pipeline::stage::ExecutionContext,
     row::MaybeOwnedRow,
@@ -205,6 +207,12 @@ impl PlaysExecutor {
             .into_iter()
             .map(|role_type| (object_type.clone(), role_type))
             .collect())
+    }
+}
+
+impl Display for PlaysExecutor {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        writeln!(f, "[{}], mode={}", &self.plays, &self.iterate_mode)
     }
 }
 

--- a/executor/instruction/plays_executor.rs
+++ b/executor/instruction/plays_executor.rs
@@ -5,21 +5,20 @@
  */
 
 use std::{
-    collections::{BTreeMap, BTreeSet, HashMap, },
+    collections::{BTreeMap, BTreeSet, HashMap},
+    fmt::{Display, Formatter},
     iter,
     sync::Arc,
     vec,
 };
-use std::fmt::{Display, Formatter};
 
-use itertools::Itertools;
-
-use answer::{Type, variable_value::VariableValue};
+use answer::{variable_value::VariableValue, Type};
 use compiler::{executable::match_::instructions::type_::PlaysInstruction, ExecutorVariable};
 use concept::{
     error::ConceptReadError,
-    type_::{object_type::ObjectType, ObjectTypeAPI, PlayerAPI, role_type::RoleType, type_manager::TypeManager},
+    type_::{object_type::ObjectType, role_type::RoleType, type_manager::TypeManager, ObjectTypeAPI, PlayerAPI},
 };
+use itertools::Itertools;
 use lending_iterator::{
     adaptors::{Map, TryFilter},
     AsHkt, AsNarrowingIterator, LendingIterator,
@@ -28,9 +27,9 @@ use storage::snapshot::ReadableSnapshot;
 
 use crate::{
     instruction::{
-        BinaryIterateMode,
-        Checker,
-        FilterFn, iterator::{SortedTupleIterator, TupleIterator}, tuple::{plays_to_tuple_player_role, plays_to_tuple_role_player, PlaysToTupleFn, TuplePositions, TupleResult}, type_from_row_or_annotations, VariableModes,
+        iterator::{SortedTupleIterator, TupleIterator},
+        tuple::{plays_to_tuple_player_role, plays_to_tuple_role_player, PlaysToTupleFn, TuplePositions, TupleResult},
+        type_from_row_or_annotations, BinaryIterateMode, Checker, FilterFn, VariableModes,
     },
     pipeline::stage::ExecutionContext,
     row::MaybeOwnedRow,

--- a/executor/instruction/plays_reverse_executor.rs
+++ b/executor/instruction/plays_reverse_executor.rs
@@ -5,14 +5,12 @@
  */
 
 use std::{
-    collections::{BTreeMap, BTreeSet, HashMap, },
+    collections::{BTreeMap, BTreeSet, HashMap},
+    fmt::{Display, Formatter},
     iter,
     sync::Arc,
     vec,
 };
-use std::fmt::{Display, Formatter};
-
-use itertools::Itertools;
 
 use answer::Type;
 use compiler::{executable::match_::instructions::type_::PlaysReverseInstruction, ExecutorVariable};
@@ -20,23 +18,23 @@ use concept::{
     error::ConceptReadError,
     type_::{object_type::ObjectType, role_type::RoleType},
 };
+use itertools::Itertools;
 use lending_iterator::{AsHkt, AsNarrowingIterator, LendingIterator};
 use storage::snapshot::ReadableSnapshot;
 
+use super::type_from_row_or_annotations;
 use crate::{
     instruction::{
-        BinaryIterateMode,
-        Checker,
         iterator::{SortedTupleIterator, TupleIterator},
         plays_executor::{
-            EXTRACT_PLAYER, EXTRACT_ROLE, PlaysFilterFn, PlaysTupleIterator, PlaysVariableValueExtractor,
-        }, tuple::{plays_to_tuple_player_role, plays_to_tuple_role_player, TuplePositions}, VariableModes,
+            PlaysFilterFn, PlaysTupleIterator, PlaysVariableValueExtractor, EXTRACT_PLAYER, EXTRACT_ROLE,
+        },
+        tuple::{plays_to_tuple_player_role, plays_to_tuple_role_player, TuplePositions},
+        BinaryIterateMode, Checker, VariableModes,
     },
     pipeline::stage::ExecutionContext,
     row::MaybeOwnedRow,
 };
-
-use super::type_from_row_or_annotations;
 
 pub(crate) struct PlaysReverseExecutor {
     plays: ir::pattern::constraint::Plays<ExecutorVariable>,

--- a/executor/instruction/plays_reverse_executor.rs
+++ b/executor/instruction/plays_reverse_executor.rs
@@ -10,6 +10,9 @@ use std::{
     sync::Arc,
     vec,
 };
+use std::fmt::{Display, Formatter};
+
+use itertools::Itertools;
 
 use answer::Type;
 use compiler::{executable::match_::instructions::type_::PlaysReverseInstruction, ExecutorVariable};
@@ -17,23 +20,23 @@ use concept::{
     error::ConceptReadError,
     type_::{object_type::ObjectType, role_type::RoleType},
 };
-use itertools::Itertools;
 use lending_iterator::{AsHkt, AsNarrowingIterator, LendingIterator};
 use storage::snapshot::ReadableSnapshot;
 
-use super::type_from_row_or_annotations;
 use crate::{
     instruction::{
+        BinaryIterateMode,
+        Checker,
         iterator::{SortedTupleIterator, TupleIterator},
         plays_executor::{
-            PlaysFilterFn, PlaysTupleIterator, PlaysVariableValueExtractor, EXTRACT_PLAYER, EXTRACT_ROLE,
-        },
-        tuple::{plays_to_tuple_player_role, plays_to_tuple_role_player, TuplePositions},
-        BinaryIterateMode, Checker, VariableModes,
+            EXTRACT_PLAYER, EXTRACT_ROLE, PlaysFilterFn, PlaysTupleIterator, PlaysVariableValueExtractor,
+        }, tuple::{plays_to_tuple_player_role, plays_to_tuple_role_player, TuplePositions}, VariableModes,
     },
     pipeline::stage::ExecutionContext,
     row::MaybeOwnedRow,
 };
+
+use super::type_from_row_or_annotations;
 
 pub(crate) struct PlaysReverseExecutor {
     plays: ir::pattern::constraint::Plays<ExecutorVariable>,
@@ -186,6 +189,12 @@ impl PlaysReverseExecutor {
                 )))
             }
         }
+    }
+}
+
+impl Display for PlaysReverseExecutor {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        writeln!(f, "Reverse[{}], mode={}", &self.plays, &self.iterate_mode)
     }
 }
 

--- a/executor/instruction/relates_executor.rs
+++ b/executor/instruction/relates_executor.rs
@@ -6,20 +6,19 @@
 
 use std::{
     collections::{BTreeMap, BTreeSet, HashMap},
+    fmt::{Display, Formatter},
     iter,
     sync::Arc,
     vec,
 };
-use std::fmt::{Display, Formatter};
 
-use itertools::Itertools;
-
-use answer::{Type, variable_value::VariableValue};
+use answer::{variable_value::VariableValue, Type};
 use compiler::{executable::match_::instructions::type_::RelatesInstruction, ExecutorVariable};
 use concept::{
     error::ConceptReadError,
     type_::{relation_type::RelationType, role_type::RoleType, type_manager::TypeManager},
 };
+use itertools::Itertools;
 use lending_iterator::{
     adaptors::{Map, TryFilter},
     AsHkt, AsNarrowingIterator, LendingIterator,
@@ -28,12 +27,12 @@ use storage::snapshot::ReadableSnapshot;
 
 use crate::{
     instruction::{
-        BinaryIterateMode,
-        Checker,
-        FilterFn, iterator::{SortedTupleIterator, TupleIterator}, tuple::{
+        iterator::{SortedTupleIterator, TupleIterator},
+        tuple::{
             relates_to_tuple_relation_role, relates_to_tuple_role_relation, RelatesToTupleFn, TuplePositions,
             TupleResult,
-        }, type_from_row_or_annotations, VariableModes,
+        },
+        type_from_row_or_annotations, BinaryIterateMode, Checker, FilterFn, VariableModes,
     },
     pipeline::stage::ExecutionContext,
     row::MaybeOwnedRow,

--- a/executor/instruction/relates_executor.rs
+++ b/executor/instruction/relates_executor.rs
@@ -10,14 +10,16 @@ use std::{
     sync::Arc,
     vec,
 };
+use std::fmt::{Display, Formatter};
 
-use answer::{variable_value::VariableValue, Type};
+use itertools::Itertools;
+
+use answer::{Type, variable_value::VariableValue};
 use compiler::{executable::match_::instructions::type_::RelatesInstruction, ExecutorVariable};
 use concept::{
     error::ConceptReadError,
     type_::{relation_type::RelationType, role_type::RoleType, type_manager::TypeManager},
 };
-use itertools::Itertools;
 use lending_iterator::{
     adaptors::{Map, TryFilter},
     AsHkt, AsNarrowingIterator, LendingIterator,
@@ -26,12 +28,12 @@ use storage::snapshot::ReadableSnapshot;
 
 use crate::{
     instruction::{
-        iterator::{SortedTupleIterator, TupleIterator},
-        tuple::{
+        BinaryIterateMode,
+        Checker,
+        FilterFn, iterator::{SortedTupleIterator, TupleIterator}, tuple::{
             relates_to_tuple_relation_role, relates_to_tuple_role_relation, RelatesToTupleFn, TuplePositions,
             TupleResult,
-        },
-        type_from_row_or_annotations, BinaryIterateMode, Checker, FilterFn, VariableModes,
+        }, type_from_row_or_annotations, VariableModes,
     },
     pipeline::stage::ExecutionContext,
     row::MaybeOwnedRow,
@@ -208,6 +210,12 @@ impl RelatesExecutor {
             .into_iter()
             .map(|role_type| (relation_type.clone(), role_type))
             .collect())
+    }
+}
+
+impl Display for RelatesExecutor {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        writeln!(f, "[{}], mode={}", &self.relates, &self.iterate_mode)
     }
 }
 

--- a/executor/instruction/relates_reverse_executor.rs
+++ b/executor/instruction/relates_reverse_executor.rs
@@ -10,6 +10,9 @@ use std::{
     sync::Arc,
     vec,
 };
+use std::fmt::{Display, Formatter};
+
+use itertools::Itertools;
 
 use answer::Type;
 use compiler::{executable::match_::instructions::type_::RelatesReverseInstruction, ExecutorVariable};
@@ -17,18 +20,17 @@ use concept::{
     error::ConceptReadError,
     type_::{relation_type::RelationType, role_type::RoleType},
 };
-use itertools::Itertools;
 use lending_iterator::{AsHkt, AsNarrowingIterator, LendingIterator};
 use storage::snapshot::ReadableSnapshot;
 
 use crate::{
     instruction::{
+        BinaryIterateMode,
+        Checker,
         iterator::{SortedTupleIterator, TupleIterator},
         relates_executor::{
-            RelatesFilterFn, RelatesTupleIterator, RelatesVariableValueExtractor, EXTRACT_RELATION, EXTRACT_ROLE,
-        },
-        tuple::{relates_to_tuple_relation_role, relates_to_tuple_role_relation, TuplePositions},
-        type_from_row_or_annotations, BinaryIterateMode, Checker, VariableModes,
+            EXTRACT_RELATION, EXTRACT_ROLE, RelatesFilterFn, RelatesTupleIterator, RelatesVariableValueExtractor,
+        }, tuple::{relates_to_tuple_relation_role, relates_to_tuple_role_relation, TuplePositions}, type_from_row_or_annotations, VariableModes,
     },
     pipeline::stage::ExecutionContext,
     row::MaybeOwnedRow,
@@ -186,6 +188,12 @@ impl RelatesReverseExecutor {
                 )))
             }
         }
+    }
+}
+
+impl Display for RelatesReverseExecutor {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        writeln!(f, "Reverse[{}], mode={}", &self.relates, &self.iterate_mode)
     }
 }
 

--- a/executor/instruction/relates_reverse_executor.rs
+++ b/executor/instruction/relates_reverse_executor.rs
@@ -5,14 +5,12 @@
  */
 
 use std::{
-    collections::{BTreeMap, BTreeSet, HashMap, },
+    collections::{BTreeMap, BTreeSet, HashMap},
+    fmt::{Display, Formatter},
     iter,
     sync::Arc,
     vec,
 };
-use std::fmt::{Display, Formatter};
-
-use itertools::Itertools;
 
 use answer::Type;
 use compiler::{executable::match_::instructions::type_::RelatesReverseInstruction, ExecutorVariable};
@@ -20,17 +18,18 @@ use concept::{
     error::ConceptReadError,
     type_::{relation_type::RelationType, role_type::RoleType},
 };
+use itertools::Itertools;
 use lending_iterator::{AsHkt, AsNarrowingIterator, LendingIterator};
 use storage::snapshot::ReadableSnapshot;
 
 use crate::{
     instruction::{
-        BinaryIterateMode,
-        Checker,
         iterator::{SortedTupleIterator, TupleIterator},
         relates_executor::{
-            EXTRACT_RELATION, EXTRACT_ROLE, RelatesFilterFn, RelatesTupleIterator, RelatesVariableValueExtractor,
-        }, tuple::{relates_to_tuple_relation_role, relates_to_tuple_role_relation, TuplePositions}, type_from_row_or_annotations, VariableModes,
+            RelatesFilterFn, RelatesTupleIterator, RelatesVariableValueExtractor, EXTRACT_RELATION, EXTRACT_ROLE,
+        },
+        tuple::{relates_to_tuple_relation_role, relates_to_tuple_role_relation, TuplePositions},
+        type_from_row_or_annotations, BinaryIterateMode, Checker, VariableModes,
     },
     pipeline::stage::ExecutionContext,
     row::MaybeOwnedRow,

--- a/executor/instruction/sub_executor.rs
+++ b/executor/instruction/sub_executor.rs
@@ -9,23 +9,25 @@ use std::{
     sync::Arc,
     vec,
 };
+use std::fmt::{Display, Formatter};
 
-use answer::{variable_value::VariableValue, Type};
+use itertools::Itertools;
+
+use answer::{Type, variable_value::VariableValue};
 use compiler::{executable::match_::instructions::type_::SubInstruction, ExecutorVariable};
 use concept::error::ConceptReadError;
-use itertools::Itertools;
 use lending_iterator::{
     adaptors::{Map, TryFilter},
-    higher_order::AdHocHkt,
-    AsLendingIterator, LendingIterator,
+    AsLendingIterator,
+    higher_order::AdHocHkt, LendingIterator,
 };
 use storage::snapshot::ReadableSnapshot;
 
 use crate::{
     instruction::{
-        iterator::{SortedTupleIterator, TupleIterator},
-        tuple::{sub_to_tuple_sub_super, sub_to_tuple_super_sub, SubToTupleFn, TuplePositions, TupleResult},
-        type_from_row_or_annotations, BinaryIterateMode, Checker, FilterFn, VariableModes,
+        BinaryIterateMode,
+        Checker,
+        FilterFn, iterator::{SortedTupleIterator, TupleIterator}, tuple::{sub_to_tuple_sub_super, sub_to_tuple_super_sub, SubToTupleFn, TuplePositions, TupleResult}, type_from_row_or_annotations, VariableModes,
     },
     pipeline::stage::ExecutionContext,
     row::MaybeOwnedRow,
@@ -174,6 +176,12 @@ impl SubExecutor {
                 )))
             }
         }
+    }
+}
+
+impl Display for SubExecutor {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        writeln!(f, "[{}], mode={}", &self.sub, &self.iterate_mode)
     }
 }
 

--- a/executor/instruction/sub_executor.rs
+++ b/executor/instruction/sub_executor.rs
@@ -6,28 +6,27 @@
 
 use std::{
     collections::{BTreeMap, BTreeSet},
+    fmt::{Display, Formatter},
     sync::Arc,
     vec,
 };
-use std::fmt::{Display, Formatter};
 
-use itertools::Itertools;
-
-use answer::{Type, variable_value::VariableValue};
+use answer::{variable_value::VariableValue, Type};
 use compiler::{executable::match_::instructions::type_::SubInstruction, ExecutorVariable};
 use concept::error::ConceptReadError;
+use itertools::Itertools;
 use lending_iterator::{
     adaptors::{Map, TryFilter},
-    AsLendingIterator,
-    higher_order::AdHocHkt, LendingIterator,
+    higher_order::AdHocHkt,
+    AsLendingIterator, LendingIterator,
 };
 use storage::snapshot::ReadableSnapshot;
 
 use crate::{
     instruction::{
-        BinaryIterateMode,
-        Checker,
-        FilterFn, iterator::{SortedTupleIterator, TupleIterator}, tuple::{sub_to_tuple_sub_super, sub_to_tuple_super_sub, SubToTupleFn, TuplePositions, TupleResult}, type_from_row_or_annotations, VariableModes,
+        iterator::{SortedTupleIterator, TupleIterator},
+        tuple::{sub_to_tuple_sub_super, sub_to_tuple_super_sub, SubToTupleFn, TuplePositions, TupleResult},
+        type_from_row_or_annotations, BinaryIterateMode, Checker, FilterFn, VariableModes,
     },
     pipeline::stage::ExecutionContext,
     row::MaybeOwnedRow,

--- a/executor/instruction/sub_reverse_executor.rs
+++ b/executor/instruction/sub_reverse_executor.rs
@@ -6,25 +6,24 @@
 
 use std::{
     collections::{BTreeMap, BTreeSet},
+    fmt::{Display, Formatter},
     sync::Arc,
     vec,
 };
-use std::fmt::{Display, Formatter};
-
-use itertools::Itertools;
 
 use answer::Type;
 use compiler::{executable::match_::instructions::type_::SubReverseInstruction, ExecutorVariable};
 use concept::error::ConceptReadError;
-use lending_iterator::{AsLendingIterator, higher_order::AdHocHkt, LendingIterator};
+use itertools::Itertools;
+use lending_iterator::{higher_order::AdHocHkt, AsLendingIterator, LendingIterator};
 use storage::snapshot::ReadableSnapshot;
 
 use crate::{
     instruction::{
-        BinaryIterateMode,
-        Checker,
-        FilterFn,
-        iterator::{SortedTupleIterator, TupleIterator}, sub_executor::{EXTRACT_SUB, EXTRACT_SUPER, NarrowingTupleIterator, SubTupleIterator}, tuple::{sub_to_tuple_sub_super, sub_to_tuple_super_sub, TuplePositions}, type_from_row_or_annotations, VariableModes,
+        iterator::{SortedTupleIterator, TupleIterator},
+        sub_executor::{NarrowingTupleIterator, SubTupleIterator, EXTRACT_SUB, EXTRACT_SUPER},
+        tuple::{sub_to_tuple_sub_super, sub_to_tuple_super_sub, TuplePositions},
+        type_from_row_or_annotations, BinaryIterateMode, Checker, FilterFn, VariableModes,
     },
     pipeline::stage::ExecutionContext,
     row::MaybeOwnedRow,

--- a/executor/instruction/sub_reverse_executor.rs
+++ b/executor/instruction/sub_reverse_executor.rs
@@ -9,20 +9,22 @@ use std::{
     sync::Arc,
     vec,
 };
+use std::fmt::{Display, Formatter};
+
+use itertools::Itertools;
 
 use answer::Type;
 use compiler::{executable::match_::instructions::type_::SubReverseInstruction, ExecutorVariable};
 use concept::error::ConceptReadError;
-use itertools::Itertools;
-use lending_iterator::{higher_order::AdHocHkt, AsLendingIterator, LendingIterator};
+use lending_iterator::{AsLendingIterator, higher_order::AdHocHkt, LendingIterator};
 use storage::snapshot::ReadableSnapshot;
 
 use crate::{
     instruction::{
-        iterator::{SortedTupleIterator, TupleIterator},
-        sub_executor::{NarrowingTupleIterator, SubTupleIterator, EXTRACT_SUB, EXTRACT_SUPER},
-        tuple::{sub_to_tuple_sub_super, sub_to_tuple_super_sub, TuplePositions},
-        type_from_row_or_annotations, BinaryIterateMode, Checker, FilterFn, VariableModes,
+        BinaryIterateMode,
+        Checker,
+        FilterFn,
+        iterator::{SortedTupleIterator, TupleIterator}, sub_executor::{EXTRACT_SUB, EXTRACT_SUPER, NarrowingTupleIterator, SubTupleIterator}, tuple::{sub_to_tuple_sub_super, sub_to_tuple_super_sub, TuplePositions}, type_from_row_or_annotations, VariableModes,
     },
     pipeline::stage::ExecutionContext,
     row::MaybeOwnedRow,
@@ -145,6 +147,12 @@ impl SubReverseExecutor {
                 )))
             }
         }
+    }
+}
+
+impl Display for SubReverseExecutor {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        writeln!(f, "Reverse[{}], mode={}", &self.sub, &self.iterate_mode)
     }
 }
 

--- a/executor/instruction/tuple.rs
+++ b/executor/instruction/tuple.rs
@@ -4,7 +4,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-use answer::{variable_value::VariableValue, Thing, Type};
+use answer::{Thing, Type, variable_value::VariableValue};
 use compiler::ExecutorVariable;
 use concept::{
     error::ConceptReadError,

--- a/executor/instruction/tuple.rs
+++ b/executor/instruction/tuple.rs
@@ -4,7 +4,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-use answer::{Thing, Type, variable_value::VariableValue};
+use answer::{variable_value::VariableValue, Thing, Type};
 use compiler::ExecutorVariable;
 use concept::{
     error::ConceptReadError,
@@ -12,10 +12,7 @@ use concept::{
         has::Has,
         relation::{Relation, RolePlayer},
     },
-    type_::{
-        attribute_type::AttributeType, object_type::ObjectType,
-        relation_type::RelationType, role_type::RoleType,
-    },
+    type_::{attribute_type::AttributeType, object_type::ObjectType, relation_type::RelationType, role_type::RoleType},
 };
 use lending_iterator::higher_order::Hkt;
 

--- a/executor/instruction/type_list_executor.rs
+++ b/executor/instruction/type_list_executor.rs
@@ -5,24 +5,26 @@
  */
 
 use std::{collections::HashMap, iter, vec};
+use std::fmt::{Display, Formatter};
 
-use answer::{variable_value::VariableValue, Type};
+use itertools::Itertools;
+
+use answer::{Type, variable_value::VariableValue};
 use compiler::{executable::match_::instructions::type_::TypeListInstruction, ExecutorVariable};
 use concept::error::ConceptReadError;
-use itertools::Itertools;
 use lending_iterator::{
     adaptors::{Map, TryFilter},
-    higher_order::AdHocHkt,
-    AsLendingIterator, LendingIterator,
+    AsLendingIterator,
+    higher_order::AdHocHkt, LendingIterator,
 };
 use storage::snapshot::ReadableSnapshot;
 
 use crate::{
     instruction::{
+        Checker,
+        FilterFn,
         iterator::{SortedTupleIterator, TupleIterator},
-        sub_executor::NarrowingTupleIterator,
-        tuple::{type_to_tuple, TuplePositions, TupleResult, TypeToTupleFn},
-        Checker, FilterFn, VariableModes,
+        sub_executor::NarrowingTupleIterator, tuple::{TuplePositions, TupleResult, type_to_tuple, TypeToTupleFn}, VariableModes,
     },
     pipeline::stage::ExecutionContext,
     row::MaybeOwnedRow,
@@ -79,5 +81,15 @@ impl TypeListExecutor {
             AsLendingIterator::new(iterator).try_filter::<_, TypeFilterFn, Type, _>(filter_for_row).map(type_to_tuple),
         );
         Ok(TupleIterator::Type(SortedTupleIterator::new(as_tuples, self.tuple_positions.clone(), &self.variable_modes)))
+    }
+}
+
+impl Display for TypeListExecutor {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "Type [")?;
+        for type_ in &self.types {
+            write!(f, "{}, ", type_)?;
+        }
+        writeln!(f, "], variable modes={:?}", &self.variable_modes)
     }
 }

--- a/executor/instruction/type_list_executor.rs
+++ b/executor/instruction/type_list_executor.rs
@@ -4,27 +4,29 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-use std::{collections::HashMap, iter, vec};
-use std::fmt::{Display, Formatter};
+use std::{
+    collections::HashMap,
+    fmt::{Display, Formatter},
+    iter, vec,
+};
 
-use itertools::Itertools;
-
-use answer::{Type, variable_value::VariableValue};
+use answer::{variable_value::VariableValue, Type};
 use compiler::{executable::match_::instructions::type_::TypeListInstruction, ExecutorVariable};
 use concept::error::ConceptReadError;
+use itertools::Itertools;
 use lending_iterator::{
     adaptors::{Map, TryFilter},
-    AsLendingIterator,
-    higher_order::AdHocHkt, LendingIterator,
+    higher_order::AdHocHkt,
+    AsLendingIterator, LendingIterator,
 };
 use storage::snapshot::ReadableSnapshot;
 
 use crate::{
     instruction::{
-        Checker,
-        FilterFn,
         iterator::{SortedTupleIterator, TupleIterator},
-        sub_executor::NarrowingTupleIterator, tuple::{TuplePositions, TupleResult, type_to_tuple, TypeToTupleFn}, VariableModes,
+        sub_executor::NarrowingTupleIterator,
+        tuple::{type_to_tuple, TuplePositions, TupleResult, TypeToTupleFn},
+        Checker, FilterFn, VariableModes,
     },
     pipeline::stage::ExecutionContext,
     row::MaybeOwnedRow,

--- a/executor/lib.rs
+++ b/executor/lib.rs
@@ -21,11 +21,11 @@ pub mod error;
 pub(crate) mod instruction;
 pub mod match_executor;
 pub mod pipeline;
+mod profile;
 pub mod read;
 pub(crate) mod reduce_executor;
 pub mod row;
 pub mod write;
-mod profile;
 
 // TODO: use a bit-vec, since we have a continuously allocated range of positions
 // ---> for now, using a byte vec, which is 8x wasteful and on the heap!

--- a/executor/lib.rs
+++ b/executor/lib.rs
@@ -25,6 +25,7 @@ pub mod read;
 pub(crate) mod reduce_executor;
 pub mod row;
 pub mod write;
+mod profile;
 
 // TODO: use a bit-vec, since we have a continuously allocated range of positions
 // ---> for now, using a byte vec, which is 8x wasteful and on the heap!

--- a/executor/lib.rs
+++ b/executor/lib.rs
@@ -21,7 +21,7 @@ pub mod error;
 pub(crate) mod instruction;
 pub mod match_executor;
 pub mod pipeline;
-mod profile;
+pub mod profile;
 pub mod read;
 pub(crate) mod reduce_executor;
 pub mod row;

--- a/executor/match_executor.rs
+++ b/executor/match_executor.rs
@@ -17,6 +17,7 @@ use crate::{
     batch::{FixedBatch, FixedBatchRowIterator},
     error::ReadExecutionError,
     pipeline::stage::ExecutionContext,
+    profile::QueryProfile,
     read::{
         pattern_executor::PatternExecutor, tabled_functions::TabledFunctions, QueryPatternSuspensions,
         TODO_REMOVE_create_executors_for_match,
@@ -40,6 +41,7 @@ impl MatchExecutor {
         thing_manager: &Arc<ThingManager>,
         input: MaybeOwnedRow<'_>,
         function_registry: Arc<ExecutableFunctionRegistry>,
+        profile: &QueryProfile,
     ) -> Result<Self, Box<ConceptReadError>> {
         Ok(Self {
             entry: TODO_REMOVE_create_executors_for_match(
@@ -47,6 +49,7 @@ impl MatchExecutor {
                 thing_manager,
                 &function_registry,
                 match_executable,
+                profile,
             )?,
             tabled_functions: TabledFunctions::new(function_registry),
             input: Some(input.into_owned()),

--- a/executor/pipeline/delete.rs
+++ b/executor/pipeline/delete.rs
@@ -16,11 +16,11 @@ use crate::{
         stage::{ExecutionContext, StageAPI},
         PipelineExecutionError, StageIterator, WrittenRowsIterator,
     },
+    profile::StageProfile,
     row::Row,
     write::{write_instruction::AsWriteInstruction, WriteError},
     ExecutionInterrupt,
 };
-use crate::profile::StageProfile;
 
 pub struct DeleteStageExecutor<PreviousStage> {
     executable: Arc<DeleteExecutable>,
@@ -62,9 +62,14 @@ where
         for index in 0..batch.len() {
             // TODO: parallelise -- though this requires our snapshots support parallel writes!
             let mut row = batch.get_row_mut(index);
-            if let Err(err) =
-                execute_delete(&self.executable, snapshot_mut, &context.thing_manager, &context.parameters, &mut row, &profile)
-            {
+            if let Err(err) = execute_delete(
+                &self.executable,
+                snapshot_mut,
+                &context.thing_manager,
+                &context.parameters,
+                &mut row,
+                &profile,
+            ) {
                 return Err((Box::new(PipelineExecutionError::WriteError { typedb_source: err }), context));
             }
 

--- a/executor/pipeline/fetch.rs
+++ b/executor/pipeline/fetch.rs
@@ -41,7 +41,7 @@ use crate::{
         stage::{ExecutionContext, StageAPI},
         PipelineExecutionError,
     },
-    profile::QueryProfile,
+    profile::{QueryProfile, StageProfile},
     read::{
         pattern_executor::PatternExecutor, step_executor::create_executors_for_function,
         tabled_functions::TabledFunctions, QueryPatternSuspensions,
@@ -49,7 +49,6 @@ use crate::{
     row::MaybeOwnedRow,
     ExecutionInterrupt,
 };
-use crate::profile::StageProfile;
 
 macro_rules! exactly_one_or_return_err {
     ($call:expr, $error:expr) => {{

--- a/executor/pipeline/fetch.rs
+++ b/executor/pipeline/fetch.rs
@@ -21,6 +21,7 @@ use compiler::{
     },
     VariablePosition,
 };
+use compiler::executable::next_executable_id;
 use concept::{
     error::ConceptReadError,
     thing::{
@@ -79,7 +80,7 @@ impl<Snapshot: ReadableSnapshot + 'static> FetchStageExecutor<Snapshot> {
         context: ExecutionContext<Snapshot>,
         interrupt: ExecutionInterrupt,
     ) -> (impl Iterator<Item = Result<ConceptDocument, Box<PipelineExecutionError>>>, ExecutionContext<Snapshot>) {
-        let ExecutionContext { snapshot, thing_manager, parameters } = context.clone();
+        let ExecutionContext { snapshot, thing_manager, parameters, profile: _profile, } = context.clone();
         let executable = self.executable;
         let functions = self.functions;
         let documents_iterator = previous_iterator
@@ -521,7 +522,7 @@ fn prepare_single_function_execution<Snapshot: ReadableSnapshot + 'static>(
 
     let step_executors = create_executors_for_function(&snapshot, &thing_manager, &functions_registry, function)
         .map_err(|err| FetchExecutionError::ConceptRead { source: err })?;
-    let mut pattern_executor = PatternExecutor::new(step_executors);
+    let mut pattern_executor = PatternExecutor::new(next_executable_id(), step_executors);
     pattern_executor.prepare(FixedBatch::from(args));
     Ok((pattern_executor, Arc::new(ExecutionContext::new(snapshot, thing_manager, parameters))))
 }

--- a/executor/pipeline/insert.rs
+++ b/executor/pipeline/insert.rs
@@ -21,11 +21,11 @@ use crate::{
         stage::{ExecutionContext, StageAPI},
         PipelineExecutionError, StageIterator, WrittenRowsIterator,
     },
+    profile::StageProfile,
     row::{MaybeOwnedRow, Row},
     write::{write_instruction::AsWriteInstruction, WriteError},
     ExecutionInterrupt,
 };
-use crate::profile::StageProfile;
 
 pub struct InsertStageExecutor<PreviousStage> {
     executable: Arc<InsertExecutable>,
@@ -72,9 +72,14 @@ where
             // TODO: parallelise -- though this requires our snapshots support parallel writes!
             let mut row = batch.get_row_mut(index);
 
-            if let Err(err) =
-                execute_insert(&executable, snapshot_mut, &context.thing_manager, &context.parameters, &mut row, &profile)
-            {
+            if let Err(err) = execute_insert(
+                &executable,
+                snapshot_mut,
+                &context.thing_manager,
+                &context.parameters,
+                &mut row,
+                &profile,
+            ) {
                 return Err((Box::new(PipelineExecutionError::WriteError { typedb_source: err }), context));
             }
 

--- a/executor/pipeline/insert.rs
+++ b/executor/pipeline/insert.rs
@@ -4,7 +4,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-use std::{sync::Arc, time::Instant};
+use std::sync::Arc;
 
 use compiler::executable::insert::{
     executable::InsertExecutable,

--- a/executor/pipeline/insert.rs
+++ b/executor/pipeline/insert.rs
@@ -4,8 +4,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-use std::sync::Arc;
-use std::time::Instant;
+use std::{sync::Arc, time::Instant};
 
 use compiler::executable::insert::{
     executable::InsertExecutable,
@@ -84,9 +83,9 @@ where
             }
         }
         let end = Instant::now();
-        
-        println!("Time to execute stage before insert: {} us",  after_read.duration_since(start).as_micros());
-        println!("Time to execute insert: {} us",  end.duration_since(after_read).as_micros());
+
+        println!("Time to execute stage before insert: {} us", after_read.duration_since(start).as_micros());
+        println!("Time to execute insert: {} us", end.duration_since(after_read).as_micros());
 
         Ok((WrittenRowsIterator::new(batch), context))
     }

--- a/executor/pipeline/match_.rs
+++ b/executor/pipeline/match_.rs
@@ -91,7 +91,7 @@ where
 
     fn next(&mut self) -> Option<Self::Item<'_>> {
         while !self.current_iterator.as_mut().is_some_and(|iter| iter.peek().is_some()) {
-            let ExecutionContext { snapshot, thing_manager, .. } = &self.context;
+            let ExecutionContext { snapshot, thing_manager, profile, .. } = &self.context;
 
             let input_row = match self.source_iterator.next()? {
                 Ok(row) => row,
@@ -104,6 +104,7 @@ where
                 thing_manager,
                 input_row,
                 self.function_registry.clone(),
+                &profile,
             )
             .map_err(|err| Box::new(PipelineExecutionError::InitialisingMatchIterator { source: err }));
 

--- a/executor/pipeline/modifiers.rs
+++ b/executor/pipeline/modifiers.rs
@@ -55,7 +55,13 @@ where
             Ok(batch) => batch,
             Err(err) => return Err((err, context)),
         };
-        Ok((SortStageIterator::from_unsorted(batch, &executable), context))
+        let batch_len = batch.len();
+        let profile = context.profile.profile_stage(|| String::from("Sort"), executable.executable_id);
+        let step_profile = profile.extend_or_get(1, || String::from("Sort execution"));
+        let measurement = step_profile.start_measurement();
+        let sorted_iterator = SortStageIterator::from_unsorted(batch, &executable);
+        measurement.end(&step_profile, 1, batch_len as u64);
+        Ok((sorted_iterator, context))
     }
 }
 

--- a/executor/pipeline/pipeline.rs
+++ b/executor/pipeline/pipeline.rs
@@ -16,7 +16,7 @@ use compiler::{
 };
 use concept::thing::thing_manager::ThingManager;
 use error::typedb_error;
-use ir::pipeline::{ParameterRegistry, };
+use ir::pipeline::ParameterRegistry;
 use storage::snapshot::{ReadableSnapshot, WritableSnapshot};
 
 use crate::{
@@ -53,9 +53,7 @@ impl<Snapshot: ReadableSnapshot + 'static, Nonterminals: StageAPI<Snapshot>> Pip
     ) -> Self {
         let named_outputs = last_stage_output_positions
             .iter()
-            .filter_map(|(variable, &position)| {
-                variable_names.get(variable).map(|name| (name.clone(), position))
-            })
+            .filter_map(|(variable, &position)| variable_names.get(variable).map(|name| (name.clone(), position)))
             .collect::<HashMap<_, _>>();
 
         match executable_fetch {

--- a/executor/pipeline/reduce.rs
+++ b/executor/pipeline/reduce.rs
@@ -6,7 +6,7 @@
 
 use std::sync::Arc;
 
-use compiler::executable::reduce::{ReduceExecutable, };
+use compiler::executable::reduce::ReduceExecutable;
 use storage::snapshot::ReadableSnapshot;
 
 use crate::{

--- a/executor/pipeline/reduce.rs
+++ b/executor/pipeline/reduce.rs
@@ -46,10 +46,15 @@ where
     > {
         let Self { previous, executable, .. } = self;
         let (previous_iterator, context) = previous.into_iterator(interrupt)?;
+
+        let profile = context.profile.profile_stage(|| String::from("Reduce"), executable.executable_id);
+        let step_profile = profile.extend_or_get(0, || String::from("Reduction"));
+        let measurement = step_profile.start_measurement();
         let rows = match reduce_iterator(&context, executable, previous_iterator) {
             Ok(rows) => rows,
             Err(err) => return Err((err, context)),
         };
+        measurement.end(&step_profile, 1, rows.len() as u64);
         Ok((WrittenRowsIterator::new(rows), context))
     }
 }

--- a/executor/pipeline/stage.rs
+++ b/executor/pipeline/stage.rs
@@ -4,7 +4,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-use std::{mem::discriminant, sync::Arc};
+use std::sync::Arc;
 
 use concept::{thing::thing_manager::ThingManager, type_::type_manager::TypeManager};
 use ir::pipeline::ParameterRegistry;

--- a/executor/pipeline/stage.rs
+++ b/executor/pipeline/stage.rs
@@ -5,12 +5,12 @@
  */
 
 use std::{mem::discriminant, sync::Arc};
-use tracing::Level;
 
 use concept::{thing::thing_manager::ThingManager, type_::type_manager::TypeManager};
 use ir::pipeline::ParameterRegistry;
 use lending_iterator::LendingIterator;
 use storage::snapshot::{ReadableSnapshot, WritableSnapshot};
+use tracing::Level;
 
 use crate::{
     batch::Batch,

--- a/executor/pipeline/stage.rs
+++ b/executor/pipeline/stage.rs
@@ -5,6 +5,7 @@
  */
 
 use std::{mem::discriminant, sync::Arc};
+use tracing::Level;
 
 use concept::{thing::thing_manager::ThingManager, type_::type_manager::TypeManager};
 use ir::pipeline::ParameterRegistry;
@@ -40,7 +41,9 @@ pub struct ExecutionContext<Snapshot> {
 
 impl<Snapshot> ExecutionContext<Snapshot> {
     pub fn new(snapshot: Arc<Snapshot>, thing_manager: Arc<ThingManager>, parameters: Arc<ParameterRegistry>) -> Self {
-        Self { snapshot, thing_manager, parameters, profile: Arc::new(QueryProfile::new(true)) }
+        // TODO: in the future, we should use a parameter passed either at Query or Transaction time
+        let is_tracing = tracing::enabled!(Level::TRACE);
+        Self { snapshot, thing_manager, parameters, profile: Arc::new(QueryProfile::new(is_tracing)) }
     }
 
     pub(crate) fn clone_with_replaced_parameters(&self, parameters: Arc<ParameterRegistry>) -> Self {

--- a/executor/pipeline/stage.rs
+++ b/executor/pipeline/stage.rs
@@ -4,8 +4,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-use std::mem::discriminant;
-use std::sync::Arc;
+use std::{mem::discriminant, sync::Arc};
 
 use concept::{thing::thing_manager::ThingManager, type_::type_manager::TypeManager};
 use ir::pipeline::ParameterRegistry;
@@ -26,10 +25,10 @@ use crate::{
         reduce::ReduceStageExecutor,
         PipelineExecutionError, WrittenRowsIterator,
     },
+    profile::QueryProfile,
     row::MaybeOwnedRow,
     ExecutionInterrupt,
 };
-use crate::profile::QueryProfile;
 
 #[derive(Debug)]
 pub struct ExecutionContext<Snapshot> {
@@ -41,15 +40,15 @@ pub struct ExecutionContext<Snapshot> {
 
 impl<Snapshot> ExecutionContext<Snapshot> {
     pub fn new(snapshot: Arc<Snapshot>, thing_manager: Arc<ThingManager>, parameters: Arc<ParameterRegistry>) -> Self {
-        Self { snapshot, thing_manager, parameters, profile: Arc::new(QueryProfile::new(false)) }
+        Self { snapshot, thing_manager, parameters, profile: Arc::new(QueryProfile::new(true)) }
     }
 
     pub(crate) fn clone_with_replaced_parameters(&self, parameters: Arc<ParameterRegistry>) -> Self {
-        Self { 
+        Self {
             snapshot: self.snapshot.clone(),
             thing_manager: self.thing_manager.clone(),
             parameters,
-            profile: self.profile.clone() 
+            profile: self.profile.clone(),
         }
     }
 
@@ -73,7 +72,12 @@ impl<Snapshot> ExecutionContext<Snapshot> {
 impl<Snapshot> Clone for ExecutionContext<Snapshot> {
     fn clone(&self) -> Self {
         let Self { snapshot, thing_manager, parameters, profile } = self;
-        Self { snapshot: snapshot.clone(), thing_manager: thing_manager.clone(), parameters: parameters.clone(), profile: profile.clone() }
+        Self {
+            snapshot: snapshot.clone(),
+            thing_manager: thing_manager.clone(),
+            parameters: parameters.clone(),
+            profile: profile.clone(),
+        }
     }
 }
 

--- a/executor/pipeline/stage.rs
+++ b/executor/pipeline/stage.rs
@@ -4,6 +4,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
+use std::mem::discriminant;
 use std::sync::Arc;
 
 use concept::{thing::thing_manager::ThingManager, type_::type_manager::TypeManager};
@@ -28,21 +29,28 @@ use crate::{
     row::MaybeOwnedRow,
     ExecutionInterrupt,
 };
+use crate::profile::QueryProfile;
 
 #[derive(Debug)]
 pub struct ExecutionContext<Snapshot> {
     pub snapshot: Arc<Snapshot>,
     pub thing_manager: Arc<ThingManager>,
     pub parameters: Arc<ParameterRegistry>,
+    pub profile: Arc<QueryProfile>,
 }
 
 impl<Snapshot> ExecutionContext<Snapshot> {
     pub fn new(snapshot: Arc<Snapshot>, thing_manager: Arc<ThingManager>, parameters: Arc<ParameterRegistry>) -> Self {
-        Self { snapshot, thing_manager, parameters }
+        Self { snapshot, thing_manager, parameters, profile: Arc::new(QueryProfile::new(false)) }
     }
 
     pub(crate) fn clone_with_replaced_parameters(&self, parameters: Arc<ParameterRegistry>) -> Self {
-        Self { snapshot: self.snapshot.clone(), thing_manager: self.thing_manager.clone(), parameters }
+        Self { 
+            snapshot: self.snapshot.clone(),
+            thing_manager: self.thing_manager.clone(),
+            parameters,
+            profile: self.profile.clone() 
+        }
     }
 
     pub(crate) fn snapshot(&self) -> &Arc<Snapshot> {
@@ -64,8 +72,8 @@ impl<Snapshot> ExecutionContext<Snapshot> {
 
 impl<Snapshot> Clone for ExecutionContext<Snapshot> {
     fn clone(&self) -> Self {
-        let Self { snapshot, thing_manager, parameters } = self;
-        Self { snapshot: snapshot.clone(), thing_manager: thing_manager.clone(), parameters: parameters.clone() }
+        let Self { snapshot, thing_manager, parameters, profile } = self;
+        Self { snapshot: snapshot.clone(), thing_manager: thing_manager.clone(), parameters: parameters.clone(), profile: profile.clone() }
     }
 }
 

--- a/executor/profile.rs
+++ b/executor/profile.rs
@@ -1,0 +1,123 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex, RwLock};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::Instant;
+
+#[derive(Debug)]
+pub struct QueryProfile {
+    pattern_profiles: RwLock<HashMap<u64, Arc<PatternProfile>>>,
+    enabled: bool,
+}
+
+impl QueryProfile {
+    pub fn new(enabled: bool) -> Self {
+        Self { pattern_profiles: RwLock::new(HashMap::new()), enabled }
+    }
+    
+    pub fn profile_pattern(&self, id: u64) -> Arc<PatternProfile> {
+        if self.enabled {
+            let mut profiles = self.pattern_profiles.read().unwrap();
+            if let Some(profile) = profiles.get(&id) {
+                profile.clone()
+            } else {
+                drop(profiles);
+                self.pattern_profiles.write().unwrap().insert(id, Arc::new(PatternProfile::new(true))).unwrap()
+            }
+        } else {
+            Arc::new(PatternProfile::new(false))
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct PatternProfile {
+    step_profiles: Vec<Arc<StepProfile>>,
+    enabled: bool,
+}
+
+impl PatternProfile {
+    
+    fn new(enabled: bool) -> Self {
+        Self { step_profiles: Vec::new(), enabled }
+    }
+    
+    fn add_step(&mut self, description_getter: fn() -> String) -> Arc<StepProfile> {
+        let profile = if self.enabled {
+            StepProfile::new_enabled(description_getter())
+        } else {
+            StepProfile::new_disabled()
+        };
+        self.step_profiles.push(Arc::new(profile));
+        self.step_profiles.last().unwrap().clone()
+    }
+}
+
+#[derive(Debug)]
+pub struct StepProfile {
+    data: Option<StepProfileData>
+}
+
+#[derive(Debug)]
+struct StepProfileData {
+    description: String,
+    rows: AtomicU64,
+    nanos: AtomicU64,
+}
+
+impl StepProfile {
+    fn new_enabled(description: String) -> Self {
+        Self {
+            data: Some(StepProfileData {
+                description,
+                rows: AtomicU64::new(0),
+                nanos: AtomicU64::new(0),
+            })
+        }
+    }
+    
+    fn new_disabled() -> Self {
+        Self { data: None }
+    }
+
+    fn start_measurement(&self) -> StepProfileMeasurement<'_> {
+        if self.data.is_some() {
+            StepProfileMeasurement::new(self, Some(Instant::now()))
+        } else {
+            StepProfileMeasurement::new(self, None)
+        }
+    }
+}
+
+pub struct StepProfileMeasurement<'a> {
+    profile: &'a StepProfile,
+    start: Option<Instant>,
+}
+
+impl<'a> StepProfileMeasurement<'a> {
+    fn new(step_profile: &'a StepProfile, start: Option<Instant>) -> Self {
+        Self {
+            profile: step_profile,
+            start,
+        }
+    }
+
+    fn end(self, rows_produced: u64) {
+        match self.start {
+            None => {}
+            Some(start) => {
+                let end = Instant::now();
+                let duration = end.duration_since(start).as_nanos() as u64;
+                let profile_data = self.profile.data.as_ref().unwrap();
+                profile_data.rows.fetch_add(rows_produced, Ordering::Relaxed);
+                profile_data.nanos.fetch_add(duration, Ordering::Relaxed);
+            }
+        }
+    }
+}

--- a/executor/profile.rs
+++ b/executor/profile.rs
@@ -13,6 +13,7 @@ use std::{
     },
     time::{Duration, Instant},
 };
+
 use itertools::Itertools;
 
 #[derive(Debug)]
@@ -25,7 +26,7 @@ impl QueryProfile {
     pub fn new(enabled: bool) -> Self {
         Self { stage_profiles: RwLock::new(HashMap::new()), enabled }
     }
-    
+
     pub fn is_enabled(&self) -> bool {
         self.enabled
     }

--- a/executor/profile.rs
+++ b/executor/profile.rs
@@ -33,7 +33,7 @@ impl QueryProfile {
 
     pub fn profile_stage(&self, description_fn: impl Fn() -> String, id: u64) -> Arc<StageProfile> {
         if self.enabled {
-            let mut profiles = self.stage_profiles.read().unwrap();
+            let profiles = self.stage_profiles.read().unwrap();
             if let Some(profile) = profiles.get(&id) {
                 profile.clone()
             } else {
@@ -94,7 +94,6 @@ impl StageProfile {
 
 impl Display for StageProfile {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        let mut aggregate_time = 0;
         for (i, step_profile) in self.step_profiles.read().unwrap().iter().enumerate() {
             match step_profile.data.as_ref() {
                 None => writeln!(f, "    {}.\n", i)?,

--- a/executor/read/immediate_executor.rs
+++ b/executor/read/immediate_executor.rs
@@ -132,6 +132,8 @@ pub(super) struct IntersectionExecutor {
     intersection_multiplicity: u64,
 
     output: Option<FixedBatch>,
+    
+    rows_produced: u64,
 }
 
 impl IntersectionExecutor {
@@ -162,6 +164,7 @@ impl IntersectionExecutor {
             intersection_row: vec![VariableValue::Empty; output_width as usize],
             intersection_multiplicity: 1,
             output: None,
+            rows_produced: 0,
         })
     }
 
@@ -176,6 +179,14 @@ impl IntersectionExecutor {
         self.may_create_intersection_iterators(context)?;
         Ok(())
     }
+    
+    fn formatted_executors(&self) -> String {
+        let mut string = String::new();
+        for executor in &self.instruction_executors {
+            string.push_str(&format!("{}\n", executor));
+        }
+        string
+    }
 
     fn batch_continue(
         &mut self,
@@ -184,6 +195,7 @@ impl IntersectionExecutor {
     ) -> Result<Option<FixedBatch>, ReadExecutionError> {
         debug_assert!(self.output.is_none());
         self.may_compute_next_batch(context)?;
+        println!("Instructions:\n {} ==> produced rows: {}", self.formatted_executors(), self.rows_produced);
         Ok(self.output.take())
     }
 
@@ -213,6 +225,7 @@ impl IntersectionExecutor {
                 row.set(position, value);
             }
         }
+        self.rows_produced += 1;
     }
 
     fn compute_next_row(

--- a/executor/read/immediate_executor.rs
+++ b/executor/read/immediate_executor.rs
@@ -25,6 +25,7 @@ use crate::{
     error::ReadExecutionError,
     instruction::{iterator::TupleIterator, Checker, InstructionExecutor},
     pipeline::stage::ExecutionContext,
+    profile::StepProfile,
     read::{
         expression_executor::{evaluate_expression, ExpressionValue},
         step_executor::StepExecutors,
@@ -51,6 +52,7 @@ impl ImmediateExecutor {
         step: &IntersectionStep,
         snapshot: &Arc<impl ReadableSnapshot + 'static>,
         thing_manager: &Arc<ThingManager>,
+        profile: Arc<StepProfile>,
     ) -> Result<Self, Box<ConceptReadError>> {
         let IntersectionStep { sort_variable, instructions, selected_variables, output_width, .. } = step;
 
@@ -61,18 +63,29 @@ impl ImmediateExecutor {
             selected_variables.clone(),
             snapshot,
             thing_manager,
+            profile,
         )?;
         Ok(Self::SortedJoin(executor))
     }
 
-    pub(crate) fn new_unsorted_join(step: &UnsortedJoinStep) -> Result<Self, Box<ConceptReadError>> {
+    pub(crate) fn new_unsorted_join(
+        step: &UnsortedJoinStep,
+        step_profile: Arc<StepProfile>,
+    ) -> Result<Self, Box<ConceptReadError>> {
         let UnsortedJoinStep { iterate_instruction, check_instructions, output_width, .. } = step;
-        let executor =
-            UnsortedJoinExecutor::new(iterate_instruction.clone(), check_instructions.clone(), *output_width);
+        let executor = UnsortedJoinExecutor::new(
+            iterate_instruction.clone(),
+            check_instructions.clone(),
+            *output_width,
+            step_profile,
+        );
         Ok(Self::UnsortedJoin(executor))
     }
 
-    pub(crate) fn new_assignment(step: &AssignmentStep) -> Result<Self, Box<ConceptReadError>> {
+    pub(crate) fn new_assignment(
+        step: &AssignmentStep,
+        step_profile: Arc<StepProfile>,
+    ) -> Result<Self, Box<ConceptReadError>> {
         let AssignmentStep { expression, input_positions, unbound, selected_variables, output_width } = step;
         Ok(Self::Assignment(AssignExecutor::new(
             expression.clone(),
@@ -80,12 +93,18 @@ impl ImmediateExecutor {
             *unbound,
             selected_variables.clone(),
             *output_width,
+            step_profile,
         )))
     }
 
-    pub(crate) fn new_check(step: &CheckStep) -> Result<Self, Box<ConceptReadError>> {
+    pub(crate) fn new_check(step: &CheckStep, step_profile: Arc<StepProfile>) -> Result<Self, Box<ConceptReadError>> {
         let CheckStep { check_instructions, selected_variables, output_width } = step;
-        Ok(Self::Check(CheckExecutor::new(check_instructions.clone(), selected_variables.clone(), *output_width)))
+        Ok(Self::Check(CheckExecutor::new(
+            check_instructions.clone(),
+            selected_variables.clone(),
+            *output_width,
+            step_profile,
+        )))
     }
 
     pub(crate) fn prepare(
@@ -132,8 +151,8 @@ pub(super) struct IntersectionExecutor {
     intersection_multiplicity: u64,
 
     output: Option<FixedBatch>,
-    
-    rows_produced: u64,
+
+    profile: Arc<StepProfile>,
 }
 
 impl IntersectionExecutor {
@@ -144,6 +163,7 @@ impl IntersectionExecutor {
         select_variables: Vec<VariablePosition>,
         snapshot: &Arc<impl ReadableSnapshot + 'static>,
         thing_manager: &Arc<ThingManager>,
+        profile: Arc<StepProfile>,
     ) -> Result<Self, Box<ConceptReadError>> {
         let instruction_count = instructions.len();
         let executors: Vec<InstructionExecutor> = instructions
@@ -164,7 +184,7 @@ impl IntersectionExecutor {
             intersection_row: vec![VariableValue::Empty; output_width as usize],
             intersection_multiplicity: 1,
             output: None,
-            rows_produced: 0,
+            profile,
         })
     }
 
@@ -179,14 +199,6 @@ impl IntersectionExecutor {
         self.may_create_intersection_iterators(context)?;
         Ok(())
     }
-    
-    fn formatted_executors(&self) -> String {
-        let mut string = String::new();
-        for executor in &self.instruction_executors {
-            string.push_str(&format!("{}\n", executor));
-        }
-        string
-    }
 
     fn batch_continue(
         &mut self,
@@ -195,7 +207,6 @@ impl IntersectionExecutor {
     ) -> Result<Option<FixedBatch>, ReadExecutionError> {
         debug_assert!(self.output.is_none());
         self.may_compute_next_batch(context)?;
-        println!("Instructions:\n {} ==> produced rows: {}", self.formatted_executors(), self.rows_produced);
         Ok(self.output.take())
     }
 
@@ -203,6 +214,7 @@ impl IntersectionExecutor {
         &mut self,
         context: &ExecutionContext<impl ReadableSnapshot + 'static>,
     ) -> Result<(), ReadExecutionError> {
+        let measurement = self.profile.start_measurement();
         if self.compute_next_row(context)? {
             // don't allocate batch until 1 answer is confirmed
             let mut batch = FixedBatch::new(self.output_width);
@@ -212,6 +224,7 @@ impl IntersectionExecutor {
             }
             self.output = Some(batch);
         }
+        measurement.end(&self.profile, 1, self.output.as_ref().map(|batch| batch.len()).unwrap_or(0) as u64);
         Ok(())
     }
 
@@ -225,7 +238,6 @@ impl IntersectionExecutor {
                 row.set(position, value);
             }
         }
-        self.rows_produced += 1;
     }
 
     fn compute_next_row(
@@ -408,7 +420,10 @@ impl IntersectionExecutor {
         for &position in &self.outputs_selected {
             // note: some input variable positions are re-used across stages, so we should only copy
             //       inputs into the output row if it is not already populated by the intersection
-            if position.as_usize() < input_row.len() && !input_row.get(position).is_empty() && row.get(position).is_empty() {
+            if position.as_usize() < input_row.len()
+                && !input_row.get(position).is_empty()
+                && row.get(position).is_empty()
+            {
                 row.set(position, input_row.get(position).clone().into_owned())
             }
         }
@@ -602,6 +617,7 @@ pub(super) struct UnsortedJoinExecutor {
 
     output_width: u32,
     output: Option<FixedBatch>,
+    profile: Arc<StepProfile>,
 }
 
 impl UnsortedJoinExecutor {
@@ -609,8 +625,9 @@ impl UnsortedJoinExecutor {
         iterate: ConstraintInstruction<ExecutorVariable>,
         checks: Vec<ConstraintInstruction<ExecutorVariable>>,
         total_vars: u32,
+        profile: Arc<StepProfile>,
     ) -> Self {
-        Self { iterate, checks, output_width: total_vars, output: None }
+        Self { iterate, checks, output_width: total_vars, output: None, profile }
     }
 
     fn prepare(
@@ -635,6 +652,7 @@ pub(super) struct AssignExecutor {
     output: ExecutorVariable,
     selected_variables: Vec<VariablePosition>,
     output_width: u32,
+    profile: Arc<StepProfile>,
 
     prepared_input: Option<FixedBatch>,
 }
@@ -646,8 +664,9 @@ impl AssignExecutor {
         output: ExecutorVariable,
         selected_variables: Vec<VariablePosition>,
         output_width: u32,
+        profile: Arc<StepProfile>,
     ) -> Self {
-        Self { expression, inputs, output, selected_variables, output_width, prepared_input: None }
+        Self { expression, inputs, output, selected_variables, output_width, profile, prepared_input: None }
     }
 
     fn prepare(
@@ -667,10 +686,9 @@ impl AssignExecutor {
         if self.prepared_input.is_none() {
             return Ok(None);
         }
-
+        let measurement = self.profile.start_measurement();
         let mut input = Peekable::new(FixedBatchRowIterator::new(Ok(self.prepared_input.take().unwrap())));
         debug_assert!(input.peek().is_some());
-
         let mut output = FixedBatch::new(self.output_width);
 
         while !output.is_full() {
@@ -700,6 +718,7 @@ impl AssignExecutor {
                 }
             })
         }
+        measurement.end(&self.profile, 1, output.len() as u64);
 
         if output.is_empty() {
             Ok(None)
@@ -714,6 +733,7 @@ pub(super) struct CheckExecutor {
     selected_variables: Vec<VariablePosition>,
     output_width: u32,
     input: Option<FixedBatch>,
+    profile: Arc<StepProfile>,
 }
 
 impl CheckExecutor {
@@ -721,9 +741,10 @@ impl CheckExecutor {
         checks: Vec<CheckInstruction<ExecutorVariable>>,
         selected_variables: Vec<VariablePosition>,
         output_width: u32,
+        profile: Arc<StepProfile>,
     ) -> Self {
         let checker = Checker::new(checks, HashMap::new());
-        Self { checker, selected_variables, output_width, input: None }
+        Self { checker, selected_variables, output_width, input: None, profile }
     }
 
     fn prepare(
@@ -743,7 +764,7 @@ impl CheckExecutor {
         let Some(input_batch) = self.input.take() else {
             return Ok(None);
         };
-
+        let measurement = self.profile.start_measurement();
         let mut input = Peekable::new(FixedBatchRowIterator::new(Ok(input_batch)));
         debug_assert!(input.peek().is_some());
 
@@ -762,7 +783,7 @@ impl CheckExecutor {
                 })
             }
         }
-
+        measurement.end(&self.profile, 1, output.len() as u64);
         if output.is_empty() {
             Ok(None)
         } else {

--- a/executor/read/mod.rs
+++ b/executor/read/mod.rs
@@ -43,24 +43,24 @@ pub(super) fn TODO_REMOVE_create_executors_for_match(
 ) -> Result<PatternExecutor, Box<ConceptReadError>> {
     let executors =
         step_executor::create_executors_for_match(snapshot, thing_manager, function_registry, match_executable)?;
-    Ok(PatternExecutor::new(executors))
+    Ok(PatternExecutor::new(match_executable.executable_id(), executors))
 }
 
-pub(super) fn create_executors_for_pipeline(
-    snapshot: &Arc<impl ReadableSnapshot + 'static>,
-    thing_manager: &Arc<ThingManager>,
-    function_registry: &ExecutableFunctionRegistry,
-    executable_stages: &Vec<ExecutableStage>,
-) -> Result<PatternExecutor, Box<ConceptReadError>> {
-    let executors = create_executors_for_pipeline_stages(
-        snapshot,
-        thing_manager,
-        function_registry,
-        executable_stages,
-        executable_stages.len() - 1,
-    )?;
-    Ok(PatternExecutor::new(executors))
-}
+// pub(super) fn create_executors_for_pipeline(
+//     snapshot: &Arc<impl ReadableSnapshot + 'static>,
+//     thing_manager: &Arc<ThingManager>,
+//     function_registry: &ExecutableFunctionRegistry,
+//     executable_stages: &Vec<ExecutableStage>,
+// ) -> Result<PatternExecutor, Box<ConceptReadError>> {
+//     let executors = create_executors_for_pipeline_stages(
+//         snapshot,
+//         thing_manager,
+//         function_registry,
+//         executable_stages,
+//         executable_stages.len() - 1,
+//     )?;
+//     Ok(PatternExecutor::new(executors))
+// }
 
 #[derive(Debug)]
 pub(crate) enum PatternSuspension {

--- a/executor/read/mod.rs
+++ b/executor/read/mod.rs
@@ -6,17 +6,16 @@
 
 use std::sync::Arc;
 
-use compiler::executable::{
-    match_::planner::{function_plan::ExecutableFunctionRegistry, match_executable::MatchExecutable},
-    pipeline::ExecutableStage,
+use compiler::executable::match_::planner::{
+    function_plan::ExecutableFunctionRegistry, match_executable::MatchExecutable,
 };
 use concept::{error::ConceptReadError, thing::thing_manager::ThingManager};
 use storage::snapshot::ReadableSnapshot;
 
 use crate::{
+    profile::QueryProfile,
     read::{
         pattern_executor::{BranchIndex, ExecutorIndex, PatternExecutor},
-        step_executor::create_executors_for_pipeline_stages,
         tabled_call_executor::TabledCallExecutor,
         tabled_functions::TableIndex,
     },
@@ -40,9 +39,15 @@ pub(super) fn TODO_REMOVE_create_executors_for_match(
     thing_manager: &Arc<ThingManager>,
     function_registry: &ExecutableFunctionRegistry,
     match_executable: &MatchExecutable,
+    profile: &QueryProfile,
 ) -> Result<PatternExecutor, Box<ConceptReadError>> {
-    let executors =
-        step_executor::create_executors_for_match(snapshot, thing_manager, function_registry, match_executable)?;
+    let executors = step_executor::create_executors_for_match(
+        snapshot,
+        thing_manager,
+        function_registry,
+        profile,
+        match_executable,
+    )?;
     Ok(PatternExecutor::new(match_executable.executable_id(), executors))
 }
 

--- a/executor/read/mod.rs
+++ b/executor/read/mod.rs
@@ -51,22 +51,6 @@ pub(super) fn TODO_REMOVE_create_executors_for_match(
     Ok(PatternExecutor::new(match_executable.executable_id(), executors))
 }
 
-// pub(super) fn create_executors_for_pipeline(
-//     snapshot: &Arc<impl ReadableSnapshot + 'static>,
-//     thing_manager: &Arc<ThingManager>,
-//     function_registry: &ExecutableFunctionRegistry,
-//     executable_stages: &Vec<ExecutableStage>,
-// ) -> Result<PatternExecutor, Box<ConceptReadError>> {
-//     let executors = create_executors_for_pipeline_stages(
-//         snapshot,
-//         thing_manager,
-//         function_registry,
-//         executable_stages,
-//         executable_stages.len() - 1,
-//     )?;
-//     Ok(PatternExecutor::new(executors))
-// }
-
 #[derive(Debug)]
 pub(crate) enum PatternSuspension {
     AtTabledCall(TabledCallSuspension),

--- a/executor/read/nested_pattern_executor.rs
+++ b/executor/read/nested_pattern_executor.rs
@@ -11,6 +11,7 @@ use ir::pipeline::ParameterRegistry;
 
 use crate::{
     batch::FixedBatch,
+    profile::StepProfile,
     read::{pattern_executor::PatternExecutor, step_executor::StepExecutors},
     row::MaybeOwnedRow,
 };

--- a/executor/read/nested_pattern_executor.rs
+++ b/executor/read/nested_pattern_executor.rs
@@ -11,7 +11,6 @@ use ir::pipeline::ParameterRegistry;
 
 use crate::{
     batch::FixedBatch,
-    profile::StepProfile,
     read::{pattern_executor::PatternExecutor, step_executor::StepExecutors},
     row::MaybeOwnedRow,
 };

--- a/executor/read/pattern_executor.rs
+++ b/executor/read/pattern_executor.rs
@@ -14,7 +14,7 @@ use crate::{
     batch::{FixedBatch, FixedBatchRowIterator},
     error::ReadExecutionError,
     pipeline::stage::ExecutionContext,
-    profile::PatternProfile,
+    profile::StageProfile,
     read::{
         control_instruction::{
             CollectingStage, ControlInstruction, ExecuteDisjunction, ExecuteImmediate, ExecuteInlinedFunction,

--- a/executor/read/pattern_executor.rs
+++ b/executor/read/pattern_executor.rs
@@ -4,7 +4,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-use std::ops::DerefMut;
+use std::{ops::DerefMut, sync::Arc};
 
 use compiler::VariablePosition;
 use lending_iterator::LendingIterator;
@@ -14,6 +14,7 @@ use crate::{
     batch::{FixedBatch, FixedBatchRowIterator},
     error::ReadExecutionError,
     pipeline::stage::ExecutionContext,
+    profile::PatternProfile,
     read::{
         control_instruction::{
             CollectingStage, ControlInstruction, ExecuteDisjunction, ExecuteImmediate, ExecuteInlinedFunction,

--- a/executor/read/pattern_executor.rs
+++ b/executor/read/pattern_executor.rs
@@ -4,7 +4,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-use std::{ops::DerefMut, sync::Arc};
+use std::ops::DerefMut;
 
 use compiler::VariablePosition;
 use lending_iterator::LendingIterator;
@@ -14,7 +14,6 @@ use crate::{
     batch::{FixedBatch, FixedBatchRowIterator},
     error::ReadExecutionError,
     pipeline::stage::ExecutionContext,
-    profile::StageProfile,
     read::{
         control_instruction::{
             CollectingStage, ControlInstruction, ExecuteDisjunction, ExecuteImmediate, ExecuteInlinedFunction,
@@ -293,7 +292,7 @@ impl PatternExecutor {
                     self.execute_tabled_call(context, interrupt, tabled_functions, suspensions, index)?;
                 }
                 ControlInstruction::CollectingStage(CollectingStage { index }) => {
-                    let (pattern, mut collector) = executors[index.0].unwrap_collecting_stage().to_parts_mut();
+                    let (pattern, collector) = executors[index.0].unwrap_collecting_stage().to_parts_mut();
                     match pattern.batch_continue(context, interrupt, tabled_functions, suspensions)? {
                         Some(batch) => {
                             collector.accept(context, batch);

--- a/executor/read/pattern_executor.rs
+++ b/executor/read/pattern_executor.rs
@@ -46,13 +46,14 @@ impl ExecutorIndex {
 }
 
 pub(crate) struct PatternExecutor {
+    executable_id: u64,
     executors: Vec<StepExecutors>,
     control_stack: Vec<ControlInstruction>,
 }
 
 impl PatternExecutor {
-    pub fn new(executors: Vec<StepExecutors>) -> Self {
-        PatternExecutor { executors, control_stack: Vec::new() }
+    pub fn new(executable_id: u64, executors: Vec<StepExecutors>) -> Self {
+        PatternExecutor { executable_id, executors, control_stack: Vec::new() }
     }
 
     pub(crate) fn has_empty_control_stack(&self) -> bool {
@@ -101,7 +102,7 @@ impl PatternExecutor {
         //  We could switch to iteration & handle the stack ourselves: StackFrame { pattern_executor, return_address }
         // debug_assert!(self.control_stack.len() > 0);
         while self.control_stack.last().is_some() {
-            let Self { control_stack, executors } = self;
+            let Self { control_stack, executors, executable_id: _ } = self;
             // TODO: inject interrupt into Checkers that could filter out many rows without ending as well.
             if let Some(interrupt) = interrupt.check() {
                 return Err(ReadExecutionError::Interrupted { interrupt });

--- a/executor/read/step_executor.rs
+++ b/executor/read/step_executor.rs
@@ -4,7 +4,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-use std::sync::Arc;
+use std::{fmt, sync::Arc};
 
 use compiler::{
     executable::{
@@ -13,6 +13,7 @@ use compiler::{
             function_plan::ExecutableFunctionRegistry,
             match_executable::{ExecutionStep, MatchExecutable},
         },
+        next_executable_id,
         pipeline::ExecutableStage,
     },
     VariablePosition,
@@ -20,16 +21,15 @@ use compiler::{
 use concept::{error::ConceptReadError, thing::thing_manager::ThingManager};
 use itertools::Itertools;
 use storage::snapshot::ReadableSnapshot;
-use typeql::schema::definable::function::SingleSelector;
-use compiler::executable::next_executable_id;
+use typeql::{match_, schema::definable::function::SingleSelector};
 
-use crate::read::{
-    collecting_stage_executor::CollectingStageExecutor,
-    immediate_executor::ImmediateExecutor,
-    nested_pattern_executor::NestedPatternExecutor,
-    pattern_executor::PatternExecutor,
-    stream_modifier::{StreamModifierExecutor},
-    tabled_call_executor::TabledCallExecutor,
+use crate::{
+    profile::{PatternProfile, QueryProfile},
+    read::{
+        collecting_stage_executor::CollectingStageExecutor, immediate_executor::ImmediateExecutor,
+        nested_pattern_executor::NestedPatternExecutor, pattern_executor::PatternExecutor,
+        stream_modifier::StreamModifierExecutor, tabled_call_executor::TabledCallExecutor,
+    },
 };
 
 pub enum StepExecutors {
@@ -89,34 +89,56 @@ pub(crate) fn create_executors_for_match(
     snapshot: &Arc<impl ReadableSnapshot + 'static>,
     thing_manager: &Arc<ThingManager>,
     function_registry: &ExecutableFunctionRegistry,
+    query_profile: &QueryProfile,
     match_executable: &MatchExecutable,
 ) -> Result<Vec<StepExecutors>, Box<ConceptReadError>> {
+    let pattern_profile = query_profile.profile_pattern(|| String::from("Match"), match_executable.executable_id());
     let mut steps = Vec::with_capacity(match_executable.steps().len());
-    for step in match_executable.steps() {
+    for (index, step) in match_executable.steps().iter().enumerate() {
         match step {
             ExecutionStep::Intersection(inner) => {
-                let step = ImmediateExecutor::new_intersection(inner, snapshot, thing_manager)?;
+                let step_profile = pattern_profile.extend_or_get(index, || format!("{}", inner));
+                let step = ImmediateExecutor::new_intersection(inner, snapshot, thing_manager, step_profile)?;
                 steps.push(step.into());
             }
             ExecutionStep::UnsortedJoin(inner) => {
-                let step = ImmediateExecutor::new_unsorted_join(inner)?;
+                let step_profile = pattern_profile.extend_or_get(index, || format!("{}", inner));
+                let step = ImmediateExecutor::new_unsorted_join(inner, step_profile)?;
                 steps.push(step.into());
             }
             ExecutionStep::Assignment(inner) => {
-                let step = ImmediateExecutor::new_assignment(inner)?;
+                let step_profile = pattern_profile.extend_or_get(index, || format!("{}", inner));
+                let step = ImmediateExecutor::new_assignment(inner, step_profile)?;
                 steps.push(step.into());
             }
             ExecutionStep::Check(inner) => {
-                let step = ImmediateExecutor::new_check(inner)?;
+                let step_profile = pattern_profile.extend_or_get(index, || format!("{}", inner));
+                let step = ImmediateExecutor::new_check(inner, step_profile)?;
                 steps.push(step.into());
             }
             ExecutionStep::Negation(negation_step) => {
+                // NOTE: still create the profile so each step has an entry in the profile, even if unused
+                let _step_profile = pattern_profile.extend_or_get(index, || format!("{}", negation_step));
+                let inner = create_executors_for_match(
+                    snapshot,
+                    thing_manager,
+                    function_registry,
+                    query_profile,
+                    &negation_step.negation,
+                )?;
                 // I shouldn't need to pass recursive here since it's stratified
-                let inner =
-                    create_executors_for_match(snapshot, thing_manager, function_registry, &negation_step.negation)?;
-                steps.push(NestedPatternExecutor::new_negation(PatternExecutor::new(negation_step.negation.executable_id(), inner)).into())
+                steps.push(
+                    NestedPatternExecutor::new_negation(PatternExecutor::new(
+                        negation_step.negation.executable_id(),
+                        inner,
+                    ))
+                    .into(),
+                )
             }
             ExecutionStep::FunctionCall(function_call) => {
+                // NOTE: still create the profile so each step has an entry in the profile, even if unused
+                let _step_profile = pattern_profile.extend_or_get(index, || format!("{}", function_call));
+
                 let function = function_registry.get(function_call.function_id.clone());
                 if function.is_tabled == FunctionTablingType::Tabled {
                     let executor = TabledCallExecutor::new(
@@ -127,8 +149,13 @@ pub(crate) fn create_executors_for_match(
                     );
                     steps.push(StepExecutors::TabledCall(executor))
                 } else {
-                    let inner_executors =
-                        create_executors_for_function(snapshot, thing_manager, function_registry, function)?;
+                    let inner_executors = create_executors_for_function(
+                        snapshot,
+                        thing_manager,
+                        function_registry,
+                        query_profile,
+                        function,
+                    )?;
                     let inner = PatternExecutor::new(function.executable_id, inner_executors);
                     let step = NestedPatternExecutor::new_inlined_function(
                         inner,
@@ -139,13 +166,21 @@ pub(crate) fn create_executors_for_match(
                 }
             }
             ExecutionStep::Disjunction(step) => {
+                // NOTE: still create the profile so each step has an entry in the profile, even if unused
+                let _step_profile = pattern_profile.extend_or_get(index, || format!("{}", step));
+
                 // I shouldn't need to pass recursive here since it's stratified
                 let branches = step
                     .branches
                     .iter()
                     .map(|branch_executable| {
-                        let executors =
-                            create_executors_for_match(snapshot, thing_manager, function_registry, &branch_executable)?;
+                        let executors = create_executors_for_match(
+                            snapshot,
+                            thing_manager,
+                            function_registry,
+                            query_profile,
+                            &branch_executable,
+                        )?;
                         Ok::<_, Box<_>>(PatternExecutor::new(branch_executable.executable_id(), executors))
                     })
                     .try_collect()?;
@@ -172,6 +207,7 @@ pub(crate) fn create_executors_for_function(
     snapshot: &Arc<impl ReadableSnapshot + 'static>,
     thing_manager: &Arc<ThingManager>,
     function_registry: &ExecutableFunctionRegistry,
+    query_profile: &QueryProfile,
     executable_function: &ExecutableFunction,
 ) -> Result<Vec<StepExecutors>, Box<ConceptReadError>> {
     let executable_stages = &executable_function.executable_stages;
@@ -179,6 +215,7 @@ pub(crate) fn create_executors_for_function(
         snapshot,
         thing_manager,
         function_registry,
+        query_profile,
         executable_stages,
         executable_stages.len() - 1,
     )?;
@@ -190,14 +227,21 @@ pub(crate) fn create_executors_for_function(
         ExecutableReturn::Single(selector, positions) => {
             steps.push(StepExecutors::ReshapeForReturn(positions.clone()));
             let step = match selector {
-                SingleSelector::First => StreamModifierExecutor::new_first(PatternExecutor::new(executable_function.executable_id, steps)),
-                SingleSelector::Last => StreamModifierExecutor::new_last(PatternExecutor::new(executable_function.executable_id, steps)),
+                SingleSelector::First => {
+                    StreamModifierExecutor::new_first(PatternExecutor::new(executable_function.executable_id, steps))
+                }
+                SingleSelector::Last => {
+                    StreamModifierExecutor::new_last(PatternExecutor::new(executable_function.executable_id, steps))
+                }
             };
             Ok(vec![step.into()])
         }
         ExecutableReturn::Check => todo!("ExecutableReturn::Check"),
         ExecutableReturn::Reduce(executable) => {
-            let step = CollectingStageExecutor::new_reduce(PatternExecutor::new(executable_function.executable_id, steps), executable.clone());
+            let step = CollectingStageExecutor::new_reduce(
+                PatternExecutor::new(executable_function.executable_id, steps),
+                executable.clone(),
+            );
             Ok(vec![StepExecutors::CollectingStage(step)])
         }
     }
@@ -207,6 +251,7 @@ pub(super) fn create_executors_for_pipeline_stages(
     snapshot: &Arc<impl ReadableSnapshot + 'static>,
     thing_manager: &Arc<ThingManager>,
     function_registry: &ExecutableFunctionRegistry,
+    query_profile: &QueryProfile,
     executable_stages: &Vec<ExecutableStage>,
     at_index: usize,
 ) -> Result<Vec<StepExecutors>, Box<ConceptReadError>> {
@@ -215,6 +260,7 @@ pub(super) fn create_executors_for_pipeline_stages(
             snapshot,
             thing_manager,
             function_registry,
+            query_profile,
             executable_stages,
             at_index - 1,
         )?
@@ -224,28 +270,38 @@ pub(super) fn create_executors_for_pipeline_stages(
 
     match &executable_stages[at_index] {
         ExecutableStage::Match(match_executable) => {
-            let mut match_stages =
-                create_executors_for_match(snapshot, thing_manager, function_registry, match_executable)?;
+            let mut match_stages = create_executors_for_match(
+                snapshot,
+                thing_manager,
+                function_registry,
+                query_profile,
+                match_executable,
+            )?;
             previous_stage_steps.append(&mut match_stages);
             Ok(previous_stage_steps)
         }
         ExecutableStage::Select(_) => todo!(),
         ExecutableStage::Offset(offset_executable) => {
             let step = StreamModifierExecutor::new_offset(
-                // TODO: not sure if these are correct new executable IDs or should be different? 
+                // TODO: not sure if these are correct new executable IDs or should be different?
                 PatternExecutor::new(next_executable_id(), previous_stage_steps),
                 offset_executable.offset,
             );
             Ok(vec![step.into()])
         }
         ExecutableStage::Limit(limit_executable) => {
-            let step =
-                StreamModifierExecutor::new_limit(PatternExecutor::new(next_executable_id(), previous_stage_steps), limit_executable.limit);
+            let step = StreamModifierExecutor::new_limit(
+                PatternExecutor::new(next_executable_id(), previous_stage_steps),
+                limit_executable.limit,
+            );
             Ok(vec![step.into()])
         }
         ExecutableStage::Require(_) => todo!(),
         ExecutableStage::Sort(sort_executable) => {
-            let step = CollectingStageExecutor::new_sort(PatternExecutor::new(next_executable_id(), previous_stage_steps), sort_executable);
+            let step = CollectingStageExecutor::new_sort(
+                PatternExecutor::new(next_executable_id(), previous_stage_steps),
+                sort_executable,
+            );
             Ok(vec![StepExecutors::CollectingStage(step)])
         }
         ExecutableStage::Reduce(reduce_stage_executable) => {

--- a/executor/read/step_executor.rs
+++ b/executor/read/step_executor.rs
@@ -24,7 +24,7 @@ use storage::snapshot::ReadableSnapshot;
 use typeql::{match_, schema::definable::function::SingleSelector};
 
 use crate::{
-    profile::{StageProfile, QueryProfile},
+    profile::{QueryProfile, StageProfile},
     read::{
         collecting_stage_executor::CollectingStageExecutor, immediate_executor::ImmediateExecutor,
         nested_pattern_executor::NestedPatternExecutor, pattern_executor::PatternExecutor,

--- a/executor/read/step_executor.rs
+++ b/executor/read/step_executor.rs
@@ -4,7 +4,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-use std::{fmt, sync::Arc};
+use std::sync::Arc;
 
 use compiler::{
     executable::{
@@ -21,10 +21,10 @@ use compiler::{
 use concept::{error::ConceptReadError, thing::thing_manager::ThingManager};
 use itertools::Itertools;
 use storage::snapshot::ReadableSnapshot;
-use typeql::{match_, schema::definable::function::SingleSelector};
+use typeql::schema::definable::function::SingleSelector;
 
 use crate::{
-    profile::{QueryProfile, StageProfile},
+    profile::QueryProfile,
     read::{
         collecting_stage_executor::CollectingStageExecutor, immediate_executor::ImmediateExecutor,
         nested_pattern_executor::NestedPatternExecutor, pattern_executor::PatternExecutor,

--- a/executor/read/tabled_functions.rs
+++ b/executor/read/tabled_functions.rs
@@ -42,6 +42,7 @@ impl TabledFunctions {
                 &context.snapshot,
                 &context.thing_manager,
                 &self.function_registry,
+                &context.profile,
                 function,
             )
             .map_err(|source| ReadExecutionError::ConceptRead { source })?;

--- a/executor/read/tabled_functions.rs
+++ b/executor/read/tabled_functions.rs
@@ -45,7 +45,7 @@ impl TabledFunctions {
                 function,
             )
             .map_err(|source| ReadExecutionError::ConceptRead { source })?;
-            let pattern_executor = PatternExecutor::new(executors);
+            let pattern_executor = PatternExecutor::new(function.executable_id, executors);
             let width = match &function.returns {
                 ExecutableReturn::Stream(v) => v.len() as u32,
                 _ => todo!(),

--- a/executor/tests/compile_execute.rs
+++ b/executor/tests/compile_execute.rs
@@ -22,7 +22,8 @@ use concept::{
     type_::type_manager::TypeManager,
 };
 use executor::{
-    match_executor::MatchExecutor, pipeline::stage::ExecutionContext, row::MaybeOwnedRow, ExecutionInterrupt,
+    match_executor::MatchExecutor, pipeline::stage::ExecutionContext, profile::QueryProfile, row::MaybeOwnedRow,
+    ExecutionInterrupt,
 };
 use function::function_manager::FunctionManager;
 use ir::{
@@ -129,6 +130,7 @@ fn test_has_planning_traversal() {
         &thing_manager,
         MaybeOwnedRow::empty(),
         Arc::new(ExecutableFunctionRegistry::empty()),
+        &QueryProfile::new(false),
     )
     .unwrap();
 
@@ -225,6 +227,7 @@ fn test_expression_planning_traversal() {
         &thing_manager,
         MaybeOwnedRow::empty(),
         Arc::new(ExecutableFunctionRegistry::empty()),
+        &QueryProfile::new(false),
     )
     .unwrap();
 
@@ -309,6 +312,7 @@ fn test_links_planning_traversal() {
         &thing_manager,
         MaybeOwnedRow::empty(),
         Arc::new(ExecutableFunctionRegistry::empty()),
+        &QueryProfile::new(false),
     )
     .unwrap();
 
@@ -400,6 +404,7 @@ fn test_links_intersection() {
         &thing_manager,
         MaybeOwnedRow::empty(),
         Arc::new(ExecutableFunctionRegistry::empty()),
+        &QueryProfile::new(false),
     )
     .unwrap();
 
@@ -482,6 +487,7 @@ fn test_negation_planning_traversal() {
         &thing_manager,
         MaybeOwnedRow::empty(),
         Arc::new(ExecutableFunctionRegistry::empty()),
+        &QueryProfile::new(false),
     )
     .unwrap();
 
@@ -585,6 +591,7 @@ fn test_forall_planning_traversal() {
         &thing_manager,
         MaybeOwnedRow::empty(),
         Arc::new(ExecutableFunctionRegistry::empty()),
+        &QueryProfile::new(false),
     )
     .unwrap();
 
@@ -674,6 +681,7 @@ fn test_named_var_select() {
         &thing_manager,
         MaybeOwnedRow::empty(),
         Arc::new(ExecutableFunctionRegistry::empty()),
+        &QueryProfile::new(false),
     )
     .unwrap();
 
@@ -763,6 +771,7 @@ fn test_disjunction_planning_traversal() {
         &thing_manager,
         MaybeOwnedRow::empty(),
         Arc::new(ExecutableFunctionRegistry::empty()),
+        &QueryProfile::new(false),
     )
     .unwrap();
 
@@ -856,6 +865,7 @@ fn test_disjunction_planning_nested_negations() {
         &thing_manager,
         MaybeOwnedRow::empty(),
         Arc::new(ExecutableFunctionRegistry::empty()),
+        &QueryProfile::new(false),
     )
     .unwrap();
 

--- a/executor/tests/compile_execute.rs
+++ b/executor/tests/compile_execute.rs
@@ -31,8 +31,7 @@ use ir::{
 };
 use itertools::Itertools;
 use lending_iterator::LendingIterator;
-use query::query_cache::QueryCache;
-use query::query_manager::QueryManager;
+use query::{query_cache::QueryCache, query_manager::QueryManager};
 use storage::{
     durability_client::WALClient, sequence_number::SequenceNumber, snapshot::CommittableSnapshot, MVCCStorage,
 };

--- a/executor/tests/execute_comparison_check.rs
+++ b/executor/tests/execute_comparison_check.rs
@@ -24,12 +24,14 @@ use compiler::{
     },
     ExecutorVariable, VariablePosition,
 };
+use compiler::executable::next_executable_id;
 use concept::type_::{annotation::AnnotationIndependent, attribute_type::AttributeTypeAnnotation};
 use encoding::value::{label::Label, value::Value, value_type::ValueType};
 use executor::{
     error::ReadExecutionError, match_executor::MatchExecutor, pipeline::stage::ExecutionContext, row::MaybeOwnedRow,
     ExecutionInterrupt,
 };
+use executor::profile::QueryProfile;
 use ir::{
     pattern::constraint::{Comparator, IsaKind},
     pipeline::block::Block,
@@ -151,7 +153,7 @@ fn attribute_equality() {
         )),
     ];
 
-    let executable = MatchExecutable::new(steps, variable_positions, row_vars);
+    let executable = MatchExecutable::new(next_executable_id(), steps, variable_positions, row_vars);
 
     // Executor
     let snapshot = Arc::new(storage.clone().open_snapshot_read());
@@ -161,6 +163,7 @@ fn attribute_equality() {
         &thing_manager,
         MaybeOwnedRow::empty(),
         Arc::new(ExecutableFunctionRegistry::empty()),
+        &QueryProfile::new(false),
     )
     .unwrap();
 

--- a/executor/tests/execute_function.rs
+++ b/executor/tests/execute_function.rs
@@ -16,8 +16,7 @@ use executor::{
 };
 use function::function_manager::FunctionManager;
 use lending_iterator::LendingIterator;
-use query::query_cache::QueryCache;
-use query::query_manager::QueryManager;
+use query::{query_cache::QueryCache, query_manager::QueryManager};
 use storage::{durability_client::WALClient, snapshot::CommittableSnapshot, MVCCStorage};
 use test_utils::TempDir;
 use test_utils_concept::{load_managers, setup_concept_storage};

--- a/executor/tests/execute_has.rs
+++ b/executor/tests/execute_has.rs
@@ -15,15 +15,18 @@ use compiler::{
         function::{AnnotatedUnindexedFunctions, IndexedAnnotatedFunctions},
         match_inference::infer_types,
     },
-    executable::match_::{
-        instructions::{
-            thing::{HasInstruction, HasReverseInstruction, IsaInstruction},
-            ConstraintInstruction, Inputs,
+    executable::{
+        match_::{
+            instructions::{
+                thing::{HasInstruction, HasReverseInstruction, IsaInstruction},
+                ConstraintInstruction, Inputs,
+            },
+            planner::{
+                function_plan::ExecutableFunctionRegistry,
+                match_executable::{ExecutionStep, IntersectionStep, MatchExecutable},
+            },
         },
-        planner::{
-            function_plan::ExecutableFunctionRegistry,
-            match_executable::{ExecutionStep, IntersectionStep, MatchExecutable},
-        },
+        next_executable_id,
     },
     ExecutorVariable, VariablePosition,
 };
@@ -33,8 +36,8 @@ use concept::{
 };
 use encoding::value::{label::Label, value::Value, value_type::ValueType};
 use executor::{
-    error::ReadExecutionError, match_executor::MatchExecutor, pipeline::stage::ExecutionContext, row::MaybeOwnedRow,
-    ExecutionInterrupt,
+    error::ReadExecutionError, match_executor::MatchExecutor, pipeline::stage::ExecutionContext, profile::QueryProfile,
+    row::MaybeOwnedRow, ExecutionInterrupt,
 };
 use ir::{
     pattern::constraint::IsaKind,
@@ -183,7 +186,7 @@ fn traverse_has_unbounded_sorted_from() {
         &named_variables,
         2,
     ))];
-    let executable = MatchExecutable::new(steps, variable_positions, row_vars);
+    let executable = MatchExecutable::new(next_executable_id(), steps, variable_positions, row_vars);
 
     // Executor
     let snapshot = Arc::new(snapshot);
@@ -193,6 +196,7 @@ fn traverse_has_unbounded_sorted_from() {
         &thing_manager,
         MaybeOwnedRow::empty(),
         Arc::new(ExecutableFunctionRegistry::empty()),
+        &QueryProfile::new(false),
     )
     .unwrap();
 
@@ -300,7 +304,7 @@ fn traverse_has_bounded_sorted_from_chain_intersect() {
             3,
         )),
     ];
-    let executable = MatchExecutable::new(steps, variable_positions, row_vars);
+    let executable = MatchExecutable::new(next_executable_id(), steps, variable_positions, row_vars);
 
     // Executor
     let snapshot = Arc::new(snapshot);
@@ -310,6 +314,7 @@ fn traverse_has_bounded_sorted_from_chain_intersect() {
         &thing_manager,
         MaybeOwnedRow::empty(),
         Arc::new(ExecutableFunctionRegistry::empty()),
+        &QueryProfile::new(false),
     )
     .unwrap();
 
@@ -408,7 +413,7 @@ fn traverse_has_unbounded_sorted_from_intersect() {
         &named_variables,
         3,
     ))];
-    let executable = MatchExecutable::new(steps, variable_positions, row_vars);
+    let executable = MatchExecutable::new(next_executable_id(), steps, variable_positions, row_vars);
 
     // Executor
     let snapshot = Arc::new(snapshot);
@@ -418,6 +423,7 @@ fn traverse_has_unbounded_sorted_from_intersect() {
         &thing_manager,
         MaybeOwnedRow::empty(),
         Arc::new(ExecutableFunctionRegistry::empty()),
+        &QueryProfile::new(false),
     )
     .unwrap();
 
@@ -498,7 +504,7 @@ fn traverse_has_unbounded_sorted_to_merged() {
         &named_variables,
         2,
     ))];
-    let executable = MatchExecutable::new(steps, variable_positions.clone(), row_vars);
+    let executable = MatchExecutable::new(next_executable_id(), steps, variable_positions.clone(), row_vars);
 
     // Executor
     let snapshot = Arc::new(snapshot);
@@ -508,6 +514,7 @@ fn traverse_has_unbounded_sorted_to_merged() {
         &thing_manager,
         MaybeOwnedRow::empty(),
         Arc::new(ExecutableFunctionRegistry::empty()),
+        &QueryProfile::new(false),
     )
     .unwrap();
 
@@ -609,7 +616,7 @@ fn traverse_has_reverse_unbounded_sorted_from() {
         &named_variables,
         2,
     ))];
-    let executable = MatchExecutable::new(steps, variable_positions, row_vars);
+    let executable = MatchExecutable::new(next_executable_id(), steps, variable_positions, row_vars);
 
     // Executor
     let snapshot = Arc::new(snapshot);
@@ -619,6 +626,7 @@ fn traverse_has_reverse_unbounded_sorted_from() {
         &thing_manager,
         MaybeOwnedRow::empty(),
         Arc::new(ExecutableFunctionRegistry::empty()),
+        &QueryProfile::new(false),
     )
     .unwrap();
 

--- a/executor/tests/execute_isa.rs
+++ b/executor/tests/execute_isa.rs
@@ -15,22 +15,25 @@ use compiler::{
         function::{AnnotatedUnindexedFunctions, IndexedAnnotatedFunctions},
         match_inference::infer_types,
     },
-    executable::match_::{
-        instructions::{
-            thing::{IsaInstruction, IsaReverseInstruction},
-            ConstraintInstruction, Inputs,
+    executable::{
+        match_::{
+            instructions::{
+                thing::{IsaInstruction, IsaReverseInstruction},
+                ConstraintInstruction, Inputs,
+            },
+            planner::{
+                function_plan::ExecutableFunctionRegistry,
+                match_executable::{ExecutionStep, IntersectionStep, MatchExecutable},
+            },
         },
-        planner::{
-            function_plan::ExecutableFunctionRegistry,
-            match_executable::{ExecutionStep, IntersectionStep, MatchExecutable},
-        },
+        next_executable_id,
     },
     ExecutorVariable, VariablePosition,
 };
 use encoding::value::label::Label;
 use executor::{
-    error::ReadExecutionError, match_executor::MatchExecutor, pipeline::stage::ExecutionContext, row::MaybeOwnedRow,
-    ExecutionInterrupt,
+    error::ReadExecutionError, match_executor::MatchExecutor, pipeline::stage::ExecutionContext, profile::QueryProfile,
+    row::MaybeOwnedRow, ExecutionInterrupt,
 };
 use ir::{
     pattern::{constraint::IsaKind, Vertex},
@@ -131,7 +134,7 @@ fn traverse_isa_unbounded_sorted_thing() {
         2,
     ))];
 
-    let executable = MatchExecutable::new(steps, variable_positions, row_vars);
+    let executable = MatchExecutable::new(next_executable_id(), steps, variable_positions, row_vars);
 
     // Executor
     let snapshot = Arc::new(storage.clone().open_snapshot_read());
@@ -141,6 +144,7 @@ fn traverse_isa_unbounded_sorted_thing() {
         &thing_manager,
         MaybeOwnedRow::empty(),
         Arc::new(ExecutableFunctionRegistry::empty()),
+        &QueryProfile::new(false),
     )
     .unwrap();
 
@@ -219,7 +223,7 @@ fn traverse_isa_unbounded_sorted_type() {
         2,
     ))];
 
-    let executable = MatchExecutable::new(steps, variable_positions, row_vars);
+    let executable = MatchExecutable::new(next_executable_id(), steps, variable_positions, row_vars);
 
     // Executor
     let snapshot = Arc::new(storage.clone().open_snapshot_read());
@@ -229,6 +233,7 @@ fn traverse_isa_unbounded_sorted_type() {
         &thing_manager,
         MaybeOwnedRow::empty(),
         Arc::new(ExecutableFunctionRegistry::empty()),
+        &QueryProfile::new(false),
     )
     .unwrap();
 
@@ -321,7 +326,7 @@ fn traverse_isa_bounded_thing() {
         )),
     ];
 
-    let executable = MatchExecutable::new(steps, variable_positions, row_vars);
+    let executable = MatchExecutable::new(next_executable_id(), steps, variable_positions, row_vars);
 
     // Executor
     let snapshot = Arc::new(storage.clone().open_snapshot_read());
@@ -331,6 +336,7 @@ fn traverse_isa_bounded_thing() {
         &thing_manager,
         MaybeOwnedRow::empty(),
         Arc::new(ExecutableFunctionRegistry::empty()),
+        &QueryProfile::new(false),
     )
     .unwrap();
 
@@ -411,7 +417,7 @@ fn traverse_isa_reverse_unbounded_sorted_thing() {
         2,
     ))];
 
-    let executable = MatchExecutable::new(steps, variable_positions, row_vars);
+    let executable = MatchExecutable::new(next_executable_id(), steps, variable_positions, row_vars);
 
     // Executor
     let snapshot = Arc::new(storage.clone().open_snapshot_read());
@@ -421,6 +427,7 @@ fn traverse_isa_reverse_unbounded_sorted_thing() {
         &thing_manager,
         MaybeOwnedRow::empty(),
         Arc::new(ExecutableFunctionRegistry::empty()),
+        &QueryProfile::new(false),
     )
     .unwrap();
 
@@ -499,7 +506,7 @@ fn traverse_isa_reverse_unbounded_sorted_type() {
         2,
     ))];
 
-    let executable = MatchExecutable::new(steps, variable_positions, row_vars);
+    let executable = MatchExecutable::new(next_executable_id(), steps, variable_positions, row_vars);
 
     // Executor
     let snapshot = Arc::new(storage.clone().open_snapshot_read());
@@ -509,6 +516,7 @@ fn traverse_isa_reverse_unbounded_sorted_type() {
         &thing_manager,
         MaybeOwnedRow::empty(),
         Arc::new(ExecutableFunctionRegistry::empty()),
+        &QueryProfile::new(false),
     )
     .unwrap();
 
@@ -601,7 +609,7 @@ fn traverse_isa_reverse_bounded_type_exact() {
         )),
     ];
 
-    let executable = MatchExecutable::new(steps, variable_positions, row_vars);
+    let executable = MatchExecutable::new(next_executable_id(), steps, variable_positions, row_vars);
 
     // Executor
     let snapshot = Arc::new(storage.clone().open_snapshot_read());
@@ -611,6 +619,7 @@ fn traverse_isa_reverse_bounded_type_exact() {
         &thing_manager,
         MaybeOwnedRow::empty(),
         Arc::new(ExecutableFunctionRegistry::empty()),
+        &QueryProfile::new(false),
     )
     .unwrap();
 
@@ -707,7 +716,7 @@ fn traverse_isa_reverse_bounded_type_subtype() {
         )),
     ];
 
-    let executable = MatchExecutable::new(steps, variable_positions, row_vars);
+    let executable = MatchExecutable::new(next_executable_id(), steps, variable_positions, row_vars);
 
     // Executor
     let snapshot = Arc::new(storage.clone().open_snapshot_read());
@@ -717,6 +726,7 @@ fn traverse_isa_reverse_bounded_type_subtype() {
         &thing_manager,
         MaybeOwnedRow::empty(),
         Arc::new(ExecutableFunctionRegistry::empty()),
+        &QueryProfile::new(false),
     )
     .unwrap();
 
@@ -797,7 +807,7 @@ fn traverse_isa_reverse_fixed_type_exact() {
         1,
     ))];
 
-    let executable = MatchExecutable::new(steps, variable_positions, row_vars);
+    let executable = MatchExecutable::new(next_executable_id(), steps, variable_positions, row_vars);
 
     // Executor
     let snapshot = Arc::new(storage.clone().open_snapshot_read());
@@ -807,6 +817,7 @@ fn traverse_isa_reverse_fixed_type_exact() {
         &thing_manager,
         MaybeOwnedRow::empty(),
         Arc::new(ExecutableFunctionRegistry::empty()),
+        &QueryProfile::new(false),
     )
     .unwrap();
 
@@ -886,7 +897,7 @@ fn traverse_isa_reverse_fixed_type_subtype() {
         1,
     ))];
 
-    let executable = MatchExecutable::new(steps, variable_positions, row_vars);
+    let executable = MatchExecutable::new(next_executable_id(), steps, variable_positions, row_vars);
 
     // Executor
     let snapshot = Arc::new(storage.clone().open_snapshot_read());
@@ -896,6 +907,7 @@ fn traverse_isa_reverse_fixed_type_subtype() {
         &thing_manager,
         MaybeOwnedRow::empty(),
         Arc::new(ExecutableFunctionRegistry::empty()),
+        &QueryProfile::new(false),
     )
     .unwrap();
 

--- a/executor/tests/execute_links.rs
+++ b/executor/tests/execute_links.rs
@@ -15,15 +15,18 @@ use compiler::{
         function::{AnnotatedUnindexedFunctions, IndexedAnnotatedFunctions},
         match_inference::infer_types,
     },
-    executable::match_::{
-        instructions::{
-            thing::{IsaInstruction, LinksInstruction, LinksReverseInstruction},
-            ConstraintInstruction, Inputs,
+    executable::{
+        match_::{
+            instructions::{
+                thing::{IsaInstruction, LinksInstruction, LinksReverseInstruction},
+                ConstraintInstruction, Inputs,
+            },
+            planner::{
+                function_plan::ExecutableFunctionRegistry,
+                match_executable::{ExecutionStep, IntersectionStep, MatchExecutable},
+            },
         },
-        planner::{
-            function_plan::ExecutableFunctionRegistry,
-            match_executable::{ExecutionStep, IntersectionStep, MatchExecutable},
-        },
+        next_executable_id,
     },
     ExecutorVariable, VariablePosition,
 };
@@ -36,8 +39,8 @@ use concept::{
 };
 use encoding::value::{label::Label, value::Value, value_type::ValueType};
 use executor::{
-    error::ReadExecutionError, match_executor::MatchExecutor, pipeline::stage::ExecutionContext, row::MaybeOwnedRow,
-    ExecutionInterrupt,
+    error::ReadExecutionError, match_executor::MatchExecutor, pipeline::stage::ExecutionContext, profile::QueryProfile,
+    row::MaybeOwnedRow, ExecutionInterrupt,
 };
 use ir::{
     pattern::constraint::IsaKind,
@@ -273,7 +276,7 @@ fn traverse_links_unbounded_sorted_from() {
         3,
     ))];
 
-    let executable = MatchExecutable::new(steps, variable_positions, row_vars);
+    let executable = MatchExecutable::new(next_executable_id(), steps, variable_positions, row_vars);
 
     // Executor
     let snapshot = Arc::new(storage.clone().open_snapshot_read());
@@ -283,6 +286,7 @@ fn traverse_links_unbounded_sorted_from() {
         &thing_manager,
         MaybeOwnedRow::empty(),
         Arc::new(ExecutableFunctionRegistry::empty()),
+        &QueryProfile::new(false),
     )
     .unwrap();
 
@@ -378,7 +382,7 @@ fn traverse_links_unbounded_sorted_to() {
         2,
     ))];
 
-    let executable = MatchExecutable::new(steps, variable_positions, row_vars);
+    let executable = MatchExecutable::new(next_executable_id(), steps, variable_positions, row_vars);
 
     // Executor
     let snapshot = Arc::new(storage.clone().open_snapshot_read());
@@ -388,6 +392,7 @@ fn traverse_links_unbounded_sorted_to() {
         &thing_manager,
         MaybeOwnedRow::empty(),
         Arc::new(ExecutableFunctionRegistry::empty()),
+        &QueryProfile::new(false),
     )
     .unwrap();
 
@@ -500,7 +505,7 @@ fn traverse_links_bounded_relation() {
         )),
     ];
 
-    let executable = MatchExecutable::new(steps, variable_positions, row_vars);
+    let executable = MatchExecutable::new(next_executable_id(), steps, variable_positions, row_vars);
 
     // Executor
     let snapshot = Arc::new(storage.clone().open_snapshot_read());
@@ -510,6 +515,7 @@ fn traverse_links_bounded_relation() {
         &thing_manager,
         MaybeOwnedRow::empty(),
         Arc::new(ExecutableFunctionRegistry::empty()),
+        &QueryProfile::new(false),
     )
     .unwrap();
 
@@ -636,7 +642,7 @@ fn traverse_links_bounded_relation_player() {
         )),
     ];
 
-    let executable = MatchExecutable::new(steps, variable_positions, row_vars);
+    let executable = MatchExecutable::new(next_executable_id(), steps, variable_positions, row_vars);
 
     // Executor
     let snapshot = Arc::new(storage.clone().open_snapshot_read());
@@ -646,6 +652,7 @@ fn traverse_links_bounded_relation_player() {
         &thing_manager,
         MaybeOwnedRow::empty(),
         Arc::new(ExecutableFunctionRegistry::empty()),
+        &QueryProfile::new(false),
     )
     .unwrap();
 
@@ -742,7 +749,7 @@ fn traverse_links_reverse_unbounded_sorted_from() {
         2,
     ))];
 
-    let executable = MatchExecutable::new(steps, variable_positions, row_vars);
+    let executable = MatchExecutable::new(next_executable_id(), steps, variable_positions, row_vars);
 
     // Executor
     let snapshot = Arc::new(storage.clone().open_snapshot_read());
@@ -752,6 +759,7 @@ fn traverse_links_reverse_unbounded_sorted_from() {
         &thing_manager,
         MaybeOwnedRow::empty(),
         Arc::new(ExecutableFunctionRegistry::empty()),
+        &QueryProfile::new(false),
     )
     .unwrap();
 
@@ -849,7 +857,7 @@ fn traverse_links_reverse_unbounded_sorted_to() {
         2,
     ))];
 
-    let executable = MatchExecutable::new(steps, variable_positions, row_vars);
+    let executable = MatchExecutable::new(next_executable_id(), steps, variable_positions, row_vars);
 
     // Executor
     let snapshot = Arc::new(storage.clone().open_snapshot_read());
@@ -859,6 +867,7 @@ fn traverse_links_reverse_unbounded_sorted_to() {
         &thing_manager,
         MaybeOwnedRow::empty(),
         Arc::new(ExecutableFunctionRegistry::empty()),
+        &QueryProfile::new(false),
     )
     .unwrap();
 
@@ -968,7 +977,7 @@ fn traverse_links_reverse_bounded_player() {
         )),
     ];
 
-    let executable = MatchExecutable::new(steps, variable_positions, row_vars);
+    let executable = MatchExecutable::new(next_executable_id(), steps, variable_positions, row_vars);
 
     // Executor
     let snapshot = Arc::new(storage.clone().open_snapshot_read());
@@ -978,6 +987,7 @@ fn traverse_links_reverse_bounded_player() {
         &thing_manager,
         MaybeOwnedRow::empty(),
         Arc::new(ExecutableFunctionRegistry::empty()),
+        &QueryProfile::new(false),
     )
     .unwrap();
 
@@ -1104,7 +1114,7 @@ fn traverse_links_reverse_bounded_player_relation() {
         )),
     ];
 
-    let executable = MatchExecutable::new(steps, variable_positions, row_vars);
+    let executable = MatchExecutable::new(next_executable_id(), steps, variable_positions, row_vars);
 
     // Executor
     let snapshot = Arc::new(storage.clone().open_snapshot_read());
@@ -1114,6 +1124,7 @@ fn traverse_links_reverse_bounded_player_relation() {
         &thing_manager,
         MaybeOwnedRow::empty(),
         Arc::new(ExecutableFunctionRegistry::empty()),
+        &QueryProfile::new(false),
     )
     .unwrap();
 

--- a/executor/tests/execute_select.rs
+++ b/executor/tests/execute_select.rs
@@ -15,12 +15,15 @@ use compiler::{
         function::{AnnotatedUnindexedFunctions, IndexedAnnotatedFunctions},
         match_inference::infer_types,
     },
-    executable::match_::{
-        instructions::{thing::HasInstruction, ConstraintInstruction, Inputs},
-        planner::{
-            function_plan::ExecutableFunctionRegistry,
-            match_executable::{ExecutionStep, IntersectionStep, MatchExecutable},
+    executable::{
+        match_::{
+            instructions::{thing::HasInstruction, ConstraintInstruction, Inputs},
+            planner::{
+                function_plan::ExecutableFunctionRegistry,
+                match_executable::{ExecutionStep, IntersectionStep, MatchExecutable},
+            },
         },
+        next_executable_id,
     },
     ExecutorVariable, VariablePosition,
 };
@@ -30,8 +33,8 @@ use concept::{
 };
 use encoding::value::{label::Label, value::Value, value_type::ValueType};
 use executor::{
-    error::ReadExecutionError, match_executor::MatchExecutor, pipeline::stage::ExecutionContext, row::MaybeOwnedRow,
-    ExecutionInterrupt,
+    error::ReadExecutionError, match_executor::MatchExecutor, pipeline::stage::ExecutionContext, profile::QueryProfile,
+    row::MaybeOwnedRow, ExecutionInterrupt,
 };
 use ir::{
     pattern::constraint::IsaKind,
@@ -211,7 +214,7 @@ fn anonymous_vars_not_enumerated_or_counted() {
         &named_variables,
         1,
     ))];
-    let executable = MatchExecutable::new(steps, variable_positions, row_vars);
+    let executable = MatchExecutable::new(next_executable_id(), steps, variable_positions, row_vars);
 
     // Executor
     let snapshot = Arc::new(storage.clone().open_snapshot_read());
@@ -222,6 +225,7 @@ fn anonymous_vars_not_enumerated_or_counted() {
         &thing_manager,
         MaybeOwnedRow::empty(),
         Arc::new(ExecutableFunctionRegistry::empty()),
+        &QueryProfile::new(false),
     )
     .unwrap();
 
@@ -314,7 +318,7 @@ fn unselected_named_vars_counted() {
         1,
     ))];
 
-    let executable = MatchExecutable::new(steps, variable_positions, row_vars);
+    let executable = MatchExecutable::new(next_executable_id(), steps, variable_positions, row_vars);
 
     // Executor
     let snapshot: Arc<ReadSnapshot<WALClient>> = Arc::new(storage.clone().open_snapshot_read());
@@ -325,6 +329,7 @@ fn unselected_named_vars_counted() {
         &thing_manager,
         MaybeOwnedRow::empty(),
         Arc::new(ExecutableFunctionRegistry::empty()),
+        &QueryProfile::new(false),
     )
     .unwrap();
 
@@ -440,7 +445,7 @@ fn cartesian_named_counted_checked() {
         2,
     ))];
 
-    let match_executable = MatchExecutable::new(steps, variable_positions, row_vars);
+    let match_executable = MatchExecutable::new(next_executable_id(), steps, variable_positions, row_vars);
 
     // Executor
     let snapshot: Arc<ReadSnapshot<WALClient>> = Arc::new(storage.clone().open_snapshot_read());
@@ -451,6 +456,7 @@ fn cartesian_named_counted_checked() {
         &thing_manager,
         MaybeOwnedRow::empty(),
         Arc::new(ExecutableFunctionRegistry::empty()),
+        &QueryProfile::new(false),
     )
     .unwrap();
 

--- a/executor/tests/pipelines.rs
+++ b/executor/tests/pipelines.rs
@@ -17,8 +17,7 @@ use executor::{
 };
 use function::function_manager::FunctionManager;
 use lending_iterator::LendingIterator;
-use query::query_cache::QueryCache;
-use query::query_manager::QueryManager;
+use query::{query_cache::QueryCache, query_manager::QueryManager};
 use storage::{durability_client::WALClient, snapshot::CommittableSnapshot, MVCCStorage};
 use test_utils::{assert_matches, TempDir};
 use test_utils_concept::{load_managers, setup_concept_storage};

--- a/executor/tests/writes.rs
+++ b/executor/tests/writes.rs
@@ -31,6 +31,7 @@ use executor::{
         stage::{ExecutionContext, StageAPI, StageIterator},
         PipelineExecutionError,
     },
+    profile::QueryProfile,
     row::MaybeOwnedRow,
     write::WriteError,
     ExecutionInterrupt,
@@ -193,7 +194,12 @@ fn execute_insert<Snapshot: WritableSnapshot + 'static>(
     let snapshot = Arc::new(snapshot);
     let initial = ShimStage::new(
         input_rows,
-        ExecutionContext { snapshot, thing_manager, parameters: Arc::new(value_parameters) },
+        ExecutionContext {
+            snapshot,
+            thing_manager,
+            parameters: Arc::new(value_parameters),
+            profile: Arc::new(QueryProfile::new(false)),
+        },
     );
     let insert_executor = InsertStageExecutor::new(Arc::new(insert_plan), initial);
     let (output_iter, context) =
@@ -277,7 +283,12 @@ fn execute_delete<Snapshot: WritableSnapshot + 'static>(
     let snapshot = Arc::new(snapshot);
     let initial = ShimStage::new(
         input_rows,
-        ExecutionContext { snapshot, thing_manager, parameters: Arc::new(value_parameters) },
+        ExecutionContext {
+            snapshot,
+            thing_manager,
+            parameters: Arc::new(value_parameters),
+            profile: Arc::new(QueryProfile::new(false)),
+        },
     );
     let delete_executor = DeleteStageExecutor::new(Arc::new(delete_plan), initial);
     let (output_iter, context) =

--- a/executor/write/write_instruction.rs
+++ b/executor/write/write_instruction.rs
@@ -131,7 +131,7 @@ impl AsWriteInstruction for compiler::executable::insert::instructions::Has {
     }
 }
 
-impl AsWriteInstruction for compiler::executable::insert::instructions::RolePlayer {
+impl AsWriteInstruction for compiler::executable::insert::instructions::Links {
     fn execute(
         &self,
         snapshot: &mut impl WritableSnapshot,
@@ -198,7 +198,7 @@ impl AsWriteInstruction for compiler::executable::delete::instructions::Has {
     }
 }
 
-impl AsWriteInstruction for compiler::executable::delete::instructions::RolePlayer {
+impl AsWriteInstruction for compiler::executable::delete::instructions::Links {
     fn execute(
         &self,
         snapshot: &mut impl WritableSnapshot,

--- a/ir/pipeline/fetch.rs
+++ b/ir/pipeline/fetch.rs
@@ -4,16 +4,18 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-use std::collections::{HashMap, HashSet};
-use std::hash::{DefaultHasher, Hasher};
-use std::mem;
+use std::{
+    collections::{HashMap, HashSet},
+    hash::{DefaultHasher, Hasher},
+    mem,
+};
 
 use answer::variable::Variable;
 use structural_equality::{ordered_hash_combine, StructuralEquality};
 
 use crate::{
     pattern::ParameterID,
-    pipeline::{function::Function },
+    pipeline::function::Function,
     translation::{pipeline::TranslatedStage, TranslationContext},
 };
 
@@ -72,8 +74,8 @@ impl StructuralEquality for FetchSome {
                 FetchSome::ListFunction(function) => function.hash(),
                 FetchSome::ListSubFetch(fetch) => fetch.hash(),
                 FetchSome::ListAttributesAsList(fetch) => fetch.hash(),
-                FetchSome::ListAttributesFromList(fetch) => fetch.hash()
-            }
+                FetchSome::ListAttributesFromList(fetch) => fetch.hash(),
+            },
         )
     }
 
@@ -86,7 +88,9 @@ impl StructuralEquality for FetchSome {
             (Self::ListFunction(inner), Self::ListFunction(other_inner)) => inner.equals(other_inner),
             (Self::ListSubFetch(inner), Self::ListSubFetch(other_inner)) => inner.equals(other_inner),
             (Self::ListAttributesAsList(inner), Self::ListAttributesAsList(other_inner)) => inner.equals(other_inner),
-            (Self::ListAttributesFromList(inner), Self::ListAttributesFromList(other_inner)) => inner.equals(other_inner),
+            (Self::ListAttributesFromList(inner), Self::ListAttributesFromList(other_inner)) => {
+                inner.equals(other_inner)
+            }
 
             (Self::SingleVar(_), _)
             | (Self::SingleAttribute(_), _)
@@ -145,18 +149,14 @@ impl StructuralEquality for FetchObject {
             match self {
                 FetchObject::Entries(entries) => StructuralEquality::hash(entries),
                 FetchObject::Attributes(variable) => variable.hash(),
-            }
+            },
         )
     }
 
     fn equals(&self, other: &Self) -> bool {
         match (self, other) {
-            (Self::Entries(entries), Self::Entries(other_entries)) => {
-                entries.equals(other_entries)
-            },
-            (Self::Attributes(var), Self::Attributes(other_var)) => {
-                var.equals(other_var)
-            },
+            (Self::Entries(entries), Self::Entries(other_entries)) => entries.equals(other_entries),
+            (Self::Attributes(var), Self::Attributes(other_var)) => var.equals(other_var),
             (Self::Entries(_), _) | (Self::Attributes(_), _) => false,
         }
     }
@@ -172,10 +172,7 @@ pub struct FetchListSubFetch {
 
 impl StructuralEquality for FetchListSubFetch {
     fn hash(&self) -> u64 {
-        ordered_hash_combine(
-            self.stages.hash(),
-            self.fetch.hash(),
-        )
+        ordered_hash_combine(self.stages.hash(), self.fetch.hash())
     }
 
     fn equals(&self, other: &Self) -> bool {

--- a/ir/pipeline/mod.rs
+++ b/ir/pipeline/mod.rs
@@ -5,7 +5,6 @@
  */
 
 use std::{collections::HashMap, error::Error, fmt, sync::Arc};
-use std::collections::HashSet;
 
 use answer::variable::Variable;
 use encoding::value::value::Value;

--- a/ir/tests/structural_equality.rs
+++ b/ir/tests/structural_equality.rs
@@ -5,12 +5,14 @@
  */
 
 use ir::{
-    pipeline::function_signature::HashMapFunctionSignatureIndex, translation::function::translate_typeql_function,
+    pipeline::function_signature::HashMapFunctionSignatureIndex,
+    translation::{
+        function::translate_typeql_function,
+        pipeline::{translate_pipeline, TranslatedPipeline},
+    },
 };
-use ir::translation::pipeline::{translate_pipeline, TranslatedPipeline};
 use structural_equality::{is_structurally_equivalent, StructuralEquality};
 use test_utils_storage::mock_snapshot::MockSnapshot;
-
 
 #[test]
 fn test_function_equivalence() {
@@ -150,11 +152,12 @@ fetch {
   'my-key': { $ol.* }
 };
 ";
-    let TranslatedPipeline { translated_preamble, translated_stages, translated_fetch, ..} = translate_pipeline(
+    let TranslatedPipeline { translated_preamble, translated_stages, translated_fetch, .. } = translate_pipeline(
         &MockSnapshot {},
         &HashMapFunctionSignatureIndex::empty(),
         &typeql::parse_query(pipeline).unwrap().into_pipeline(),
-    ).unwrap();
+    )
+    .unwrap();
     assert!(translated_preamble.equals(&translated_preamble));
     assert!(translated_stages.equals(&translated_stages));
     assert!(translated_fetch.equals(&translated_fetch));
@@ -191,12 +194,12 @@ fetch {
         &MockSnapshot {},
         &HashMapFunctionSignatureIndex::empty(),
         &typeql::parse_query(structurally_equivalent_pipeline).unwrap().into_pipeline(),
-    ).unwrap();
+    )
+    .unwrap();
 
     assert!(equivalent_translated_preamble.equals(&equivalent_translated_preamble));
     assert!(equivalent_translated_stages.equals(&equivalent_translated_stages));
     assert!(equivalent_translated_fetch.equals(&equivalent_translated_fetch));
-
 
     assert!(is_structurally_equivalent(&translated_preamble, &equivalent_translated_preamble));
     assert!(is_structurally_equivalent(&translated_stages, &equivalent_translated_stages));
@@ -227,11 +230,12 @@ insert $ol has OL_DELIVERY_D 2024-11-18T15:06:09.224;
 fetch {
   'my-key': { $ol.* }
 };";
-    let TranslatedPipeline { translated_preamble, translated_stages, translated_fetch, ..} = translate_pipeline(
+    let TranslatedPipeline { translated_preamble, translated_stages, translated_fetch, .. } = translate_pipeline(
         &MockSnapshot {},
         &HashMapFunctionSignatureIndex::empty(),
         &typeql::parse_query(pipeline).unwrap().into_pipeline(),
-    ).unwrap();
+    )
+    .unwrap();
     assert!(translated_preamble.equals(&translated_preamble));
     assert!(translated_stages.equals(&translated_stages));
     assert!(translated_fetch.equals(&translated_fetch));
@@ -267,12 +271,12 @@ fetch {
         &MockSnapshot {},
         &HashMapFunctionSignatureIndex::empty(),
         &typeql::parse_query(different).unwrap().into_pipeline(),
-    ).unwrap();
+    )
+    .unwrap();
 
     assert!(different_translated_preamble.equals(&different_translated_preamble));
     assert!(different_translated_stages.equals(&different_translated_stages));
     assert!(different_translated_fetch.equals(&different_translated_fetch));
-
 
     assert!(!is_structurally_equivalent(&translated_preamble, &different_translated_preamble));
     assert!(!is_structurally_equivalent(&translated_stages, &different_translated_stages));
@@ -282,23 +286,22 @@ fetch {
 #[test]
 fn test_anonymous_non_equivalence() {
     let query = "match $x relates $_ as parent;";
-    let TranslatedPipeline { translated_stages, ..} = translate_pipeline(
+    let TranslatedPipeline { translated_stages, .. } = translate_pipeline(
         &MockSnapshot {},
         &HashMapFunctionSignatureIndex::empty(),
         &typeql::parse_query(query).unwrap().into_pipeline(),
-    ).unwrap();
+    )
+    .unwrap();
     assert!(translated_stages.equals(&translated_stages));
-    
+
     let non_equivalent_query = "match $x relates $role as parent;";
-    let TranslatedPipeline {
-        translated_stages: different_translated_stages,
-        ..
-    } = translate_pipeline(
+    let TranslatedPipeline { translated_stages: different_translated_stages, .. } = translate_pipeline(
         &MockSnapshot {},
         &HashMapFunctionSignatureIndex::empty(),
         &typeql::parse_query(non_equivalent_query).unwrap().into_pipeline(),
-    ).unwrap();
+    )
+    .unwrap();
     assert!(different_translated_stages.equals(&different_translated_stages));
-    
+
     assert!(!is_structurally_equivalent(&translated_stages, &different_translated_stages));
 }

--- a/query/benches/bench_insert_queries.rs
+++ b/query/benches/bench_insert_queries.rs
@@ -31,8 +31,7 @@ use executor::{
 use function::function_manager::FunctionManager;
 use lending_iterator::LendingIterator;
 use pprof::ProfilerGuard;
-use query::{error::QueryError, query_manager::QueryManager};
-use query::query_cache::QueryCache;
+use query::{error::QueryError, query_cache::QueryCache, query_manager::QueryManager};
 use storage::{
     durability_client::WALClient,
     snapshot::{CommittableSnapshot, WritableSnapshot},

--- a/query/benches/bench_insert_queries_multithreaded.rs
+++ b/query/benches/bench_insert_queries_multithreaded.rs
@@ -24,14 +24,10 @@ use encoding::{
     graph::definition::definition_key_generator::DefinitionKeyGenerator,
     value::{label::Label, value_type::ValueType},
 };
-use executor::{
-    pipeline::stage::{StageIterator},
-    ExecutionInterrupt,
-};
+use executor::{pipeline::stage::StageIterator, ExecutionInterrupt};
 use function::function_manager::FunctionManager;
 use lending_iterator::LendingIterator;
-use query::{error::QueryError, query_manager::QueryManager};
-use query::query_cache::QueryCache;
+use query::{error::QueryError, query_cache::QueryCache, query_manager::QueryManager};
 use storage::{
     durability_client::WALClient,
     snapshot::{CommittableSnapshot, WritableSnapshot},

--- a/query/tests/define.rs
+++ b/query/tests/define.rs
@@ -4,8 +4,6 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-use std::sync::Arc;
-use query::query_cache::QueryCache;
 use query::query_manager::QueryManager;
 use storage::snapshot::CommittableSnapshot;
 use test_utils_concept::{load_managers, setup_concept_storage};

--- a/query/tests/fetch.rs
+++ b/query/tests/fetch.rs
@@ -10,8 +10,7 @@ use concept::{thing::thing_manager::ThingManager, type_::type_manager::TypeManag
 use encoding::graph::definition::definition_key_generator::DefinitionKeyGenerator;
 use executor::ExecutionInterrupt;
 use function::function_manager::FunctionManager;
-use query::query_cache::QueryCache;
-use query::query_manager::QueryManager;
+use query::{query_cache::QueryCache, query_manager::QueryManager};
 use storage::{durability_client::WALClient, snapshot::CommittableSnapshot, MVCCStorage};
 use test_utils_concept::{load_managers, setup_concept_storage};
 use test_utils_encoding::create_core_storage;

--- a/resource/perf_counters.rs
+++ b/resource/perf_counters.rs
@@ -7,6 +7,7 @@
 // let's start with a simple and fast global list of NAME = COUNTER for now.
 
 use std::sync::atomic::{AtomicU64, Ordering};
+
 use crate::constants::server::PERF_COUNTERS_ENABLED;
 
 pub struct Counter {
@@ -18,7 +19,7 @@ impl Counter {
     const fn new(enabled: bool) -> Self {
         Self { counter: AtomicU64::new(0), enabled }
     }
-    
+
     pub fn increment(&self) {
         if self.enabled {
             self.counter.fetch_add(1, Ordering::Relaxed);

--- a/storage/tests/test_isolation.rs
+++ b/storage/tests/test_isolation.rs
@@ -23,7 +23,6 @@ use test_utils_storage::{create_storage, load_storage, test_keyspace_set};
 
 use self::TestKeyspaceSet::Keyspace;
 
-
 test_keyspace_set! {
     Keyspace => 0: "keyspace",
 }

--- a/storage/tests/test_mvcc.rs
+++ b/storage/tests/test_mvcc.rs
@@ -31,7 +31,6 @@ use test_utils::{create_tmp_dir, init_logging};
 use test_utils_storage::{create_storage, test_keyspace_set};
 use TestKeyspaceSet::Keyspace;
 
-
 test_keyspace_set! {
     Keyspace => 0: "keyspace",
 }

--- a/storage/tests/test_recovery.rs
+++ b/storage/tests/test_recovery.rs
@@ -17,7 +17,6 @@ use storage::{
 use test_utils::{create_tmp_dir, init_logging};
 use test_utils_storage::{checkpoint_storage, create_storage, load_storage, test_keyspace_set};
 
-
 #[test]
 fn wal_and_checkpoint_ok() {
     test_keyspace_set! { Keyspace => 0: "keyspace" }

--- a/storage/tests/test_snapshot.rs
+++ b/storage/tests/test_snapshot.rs
@@ -20,7 +20,6 @@ use test_utils_storage::{create_storage, test_keyspace_set};
 
 use self::TestKeyspaceSet::Keyspace;
 
-
 test_keyspace_set! {
     Keyspace => 0: "keyspace",
 }

--- a/storage/tests/test_storage.rs
+++ b/storage/tests/test_storage.rs
@@ -20,7 +20,6 @@ use storage::{
 use test_utils::{create_tmp_dir, init_logging};
 use test_utils_storage::{checkpoint_storage, create_storage, load_storage, test_keyspace_set};
 
-
 #[test]
 fn create_delete() {
     test_keyspace_set! {}

--- a/storage/tests/test_utils_storage/mock_snapshot.rs
+++ b/storage/tests/test_utils_storage/mock_snapshot.rs
@@ -4,16 +4,17 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-
 use std::iter::empty;
+
 use bytes::byte_array::ByteArray;
-use storage::key_range::KeyRange;
-use storage::key_value::{StorageKey, StorageKeyArray, StorageKeyReference};
-use storage::sequence_number::SequenceNumber;
-use storage::snapshot::{ReadableSnapshot, SnapshotGetError};
-use storage::snapshot::buffer::BufferRangeIterator;
-use storage::snapshot::iterator::SnapshotRangeIterator;
-use storage::snapshot::write::Write;
+use storage::{
+    key_range::KeyRange,
+    key_value::{StorageKey, StorageKeyArray, StorageKeyReference},
+    sequence_number::SequenceNumber,
+    snapshot::{
+        buffer::BufferRangeIterator, iterator::SnapshotRangeIterator, write::Write, ReadableSnapshot, SnapshotGetError,
+    },
+};
 
 pub struct MockSnapshot {}
 

--- a/tests/behaviour/steps/lib.rs
+++ b/tests/behaviour/steps/lib.rs
@@ -17,7 +17,6 @@ use std::{
 
 use ::concept::thing::{attribute::Attribute, object::Object};
 use ::query::error::QueryError;
-use answer::variable_value::VariableValue;
 use cucumber::{gherkin::Feature, StatsWriter, World};
 use database::Database;
 use futures::{

--- a/tests/behaviour/steps/query/typeql.rs
+++ b/tests/behaviour/steps/query/typeql.rs
@@ -99,7 +99,13 @@ fn execute_write_query(
         return Err(BehaviourTestExecutionError::UseInvalidTransactionAsWrite);
     }
 
-    with_write_tx_deconstructed!(context, |snapshot, type_manager, thing_manager, function_manager, query_manager, _db, _opts| {
+    with_write_tx_deconstructed!(context, |snapshot,
+                                           type_manager,
+                                           thing_manager,
+                                           function_manager,
+                                           query_manager,
+                                           _db,
+                                           _opts| {
         let snapshot = Arc::into_inner(snapshot).unwrap();
         let pipeline_result = query_manager.prepare_write_pipeline(
             snapshot,


### PR DESCRIPTION
## Release notes: product changes

We implement a useful debugging feature - a query analyzer. This is similar to Postgres's `Explain Analyze`, which produces both the query plan plus some details about the data that has flowed through the query plan and the time at each step within it.

Example output:
```
Query profile[measurements_enabled=true]
  -----
  Stage or Pattern [id=0] - Match
    0. Sorted Iterator Intersection [bound_vars=[], output_size=1, sort_by=p0]
      [p0 isa ITEM] filter [] with (outputs=p0, )
    ==> batches: 158, rows: 10000, micros: 6407

    1. Sorted Iterator Intersection [bound_vars=[p0], output_size=2, sort_by=p1]
      Reverse[p1 rp p0 (role: __$2__)] filter [] with (inputs=p0, outputs=p1, checks=__$2__, )
    ==> batches: 854, rows: 39967, micros: 75716

  -----
  Stage or Pattern [id=1] - Reduce
    0. Reduction
    ==> batches: 1, rows: 10000, micros: 116035

  -----
  Stage or Pattern [id=2] - Insert
    0. Put attribute
    ==> batches: 10000, rows: 10000, micros: 5890

    1. Put has
    ==> batches: 10000, rows: 10000, micros: 54264
  ```

When disabled, profiling is a no-op (no strings are created, locks taken, or times measured), though there is still some cost associated with cloning Arcs containing the profiling data structures around. 

To enable query profiling, the easiest way (for now) is to enable TRACE logging level for the `executor` package, currrently configured in `//common/logger/logger.rs`:
```
.add_directive(LevelFilter::INFO.into())
// add:
// .add_directive("executor=trace".parse().unwrap())
```

Alternatively, just set the `enable` boolean to `true` in the `QueryProfile::new()` constructor.

## Motivation

To iterate more quickly debugging and finding performance issues, this kind of performance analyser, though it comes with some runtime overhead, is very useful to verify each stage of a query execution is producing the rows expected, and for verifying the amount of time taken to produce the rows. These together allow us to pinpoint 1) bad query plans, and 2) expensive operations.

## Implementation

We add a new struct `QueryProfile`, and its children, which are passed throughout the `//executor` package and used to record operations and timing against.

In the future, we should allow both returning this to the user in the Driver, and also enable or disable it per-query via the query options in the driver.


