### PR TITLE
Add more typing information into key prefixes to optimise storage lookups

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -924,6 +924,7 @@ dependencies = [
  "itertools 0.10.5",
  "lending_iterator",
  "logger",
+ "primitive",
  "query",
  "resource",
  "storage",

--- a/common/primitive/primitives.rs
+++ b/common/primitive/primitives.rs
@@ -4,6 +4,11 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
+use std::ops::Bound;
+
 pub mod either;
 pub mod maybe_owns;
 pub mod prefix;
+
+// a type that implements RangeBounds<T>
+pub type Bounds<T> = (Bound<T>, Bound<T>);

--- a/concept/iterator.rs
+++ b/concept/iterator.rs
@@ -101,7 +101,7 @@ macro_rules! edge_iterator {
                 $name { snapshot_iterator: Some(snapshot_iterator) }
             }
 
-            pub(crate) fn new_empty() -> Self {
+            pub fn new_empty() -> Self {
                 $name { snapshot_iterator: None }
             }
 

--- a/concept/tests/test_statistics.rs
+++ b/concept/tests/test_statistics.rs
@@ -112,7 +112,8 @@ fn read_statistics(storage: Arc<MVCCStorage<WALClient>>, thing_manager: &ThingMa
         let owner_type = entity.type_().into_object_type();
         let has_iter = entity.get_has_unordered(&snapshot, thing_manager);
         for has in has_iter {
-            let (attribute, count) = has.unwrap();
+            let (has, count) = has.unwrap();
+            let attribute = has.attribute();
             *statistics.has_attribute_counts.entry(owner_type).or_default().entry(attribute.type_()).or_default() +=
                 count;
             *statistics.attribute_owner_counts.entry(attribute.type_()).or_default().entry(owner_type).or_default() +=
@@ -128,7 +129,8 @@ fn read_statistics(storage: Arc<MVCCStorage<WALClient>>, thing_manager: &ThingMa
         let owner_type = relation.type_().into_object_type();
         let has_iter = relation.get_has_unordered(&snapshot, thing_manager);
         for has in has_iter {
-            let (attribute, count) = has.unwrap();
+            let (has, count) = has.unwrap();
+            let attribute = has.attribute();
             *statistics.has_attribute_counts.entry(owner_type).or_default().entry(attribute.type_()).or_default() +=
                 count;
             *statistics.attribute_owner_counts.entry(attribute.type_()).or_default().entry(owner_type).or_default() +=

--- a/concept/tests/test_thing.rs
+++ b/concept/tests/test_thing.rs
@@ -6,7 +6,7 @@
 
 #![deny(unused_must_use)]
 
-use std::{borrow::Cow, collections::HashMap};
+use std::{borrow::Cow, collections::HashMap, ops::Bound};
 
 use concept::{
     error::ConceptReadError,
@@ -20,6 +20,7 @@ use concept::{
     type_::{
         annotation::{AnnotationCardinality, AnnotationDistinct, AnnotationIndependent, AnnotationUnique},
         attribute_type::AttributeTypeAnnotation,
+        object_type::ObjectType,
         owns::OwnsAnnotation,
         relates::RelatesAnnotation,
         type_manager::TypeManager,
@@ -202,6 +203,207 @@ fn has() {
         let person_1 = people.first().unwrap();
         let retrieved_attributes_count = person_1.get_has_unordered(&snapshot, &thing_manager).count();
         assert_eq!(retrieved_attributes_count, 2);
+    }
+}
+
+#[test]
+fn get_has_reverse_in_range() {
+    let (_tmp_dir, mut storage) = create_core_storage();
+    setup_concept_storage(&mut storage);
+
+    let age_label = Label::build("age");
+    let name_label = Label::build("name");
+    let person_label = Label::build("person");
+    let company_label = Label::build("company");
+
+    let age_value_10: i64 = 10;
+    let age_value_11: i64 = 11;
+    let inlineable_name: &str = "TypeDB";
+    let uninlinable_name: &str = "TypeDB Incorporated In America";
+
+    let mut snapshot: WriteSnapshot<WALClient> = storage.clone().open_snapshot_write();
+    {
+        let (type_manager, thing_manager) = load_managers(storage.clone(), None);
+
+        let age_type = type_manager.create_attribute_type(&mut snapshot, &age_label).unwrap();
+        age_type.set_value_type(&mut snapshot, &type_manager, &thing_manager, ValueType::Long).unwrap();
+        age_type
+            .set_annotation(
+                &mut snapshot,
+                &type_manager,
+                &thing_manager,
+                AttributeTypeAnnotation::Independent(AnnotationIndependent),
+            )
+            .unwrap();
+        let name_type = type_manager.create_attribute_type(&mut snapshot, &name_label).unwrap();
+        name_type.set_value_type(&mut snapshot, &type_manager, &thing_manager, ValueType::String).unwrap();
+        name_type
+            .set_annotation(
+                &mut snapshot,
+                &type_manager,
+                &thing_manager,
+                AttributeTypeAnnotation::Independent(AnnotationIndependent),
+            )
+            .unwrap();
+
+        let person_type = type_manager.create_entity_type(&mut snapshot, &person_label).unwrap();
+        let person_owns_age = person_type
+            .set_owns(&mut snapshot, &type_manager, &thing_manager, age_type.clone(), Ordering::Unordered)
+            .unwrap();
+        person_owns_age
+            .set_annotation(
+                &mut snapshot,
+                &type_manager,
+                &thing_manager,
+                OwnsAnnotation::Cardinality(AnnotationCardinality::new(0, None)),
+            )
+            .unwrap();
+        let person_owns_name = person_type
+            .set_owns(&mut snapshot, &type_manager, &thing_manager, name_type.clone(), Ordering::Unordered)
+            .unwrap();
+        person_owns_name
+            .set_annotation(
+                &mut snapshot,
+                &type_manager,
+                &thing_manager,
+                OwnsAnnotation::Cardinality(AnnotationCardinality::new(0, None)),
+            )
+            .unwrap();
+
+        let company_type = type_manager.create_entity_type(&mut snapshot, &company_label).unwrap();
+        let company_owns_age = company_type
+            .set_owns(&mut snapshot, &type_manager, &thing_manager, age_type.clone(), Ordering::Unordered)
+            .unwrap();
+        company_owns_age
+            .set_annotation(
+                &mut snapshot,
+                &type_manager,
+                &thing_manager,
+                OwnsAnnotation::Cardinality(AnnotationCardinality::new(0, None)),
+            )
+            .unwrap();
+        let company_owns_name = company_type
+            .set_owns(&mut snapshot, &type_manager, &thing_manager, name_type.clone(), Ordering::Unordered)
+            .unwrap();
+        company_owns_name
+            .set_annotation(
+                &mut snapshot,
+                &type_manager,
+                &thing_manager,
+                OwnsAnnotation::Cardinality(AnnotationCardinality::new(0, None)),
+            )
+            .unwrap();
+
+        let person_1 = thing_manager.create_entity(&mut snapshot, person_type.clone()).unwrap();
+        let company_1 = thing_manager.create_entity(&mut snapshot, company_type.clone()).unwrap();
+        let age_10 =
+            thing_manager.create_attribute(&mut snapshot, age_type.clone(), Value::Long(age_value_10)).unwrap();
+        let age_11 =
+            thing_manager.create_attribute(&mut snapshot, age_type.clone(), Value::Long(age_value_11)).unwrap();
+        let name_inline = thing_manager
+            .create_attribute(&mut snapshot, name_type.clone(), Value::String(Cow::Borrowed(inlineable_name)))
+            .unwrap();
+        let name_hashed = thing_manager
+            .create_attribute(&mut snapshot, name_type.clone(), Value::String(Cow::Borrowed(uninlinable_name)))
+            .unwrap();
+
+        person_1.set_has_unordered(&mut snapshot, &thing_manager, age_10.clone()).unwrap();
+        person_1.set_has_unordered(&mut snapshot, &thing_manager, age_11.clone()).unwrap();
+        person_1.set_has_unordered(&mut snapshot, &thing_manager, name_inline.clone()).unwrap();
+        person_1.set_has_unordered(&mut snapshot, &thing_manager, name_hashed.clone()).unwrap();
+
+        company_1.set_has_unordered(&mut snapshot, &thing_manager, age_10).unwrap();
+        company_1.set_has_unordered(&mut snapshot, &thing_manager, age_11).unwrap();
+        company_1.set_has_unordered(&mut snapshot, &thing_manager, name_inline).unwrap();
+        company_1.set_has_unordered(&mut snapshot, &thing_manager, name_hashed).unwrap();
+        thing_manager.finalise(&mut snapshot).unwrap();
+    }
+    snapshot.commit().unwrap();
+
+    {
+        let snapshot: ReadSnapshot<WALClient> = storage.clone().open_snapshot_read();
+        let (type_manager, thing_manager) = load_managers(storage.clone(), None);
+
+        let person_type = type_manager.get_entity_type(&snapshot, &person_label).unwrap().unwrap();
+        let company_type = type_manager.get_entity_type(&snapshot, &company_label).unwrap().unwrap();
+        let age_type = type_manager.get_attribute_type(&snapshot, &age_label).unwrap().unwrap();
+        let name_type = type_manager.get_attribute_type(&snapshot, &name_label).unwrap().unwrap();
+
+        let age_owners_start_value_inclusive = thing_manager
+            .get_has_reverse_in_range(
+                &snapshot,
+                age_type.clone(),
+                &(Bound::Included(Value::Long(age_value_10)), Bound::Unbounded),
+                &(Bound::Included(ObjectType::Entity(person_type.clone())), Bound::Unbounded),
+            )
+            .unwrap();
+        assert_eq!(age_owners_start_value_inclusive.count(), 4);
+
+        let age_owners_start_value_exclusive = thing_manager
+            .get_has_reverse_in_range(
+                &snapshot,
+                age_type.clone(),
+                &(Bound::Excluded(Value::Long(age_value_10)), Bound::Unbounded),
+                &(Bound::Included(ObjectType::Entity(person_type.clone())), Bound::Unbounded),
+            )
+            .unwrap();
+        assert_eq!(age_owners_start_value_exclusive.count(), 2);
+
+        let age_owners_start_value_inclusive_end_value_exclusive = thing_manager
+            .get_has_reverse_in_range(
+                &snapshot,
+                age_type.clone(),
+                &(Bound::Included(Value::Long(age_value_10)), Bound::Excluded(Value::Long(age_value_11))),
+                &(Bound::Included(ObjectType::Entity(person_type.clone())), Bound::Unbounded),
+            )
+            .unwrap();
+        assert_eq!(age_owners_start_value_inclusive_end_value_exclusive.count(), 2);
+
+        let age_owners_start_value_excluded_end_value_exclusive = thing_manager
+            .get_has_reverse_in_range(
+                &snapshot,
+                age_type.clone(),
+                &(Bound::Excluded(Value::Long(age_value_10)), Bound::Excluded(Value::Long(age_value_11))),
+                &(Bound::Included(ObjectType::Entity(person_type.clone())), Bound::Unbounded),
+            )
+            .unwrap();
+        assert_eq!(age_owners_start_value_excluded_end_value_exclusive.count(), 0);
+
+        let age_owners_start_value_included_start_type_excluded = thing_manager
+            .get_has_reverse_in_range(
+                &snapshot,
+                age_type.clone(),
+                &(Bound::Included(Value::Long(age_value_10)), Bound::Unbounded),
+                &(Bound::Excluded(ObjectType::Entity(person_type.clone())), Bound::Unbounded),
+            )
+            .unwrap();
+        // should skip age10-person, and return age10-company + age11-person + age11-company
+        assert_eq!(age_owners_start_value_included_start_type_excluded.count(), 3);
+
+        let age_owners_start_value_excluded_start_type_excluded = thing_manager
+            .get_has_reverse_in_range(
+                &snapshot,
+                age_type.clone(),
+                &(Bound::Excluded(Value::Long(age_value_10)), Bound::Unbounded),
+                &(Bound::Excluded(ObjectType::Entity(person_type.clone())), Bound::Unbounded),
+            )
+            .unwrap();
+        // should skip age10-person, age10-company, and the impl should be able to work out the next prefix is age(10+1)-(person+1), and return only age11-company
+        assert_eq!(age_owners_start_value_excluded_start_type_excluded.count(), 1);
+
+        let age_owners_end_value_included_end_type_excluded = thing_manager
+            .get_has_reverse_in_range(
+                &snapshot,
+                age_type.clone(),
+                &(Bound::Unbounded, Bound::Included(Value::Long(age_value_11))),
+                &(
+                    Bound::Excluded(ObjectType::Entity(person_type.clone())),
+                    Bound::Excluded(ObjectType::Entity(company_type.clone())),
+                ),
+            )
+            .unwrap();
+        // should construct open start age* (making Excluded person type irrelevant), and end before age11-company, returning only age10-person + age10-company + age11-person
+        assert_eq!(age_owners_end_value_included_end_type_excluded.count(), 3);
     }
 }
 

--- a/concept/tests/test_thing.rs
+++ b/concept/tests/test_thing.rs
@@ -307,15 +307,15 @@ fn get_has_reverse_in_range() {
             .create_attribute(&mut snapshot, name_type.clone(), Value::String(Cow::Borrowed(uninlinable_name)))
             .unwrap();
 
-        person_1.set_has_unordered(&mut snapshot, &thing_manager, age_10.clone()).unwrap();
-        person_1.set_has_unordered(&mut snapshot, &thing_manager, age_11.clone()).unwrap();
-        person_1.set_has_unordered(&mut snapshot, &thing_manager, name_inline.clone()).unwrap();
-        person_1.set_has_unordered(&mut snapshot, &thing_manager, name_hashed.clone()).unwrap();
+        person_1.set_has_unordered(&mut snapshot, &thing_manager, &age_10).unwrap();
+        person_1.set_has_unordered(&mut snapshot, &thing_manager, &age_11).unwrap();
+        person_1.set_has_unordered(&mut snapshot, &thing_manager, &name_inline).unwrap();
+        person_1.set_has_unordered(&mut snapshot, &thing_manager, &name_hashed).unwrap();
 
-        company_1.set_has_unordered(&mut snapshot, &thing_manager, age_10).unwrap();
-        company_1.set_has_unordered(&mut snapshot, &thing_manager, age_11).unwrap();
-        company_1.set_has_unordered(&mut snapshot, &thing_manager, name_inline).unwrap();
-        company_1.set_has_unordered(&mut snapshot, &thing_manager, name_hashed).unwrap();
+        company_1.set_has_unordered(&mut snapshot, &thing_manager, &age_10).unwrap();
+        company_1.set_has_unordered(&mut snapshot, &thing_manager, &age_11).unwrap();
+        company_1.set_has_unordered(&mut snapshot, &thing_manager, &name_inline).unwrap();
+        company_1.set_has_unordered(&mut snapshot, &thing_manager, &name_hashed).unwrap();
         thing_manager.finalise(&mut snapshot).unwrap();
     }
     snapshot.commit().unwrap();

--- a/concept/thing/attribute.rs
+++ b/concept/thing/attribute.rs
@@ -47,7 +47,7 @@ pub struct Attribute {
     value: OnceLock<Arc<Value<'static>>>,
 }
 
-impl<'a> Attribute {
+impl Attribute {
     pub fn type_(&self) -> AttributeType {
         AttributeType::build_from_type_id(self.vertex.type_id_())
     }
@@ -57,10 +57,10 @@ impl<'a> Attribute {
     }
 
     pub fn get_value(
-        &'a self,
+        &self,
         snapshot: &impl ReadableSnapshot,
         thing_manager: &ThingManager,
-    ) -> Result<Value<'a>, Box<ConceptReadError>> {
+    ) -> Result<Value<'_>, Box<ConceptReadError>> {
         if self.value.get().is_none() {
             let value = thing_manager.get_attribute_value(snapshot, self)?;
             let _ = self.value.set(Arc::new(value));

--- a/concept/thing/entity.rs
+++ b/concept/thing/entity.rs
@@ -98,8 +98,9 @@ impl ThingAPI for Entity {
         snapshot: &mut impl WritableSnapshot,
         thing_manager: &ThingManager,
     ) -> Result<(), Box<ConceptWriteError>> {
-        for attr in self.get_has_unordered(snapshot, thing_manager).map_ok(|(attr, _count)| attr) {
-            thing_manager.unset_has(snapshot, self, &attr?);
+        for attr in self.get_has_unordered(snapshot, thing_manager)
+            .map_ok(|(has, _count)| has.attribute()) {
+            thing_manager.unset_has(snapshot, self, attr);
         }
 
         for owns in self.type_().get_owns(snapshot, thing_manager.type_manager())?.iter() {

--- a/concept/thing/entity.rs
+++ b/concept/thing/entity.rs
@@ -98,8 +98,7 @@ impl ThingAPI for Entity {
         snapshot: &mut impl WritableSnapshot,
         thing_manager: &ThingManager,
     ) -> Result<(), Box<ConceptWriteError>> {
-        for attr in self.get_has_unordered(snapshot, thing_manager)
-            .map_ok(|(has, _count)| has.attribute()) {
+        for attr in self.get_has_unordered(snapshot, thing_manager).map_ok(|(has, _count)| has.attribute()) {
             thing_manager.unset_has(snapshot, self, &attr?);
         }
 

--- a/concept/thing/entity.rs
+++ b/concept/thing/entity.rs
@@ -100,7 +100,7 @@ impl ThingAPI for Entity {
     ) -> Result<(), Box<ConceptWriteError>> {
         for attr in self.get_has_unordered(snapshot, thing_manager)
             .map_ok(|(has, _count)| has.attribute()) {
-            thing_manager.unset_has(snapshot, self, attr);
+            thing_manager.unset_has(snapshot, self, &attr?);
         }
 
         for owns in self.type_().get_owns(snapshot, thing_manager.type_manager())?.iter() {

--- a/concept/thing/object.rs
+++ b/concept/thing/object.rs
@@ -169,7 +169,7 @@ pub trait ObjectAPI: ThingAPI<Vertex = ObjectVertex> + Copy + fmt::Debug {
         self.get_has_types_range_unordered(
             snapshot,
             thing_manager,
-            &(Bound::<AttributeType<'b>>::Unbounded, Bound::Unbounded),
+            &(Bound::<AttributeType>::Unbounded, Bound::Unbounded),
         )
     }
 
@@ -195,9 +195,9 @@ pub trait ObjectAPI: ThingAPI<Vertex = ObjectVertex> + Copy + fmt::Debug {
         self,
         snapshot: &'m impl ReadableSnapshot,
         thing_manager: &'m ThingManager,
-        attribute_types_defining_range: impl Iterator<Item = AttributeType>,
+        attribute_type_range: &impl RangeBounds<AttributeType>,
     ) -> HasIterator {
-        thing_manager.get_has_from_thing_to_type_range_unordered(snapshot, self, attribute_types_defining_range)
+        thing_manager.get_has_from_thing_unordered(snapshot, &self, attribute_type_range)
     }
 
     fn set_has_unordered(

--- a/concept/thing/object.rs
+++ b/concept/thing/object.rs
@@ -191,10 +191,10 @@ pub trait ObjectAPI: ThingAPI<Vertex = ObjectVertex> + Copy + fmt::Debug {
         thing_manager.get_has_from_thing_to_type_ordered(snapshot, self, attribute_type)
     }
 
-    fn get_has_types_range_unordered<'m>(
+    fn get_has_types_range_unordered(
         self,
-        snapshot: &'m impl ReadableSnapshot,
-        thing_manager: &'m ThingManager,
+        snapshot: &impl ReadableSnapshot,
+        thing_manager: &ThingManager,
         attribute_type_range: &impl RangeBounds<AttributeType>,
     ) -> HasIterator {
         thing_manager.get_has_from_thing_unordered(snapshot, &self, attribute_type_range)
@@ -351,27 +351,27 @@ pub trait ObjectAPI: ThingAPI<Vertex = ObjectVertex> + Copy + fmt::Debug {
         }
     }
 
-    fn get_relations<'m>(
+    fn get_relations(
         self,
         snapshot: &impl ReadableSnapshot,
-        thing_manager: &'m ThingManager,
+        thing_manager: &ThingManager,
     ) -> impl Iterator<Item = Result<Relation, Box<ConceptReadError>>> {
         thing_manager.get_relations_player(snapshot, self)
     }
 
-    fn get_relations_by_role<'m>(
+    fn get_relations_by_role(
         self,
         snapshot: &impl ReadableSnapshot,
-        thing_manager: &'m ThingManager,
+        thing_manager: &ThingManager,
         role_type: RoleType,
     ) -> impl Iterator<Item = Result<(Relation, u64), Box<ConceptReadError>>> {
         thing_manager.get_relations_player_role(snapshot, self, role_type)
     }
 
-    fn get_relations_roles<'m>(
+    fn get_relations_roles(
         self,
-        snapshot: &'m impl ReadableSnapshot,
-        thing_manager: &'m ThingManager,
+        snapshot: &impl ReadableSnapshot,
+        thing_manager: &ThingManager,
     ) -> RelationRoleIterator {
         thing_manager.get_relations_roles(snapshot, self)
     }

--- a/concept/thing/relation.rs
+++ b/concept/thing/relation.rs
@@ -352,8 +352,7 @@ impl ThingAPI for Relation {
         snapshot: &mut impl WritableSnapshot,
         thing_manager: &ThingManager,
     ) -> Result<(), Box<ConceptWriteError>> {
-        for attr in self.get_has_unordered(snapshot, thing_manager)
-            .map_ok(|(has, _value)| has.attribute()) {
+        for attr in self.get_has_unordered(snapshot, thing_manager).map_ok(|(has, _value)| has.attribute()) {
             thing_manager.unset_has(snapshot, self, &attr?);
         }
 

--- a/concept/thing/relation.rs
+++ b/concept/thing/relation.rs
@@ -354,7 +354,7 @@ impl ThingAPI for Relation {
     ) -> Result<(), Box<ConceptWriteError>> {
         for attr in self.get_has_unordered(snapshot, thing_manager)
             .map_ok(|(has, _value)| has.attribute()) {
-            thing_manager.unset_has(snapshot, self, attr?);
+            thing_manager.unset_has(snapshot, self, &attr?);
         }
 
         for owns in self.type_().get_owns(snapshot, thing_manager.type_manager())?.iter() {

--- a/concept/thing/relation.rs
+++ b/concept/thing/relation.rs
@@ -352,8 +352,9 @@ impl ThingAPI for Relation {
         snapshot: &mut impl WritableSnapshot,
         thing_manager: &ThingManager,
     ) -> Result<(), Box<ConceptWriteError>> {
-        for attr in self.get_has_unordered(snapshot, thing_manager).map_ok(|(key, _value)| key) {
-            thing_manager.unset_has(snapshot, self, &attr?);
+        for attr in self.get_has_unordered(snapshot, thing_manager)
+            .map_ok(|(has, _value)| has.attribute()) {
+            thing_manager.unset_has(snapshot, self, attr?);
         }
 
         for owns in self.type_().get_owns(snapshot, thing_manager.type_manager())?.iter() {

--- a/concept/thing/thing_manager.rs
+++ b/concept/thing/thing_manager.rs
@@ -225,9 +225,9 @@ impl ThingManager {
         })
     }
 
-    pub fn get_attributes<'this, Snapshot: ReadableSnapshot>(
-        &'this self,
-        snapshot: &'this Snapshot,
+    pub fn get_attributes<Snapshot: ReadableSnapshot>(
+        &self,
+        snapshot: &Snapshot,
     ) -> Result<AttributeIterator<InstanceIterator<Attribute>>, Box<ConceptReadError>> {
         let has_reverse_start = ThingEdgeHasReverse::prefix_from_prefix(Prefix::VertexAttribute);
         let range = KeyRange::new_within(has_reverse_start, Prefix::VertexAttribute.fixed_width_keys());
@@ -241,9 +241,9 @@ impl ThingManager {
         ))
     }
 
-    pub fn get_attributes_in<'this>(
-        &'this self,
-        snapshot: &'this impl ReadableSnapshot,
+    pub fn get_attributes_in(
+        &self,
+        snapshot: &impl ReadableSnapshot,
         attribute_type: AttributeType,
     ) -> Result<AttributeIterator<InstanceIterator<Attribute>>, Box<ConceptReadError>> {
         let attribute_value_type =
@@ -371,11 +371,11 @@ impl ThingManager {
         Ok(Some(attribute))
     }
 
-    pub fn get_attributes_in_range<'this>(
-        &'this self,
-        snapshot: &'this impl ReadableSnapshot,
+    pub fn get_attributes_in_range<'a>(
+        &self,
+        snapshot: &impl ReadableSnapshot,
         attribute_type: AttributeType,
-        range: &'this impl RangeBounds<Value<'this>>,
+        range: &impl RangeBounds<Value<'a>>,
     ) -> Result<AttributeIterator<InstanceIterator<Attribute>>, Box<ConceptReadError>> {
         if matches!(range.start_bound(), Bound::Unbounded) && matches!(range.end_bound(), Bound::Unbounded) {
             return self.get_attributes_in(snapshot, attribute_type);
@@ -792,9 +792,9 @@ impl ThingManager {
         Ok(HasReverseIterator::new(snapshot.iterate_range(&key_range)))
     }
 
-    pub fn get_attributes_by_struct_field<'this, Snapshot: ReadableSnapshot>(
-        &'this self,
-        snapshot: &'this Snapshot,
+    pub fn get_attributes_by_struct_field<Snapshot: ReadableSnapshot>(
+        &self,
+        snapshot: &Snapshot,
         attribute_type: AttributeType,
         path_to_field: Vec<StructFieldIDUInt>,
         value: Value<'_>,
@@ -1203,9 +1203,9 @@ impl ThingManager {
         )
     }
 
-    pub(crate) fn get_indexed_players<'a>(
-        &'a self,
-        snapshot: &'a impl ReadableSnapshot,
+    pub(crate) fn get_indexed_players(
+        &self,
+        snapshot: &impl ReadableSnapshot,
         from: Object,
     ) -> IndexedPlayersIterator {
         let prefix = ThingEdgeRolePlayerIndex::prefix_from(from.vertex());

--- a/concept/thing/thing_manager.rs
+++ b/concept/thing/thing_manager.rs
@@ -5,6 +5,7 @@
  */
 
 use std::{
+    any::Any,
     borrow::Cow,
     collections::{Bound, HashMap, HashSet},
     iter::once,
@@ -12,7 +13,7 @@ use std::{
     sync::Arc,
 };
 
-use bytes::{byte_array::ByteArray, Bytes};
+use bytes::{byte_array::ByteArray, util::increment, Bytes};
 use encoding::{
     graph::{
         thing::{
@@ -25,7 +26,7 @@ use encoding::{
         },
         type_::{
             property::{TypeVertexProperty, TypeVertexPropertyEncoding},
-            vertex::{PrefixedTypeVertexEncoding, TypeVertexEncoding},
+            vertex::{PrefixedTypeVertexEncoding, TypeID, TypeVertex, TypeVertexEncoding},
         },
         Typed,
     },
@@ -47,10 +48,11 @@ use encoding::{
         value_type::{ValueType, ValueTypeCategory},
         ValueEncodable,
     },
-    AsBytes, Keyable,
+    AsBytes, Keyable, Prefixed,
 };
 use itertools::{Itertools, MinMaxResult};
-use lending_iterator::LendingIterator;
+use lending_iterator::{AsHkt};
+use primitive::either::Either;
 use resource::constants::{
     encoding::StructFieldIDUInt,
     snapshot::{BUFFER_KEY_INLINE, BUFFER_VALUE_INLINE},
@@ -133,8 +135,8 @@ impl ThingManager {
 
         let prefix = <T as ThingAPI>::prefix_for_type(thing_type);
         let storage_key_prefix = <T as ThingAPI>::Vertex::build_prefix_type(prefix, thing_type.vertex().type_id_());
-        let snapshot_iterator = snapshot
-            .iterate_range(KeyRange::new_within(RangeStart::Inclusive(storage_key_prefix), prefix.fixed_width_keys()));
+        let snapshot_iterator =
+            snapshot.iterate_range(&KeyRange::new_within(storage_key_prefix, prefix.fixed_width_keys()));
         InstanceIterator::new(snapshot_iterator)
     }
 
@@ -142,7 +144,7 @@ impl ThingManager {
         let (prefix_start, prefix_end_exclusive) = T::PREFIX_RANGE_INCLUSIVE;
         let key_start = T::Vertex::build_prefix_prefix(prefix_start);
         let key_end = T::Vertex::build_prefix_prefix(prefix_end_exclusive);
-        let snapshot_iterator = snapshot.iterate_range(KeyRange::new_variable_width(
+        let snapshot_iterator = snapshot.iterate_range(&KeyRange::new_variable_width(
             RangeStart::Inclusive(key_start),
             RangeEnd::EndPrefixInclusive(key_end),
         ));
@@ -195,10 +197,9 @@ impl ThingManager {
         player: impl ObjectAPI,
     ) -> RelationRoleIterator {
         let prefix = ThingEdgeLinks::prefix_reverse_from_player(player.vertex());
-        RelationRoleIterator::new(snapshot.iterate_range(KeyRange::new_within(
-            RangeStart::Inclusive(prefix),
-            ThingEdgeLinks::FIXED_WIDTH_ENCODING_REVERSE,
-        )))
+        RelationRoleIterator::new(
+            snapshot.iterate_range(&KeyRange::new_within(prefix, ThingEdgeLinks::FIXED_WIDTH_ENCODING_REVERSE)),
+        )
     }
 
     pub(crate) fn get_relations_player(
@@ -229,10 +230,9 @@ impl ThingManager {
         snapshot: &'this Snapshot,
     ) -> Result<AttributeIterator<InstanceIterator<Attribute>>, Box<ConceptReadError>> {
         let has_reverse_start = ThingEdgeHasReverse::prefix_from_prefix(Prefix::VertexAttribute);
-        let range =
-            KeyRange::new_within(RangeStart::Inclusive(has_reverse_start), Prefix::VertexAttribute.fixed_width_keys());
-        let has_reverse_iterator_buffer = snapshot.iterate_writes_range(range.clone());
-        let has_reverse_iterator_storage = snapshot.iterate_storage_range(range);
+        let range = KeyRange::new_within(has_reverse_start, Prefix::VertexAttribute.fixed_width_keys());
+        let has_reverse_iterator_buffer = snapshot.iterate_writes_range(&range);
+        let has_reverse_iterator_storage = snapshot.iterate_storage_range(&range);
         Ok(AttributeIterator::new(
             self.get_instances::<Attribute>(snapshot),
             has_reverse_iterator_buffer,
@@ -253,10 +253,9 @@ impl ThingManager {
         };
 
         let has_reverse_prefix = ThingEdgeHasReverse::prefix_from_attribute_type(attribute_type.vertex().type_id_());
-        let range =
-            KeyRange::new_within(RangeStart::Inclusive(has_reverse_prefix), ThingEdgeHasReverse::FIXED_WIDTH_ENCODING);
-        let has_reverse_iterator_buffer = snapshot.iterate_writes_range(range.clone());
-        let has_reverse_iterator_storage = snapshot.iterate_storage_range(range);
+        let range = KeyRange::new_within(has_reverse_prefix, ThingEdgeHasReverse::FIXED_WIDTH_ENCODING);
+        let has_reverse_iterator_buffer = snapshot.iterate_writes_range(&range);
+        let has_reverse_iterator_storage = snapshot.iterate_storage_range(&range);
 
         Ok(AttributeIterator::new(
             self.get_instances_in(snapshot, attribute_type),
@@ -376,7 +375,7 @@ impl ThingManager {
         &'this self,
         snapshot: &'this impl ReadableSnapshot,
         attribute_type: AttributeType,
-        range: &impl RangeBounds<Value<'this>>,
+        range: &'this impl RangeBounds<Value<'this>>,
     ) -> Result<AttributeIterator<InstanceIterator<Attribute>>, Box<ConceptReadError>> {
         if matches!(range.start_bound(), Bound::Unbounded) && matches!(range.end_bound(), Bound::Unbounded) {
             return self.get_attributes_in(snapshot, attribute_type);
@@ -386,27 +385,66 @@ impl ThingManager {
             return Ok(AttributeIterator::new_empty());
         };
 
-        let Some((range_start, range_end)) = Self::get_value_range(attribute_value_type, range, |value| {
-            AttributeVertex::build_prefix_for_value(
-                attribute_type.vertex().type_id_(),
-                value,
-                self.vertex_generator.hasher(),
-            )
-        })?
-        else {
+        let Some((value_lower_bound, value_upper_bound)) = Self::get_value_range(attribute_value_type, range)? else {
             return Ok(AttributeIterator::new_empty());
         };
-        let key_range_start = match range_start {
-            Bound::Included(start) => RangeStart::Inclusive(start),
-            Bound::Excluded(start) => RangeStart::Exclusive(start),
+
+        let start_attribute_vertex_prefix_range = match value_lower_bound {
+            Bound::Included(lower_value) => {
+                let vertex_or_prefix = AttributeVertex::build_or_prefix_for_value(
+                    attribute_type.vertex().type_id_(),
+                    lower_value,
+                    self.vertex_generator.hasher(),
+                );
+                let storage_key_prefix = match vertex_or_prefix {
+                    Either::First(vertex) => vertex.into_storage_key(),
+                    Either::Second(incomplete_attribute_prefix) => incomplete_attribute_prefix,
+                };
+                RangeStart::Inclusive(storage_key_prefix)
+            }
+            Bound::Excluded(lower_value) => {
+                let vertex_or_prefix = AttributeVertex::build_or_prefix_for_value(
+                    attribute_type.vertex().type_id_(),
+                    lower_value,
+                    self.vertex_generator.hasher(),
+                );
+                let storage_key_prefix = match vertex_or_prefix {
+                    Either::First(vertex) => vertex.into_storage_key(),
+                    Either::Second(incomplete_attribute_prefix) => incomplete_attribute_prefix,
+                };
+                RangeStart::ExcludePrefix(storage_key_prefix)
+            }
             Bound::Unbounded => RangeStart::Inclusive(
                 AttributeVertex::build_prefix_type(AttributeVertex::PREFIX, attribute_type.vertex().type_id_())
-                    .resize_to::<BUFFER_KEY_INLINE>(),
+                    .resize_to(),
             ),
         };
-        let key_range_end = match range_end {
-            Bound::Included(end) => RangeEnd::EndPrefixInclusive(end),
-            Bound::Excluded(end) => RangeEnd::EndPrefixExclusive(end),
+
+        let end_attribute_vertex_prefix_range = match value_upper_bound {
+            Bound::Included(upper_value) => {
+                let vertex_or_prefix = AttributeVertex::build_or_prefix_for_value(
+                    attribute_type.vertex().type_id_(),
+                    upper_value,
+                    self.vertex_generator.hasher(),
+                );
+                let storage_key_prefix = match vertex_or_prefix {
+                    Either::First(vertex) => vertex.into_storage_key(),
+                    Either::Second(incomplete_attribute_prefix) => incomplete_attribute_prefix,
+                };
+                RangeEnd::EndPrefixInclusive(storage_key_prefix)
+            }
+            Bound::Excluded(upper_value) => {
+                let vertex_or_prefix = AttributeVertex::build_or_prefix_for_value(
+                    attribute_type.vertex().type_id_(),
+                    upper_value,
+                    self.vertex_generator.hasher(),
+                );
+                let storage_key_prefix = match vertex_or_prefix {
+                    Either::First(vertex) => vertex.into_storage_key(),
+                    Either::Second(incomplete_attribute_prefix) => incomplete_attribute_prefix,
+                };
+                RangeEnd::EndPrefixExclusive(storage_key_prefix)
+            }
             Bound::Unbounded => {
                 let prefix =
                     AttributeVertex::build_prefix_type(AttributeVertex::PREFIX, attribute_type.vertex().type_id_());
@@ -414,33 +452,23 @@ impl ThingManager {
                 let mut array = prefix.into_bytes().into_array();
                 array.increment().unwrap();
                 let prefix_key = StorageKey::Array(StorageKeyArray::new_raw(keyspace, array));
-                RangeEnd::EndPrefixExclusive(prefix_key.resize_to::<BUFFER_KEY_INLINE>())
+                RangeEnd::EndPrefixExclusive(prefix_key.resize_to())
             }
         };
 
         let has_reverse_start_prefix = ThingEdgeHasReverse::prefix_from_attribute_vertex_prefix(
-            key_range_start.get_value().as_reference().bytes(),
+            start_attribute_vertex_prefix_range.get_value().as_reference().bytes(),
         );
-        let has_reverse_end_prefix = match &key_range_end {
-            RangeEnd::WithinStartAsPrefix => unreachable!(),
-            RangeEnd::EndPrefixInclusive(end) => RangeEnd::EndPrefixInclusive(
-                ThingEdgeHasReverse::prefix_from_attribute_vertex_prefix(end.as_reference().bytes()),
-            ),
-            RangeEnd::EndPrefixExclusive(end) => RangeEnd::EndPrefixExclusive(
-                ThingEdgeHasReverse::prefix_from_attribute_vertex_prefix(end.as_reference().bytes()),
-            ),
-            RangeEnd::Unbounded => {
-                // we don't have to bound this since it will only be consumed while the Attributes are read
-                RangeEnd::Unbounded
-            }
-        };
+        let has_reverse_end_prefix = end_attribute_vertex_prefix_range
+            .map(|end| ThingEdgeHasReverse::prefix_from_attribute_vertex_prefix(end.as_reference().bytes()));
         let has_reverse_range =
             KeyRange::new_variable_width(RangeStart::Inclusive(has_reverse_start_prefix), has_reverse_end_prefix);
-        let has_reverse_iterator_buffer = snapshot.iterate_writes_range(has_reverse_range.clone());
-        let has_reverse_iterator_storage = snapshot.iterate_storage_range(has_reverse_range);
+        let has_reverse_iterator_buffer = snapshot.iterate_writes_range(&has_reverse_range);
+        let has_reverse_iterator_storage = snapshot.iterate_storage_range(&has_reverse_range);
 
-        let range = KeyRange::new_variable_width(key_range_start, key_range_end);
-        let snapshot_iterator = snapshot.iterate_range(range);
+        let range =
+            KeyRange::new_variable_width(start_attribute_vertex_prefix_range, end_attribute_vertex_prefix_range);
+        let snapshot_iterator = snapshot.iterate_range(&range);
         let attributes_iterator = InstanceIterator::new(snapshot_iterator);
         Ok(AttributeIterator::new(
             attributes_iterator,
@@ -450,14 +478,10 @@ impl ThingManager {
         ))
     }
 
-    fn get_value_range<'a, PrefixFn, Key>(
+    fn get_value_range<'a>(
         expected_value_type: ValueType,
-        range: &impl RangeBounds<Value<'a>>,
-        prefix_constructor: PrefixFn,
-    ) -> Result<Option<(Bound<Key>, Bound<Key>)>, Box<ConceptReadError>>
-    where
-        PrefixFn: for<'b> Fn(Value<'b>) -> Key,
-    {
+        range: &'a impl RangeBounds<Value<'a>>,
+    ) -> Result<Option<(Bound<Value<'a>>, Bound<Value<'a>>)>, Box<ConceptReadError>> {
         fn get_value_type(bound: Bound<&Value<'_>>) -> Option<ValueType> {
             match bound {
                 Bound::Included(value) | Bound::Excluded(value) => Some(value.value_type()),
@@ -473,23 +497,21 @@ impl ThingManager {
         }
         let value_type = expected_value_type;
 
-        let range_start = range.start_bound().map(|value| {
-            let value = if value_type != range_value_type {
+        let start_value_lower_bound = range.start_bound().map(|value| {
+            if value_type != range_value_type {
                 value.as_reference().approximate_cast_lower_bound(&value_type).unwrap()
             } else {
                 value.as_reference()
-            };
-            prefix_constructor(value)
+            }
         });
-        let range_end = range.end_bound().map(|value| {
-            let value = if value_type != range_value_type {
+        let end_value_upper_bound = range.end_bound().map(|value| {
+            if value_type != range_value_type {
                 value.as_reference().approximate_cast_upper_bound(&value_type).unwrap()
             } else {
                 value.as_reference()
-            };
-            prefix_constructor(value)
+            }
         });
-        Ok(Some((range_start, range_end)))
+        Ok(Some((start_value_lower_bound, end_value_upper_bound)))
     }
 
     fn get_attribute_with_value_inline(
@@ -558,14 +580,35 @@ impl ThingManager {
         Ok(has_exists)
     }
 
-    pub fn get_has_from_owner_type_range_unordered(
+    pub fn get_has_from_owner_type_range_unordered<'a>(
         &self,
         snapshot: &impl ReadableSnapshot,
-        owner_type_range: KeyRange<ObjectType>,
+        owner_type_range: &impl RangeBounds<ObjectType>,
     ) -> HasIterator {
-        let range = owner_type_range
-            .map(|type_| ThingEdgeHas::prefix_from_type(type_.into_vertex()), |_| ThingEdgeHas::FIXED_WIDTH_ENCODING);
-        HasIterator::new(snapshot.iterate_range(range))
+        let range_start = match owner_type_range.start_bound() {
+            Bound::Included(start_type) => RangeStart::Inclusive(ThingEdgeHas::prefix_from_type(start_type.vertex())),
+            Bound::Excluded(start_type) => {
+                RangeStart::ExcludePrefix(ThingEdgeHas::prefix_from_type(start_type.vertex()))
+            }
+            Bound::Unbounded => RangeStart::Inclusive(ThingEdgeHas::prefix_from_type_parts(
+                Prefix::min_object_type_prefix(),
+                TypeID::MIN,
+            )),
+        };
+        let range_end = match owner_type_range.end_bound() {
+            Bound::Included(end_type) => {
+                RangeEnd::EndPrefixInclusive(ThingEdgeHas::prefix_from_type(end_type.vertex()))
+            }
+            Bound::Excluded(end_type) => {
+                RangeEnd::EndPrefixExclusive(ThingEdgeHas::prefix_from_type(end_type.vertex()))
+            }
+            Bound::Unbounded => RangeEnd::EndPrefixInclusive(ThingEdgeHas::prefix_from_type_parts(
+                Prefix::max_object_type_prefix(),
+                TypeID::MAX,
+            )),
+        };
+        let key_range = KeyRange::new(range_start, range_end, ThingEdgeHas::FIXED_WIDTH_ENCODING);
+        HasIterator::new(snapshot.iterate_range(&key_range))
     }
 
     pub fn get_has_reverse(
@@ -574,15 +617,22 @@ impl ThingManager {
         attribute_type: AttributeType,
     ) -> Result<HasReverseIterator, Box<ConceptReadError>> {
         let prefix = ThingEdgeHasReverse::prefix_from_attribute_type(attribute_type.vertex().type_id_());
-        let range = KeyRange::new_within(RangeStart::Inclusive(prefix), ThingEdgeHasReverse::FIXED_WIDTH_ENCODING);
-        Ok(HasReverseIterator::new(snapshot.iterate_range(range)))
+        let range = KeyRange::new_within(prefix, ThingEdgeHasReverse::FIXED_WIDTH_ENCODING);
+        Ok(HasReverseIterator::new(snapshot.iterate_range(&range)))
     }
 
+    /// Given an attribute type, and a range of values, return an iterator of Has where the owners satisfy this range (best effort)
+    /// For inlineable values, this range will be fully respected, and for large values, it is an approximation and should still be checked afterward
+    /// The Owner types range hint is useful in particular when 1 Inlinable Value is provided, allowing constructing the exact
+    /// range [att type][att vertex][start owner type] --> [att type][att vertex][end owner type]
+    /// However, it is in general only a hint used to constrain the start prefix and end of the range. When multiple values are matched,
+    /// the Has's returned will likely contain Owner types _not_ in the indicated range.
     pub fn get_has_reverse_in_range<'a>(
         &self,
         snapshot: &impl ReadableSnapshot,
         attribute_type: AttributeType,
-        range: &impl RangeBounds<Value<'a>>,
+        range: &'a impl RangeBounds<Value<'a>>,
+        owner_types_range_hint: &impl RangeBounds<ObjectType>,
     ) -> Result<HasReverseIterator, Box<ConceptReadError>> {
         if matches!(range.start_bound(), Bound::Unbounded) && matches!(range.end_bound(), Bound::Unbounded) {
             return self.get_has_reverse(snapshot, attribute_type);
@@ -592,46 +642,156 @@ impl ThingManager {
             return Ok(HasReverseIterator::new_empty());
         };
 
-        let Some((range_start, range_end)) = Self::get_value_range(attribute_value_type, range, |value| {
-            let attribute_vertex_prefix = AttributeVertex::build_prefix_for_value(
-                attribute_type.vertex().type_id_(),
-                value,
-                self.vertex_generator.hasher(),
-            );
-            ThingEdgeHasReverse::prefix_from_attribute_vertex_prefix(attribute_vertex_prefix.as_reference().bytes())
-        })?
-        else {
+        let Some((value_lower_bound, value_upper_bound)) = Self::get_value_range(attribute_value_type, range)? else {
             return Ok(HasReverseIterator::new_empty());
         };
 
-        let key_range_start = match range_start {
-            Bound::Included(start) => RangeStart::Inclusive(start),
-            Bound::Excluded(start) => RangeStart::Exclusive(start),
+        let has_range_start = match value_lower_bound {
+            Bound::Included(lower_value) => {
+                let vertex_or_prefix = AttributeVertex::build_or_prefix_for_value(
+                    attribute_type.vertex().type_id_(),
+                    lower_value,
+                    self.vertex_generator.hasher(),
+                );
+                match vertex_or_prefix {
+                    Either::First(vertex) => {
+                        match owner_types_range_hint.start_bound() {
+                            Bound::Included(start) => {
+                                let start_type = start.vertex();
+                                RangeStart::Inclusive(ThingEdgeHasReverse::prefix_from_attribute_to_type(
+                                    vertex, start_type,
+                                ))
+                            }
+                            Bound::Excluded(start) => {
+                                // increment and treat as included
+                                let mut bytes: [u8; TypeVertex::LENGTH] =
+                                    start.vertex().bytes().bytes().try_into().unwrap();
+                                increment(&mut bytes).unwrap();
+                                let start_type = TypeVertex::new(Bytes::Array(ByteArray::copy(&bytes)));
+                                RangeStart::Inclusive(ThingEdgeHasReverse::prefix_from_attribute_to_type(
+                                    vertex, start_type,
+                                ))
+                            }
+                            Bound::Unbounded => {
+                                RangeStart::Inclusive(ThingEdgeHasReverse::prefix_from_attribute(vertex).resize_to())
+                            }
+                        }
+                    }
+                    Either::Second(prefix) => {
+                        // attribute vertex could not be built fully, probably due to not being an inline-valued attribute
+                        RangeStart::Inclusive(
+                            ThingEdgeHasReverse::prefix_from_attribute_vertex_prefix(prefix.as_reference().byte_ref())
+                                .resize_to(),
+                        )
+                    }
+                }
+            }
+            Bound::Excluded(lower_value) => {
+                let vertex_or_prefix = AttributeVertex::build_or_prefix_for_value(
+                    attribute_type.vertex().type_id_(),
+                    lower_value,
+                    self.vertex_generator.hasher(),
+                );
+                match vertex_or_prefix {
+                    Either::First(vertex) => {
+                        // trick: increment the vertex, since it is complete, then concat the next type - this will help
+                        // with hitting the bloom filters
+                        let storage_key = vertex.into_storage_key();
+                        let mut byte_array = storage_key.into_owned_array().into_byte_array();
+                        byte_array.increment().unwrap();
+                        let next_attribute = AttributeVertex::new(Bytes::Array(byte_array));
+                        match owner_types_range_hint.start_bound() {
+                            Bound::Included(start) => {
+                                let start_type = start.vertex();
+                                RangeStart::Inclusive(ThingEdgeHasReverse::prefix_from_attribute_to_type(
+                                    next_attribute,
+                                    start_type,
+                                ))
+                            }
+                            Bound::Excluded(start) => {
+                                // increment and treat as included
+                                let mut bytes: [u8; TypeVertex::LENGTH] =
+                                    start.vertex().bytes().bytes().try_into().unwrap();
+                                increment(&mut bytes).unwrap();
+                                let start_type = TypeVertex::new(Bytes::Array(ByteArray::copy(&bytes)));
+                                RangeStart::Inclusive(ThingEdgeHasReverse::prefix_from_attribute_to_type(
+                                    next_attribute,
+                                    start_type,
+                                ))
+                            }
+                            Bound::Unbounded => RangeStart::Inclusive(
+                                ThingEdgeHasReverse::prefix_from_attribute(next_attribute).resize_to(),
+                            ),
+                        }
+                    }
+                    Either::Second(prefix) => {
+                        // since this is not a complete vertex, and only a prefix, we shouldn't make assumptions about incrementing
+                        // to get to value + 1 in sort order
+                        RangeStart::Inclusive(
+                            ThingEdgeHasReverse::prefix_from_attribute_vertex_prefix(prefix.as_reference().byte_ref())
+                                .resize_to(),
+                        )
+                    }
+                }
+            }
             Bound::Unbounded => RangeStart::Inclusive(
-                ThingEdgeHasReverse::prefix_from_attribute_type(attribute_type.vertex().type_id_())
-                    .resize_to::<{ ThingEdgeHasReverse::LENGTH_BOUND_PREFIX_FROM }>(),
+                ThingEdgeHasReverse::prefix_from_attribute_type(attribute_type.vertex().type_id_()).resize_to(),
             ),
         };
-        let key_range_end = match range_end {
-            Bound::Included(end) => RangeEnd::EndPrefixInclusive(end),
-            Bound::Excluded(end) => RangeEnd::EndPrefixExclusive(end),
-            Bound::Unbounded => {
-                let prefix = ThingEdgeHasReverse::prefix_from_attribute_type(attribute_type.vertex().type_id_());
-                let keyspace = prefix.keyspace_id();
-                let mut array = prefix.into_bytes().into_array();
-                array.increment().unwrap();
-                let prefix_key = StorageKey::Array(StorageKeyArray::new_raw(keyspace, array));
-                RangeEnd::EndPrefixExclusive(
-                    prefix_key.resize_to::<{ ThingEdgeHasReverse::LENGTH_BOUND_PREFIX_FROM }>(),
-                )
+
+        let has_range_end = match value_upper_bound {
+            Bound::Included(upper_value) => {
+                let vertex_or_prefix = AttributeVertex::build_or_prefix_for_value(
+                    attribute_type.vertex().type_id_(),
+                    upper_value,
+                    self.vertex_generator.hasher(),
+                );
+                match vertex_or_prefix {
+                    Either::First(vertex) => match owner_types_range_hint.end_bound() {
+                        Bound::Included(end) => {
+                            let end_type = end.vertex();
+                            RangeEnd::EndPrefixInclusive(ThingEdgeHasReverse::prefix_from_attribute_to_type(
+                                vertex, end_type,
+                            ))
+                        }
+                        Bound::Excluded(end) => {
+                            let end_type = end.vertex();
+                            RangeEnd::EndPrefixExclusive(ThingEdgeHasReverse::prefix_from_attribute_to_type(
+                                vertex, end_type,
+                            ))
+                        }
+                        Bound::Unbounded => {
+                            RangeEnd::EndPrefixInclusive(ThingEdgeHasReverse::prefix_from_attribute(vertex).resize_to())
+                        }
+                    },
+                    Either::Second(prefix) => RangeEnd::EndPrefixInclusive(
+                        ThingEdgeHasReverse::prefix_from_attribute_vertex_prefix(prefix.as_reference().byte_ref())
+                            .resize_to(),
+                    ),
+                }
             }
+            Bound::Excluded(upper_value) => {
+                let vertex_or_prefix = AttributeVertex::build_or_prefix_for_value(
+                    attribute_type.vertex().type_id_(),
+                    upper_value,
+                    self.vertex_generator.hasher(),
+                );
+                match vertex_or_prefix {
+                    Either::First(vertex) => {
+                        RangeEnd::EndPrefixExclusive(ThingEdgeHasReverse::prefix_from_attribute(vertex).resize_to())
+                    }
+                    Either::Second(prefix) => RangeEnd::EndPrefixExclusive(
+                        ThingEdgeHasReverse::prefix_from_attribute_vertex_prefix(prefix.as_reference().byte_ref())
+                            .resize_to(),
+                    ),
+                }
+            }
+            Bound::Unbounded => RangeEnd::EndPrefixInclusive(
+                ThingEdgeHasReverse::prefix_from_attribute_type(attribute_type.vertex().type_id_()).resize_to(),
+            ),
         };
-        let key_range = if ThingEdgeHasReverse::FIXED_WIDTH_ENCODING {
-            KeyRange::new_fixed_width(key_range_start, key_range_end)
-        } else {
-            KeyRange::new_variable_width(key_range_start, key_range_end)
-        };
-        Ok(HasReverseIterator::new(snapshot.iterate_range(key_range)))
+        let key_range = KeyRange::new(has_range_start, has_range_end, ThingEdgeHasReverse::FIXED_WIDTH_ENCODING);
+        Ok(HasReverseIterator::new(snapshot.iterate_range(&key_range)))
     }
 
     pub fn get_attributes_by_struct_field<'this, Snapshot: ReadableSnapshot>(
@@ -656,10 +816,7 @@ impl ThingManager {
         )
         .map_err(|source| Box::new(ConceptReadError::SnapshotIterate { source }))?;
         let index_attribute_iterator = snapshot
-            .iterate_range(KeyRange::new_within(
-                RangeStart::Inclusive(prefix),
-                Prefix::IndexValueToStruct.fixed_width_keys(),
-            ))
+            .iterate_range(&KeyRange::new_within(prefix, Prefix::IndexValueToStruct.fixed_width_keys()))
             .map_static::<Result<Attribute, _>, _>(|result| {
                 result
                     .map(|(key, _)| {
@@ -672,10 +829,9 @@ impl ThingManager {
             .into_iter();
 
         let has_reverse_prefix = ThingEdgeHasReverse::prefix_from_attribute_type(attribute_type.vertex().type_id_());
-        let range =
-            KeyRange::new_within(RangeStart::Inclusive(has_reverse_prefix), ThingEdgeHasReverse::FIXED_WIDTH_ENCODING);
-        let has_reverse_iterator_buffer = snapshot.iterate_writes_range(range.clone());
-        let has_reverse_iterator_storage = snapshot.iterate_storage_range(range);
+        let range = KeyRange::new_within(has_reverse_prefix, ThingEdgeHasReverse::FIXED_WIDTH_ENCODING);
+        let has_reverse_iterator_buffer = snapshot.iterate_writes_range(&range);
+        let has_reverse_iterator_storage = snapshot.iterate_storage_range(&range);
 
         let iter = AttributeIterator::new(
             index_attribute_iterator,
@@ -686,16 +842,39 @@ impl ThingManager {
         Ok(iter)
     }
 
-    pub(crate) fn get_has_from_thing_unordered(
-        &self,
-        snapshot: &impl ReadableSnapshot,
-        owner: impl ObjectAPI,
-    ) -> HasAttributeIterator {
-        let prefix = ThingEdgeHas::prefix_from_object(owner.vertex());
-        HasAttributeIterator::new(
-            snapshot
-                .iterate_range(KeyRange::new_within(RangeStart::Inclusive(prefix), ThingEdgeHas::FIXED_WIDTH_ENCODING)),
-        )
+    pub(crate) fn get_has_from_thing_unordered<'this, 'snapshot>(
+        &'this self,
+        snapshot: &'snapshot impl ReadableSnapshot,
+        owner: &'this impl ObjectAPI,
+        attribute_type_range_hint: &'this impl RangeBounds<AttributeType>,
+    ) -> HasIterator {
+        let range_start = match attribute_type_range_hint.start_bound() {
+            Bound::Included(attribute_type) => RangeStart::Inclusive(ThingEdgeHas::prefix_from_object_to_type(
+                owner.vertex(),
+                attribute_type.vertex().type_id_(),
+            )),
+            Bound::Excluded(attribute_type) => RangeStart::ExcludePrefix(ThingEdgeHas::prefix_from_object_to_type(
+                owner.vertex(),
+                attribute_type.vertex().type_id_(),
+            )),
+            Bound::Unbounded => {
+                RangeStart::Inclusive(ThingEdgeHas::prefix_from_object_to_type(owner.vertex(), TypeID::MIN))
+            }
+        };
+        let range_end =
+            match attribute_type_range_hint.end_bound() {
+                Bound::Included(attribute_type) => RangeEnd::EndPrefixInclusive(
+                    ThingEdgeHas::prefix_from_object_to_type(owner.vertex(), attribute_type.vertex().type_id_()),
+                ),
+                Bound::Excluded(attribute_type) => RangeEnd::EndPrefixExclusive(
+                    ThingEdgeHas::prefix_from_object_to_type(owner.vertex(), attribute_type.vertex().type_id_()),
+                ),
+                Bound::Unbounded => {
+                    RangeEnd::EndPrefixInclusive(ThingEdgeHas::prefix_from_object_to_type(owner.vertex(), TypeID::MAX))
+                }
+            };
+        let key_range = KeyRange::new(range_start, range_end, ThingEdgeHas::FIXED_WIDTH_ENCODING);
+        HasIterator::new(snapshot.iterate_range(&key_range))
     }
 
     pub(crate) fn get_has_from_thing_to_type_unordered(
@@ -706,8 +885,7 @@ impl ThingManager {
     ) -> HasAttributeIterator {
         let prefix = ThingEdgeHas::prefix_from_object_to_type(owner.vertex(), attribute_type.vertex().type_id_());
         HasAttributeIterator::new(
-            snapshot
-                .iterate_range(KeyRange::new_within(RangeStart::Inclusive(prefix), ThingEdgeHas::FIXED_WIDTH_ENCODING)),
+            snapshot.iterate_range(&KeyRange::new_within(prefix, ThingEdgeHas::FIXED_WIDTH_ENCODING)),
         )
     }
 
@@ -734,36 +912,15 @@ impl ThingManager {
         Ok(attributes)
     }
 
-    pub(crate) fn get_has_from_thing_to_type_range_unordered(
+    pub(crate) fn get_owners(
         &self,
         snapshot: &impl ReadableSnapshot,
-        owner: impl ObjectAPI,
-        attribute_types: impl Iterator<Item = AttributeType>,
-    ) -> Result<HasIterator, Box<ConceptReadError>> {
-        let (min_type_id, max_type_id) = match attribute_types.minmax() {
-            MinMaxResult::NoElements => unreachable!(),
-            MinMaxResult::OneElement(type_) => (type_.vertex().type_id_(), type_.vertex().type_id_()),
-            MinMaxResult::MinMax(min, max) => (min.vertex().type_id_(), max.vertex().type_id_()),
-        };
-        let min_edge_prefix = ThingEdgeHas::prefix_from_object_to_type(owner.vertex(), min_type_id);
-        let max_edge_prefix = ThingEdgeHas::prefix_from_object_to_type(owner.vertex(), max_type_id);
-        let range = if min_edge_prefix != max_edge_prefix {
-            KeyRange::new_variable_width(
-                RangeStart::Inclusive(min_edge_prefix),
-                RangeEnd::EndPrefixInclusive(max_edge_prefix),
-            )
-        } else {
-            KeyRange::new_within(RangeStart::Inclusive(min_edge_prefix), ThingEdgeHas::FIXED_WIDTH_ENCODING)
-        };
-        Ok(HasIterator::new(snapshot.iterate_range(range)))
-    }
-
-    pub(crate) fn get_owners(&self, snapshot: &impl ReadableSnapshot, attribute: &Attribute) -> AttributeOwnerIterator {
-        let prefix = ThingEdgeHasReverse::prefix_from_attribute(attribute.vertex());
-        AttributeOwnerIterator::new(snapshot.iterate_range(KeyRange::new_within(
-            RangeStart::Inclusive(prefix),
-            ThingEdgeHasReverse::FIXED_WIDTH_ENCODING,
-        )))
+        attribute: Attribute<'_>,
+    ) -> AttributeOwnerIterator {
+        let prefix = ThingEdgeHasReverse::prefix_from_attribute(attribute.into_vertex());
+        AttributeOwnerIterator::new(
+            snapshot.iterate_range(&KeyRange::new_within(prefix, ThingEdgeHasReverse::FIXED_WIDTH_ENCODING)),
+        )
     }
 
     pub(crate) fn get_owners_by_type(
@@ -773,24 +930,46 @@ impl ThingManager {
         owner_type: impl ObjectTypeAPI,
     ) -> AttributeOwnerIterator {
         let prefix = ThingEdgeHasReverse::prefix_from_attribute_to_type(attribute.vertex(), owner_type.vertex());
-        AttributeOwnerIterator::new(snapshot.iterate_range(KeyRange::new_within(
-            RangeStart::Inclusive(prefix),
-            ThingEdgeHasReverse::FIXED_WIDTH_ENCODING,
-        )))
+        AttributeOwnerIterator::new(
+            snapshot.iterate_range(&KeyRange::new_within(prefix, ThingEdgeHasReverse::FIXED_WIDTH_ENCODING)),
+        )
     }
 
-    pub fn get_has_reverse_by_attribute_and_owner_type_range(
+    pub fn get_has_reverse_by_attribute_and_owner_type_range<'a>(
         &self,
         snapshot: &impl ReadableSnapshot,
-        attribute: &Attribute,
-        owner_type_range: KeyRange<ObjectType>,
+        attribute: Attribute<'_>,
+        owner_type_range: &'a impl RangeBounds<ObjectType<'a>>,
     ) -> HasReverseIterator {
-        let prefix = ThingEdgeHasReverse::prefix_from_attribute_to_type_range(
-            attribute.vertex(),
-            owner_type_range.start().get_value().vertex(),
-            (*owner_type_range.end()).map(|object_type| object_type.into_vertex()),
-        );
-        HasReverseIterator::new(snapshot.iterate_range(prefix))
+        let range_start = match owner_type_range.start_bound() {
+            Bound::Included(owner_start) => RangeStart::Inclusive(ThingEdgeHasReverse::prefix_from_attribute_to_type(
+                attribute.vertex(),
+                owner_start.vertex(),
+            )),
+            Bound::Excluded(owner_start) => RangeStart::ExcludePrefix(
+                ThingEdgeHasReverse::prefix_from_attribute_to_type(attribute.vertex(), owner_start.vertex()),
+            ),
+            Bound::Unbounded => RangeStart::Inclusive(ThingEdgeHasReverse::prefix_from_attribute_to_type_parts(
+                attribute.vertex(),
+                Prefix::min_object_type_prefix(),
+                TypeID::MIN,
+            )),
+        };
+        let range_end = match owner_type_range.end_bound() {
+            Bound::Included(owner_end) => RangeEnd::EndPrefixInclusive(
+                ThingEdgeHasReverse::prefix_from_attribute_to_type(attribute.vertex(), owner_end.vertex()),
+            ),
+            Bound::Excluded(owner_end) => RangeEnd::EndPrefixExclusive(
+                ThingEdgeHasReverse::prefix_from_attribute_to_type(attribute.vertex(), owner_end.vertex()),
+            ),
+            Bound::Unbounded => RangeEnd::EndPrefixInclusive(ThingEdgeHasReverse::prefix_from_attribute_to_type_parts(
+                attribute.vertex(),
+                Prefix::max_object_type_prefix(),
+                TypeID::MAX,
+            )),
+        };
+        let key_range = KeyRange::new(range_start, range_end, ThingEdgeHasReverse::FIXED_WIDTH_ENCODING);
+        HasReverseIterator::new(snapshot.iterate_range(&key_range))
     }
 
     pub(crate) fn has_owners(
@@ -800,10 +979,7 @@ impl ThingManager {
         buffered_only: bool,
     ) -> bool {
         let prefix = ThingEdgeHasReverse::prefix_from_attribute(attribute.vertex());
-        snapshot.any_in_range(
-            KeyRange::new_within(RangeStart::Inclusive(prefix), ThingEdgeHasReverse::FIXED_WIDTH_ENCODING),
-            buffered_only,
-        )
+        snapshot.any_in_range(&KeyRange::new_within(prefix, ThingEdgeHasReverse::FIXED_WIDTH_ENCODING), buffered_only)
     }
 
     pub(crate) fn has_links(
@@ -813,35 +989,75 @@ impl ThingManager {
         buffered_only: bool, // FIXME use enums
     ) -> bool {
         let prefix = ThingEdgeLinks::prefix_from_relation(relation.vertex());
-        snapshot.any_in_range(
-            KeyRange::new_within(RangeStart::Inclusive(prefix), ThingEdgeLinks::FIXED_WIDTH_ENCODING),
-            buffered_only,
-        )
+        snapshot.any_in_range(&KeyRange::new_within(prefix, ThingEdgeLinks::FIXED_WIDTH_ENCODING), buffered_only)
     }
 
     pub fn get_links_by_relation_type_range(
         &self,
         snapshot: &impl ReadableSnapshot,
-        relation_type_range: KeyRange<RelationType>,
+        relation_type_range: &impl RangeBounds<RelationType>,
     ) -> LinksIterator {
-        let range = relation_type_range.map(
-            |type_| ThingEdgeLinks::prefix_from_relation_type(type_.into_vertex()),
-            |_| ThingEdgeLinks::FIXED_WIDTH_ENCODING,
-        );
-        LinksIterator::new(snapshot.iterate_range(range))
+        let range_start = match relation_type_range.start_bound() {
+            Bound::Included(start_type) => {
+                RangeStart::Inclusive(ThingEdgeLinks::prefix_from_relation_type(start_type.vertex().type_id_()))
+            }
+            Bound::Excluded(start_type) => {
+                RangeStart::ExcludePrefix(ThingEdgeLinks::prefix_from_relation_type(start_type.vertex().type_id_()))
+            }
+            Bound::Unbounded => RangeStart::Inclusive(ThingEdgeLinks::prefix_from_relation_type(TypeID::MIN)),
+        };
+        let range_end = match relation_type_range.end_bound() {
+            Bound::Included(end_type) => {
+                RangeEnd::EndPrefixInclusive(ThingEdgeLinks::prefix_from_relation_type(end_type.vertex().type_id_()))
+            }
+            Bound::Excluded(end_type) => {
+                RangeEnd::EndPrefixExclusive(ThingEdgeLinks::prefix_from_relation_type(end_type.vertex().type_id_()))
+            }
+            Bound::Unbounded => RangeEnd::EndPrefixInclusive(ThingEdgeLinks::prefix_from_relation_type(TypeID::MAX)),
+        };
+        LinksIterator::new(snapshot.iterate_range(&KeyRange::new(
+            range_start,
+            range_end,
+            ThingEdgeLinks::FIXED_WIDTH_ENCODING,
+        )))
     }
 
     pub fn get_links_by_relation_and_player_type_range(
         &self,
         snapshot: &impl ReadableSnapshot,
         relation: Relation,
-        player_type_range: KeyRange<ObjectType>,
+        player_type_range: &impl RangeBounds<ObjectType>,
     ) -> LinksIterator {
-        let range = player_type_range.map(
-            |type_| ThingEdgeLinks::prefix_from_relation_player_type(relation.vertex(), type_.into_vertex()),
-            |_| ThingEdgeLinks::FIXED_WIDTH_ENCODING,
-        );
-        LinksIterator::new(snapshot.iterate_range(range))
+        let range_start = match player_type_range.start_bound() {
+            Bound::Included(start_type) => RangeStart::Inclusive(ThingEdgeLinks::prefix_from_relation_player_type(
+                relation.vertex(),
+                start_type.vertex(),
+            )),
+            Bound::Excluded(start_type) => RangeStart::ExcludePrefix(ThingEdgeLinks::prefix_from_relation_player_type(
+                relation.vertex(),
+                start_type.vertex(),
+            )),
+            Bound::Unbounded => RangeStart::Inclusive(ThingEdgeLinks::prefix_from_relation_player_type_parts(
+                relation.vertex(),
+                Prefix::min_object_type_prefix(),
+                TypeID::MIN,
+            )),
+        };
+        let range_end = match player_type_range.end_bound() {
+            Bound::Included(end_type) => RangeEnd::EndPrefixInclusive(
+                ThingEdgeLinks::prefix_from_relation_player_type(relation.vertex(), end_type.vertex()),
+            ),
+            Bound::Excluded(end_type) => RangeEnd::EndPrefixExclusive(
+                ThingEdgeLinks::prefix_from_relation_player_type(relation.vertex(), end_type.vertex()),
+            ),
+            Bound::Unbounded => RangeEnd::EndPrefixInclusive(ThingEdgeLinks::prefix_from_relation_player_type_parts(
+                relation.vertex(),
+                Prefix::max_object_type_prefix(),
+                TypeID::MAX,
+            )),
+        };
+        let key_range = KeyRange::new(range_start, range_end, ThingEdgeLinks::FIXED_WIDTH_ENCODING);
+        LinksIterator::new(snapshot.iterate_range(&key_range))
     }
 
     pub fn get_links_by_relation_and_player(
@@ -851,37 +1067,90 @@ impl ThingManager {
         player: impl ObjectAPI,
     ) -> LinksIterator {
         let prefix = ThingEdgeLinks::prefix_from_relation_player(relation.vertex(), player.vertex());
-        LinksIterator::new(
-            snapshot.iterate_range(KeyRange::new_within(
-                RangeStart::Inclusive(prefix),
-                ThingEdgeLinks::FIXED_WIDTH_ENCODING,
-            )),
-        )
+        LinksIterator::new(snapshot.iterate_range(&KeyRange::new_within(prefix, ThingEdgeLinks::FIXED_WIDTH_ENCODING)))
     }
 
     pub fn get_links_reverse_by_player_type_range(
         &self,
         snapshot: &impl ReadableSnapshot,
-        player_type_range: KeyRange<ObjectType>,
+        player_type_range: &impl RangeBounds<ObjectType>,
     ) -> LinksIterator {
-        let range = player_type_range.map(
-            |type_| ThingEdgeLinks::prefix_reverse_from_player_type(type_.into_vertex()),
-            |_| ThingEdgeLinks::FIXED_WIDTH_ENCODING,
-        );
-        LinksIterator::new(snapshot.iterate_range(range))
+        let range_start = match player_type_range.start_bound() {
+            Bound::Included(start_type) => RangeStart::Inclusive(ThingEdgeLinks::prefix_reverse_from_player_type(
+                start_type.vertex().prefix(),
+                start_type.vertex().type_id_(),
+            )),
+            Bound::Excluded(start_type) => RangeStart::ExcludePrefix(ThingEdgeLinks::prefix_reverse_from_player_type(
+                start_type.vertex().prefix(),
+                start_type.vertex().type_id_(),
+            )),
+            Bound::Unbounded => RangeStart::Inclusive(ThingEdgeLinks::prefix_reverse_from_player_type(
+                Prefix::min_object_type_prefix(),
+                TypeID::MIN,
+            )),
+        };
+        let range_end = match player_type_range.end_bound() {
+            Bound::Included(end_type) => RangeEnd::EndPrefixInclusive(ThingEdgeLinks::prefix_reverse_from_player_type(
+                end_type.vertex().prefix(),
+                end_type.vertex().type_id_(),
+            )),
+            Bound::Excluded(end_type) => RangeEnd::EndPrefixExclusive(ThingEdgeLinks::prefix_reverse_from_player_type(
+                end_type.vertex().prefix(),
+                end_type.vertex().type_id_(),
+            )),
+            Bound::Unbounded => RangeEnd::EndPrefixInclusive(ThingEdgeLinks::prefix_reverse_from_player_type(
+                Prefix::max_object_type_prefix(),
+                TypeID::MAX,
+            )),
+        };
+        LinksIterator::new(snapshot.iterate_range(&KeyRange::new(
+            range_start,
+            range_end,
+            ThingEdgeLinks::FIXED_WIDTH_ENCODING,
+        )))
     }
 
     pub fn get_links_reverse_by_player_and_relation_type_range(
         &self,
         snapshot: &impl ReadableSnapshot,
         player: impl ObjectAPI,
-        relation_type_range: KeyRange<RelationType>,
+        relation_type_range: &impl RangeBounds<RelationType>,
     ) -> LinksIterator {
-        let range = relation_type_range.map(
-            |type_| ThingEdgeLinks::prefix_reverse_from_player_relation_type(player.vertex(), type_.vertex()),
-            |_| ThingEdgeLinks::FIXED_WIDTH_ENCODING,
-        );
-        LinksIterator::new(snapshot.iterate_range(range))
+        let range_start = match relation_type_range.start_bound() {
+            Bound::Included(type_start) => {
+                RangeStart::Inclusive(ThingEdgeLinks::prefix_reverse_from_player_relation_type(
+                    player.vertex(),
+                    type_start.vertex().type_id_(),
+                ))
+            }
+            Bound::Excluded(type_start) => {
+                RangeStart::ExcludePrefix(ThingEdgeLinks::prefix_reverse_from_player_relation_type(
+                    player.vertex(),
+                    type_start.vertex().type_id_(),
+                ))
+            }
+            Bound::Unbounded => RangeStart::Inclusive(ThingEdgeLinks::prefix_reverse_from_player_relation_type(
+                player.vertex(),
+                TypeID::MIN,
+            )),
+        };
+        let range_end = match relation_type_range.end_bound() {
+            Bound::Included(type_end) => RangeEnd::EndPrefixInclusive(
+                ThingEdgeLinks::prefix_reverse_from_player_relation_type(player.vertex(), type_end.vertex().type_id_()),
+            ),
+            Bound::Excluded(type_end) => RangeEnd::EndPrefixExclusive(
+                ThingEdgeLinks::prefix_reverse_from_player_relation_type(player.vertex(), type_end.vertex().type_id_()),
+            ),
+            Bound::Unbounded => RangeEnd::EndPrefixInclusive(ThingEdgeLinks::prefix_reverse_from_player_relation_type(
+                player.vertex(),
+                TypeID::MAX,
+            )),
+        };
+        LinksIterator::new(snapshot.iterate_range(&KeyRange::new(
+            range_start,
+            range_end,
+            ThingEdgeLinks::FIXED_WIDTH_ENCODING,
+        )))
     }
 
     pub(crate) fn has_role_player(
@@ -902,10 +1171,7 @@ impl ThingManager {
     pub(crate) fn get_role_players(&self, snapshot: &impl ReadableSnapshot, relation: Relation) -> RolePlayerIterator {
         let prefix = ThingEdgeLinks::prefix_from_relation(relation.vertex());
         RolePlayerIterator::new(
-            snapshot.iterate_range(KeyRange::new_within(
-                RangeStart::Inclusive(prefix),
-                ThingEdgeLinks::FIXED_WIDTH_ENCODING,
-            )),
+            snapshot.iterate_range(&KeyRange::new_within(prefix, ThingEdgeLinks::FIXED_WIDTH_ENCODING)),
         )
     }
 
@@ -945,10 +1211,9 @@ impl ThingManager {
         from: Object,
     ) -> IndexedPlayersIterator {
         let prefix = ThingEdgeRolePlayerIndex::prefix_from(from.vertex());
-        IndexedPlayersIterator::new(snapshot.iterate_range(KeyRange::new_within(
-            RangeStart::Inclusive(prefix),
-            ThingEdgeRolePlayerIndex::FIXED_WIDTH_ENCODING,
-        )))
+        IndexedPlayersIterator::new(
+            snapshot.iterate_range(&KeyRange::new_within(prefix, ThingEdgeRolePlayerIndex::FIXED_WIDTH_ENCODING)),
+        )
     }
 
     pub(crate) fn get_status(
@@ -1159,8 +1424,8 @@ impl ThingManager {
         while any_deleted {
             any_deleted = false;
             for (key, _) in snapshot
-                .iterate_writes_range(KeyRange::new_within(
-                    RangeStart::Inclusive(ThingEdgeLinks::prefix()),
+                .iterate_writes_range(&KeyRange::new_within(
+                    ThingEdgeLinks::prefix(),
                     ThingEdgeLinks::FIXED_WIDTH_ENCODING,
                 ))
                 .filter(|(_, write)| matches!(write, Write::Delete))
@@ -1181,8 +1446,8 @@ impl ThingManager {
         while any_deleted {
             any_deleted = false;
             for key in snapshot
-                .iterate_writes_range(KeyRange::new_within(
-                    RangeStart::Inclusive(ObjectVertex::build_prefix_prefix(Prefix::VertexRelation)),
+                .iterate_writes_range(&KeyRange::new_within(
+                    ObjectVertex::build_prefix_prefix(Prefix::VertexRelation),
                     ObjectVertex::FIXED_WIDTH_ENCODING,
                 ))
                 .filter_map(|(key, write)| (!matches!(write, Write::Delete)).then_some(key))
@@ -1199,8 +1464,8 @@ impl ThingManager {
         while any_deleted {
             any_deleted = false;
             for relation_type in snapshot
-                .iterate_writes_range(KeyRange::new_within(
-                    RangeStart::Inclusive(TypeVertexProperty::build_prefix()),
+                .iterate_writes_range(&KeyRange::new_within(
+                    TypeVertexProperty::build_prefix(),
                     TypeVertexProperty::FIXED_WIDTH_ENCODING,
                 ))
                 .filter_map(|(key, write)| match write {
@@ -1241,10 +1506,7 @@ impl ThingManager {
 
     fn cleanup_attributes(&self, snapshot: &mut impl WritableSnapshot) -> Result<(), Box<ConceptWriteError>> {
         for (key, _write) in snapshot
-            .iterate_writes_range(KeyRange::new_within(
-                RangeStart::Inclusive(ThingEdgeHas::prefix()),
-                ThingEdgeHas::FIXED_WIDTH_ENCODING,
-            ))
+            .iterate_writes_range(&KeyRange::new_within(ThingEdgeHas::prefix(), ThingEdgeHas::FIXED_WIDTH_ENCODING))
             .filter(|(_, write)| matches!(write, Write::Delete))
         {
             let edge = ThingEdgeHas::decode(Bytes::Reference(key.byte_array()));
@@ -1259,11 +1521,11 @@ impl ThingManager {
         }
 
         for (key, _value) in snapshot
-            .iterate_writes_range(KeyRange::new_within(
-                RangeStart::Inclusive(StorageKey::new(
+            .iterate_writes_range(&KeyRange::new_within(
+                StorageKey::new(
                     AttributeVertex::KEYSPACE,
                     Bytes::inline(Prefix::VertexAttribute.prefix_id().to_bytes(), 1),
-                )),
+                ),
                 Prefix::VertexAttribute.fixed_width_keys(),
             ))
             .filter_map(|(key, write)| match write {
@@ -1279,8 +1541,8 @@ impl ThingManager {
         }
 
         for attribute_type in snapshot
-            .iterate_writes_range(KeyRange::new_within(
-                RangeStart::Inclusive(TypeVertexProperty::build_prefix()),
+            .iterate_writes_range(&KeyRange::new_within(
+                TypeVertexProperty::build_prefix(),
                 TypeVertexProperty::FIXED_WIDTH_ENCODING,
             ))
             .filter_map(|(key, write)| match write {
@@ -1371,7 +1633,7 @@ impl ThingManager {
         out_relation_role_types: &mut HashMap<Relation, HashSet<RoleType>>,
     ) -> Result<(), Box<ConceptReadError>> {
         for key in snapshot
-            .iterate_writes_range(KeyRange::new_variable_width(
+            .iterate_writes_range(&KeyRange::new_variable_width(
                 RangeStart::Inclusive(StorageKey::new(
                     ObjectVertex::KEYSPACE,
                     Bytes::<0>::reference(ObjectVertex::build_prefix_prefix(Prefix::VertexEntity).bytes()),
@@ -1416,10 +1678,9 @@ impl ThingManager {
         snapshot: &impl WritableSnapshot,
         out_object_attribute_types: &mut HashMap<Object, HashSet<AttributeType>>,
     ) -> Result<(), Box<ConceptReadError>> {
-        for (key, _) in snapshot.iterate_writes_range(KeyRange::new_within(
-            RangeStart::Inclusive(ThingEdgeHas::prefix()),
-            ThingEdgeHas::FIXED_WIDTH_ENCODING,
-        )) {
+        for (key, _) in snapshot
+            .iterate_writes_range(&KeyRange::new_within(ThingEdgeHas::prefix(), ThingEdgeHas::FIXED_WIDTH_ENCODING))
+        {
             let edge = ThingEdgeHas::decode(Bytes::Reference(key.byte_array()));
             let owner = Object::new(edge.from());
             let attribute = Attribute::new(edge.to());
@@ -1438,10 +1699,9 @@ impl ThingManager {
         out_relation_role_types: &mut HashMap<Relation, HashSet<RoleType>>,
         out_object_role_types: &mut HashMap<Object, HashSet<RoleType>>,
     ) -> Result<(), Box<ConceptReadError>> {
-        for (key, _) in snapshot.iterate_writes_range(KeyRange::new_within(
-            RangeStart::Inclusive(ThingEdgeLinks::prefix()),
-            ThingEdgeLinks::FIXED_WIDTH_ENCODING,
-        )) {
+        for (key, _) in snapshot
+            .iterate_writes_range(&KeyRange::new_within(ThingEdgeLinks::prefix(), ThingEdgeLinks::FIXED_WIDTH_ENCODING))
+        {
             let edge = ThingEdgeLinks::new(Bytes::reference(key.bytes()));
             let relation = Relation::new(edge.relation());
             let player = Object::new(edge.player());

--- a/concept/thing/thing_manager.rs
+++ b/concept/thing/thing_manager.rs
@@ -50,8 +50,8 @@ use encoding::{
     },
     AsBytes, Keyable, Prefixed,
 };
-use itertools::{Itertools, MinMaxResult};
-use lending_iterator::{AsHkt, LendingIterator};
+use itertools::Itertools;
+use lending_iterator::LendingIterator;
 use primitive::either::Either;
 use resource::constants::{
     encoding::StructFieldIDUInt,
@@ -375,7 +375,7 @@ impl ThingManager {
         &self,
         snapshot: &impl ReadableSnapshot,
         attribute_type: AttributeType,
-        range: &impl RangeBounds<Value<'a>>,
+        range: &'a impl RangeBounds<Value<'a>>,
     ) -> Result<AttributeIterator<InstanceIterator<Attribute>>, Box<ConceptReadError>> {
         if matches!(range.start_bound(), Bound::Unbounded) && matches!(range.end_bound(), Bound::Unbounded) {
             return self.get_attributes_in(snapshot, attribute_type);
@@ -664,7 +664,8 @@ impl ThingManager {
                             }
                             Bound::Excluded(start) => {
                                 // increment and treat as included
-                                let mut bytes: [u8; TypeVertex::LENGTH] = start.vertex().to_bytes().as_ref().try_into().unwrap();
+                                let mut bytes: [u8; TypeVertex::LENGTH] =
+                                    start.vertex().to_bytes().as_ref().try_into().unwrap();
                                 increment(&mut bytes).unwrap();
                                 let start_type = TypeVertex::decode(Bytes::Reference(&bytes));
                                 RangeStart::Inclusive(ThingEdgeHasReverse::prefix_from_attribute_to_type(
@@ -679,8 +680,7 @@ impl ThingManager {
                     Either::Second(prefix) => {
                         // attribute vertex could not be built fully, probably due to not being an inline-valued attribute
                         RangeStart::Inclusive(
-                            ThingEdgeHasReverse::prefix_from_attribute_vertex_prefix(prefix.bytes())
-                                .resize_to(),
+                            ThingEdgeHasReverse::prefix_from_attribute_vertex_prefix(prefix.bytes()).resize_to(),
                         )
                     }
                 }
@@ -709,7 +709,8 @@ impl ThingManager {
                             }
                             Bound::Excluded(start) => {
                                 // increment and treat as included
-                                let mut bytes: [u8; TypeVertex::LENGTH] = start.vertex().to_bytes().as_ref().try_into().unwrap();
+                                let mut bytes: [u8; TypeVertex::LENGTH] =
+                                    start.vertex().to_bytes().as_ref().try_into().unwrap();
                                 increment(&mut bytes).unwrap();
                                 let start_type = TypeVertex::decode(Bytes::Reference(&bytes));
                                 RangeStart::Inclusive(ThingEdgeHasReverse::prefix_from_attribute_to_type(
@@ -726,8 +727,7 @@ impl ThingManager {
                         // since this is not a complete vertex, and only a prefix, we shouldn't make assumptions about incrementing
                         // to get to value + 1 in sort order
                         RangeStart::Inclusive(
-                            ThingEdgeHasReverse::prefix_from_attribute_vertex_prefix(prefix.bytes())
-                                .resize_to()
+                            ThingEdgeHasReverse::prefix_from_attribute_vertex_prefix(prefix.bytes()).resize_to(),
                         )
                     }
                 }
@@ -763,8 +763,7 @@ impl ThingManager {
                         }
                     },
                     Either::Second(prefix) => RangeEnd::EndPrefixInclusive(
-                        ThingEdgeHasReverse::prefix_from_attribute_vertex_prefix(prefix.bytes())
-                            .resize_to(),
+                        ThingEdgeHasReverse::prefix_from_attribute_vertex_prefix(prefix.bytes()).resize_to(),
                     ),
                 }
             }
@@ -779,8 +778,7 @@ impl ThingManager {
                         RangeEnd::EndPrefixExclusive(ThingEdgeHasReverse::prefix_from_attribute(vertex).resize_to())
                     }
                     Either::Second(prefix) => RangeEnd::EndPrefixExclusive(
-                        ThingEdgeHasReverse::prefix_from_attribute_vertex_prefix(prefix.bytes())
-                            .resize_to(),
+                        ThingEdgeHasReverse::prefix_from_attribute_vertex_prefix(prefix.bytes()).resize_to(),
                     ),
                 }
             }
@@ -910,11 +908,7 @@ impl ThingManager {
         Ok(attributes)
     }
 
-    pub(crate) fn get_owners(
-        &self,
-        snapshot: &impl ReadableSnapshot,
-        attribute: &Attribute,
-    ) -> AttributeOwnerIterator {
+    pub(crate) fn get_owners(&self, snapshot: &impl ReadableSnapshot, attribute: &Attribute) -> AttributeOwnerIterator {
         let prefix = ThingEdgeHasReverse::prefix_from_attribute(attribute.vertex());
         AttributeOwnerIterator::new(
             snapshot.iterate_range(&KeyRange::new_within(prefix, ThingEdgeHasReverse::FIXED_WIDTH_ENCODING)),
@@ -1203,11 +1197,7 @@ impl ThingManager {
         )
     }
 
-    pub(crate) fn get_indexed_players(
-        &self,
-        snapshot: &impl ReadableSnapshot,
-        from: Object,
-    ) -> IndexedPlayersIterator {
+    pub(crate) fn get_indexed_players(&self, snapshot: &impl ReadableSnapshot, from: Object) -> IndexedPlayersIterator {
         let prefix = ThingEdgeRolePlayerIndex::prefix_from(from.vertex());
         IndexedPlayersIterator::new(
             snapshot.iterate_range(&KeyRange::new_within(prefix, ThingEdgeRolePlayerIndex::FIXED_WIDTH_ENCODING)),

--- a/concept/type_/type_manager/type_cache/kind_cache.rs
+++ b/concept/type_/type_manager/type_cache/kind_cache.rs
@@ -127,10 +127,7 @@ pub struct ObjectCache {
 impl EntityTypeCache {
     pub(super) fn create(snapshot: &impl ReadableSnapshot) -> Box<[Option<EntityTypeCache>]> {
         let entities = snapshot
-            .iterate_range(&KeyRange::new_within(
-                EntityType::prefix_for_kind(),
-                EntityType::PREFIX.fixed_width_keys(),
-            ))
+            .iterate_range(&KeyRange::new_within(EntityType::prefix_for_kind(), EntityType::PREFIX.fixed_width_keys()))
             .collect_cloned_hashset(|key, _| EntityType::read_from(Bytes::Reference(key.bytes()).into_owned()))
             .unwrap();
         let max_entity_id = entities.iter().map(|e| e.vertex().type_id_().as_u16()).max().unwrap_or(0);
@@ -186,10 +183,7 @@ impl RelationTypeCache {
 impl AttributeTypeCache {
     pub(super) fn create(snapshot: &impl ReadableSnapshot) -> Box<[Option<AttributeTypeCache>]> {
         let attributes = snapshot
-            .iterate_range(&KeyRange::new_within(
-                AttributeType::prefix_for_kind(),
-                TypeVertex::FIXED_WIDTH_ENCODING,
-            ))
+            .iterate_range(&KeyRange::new_within(AttributeType::prefix_for_kind(), TypeVertex::FIXED_WIDTH_ENCODING))
             .collect_cloned_hashset(|key, _| AttributeType::read_from(Bytes::Reference(key.bytes()).into_owned()))
             .unwrap();
         let max_attribute_id = attributes.iter().map(|a| a.vertex().type_id_().as_u16()).max().unwrap_or(0);
@@ -215,10 +209,7 @@ impl AttributeTypeCache {
 impl RoleTypeCache {
     pub(super) fn create(snapshot: &impl ReadableSnapshot) -> Box<[Option<RoleTypeCache>]> {
         let roles = snapshot
-            .iterate_range(&KeyRange::new_within(
-                RoleType::prefix_for_kind(),
-                TypeVertex::FIXED_WIDTH_ENCODING,
-            ))
+            .iterate_range(&KeyRange::new_within(RoleType::prefix_for_kind(), TypeVertex::FIXED_WIDTH_ENCODING))
             .collect_cloned_hashset(|key, _| RoleType::read_from(Bytes::Reference(key.bytes()).into_owned()))
             .unwrap();
         let max_role_id = roles.iter().map(|r| r.vertex().type_id_().as_u16()).max().unwrap_or(0);

--- a/concept/type_/type_manager/type_cache/kind_cache.rs
+++ b/concept/type_/type_manager/type_cache/kind_cache.rs
@@ -22,10 +22,7 @@ use encoding::{
     value::{label::Label, value_type::ValueType},
 };
 use lending_iterator::LendingIterator;
-use storage::{
-    key_range::{KeyRange, RangeStart},
-    snapshot::ReadableSnapshot,
-};
+use storage::{key_range::KeyRange, snapshot::ReadableSnapshot};
 
 use crate::type_::{
     attribute_type::AttributeType,
@@ -130,8 +127,8 @@ pub struct ObjectCache {
 impl EntityTypeCache {
     pub(super) fn create(snapshot: &impl ReadableSnapshot) -> Box<[Option<EntityTypeCache>]> {
         let entities = snapshot
-            .iterate_range(KeyRange::new_within(
-                RangeStart::Inclusive(EntityType::prefix_for_kind()),
+            .iterate_range(&KeyRange::new_within(
+                EntityType::prefix_for_kind(),
                 EntityType::PREFIX.fixed_width_keys(),
             ))
             .collect_cloned_hashset(|key, _| EntityType::read_from(Bytes::Reference(key.bytes()).into_owned()))
@@ -153,8 +150,8 @@ impl EntityTypeCache {
 impl RelationTypeCache {
     pub(super) fn create(snapshot: &impl ReadableSnapshot) -> Box<[Option<RelationTypeCache>]> {
         let relations = snapshot
-            .iterate_range(KeyRange::new_within(
-                RangeStart::Inclusive(RelationType::prefix_for_kind()),
+            .iterate_range(&KeyRange::new_within(
+                RelationType::prefix_for_kind(),
                 Prefix::VertexRelationType.fixed_width_keys(),
             ))
             .collect_cloned_hashset(|key, _| RelationType::read_from(Bytes::Reference(key.bytes()).into_owned()))
@@ -189,8 +186,8 @@ impl RelationTypeCache {
 impl AttributeTypeCache {
     pub(super) fn create(snapshot: &impl ReadableSnapshot) -> Box<[Option<AttributeTypeCache>]> {
         let attributes = snapshot
-            .iterate_range(KeyRange::new_within(
-                RangeStart::Inclusive(AttributeType::prefix_for_kind()),
+            .iterate_range(&KeyRange::new_within(
+                AttributeType::prefix_for_kind(),
                 TypeVertex::FIXED_WIDTH_ENCODING,
             ))
             .collect_cloned_hashset(|key, _| AttributeType::read_from(Bytes::Reference(key.bytes()).into_owned()))
@@ -218,8 +215,8 @@ impl AttributeTypeCache {
 impl RoleTypeCache {
     pub(super) fn create(snapshot: &impl ReadableSnapshot) -> Box<[Option<RoleTypeCache>]> {
         let roles = snapshot
-            .iterate_range(KeyRange::new_within(
-                RangeStart::Inclusive(RoleType::prefix_for_kind()),
+            .iterate_range(&KeyRange::new_within(
+                RoleType::prefix_for_kind(),
                 TypeVertex::FIXED_WIDTH_ENCODING,
             ))
             .collect_cloned_hashset(|key, _| RoleType::read_from(Bytes::Reference(key.bytes()).into_owned()))
@@ -252,8 +249,8 @@ impl RoleTypeCache {
 impl OwnsCache {
     pub(super) fn create(snapshot: &impl ReadableSnapshot) -> HashMap<Owns, OwnsCache> {
         let mut map = HashMap::new();
-        let mut it = snapshot.iterate_range(KeyRange::new_within(
-            RangeStart::Inclusive(TypeEdge::build_prefix(Prefix::EdgeOwnsReverse)),
+        let mut it = snapshot.iterate_range(&KeyRange::new_within(
+            TypeEdge::build_prefix(Prefix::EdgeOwnsReverse),
             TypeEdge::FIXED_WIDTH_ENCODING,
         ));
         while let Some((key, _)) = it.next().transpose().unwrap() {
@@ -274,8 +271,8 @@ impl OwnsCache {
 impl PlaysCache {
     pub(super) fn create(snapshot: &impl ReadableSnapshot) -> HashMap<Plays, PlaysCache> {
         let mut map = HashMap::new();
-        let mut it = snapshot.iterate_range(KeyRange::new_within(
-            RangeStart::Inclusive(TypeEdge::build_prefix(Prefix::EdgePlays)),
+        let mut it = snapshot.iterate_range(&KeyRange::new_within(
+            TypeEdge::build_prefix(Prefix::EdgePlays),
             TypeEdge::FIXED_WIDTH_ENCODING,
         ));
 
@@ -294,8 +291,8 @@ impl PlaysCache {
 impl RelatesCache {
     pub(super) fn create(snapshot: &impl ReadableSnapshot) -> HashMap<Relates, RelatesCache> {
         let mut map = HashMap::new();
-        let mut it = snapshot.iterate_range(KeyRange::new_within(
-            RangeStart::Inclusive(TypeEdge::build_prefix(Prefix::EdgeRelates)),
+        let mut it = snapshot.iterate_range(&KeyRange::new_within(
+            TypeEdge::build_prefix(Prefix::EdgeRelates),
             TypeEdge::FIXED_WIDTH_ENCODING,
         ));
 

--- a/concept/type_/type_manager/validation/operation_time_validation.rs
+++ b/concept/type_/type_manager/validation/operation_time_validation.rs
@@ -3183,7 +3183,8 @@ impl OperationTimeValidation {
                 // non-interesting interfaces rather creating multiple iterators
                 let has_attribute_iterator = object.get_has_unordered(snapshot, thing_manager);
                 for has_count in has_attribute_iterator {
-                    let (has, count) = has_count.map_err(|source| Box::new(DataValidationError::ConceptRead { source }))?;
+                    let (has, count) =
+                        has_count.map_err(|source| Box::new(DataValidationError::ConceptRead { source }))?;
                     let attribute = has.attribute();
                     let attribute_type = attribute.type_();
                     if !attribute_types.contains(&attribute_type) {

--- a/concept/type_/type_manager/validation/operation_time_validation.rs
+++ b/concept/type_/type_manager/validation/operation_time_validation.rs
@@ -3182,9 +3182,9 @@ impl OperationTimeValidation {
                 // We assume that it's cheaper to open an iterator once and skip all the
                 // non-interesting interfaces rather creating multiple iterators
                 let has_attribute_iterator = object.get_has_unordered(snapshot, thing_manager);
-                for attribute in has_attribute_iterator {
-                    let (attribute, count) =
-                        attribute.map_err(|source| Box::new(DataValidationError::ConceptRead { source }))?;
+                for has_count in has_attribute_iterator {
+                    let (has, count) = has_count.map_err(|source| Box::new(DataValidationError::ConceptRead { source }))?;
+                    let attribute = has.attribute();
                     let attribute_type = attribute.type_();
                     if !attribute_types.contains(&attribute_type) {
                         continue;

--- a/encoding/graph/common/schema_id_allocator.rs
+++ b/encoding/graph/common/schema_id_allocator.rs
@@ -61,7 +61,7 @@ impl<T: SchemaID + Keyable<BUFFER_KEY_INLINE>> SchemaIDAllocator<T> {
         snapshot: &mut Snapshot,
         start: u64,
     ) -> Result<Option<u64>, EncodingError> {
-        let mut schema_object_iter = snapshot.iterate_range(KeyRange::new_fixed_width(
+        let mut schema_object_iter = snapshot.iterate_range(&KeyRange::new_fixed_width(
             RangeStart::Inclusive(T::object_from_id(self.prefix, start).into_storage_key()),
             RangeEnd::EndPrefixInclusive(T::object_from_id(self.prefix, T::MAX_ID).into_storage_key()),
         ));

--- a/encoding/graph/common/value_hasher.rs
+++ b/encoding/graph/common/value_hasher.rs
@@ -11,7 +11,7 @@ use lending_iterator::LendingIterator;
 use primitive::either::Either;
 use resource::constants::snapshot::BUFFER_KEY_INLINE;
 use storage::{
-    key_range::{KeyRange, RangeStart},
+    key_range::KeyRange,
     key_value::StorageKey,
     snapshot::{iterator::SnapshotIteratorError, ReadableSnapshot},
 };
@@ -74,8 +74,8 @@ pub(crate) trait HashedID<const DISAMBIGUATED_HASH_LENGTH: usize> {
         Snapshot: ReadableSnapshot,
     {
         let tail_byte_index = key_without_tail_byte.len();
-        let mut iter = snapshot.iterate_range(KeyRange::new_within(
-            RangeStart::Inclusive(StorageKey::<BUFFER_KEY_INLINE>::new_ref(Self::KEYSPACE, key_without_tail_byte)),
+        let mut iter = snapshot.iterate_range(&KeyRange::new_within(
+            StorageKey::<BUFFER_KEY_INLINE>::new_ref(Self::KEYSPACE, key_without_tail_byte),
             Self::FIXED_WIDTH_KEYS,
         ));
         let mut next = iter.next().transpose()?;

--- a/encoding/graph/thing/edge.rs
+++ b/encoding/graph/thing/edge.rs
@@ -74,7 +74,7 @@ impl ThingEdgeHas {
         type_id: TypeID,
     ) -> StorageKey<'static, { ThingEdgeHas::LENGTH_PREFIX_FROM_TYPE }> {
         let mut bytes = ByteArray::zeros(Self::LENGTH_PREFIX_FROM_TYPE);
-        bytes[Self::INDEX_PREFIX] = &Self::PREFIX.prefix_id().byte;
+        bytes[Self::INDEX_PREFIX] = Self::PREFIX.prefix_id().byte;
         ObjectVertex::write_prefix_type(
             &mut bytes[Self::range_from_type()],
             ObjectVertex::prefix_for_type(type_prefix),
@@ -260,7 +260,7 @@ impl ThingEdgeHasReverse {
     }
 
     pub fn prefix_from_attribute_to_type_parts(
-        from: AttributeVertex<'_>,
+        from: AttributeVertex,
         to_type_prefix: Prefix,
         to_type_id: TypeID,
     ) -> StorageKey<'static, { ThingEdgeHasReverse::LENGTH_BOUND_PREFIX_FROM_TO_TYPE }> {
@@ -280,12 +280,12 @@ impl ThingEdgeHasReverse {
 
     pub fn prefix_from_attribute_to_type_range(
         from: AttributeVertex,
-        range_start: RangeStart<TypeVertex>>,
+        range_start: RangeStart<TypeVertex>,
         range_end: RangeEnd<TypeVertex>,
     ) -> KeyRange<StorageKey<'static, { ThingEdgeHasReverse::LENGTH_BOUND_PREFIX_FROM_TO_TYPE }>> {
         KeyRange::new_fixed_width(
-            range_start.map(|vertex| Self::prefix_from_attribute_to_type(from, vertex)),
-            range_end.map(|vertex| Self::prefix_from_attribute_to_type(from, vertex)),
+            range_start.map(|vertex| Self::prefix_from_attribute_to_type(from, *vertex)),
+            range_end.map(|vertex| Self::prefix_from_attribute_to_type(from, *vertex)),
         )
     }
     // end TODO
@@ -453,13 +453,13 @@ impl ThingEdgeLinks {
     }
 
     pub fn prefix_from_relation_player_type_parts(
-        relation: ObjectVertex<'_>,
+        relation: ObjectVertex,
         player_type_prefix: Prefix,
         player_type_id: TypeID,
     ) -> StorageKey<'static, { ThingEdgeLinks::LENGTH_PREFIX_FROM_TO_TYPE }> {
         let mut bytes = ByteArray::zeros(Self::LENGTH_PREFIX_FROM_TO_TYPE);
         bytes[Self::INDEX_PREFIX] = Self::PREFIX.prefix_id().byte;
-        bytes[Self::RANGE_FROM].copy_from_slice(relation.to_bytes());
+        bytes[Self::RANGE_FROM].copy_from_slice(relation.to_bytes().as_ref());
         ObjectVertex::write_prefix_type(
             &mut bytes[Self::range_to_type()],
             ObjectVertex::prefix_for_type(player_type_prefix),
@@ -508,7 +508,7 @@ impl ThingEdgeLinks {
     ) -> StorageKey<'static, { ThingEdgeLinks::LENGTH_PREFIX_FROM_TO_TYPE }> {
         let mut bytes = ByteArray::zeros(Self::LENGTH_PREFIX_FROM_TO_TYPE);
         bytes[Self::INDEX_PREFIX] = Self::PREFIX_REVERSE.prefix_id().byte;
-        bytes[Self::RANGE_FROM].copy_from_slice(player.bytes().bytes());
+        bytes[Self::RANGE_FROM].copy_from_slice(player.to_bytes().as_ref());
         ObjectVertex::write_prefix_type(
             &mut bytes[Self::range_to_type()],
             ObjectVertex::prefix_for_type(Prefix::VertexRelationType),

--- a/encoding/graph/thing/edge.rs
+++ b/encoding/graph/thing/edge.rs
@@ -65,7 +65,21 @@ impl ThingEdgeHas {
     pub fn prefix_from_type(type_: TypeVertex) -> StorageKey<'static, { ThingEdgeHas::LENGTH_PREFIX_FROM_TYPE }> {
         let mut bytes = ByteArray::zeros(Self::LENGTH_PREFIX_FROM_TYPE);
         bytes[Self::INDEX_PREFIX] = Self::PREFIX.prefix_id().byte;
-        bytes[Self::range_from_type()].copy_from_slice(ObjectVertex::build_prefix_from_type_vertex(type_).bytes());
+        ObjectVertex::write_prefix_from_type_vertex(&mut bytes[Self::range_from_type()], type_);
+        StorageKey::new_owned(Self::KEYSPACE, bytes)
+    }
+
+    pub fn prefix_from_type_parts(
+        type_prefix: Prefix,
+        type_id: TypeID,
+    ) -> StorageKey<'static, { ThingEdgeHas::LENGTH_PREFIX_FROM_TYPE }> {
+        let mut bytes = ByteArray::zeros(Self::LENGTH_PREFIX_FROM_TYPE);
+        bytes[Self::INDEX_PREFIX] = &Self::PREFIX.prefix_id().byte;
+        ObjectVertex::write_prefix_type(
+            &mut bytes[Self::range_from_type()],
+            ObjectVertex::prefix_for_type(type_prefix),
+            type_id,
+        );
         StorageKey::new_owned(Self::KEYSPACE, bytes)
     }
 
@@ -242,23 +256,35 @@ impl ThingEdgeHasReverse {
         from: AttributeVertex,
         to_type: TypeVertex,
     ) -> StorageKey<'static, { ThingEdgeHasReverse::LENGTH_BOUND_PREFIX_FROM_TO_TYPE }> {
+        Self::prefix_from_attribute_to_type_parts(from, to_type.prefix(), to_type.type_id_())
+    }
+
+    pub fn prefix_from_attribute_to_type_parts(
+        from: AttributeVertex<'_>,
+        to_type_prefix: Prefix,
+        to_type_id: TypeID,
+    ) -> StorageKey<'static, { ThingEdgeHasReverse::LENGTH_BOUND_PREFIX_FROM_TO_TYPE }> {
         let mut bytes = ByteArray::zeros(Self::LENGTH_BOUND_PREFIX_FROM_TO_TYPE);
         bytes[Self::INDEX_PREFIX] = Self::PREFIX.prefix_id().byte;
         let range_from = Self::range_from_for_vertex(from);
         bytes[range_from.clone()].copy_from_slice(&from.to_bytes());
         let to_type_range = range_from.end..range_from.end + TypeVertex::LENGTH;
-        bytes[to_type_range].copy_from_slice(ObjectVertex::build_prefix_from_type_vertex(to_type).bytes());
+        ObjectVertex::write_prefix_type(
+            &mut bytes[to_type_range],
+            ObjectVertex::prefix_for_type(to_type_prefix),
+            to_type_id,
+        );
         bytes.truncate(range_from.end + TypeVertex::LENGTH);
         StorageKey::new_owned(EncodingKeyspace::Data, bytes)
     }
 
     pub fn prefix_from_attribute_to_type_range(
         from: AttributeVertex,
-        range_start: TypeVertex,
+        range_start: RangeStart<TypeVertex>>,
         range_end: RangeEnd<TypeVertex>,
     ) -> KeyRange<StorageKey<'static, { ThingEdgeHasReverse::LENGTH_BOUND_PREFIX_FROM_TO_TYPE }>> {
         KeyRange::new_fixed_width(
-            RangeStart::Inclusive(Self::prefix_from_attribute_to_type(from, range_start)),
+            range_start.map(|vertex| Self::prefix_from_attribute_to_type(from, vertex)),
             range_end.map(|vertex| Self::prefix_from_attribute_to_type(from, vertex)),
         )
     }
@@ -400,12 +426,15 @@ impl ThingEdgeLinks {
     }
 
     pub fn prefix_from_relation_type(
-        relation_type: TypeVertex,
+        relation_type_id: TypeID,
     ) -> StorageKey<'static, { ThingEdgeLinks::LENGTH_PREFIX_FROM_TYPE }> {
         let mut bytes = ByteArray::zeros(Self::LENGTH_PREFIX_FROM_TYPE);
         bytes[Self::INDEX_PREFIX] = Self::PREFIX.prefix_id().byte;
-        bytes[Self::range_from_type()]
-            .copy_from_slice(ObjectVertex::build_prefix_from_type_vertex(relation_type).bytes());
+        ObjectVertex::write_prefix_type(
+            &mut bytes[Self::range_from_type()],
+            ObjectVertex::prefix_for_type(Prefix::VertexRelationType),
+            relation_type_id,
+        );
         StorageKey::new_owned(Self::KEYSPACE, bytes)
     }
 
@@ -420,10 +449,22 @@ impl ThingEdgeLinks {
         relation: ObjectVertex,
         player_type: TypeVertex,
     ) -> StorageKey<'static, { ThingEdgeLinks::LENGTH_PREFIX_FROM_TO_TYPE }> {
+        Self::prefix_from_relation_player_type_parts(relation, player_type.prefix(), player_type.type_id_())
+    }
+
+    pub fn prefix_from_relation_player_type_parts(
+        relation: ObjectVertex<'_>,
+        player_type_prefix: Prefix,
+        player_type_id: TypeID,
+    ) -> StorageKey<'static, { ThingEdgeLinks::LENGTH_PREFIX_FROM_TO_TYPE }> {
         let mut bytes = ByteArray::zeros(Self::LENGTH_PREFIX_FROM_TO_TYPE);
         bytes[Self::INDEX_PREFIX] = Self::PREFIX.prefix_id().byte;
-        bytes[Self::RANGE_FROM].copy_from_slice(&relation.to_bytes());
-        bytes[Self::range_to_type()].copy_from_slice(ObjectVertex::build_prefix_from_type_vertex(player_type).bytes());
+        bytes[Self::RANGE_FROM].copy_from_slice(relation.to_bytes());
+        ObjectVertex::write_prefix_type(
+            &mut bytes[Self::range_to_type()],
+            ObjectVertex::prefix_for_type(player_type_prefix),
+            player_type_id,
+        );
         StorageKey::new_owned(Self::KEYSPACE, bytes)
     }
 
@@ -448,24 +489,31 @@ impl ThingEdgeLinks {
     }
 
     pub fn prefix_reverse_from_player_type(
-        player_type: TypeVertex,
+        player_type_prefix: Prefix,
+        player_type_id: TypeID,
     ) -> StorageKey<'static, { ThingEdgeLinks::LENGTH_PREFIX_FROM }> {
         let mut bytes = ByteArray::zeros(Self::LENGTH_PREFIX_FROM_TYPE);
         bytes[Self::INDEX_PREFIX] = Self::PREFIX_REVERSE.prefix_id().byte;
-        bytes[Self::range_from_type()]
-            .copy_from_slice(ObjectVertex::build_prefix_from_type_vertex(player_type).bytes());
+        ObjectVertex::write_prefix_type(
+            &mut bytes[Self::range_from_type()],
+            ObjectVertex::prefix_for_type(player_type_prefix),
+            player_type_id,
+        );
         StorageKey::new_owned(Self::KEYSPACE, bytes)
     }
 
     pub fn prefix_reverse_from_player_relation_type(
         player: ObjectVertex,
-        relation_type: TypeVertex,
+        relation_type_id: TypeID,
     ) -> StorageKey<'static, { ThingEdgeLinks::LENGTH_PREFIX_FROM_TO_TYPE }> {
         let mut bytes = ByteArray::zeros(Self::LENGTH_PREFIX_FROM_TO_TYPE);
         bytes[Self::INDEX_PREFIX] = Self::PREFIX_REVERSE.prefix_id().byte;
-        bytes[Self::RANGE_FROM].copy_from_slice(&player.to_bytes());
-        bytes[Self::range_to_type()]
-            .copy_from_slice(ObjectVertex::build_prefix_from_type_vertex(relation_type).bytes());
+        bytes[Self::RANGE_FROM].copy_from_slice(player.bytes().bytes());
+        ObjectVertex::write_prefix_type(
+            &mut bytes[Self::range_to_type()],
+            ObjectVertex::prefix_for_type(Prefix::VertexRelationType),
+            relation_type_id,
+        );
         StorageKey::new_owned(Self::KEYSPACE, bytes)
     }
 

--- a/encoding/graph/thing/mod.rs
+++ b/encoding/graph/thing/mod.rs
@@ -48,8 +48,14 @@ pub trait ThingVertex: Prefixed<BUFFER_KEY_INLINE> + Typed<BUFFER_KEY_INLINE> + 
     fn build_prefix_type(prefix: Prefix, type_id: TypeID) -> StorageKey<'static, THING_VERTEX_LENGTH_PREFIX_TYPE> {
         debug_assert!(matches!(prefix, Prefix::VertexEntity | Prefix::VertexRelation | Prefix::VertexAttribute));
         let mut array = ByteArray::zeros(THING_VERTEX_LENGTH_PREFIX_TYPE);
-        array[Self::INDEX_PREFIX] = prefix.prefix_id().byte;
-        array[Self::RANGE_TYPE_ID].copy_from_slice(&type_id.to_bytes());
+        Self::write_prefix_type(array.as_mut(), prefix, type_id);
         StorageKey::new(Self::KEYSPACE, Bytes::Array(array))
+    }
+
+    fn write_prefix_type(bytes: &mut [u8], prefix: Prefix, type_id: TypeID) -> usize {
+        debug_assert!(bytes.len() >= THING_VERTEX_LENGTH_PREFIX_TYPE);
+        bytes[Self::INDEX_PREFIX] = prefix.prefix_id().byte;
+        bytes[Self::RANGE_TYPE_ID].copy_from_slice(&type_id.bytes());
+        THING_VERTEX_LENGTH_PREFIX_TYPE
     }
 }

--- a/encoding/graph/thing/mod.rs
+++ b/encoding/graph/thing/mod.rs
@@ -55,7 +55,7 @@ pub trait ThingVertex: Prefixed<BUFFER_KEY_INLINE> + Typed<BUFFER_KEY_INLINE> + 
     fn write_prefix_type(bytes: &mut [u8], prefix: Prefix, type_id: TypeID) -> usize {
         debug_assert!(bytes.len() >= THING_VERTEX_LENGTH_PREFIX_TYPE);
         bytes[Self::INDEX_PREFIX] = prefix.prefix_id().byte;
-        bytes[Self::RANGE_TYPE_ID].copy_from_slice(&type_id.bytes());
+        bytes[Self::RANGE_TYPE_ID].copy_from_slice(&type_id.to_bytes());
         THING_VERTEX_LENGTH_PREFIX_TYPE
     }
 }

--- a/encoding/graph/thing/vertex_attribute.rs
+++ b/encoding/graph/thing/vertex_attribute.rs
@@ -86,7 +86,7 @@ impl AttributeVertex {
         );
         bytes.truncate(Self::RANGE_TYPE_ID.end + id_length);
         if is_complete {
-            Either::First(Self::new(Bytes::Array(bytes)))
+            Either::First(Self::new(type_id, AttributeID::new(bytes.as_ref())))
         } else {
             Either::Second(StorageKey::new(Self::KEYSPACE, Bytes::Array(bytes)))
         }

--- a/encoding/graph/thing/vertex_attribute.rs
+++ b/encoding/graph/thing/vertex_attribute.rs
@@ -70,22 +70,26 @@ impl AttributeVertex {
         Some(Self::decode(bytes))
     }
 
-    pub fn build_prefix_for_value(
+    pub fn build_or_prefix_for_value(
         type_id: TypeID,
         value: Value<'_>,
         large_value_hasher: &impl Fn(&[u8]) -> u64,
-    ) -> StorageKey<'static, BUFFER_KEY_INLINE> {
+    ) -> Either<Self, StorageKey<'static, BUFFER_KEY_INLINE>> {
         // preallocate upper bound length and then truncate later
         let mut bytes = ByteArray::zeros(THING_VERTEX_LENGTH_PREFIX_TYPE + AttributeID::max_length());
         bytes[Self::INDEX_PREFIX] = Self::PREFIX.prefix_id().byte;
         bytes[Self::RANGE_TYPE_ID].copy_from_slice(&type_id.to_bytes());
-        let id_length = AttributeID::write_deterministic_value_or_prefix(
+        let (id_length, is_complete) = AttributeID::write_deterministic_value_or_prefix(
             &mut bytes[Self::RANGE_TYPE_ID.end..],
             value,
             large_value_hasher,
         );
         bytes.truncate(Self::RANGE_TYPE_ID.end + id_length);
-        StorageKey::new(Self::KEYSPACE, Bytes::Array(bytes))
+        if is_complete {
+            Either::First(Self::new(Bytes::Array(bytes)))
+        } else {
+            Either::Second(StorageKey::new(Self::KEYSPACE, Bytes::Array(bytes)))
+        }
     }
 
     pub(crate) fn write_prefix_type_attribute_id(bytes: &mut [u8], type_id: TypeID, attribute_id_part: &[u8]) -> usize {
@@ -220,24 +224,28 @@ impl AttributeID {
         bytes: &mut [u8],
         value: Value<'_>,
         large_value_hasher: &impl Fn(&[u8]) -> u64,
-    ) -> usize {
+    ) -> (usize, bool) {
         debug_assert!(bytes.len() >= AttributeID::max_length());
         match value.value_type().category() {
-            ValueTypeCategory::Boolean => BooleanAttributeID::write(value.encode_boolean(), bytes),
-            ValueTypeCategory::Long => LongAttributeID::write(value.encode_long(), bytes),
-            ValueTypeCategory::Double => DoubleAttributeID::write(value.encode_double(), bytes),
-            ValueTypeCategory::Decimal => DecimalAttributeID::write(value.encode_decimal(), bytes),
-            ValueTypeCategory::Date => DateAttributeID::write(value.encode_date(), bytes),
-            ValueTypeCategory::DateTime => DateTimeAttributeID::write(value.encode_date_time(), bytes),
-            ValueTypeCategory::DateTimeTZ => DateTimeTZAttributeID::write(value.encode_date_time_tz(), bytes),
-            ValueTypeCategory::Duration => DurationAttributeID::write(value.encode_duration(), bytes),
-            ValueTypeCategory::String => {
-                StringAttributeID::write_deterministic_prefix(value.encode_string::<64>(), large_value_hasher, bytes)
-            }
-            ValueTypeCategory::Struct => StructAttributeID::write_hashed_id_deterministic_prefix(
-                value.encode_struct::<64>(),
-                large_value_hasher,
-                bytes,
+            ValueTypeCategory::Boolean => (BooleanAttributeID::write(value.encode_boolean(), bytes), true),
+            ValueTypeCategory::Long => (LongAttributeID::write(value.encode_long(), bytes), true),
+            ValueTypeCategory::Double => (DoubleAttributeID::write(value.encode_double(), bytes), true),
+            ValueTypeCategory::Decimal => (DecimalAttributeID::write(value.encode_decimal(), bytes), true),
+            ValueTypeCategory::Date => (DateAttributeID::write(value.encode_date(), bytes), true),
+            ValueTypeCategory::DateTime => (DateTimeAttributeID::write(value.encode_date_time(), bytes), true),
+            ValueTypeCategory::DateTimeTZ => (DateTimeTZAttributeID::write(value.encode_date_time_tz(), bytes), true),
+            ValueTypeCategory::Duration => (DurationAttributeID::write(value.encode_duration(), bytes), true),
+            ValueTypeCategory::String => (
+                StringAttributeID::write_deterministic_prefix(value.encode_string::<64>(), large_value_hasher, bytes),
+                false,
+            ),
+            ValueTypeCategory::Struct => (
+                StructAttributeID::write_hashed_id_deterministic_prefix(
+                    value.encode_struct::<64>(),
+                    large_value_hasher,
+                    bytes,
+                ),
+                false,
             ),
         }
     }

--- a/encoding/graph/thing/vertex_attribute.rs
+++ b/encoding/graph/thing/vertex_attribute.rs
@@ -86,7 +86,7 @@ impl AttributeVertex {
         );
         bytes.truncate(Self::RANGE_TYPE_ID.end + id_length);
         if is_complete {
-            Either::First(Self::new(type_id, AttributeID::new(bytes.as_ref())))
+            Either::First(Self::decode(bytes.as_ref()))
         } else {
             Either::Second(StorageKey::new(Self::KEYSPACE, Bytes::Array(bytes)))
         }

--- a/encoding/graph/thing/vertex_generator.rs
+++ b/encoding/graph/thing/vertex_generator.rs
@@ -11,7 +11,7 @@ use std::sync::{
 
 use bytes::{byte_array::ByteArray, Bytes};
 use storage::{
-    key_range::{KeyRange, RangeStart},
+    key_range::KeyRange,
     key_value::StorageKey,
     snapshot::{iterator::SnapshotIteratorError, ReadableSnapshot, WritableSnapshot},
     MVCCKey, MVCCStorage,
@@ -81,15 +81,15 @@ impl ThingVertexGenerator {
     ) -> Result<Self, EncodingError> {
         let read_snapshot = storage.clone().open_snapshot_read();
         let entity_types = read_snapshot
-            .iterate_range(KeyRange::new_within(
-                RangeStart::Inclusive(build_type_vertex_prefix_key(Prefix::VertexEntityType)),
+            .iterate_range(&KeyRange::new_within(
+                build_type_vertex_prefix_key(Prefix::VertexEntityType),
                 Prefix::VertexEntityType.fixed_width_keys(),
             ))
             .collect_cloned_vec(|k, _v| TypeVertex::decode(Bytes::Reference(k.bytes())).type_id_().as_u16())
             .map_err(|err| EncodingError::ExistingTypesRead { source: err })?;
         let relation_types = read_snapshot
-            .iterate_range(KeyRange::new_within(
-                RangeStart::Inclusive(build_type_vertex_prefix_key(Prefix::VertexRelationType)),
+            .iterate_range(&KeyRange::new_within(
+                build_type_vertex_prefix_key(Prefix::VertexRelationType),
                 Prefix::VertexRelationType.fixed_width_keys(),
             ))
             .collect_cloned_vec(|k, _v| TypeVertex::decode(Bytes::Reference(k.bytes())).type_id_().as_u16())

--- a/encoding/graph/thing/vertex_object.rs
+++ b/encoding/graph/thing/vertex_object.rs
@@ -15,7 +15,7 @@ use storage::{
 
 use crate::{
     graph::{
-        thing::{ThingVertex, THING_VERTEX_LENGTH_PREFIX_TYPE},
+        thing::ThingVertex,
         type_::vertex::{TypeID, TypeVertex},
         Typed,
     },
@@ -68,15 +68,16 @@ impl ObjectVertex {
             && storage_key.bytes()[Self::INDEX_PREFIX] == Prefix::VertexRelation.prefix_id().byte
     }
 
-    pub(crate) fn build_prefix_from_type_vertex(
-        type_vertex: TypeVertex,
-    ) -> StorageKey<'static, { THING_VERTEX_LENGTH_PREFIX_TYPE }> {
-        let prefix = match type_vertex.prefix() {
+    pub(crate) fn write_prefix_from_type_vertex(bytes: &mut [u8], type_vertex: TypeVertex<'_>) -> usize {
+        Self::write_prefix_type(bytes, Self::prefix_for_type(type_vertex.prefix()), type_vertex.type_id_())
+    }
+
+    pub(crate) const fn prefix_for_type(prefix: Prefix) -> Prefix {
+        match prefix {
             Prefix::VertexEntityType => Prefix::VertexEntity,
             Prefix::VertexRelationType => Prefix::VertexRelation,
             _ => unreachable!(),
-        };
-        Self::build_prefix_type(prefix, type_vertex.type_id_())
+        }
     }
 
     pub fn object_id(&self) -> ObjectID {

--- a/encoding/graph/thing/vertex_object.rs
+++ b/encoding/graph/thing/vertex_object.rs
@@ -68,7 +68,7 @@ impl ObjectVertex {
             && storage_key.bytes()[Self::INDEX_PREFIX] == Prefix::VertexRelation.prefix_id().byte
     }
 
-    pub(crate) fn write_prefix_from_type_vertex(bytes: &mut [u8], type_vertex: TypeVertex<'_>) -> usize {
+    pub(crate) fn write_prefix_from_type_vertex(bytes: &mut [u8], type_vertex: TypeVertex) -> usize {
         Self::write_prefix_type(bytes, Self::prefix_for_type(type_vertex.prefix()), type_vertex.type_id_())
     }
 

--- a/encoding/graph/type_/vertex.rs
+++ b/encoding/graph/type_/vertex.rs
@@ -32,7 +32,7 @@ impl TypeVertex {
     pub(crate) const KEYSPACE: EncodingKeyspace = EncodingKeyspace::Schema;
     pub const FIXED_WIDTH_ENCODING: bool = true;
 
-    pub(crate) const LENGTH: usize = PrefixID::LENGTH + TypeID::LENGTH;
+    pub const LENGTH: usize = PrefixID::LENGTH + TypeID::LENGTH;
     pub(crate) const LENGTH_PREFIX: usize = PrefixID::LENGTH;
 
     pub(crate) fn new(prefix: PrefixID, type_id: TypeID) -> Self {
@@ -88,6 +88,8 @@ pub struct TypeID {
 pub type TypeIDUInt = u16;
 
 impl TypeID {
+    pub const MIN: Self = Self::build(0);
+    pub const MAX: Self = Self::build(TypeIDUInt::MAX);
     pub(crate) const LENGTH: usize = std::mem::size_of::<TypeIDUInt>();
 
     pub fn new(id: TypeIDUInt) -> Self {

--- a/encoding/graph/type_/vertex.rs
+++ b/encoding/graph/type_/vertex.rs
@@ -88,12 +88,11 @@ pub struct TypeID {
 pub type TypeIDUInt = u16;
 
 impl TypeID {
-    pub const MIN: Self = Self::build(0);
-    pub const MAX: Self = Self::build(TypeIDUInt::MAX);
+    pub const MIN: Self = Self::new(TypeIDUInt::MIN);
+    pub const MAX: Self = Self::new(TypeIDUInt::MAX);
     pub(crate) const LENGTH: usize = std::mem::size_of::<TypeIDUInt>();
 
-    pub fn new(id: TypeIDUInt) -> Self {
-        debug_assert_eq!(std::mem::size_of_val(&id), Self::LENGTH);
+    pub const fn new(id: TypeIDUInt) -> Self {
         Self { value: id }
     }
 

--- a/encoding/layout/prefix.rs
+++ b/encoding/layout/prefix.rs
@@ -61,7 +61,7 @@ macro_rules! make_prefix_enum {
 
 impl Prefix {
     pub fn max_object_type_prefix() -> Prefix {
-        if Prefix::VertexEntityType.prefix_id() < Prefix::VertexRelationType.prefix_id() {
+        if Prefix::VertexEntityType.prefix_id().byte < Prefix::VertexRelationType.prefix_id().byte {
             Prefix::VertexEntityType
         } else {
             Prefix::VertexRelationType
@@ -69,7 +69,7 @@ impl Prefix {
     }
 
     pub fn min_object_type_prefix() -> Prefix {
-        if Prefix::VertexEntityType.prefix_id() < Prefix::VertexRelationType.prefix_id() {
+        if Prefix::VertexEntityType.prefix_id().byte < Prefix::VertexRelationType.prefix_id().byte {
             Prefix::VertexRelationType
         } else {
             Prefix::VertexRelationType

--- a/encoding/layout/prefix.rs
+++ b/encoding/layout/prefix.rs
@@ -59,6 +59,24 @@ macro_rules! make_prefix_enum {
     };
 }
 
+impl Prefix {
+    pub fn max_object_type_prefix() -> Prefix {
+        if Prefix::VertexEntityType.prefix_id() < Prefix::VertexRelationType.prefix_id() {
+            Prefix::VertexEntityType
+        } else {
+            Prefix::VertexRelationType
+        }
+    }
+
+    pub fn min_object_type_prefix() -> Prefix {
+        if Prefix::VertexEntityType.prefix_id() < Prefix::VertexRelationType.prefix_id() {
+            Prefix::VertexRelationType
+        } else {
+            Prefix::VertexRelationType
+        }
+    }
+}
+
 make_prefix_enum! {
     // Reserved: 0-9
     VertexEntityType => 10, true;

--- a/executor/BUILD
+++ b/executor/BUILD
@@ -21,6 +21,7 @@ rust_library(
         "//common/error",
         "//common/lending_iterator",
         "//common/logger",
+        "//common/primitive",
         "//compiler",
         "//concept",
         "//encoding",

--- a/executor/Cargo.toml
+++ b/executor/Cargo.toml
@@ -106,7 +106,12 @@ features = {}
 		features = []
 		default-features = false
 
-	[dependencies.typeql]
+	[dependencies.primitive]
+		path = "../common/primitive"
+		features = []
+		default-features = false
+
+[dependencies.typeql]
 		features = []
 		rev = "3063987ccb66dd8a2e96cd440ab76865ea886f97"
 		git = "https://github.com/typedb/typeql"

--- a/executor/Cargo.toml
+++ b/executor/Cargo.toml
@@ -56,18 +56,23 @@ features = {}
 		version = "0.1.40"
 		default-features = false
 
+	[dependencies.primitive]
+		path = "../common/primitive"
+		features = []
+		default-features = false
+
 	[dependencies.resource]
 		path = "../resource"
 		features = []
 		default-features = false
 
-	[dependencies.logger]
-		path = "../common/logger"
+	[dependencies.concept]
+		path = "../concept"
 		features = []
 		default-features = false
 
-	[dependencies.concept]
-		path = "../concept"
+	[dependencies.logger]
+		path = "../common/logger"
 		features = []
 		default-features = false
 
@@ -106,12 +111,7 @@ features = {}
 		features = []
 		default-features = false
 
-	[dependencies.primitive]
-		path = "../common/primitive"
-		features = []
-		default-features = false
-
-[dependencies.typeql]
+	[dependencies.typeql]
 		features = []
 		rev = "3063987ccb66dd8a2e96cd440ab76865ea886f97"
 		git = "https://github.com/typedb/typeql"

--- a/executor/instruction/has_executor.rs
+++ b/executor/instruction/has_executor.rs
@@ -44,8 +44,8 @@ pub(crate) struct HasExecutor {
     variable_modes: VariableModes,
     tuple_positions: TuplePositions,
     owner_attribute_types: Arc<BTreeMap<Type, Vec<Type>>>,
-    owner_type_range: Bounds<ObjectType<'static>>,
-    attribute_type_range: Bounds<AttributeType<'static>>,
+    owner_type_range: Bounds<ObjectType>,
+    attribute_type_range: Bounds<AttributeType>,
     filter_fn: Arc<HasFilterFn>,
     owner_cache: Option<Vec<Object>>,
     checker: Checker<(Has, u64)>,
@@ -199,15 +199,15 @@ impl HasExecutor {
                     // TODO: we could create a reusable space for these temporarily held iterators
                     //       so we don't have allocate again before the merging iterator
                     let owners = self.owner_cache.as_ref().unwrap().iter();
-                    let iterators = owners
+                    let iterators: Vec<_> = owners
                         .map(|object| {
                             object.get_has_types_range_unordered(
                                 snapshot,
                                 thing_manager,
                                 &self.attribute_type_range,
-                            )))
+                            )
                         })
-                        .try_collect::<_, Vec<_>, _>()?;
+                        .collect();
 
                     // note: this will always have to heap alloc, if we use don't have a re-usable/small-vec'ed priority queue somewhere
                     let merged: KMergeBy<HasIterator, HasOrderingFn> =

--- a/executor/instruction/has_executor.rs
+++ b/executor/instruction/has_executor.rs
@@ -201,11 +201,7 @@ impl HasExecutor {
                     let owners = self.owner_cache.as_ref().unwrap().iter();
                     let iterators: Vec<_> = owners
                         .map(|object| {
-                            object.get_has_types_range_unordered(
-                                snapshot,
-                                thing_manager,
-                                &self.attribute_type_range,
-                            )
+                            object.get_has_types_range_unordered(snapshot, thing_manager, &self.attribute_type_range)
                         })
                         .collect();
 

--- a/executor/instruction/has_reverse_executor.rs
+++ b/executor/instruction/has_reverse_executor.rs
@@ -80,20 +80,19 @@ impl HasReverseExecutor {
         let owner = has.owner().as_variable().unwrap();
         let attribute = has.attribute().as_variable().unwrap();
 
-        let attribute_owner_types_range: BTreeMap<AttributeType, Bounds<ObjectType>> =
-            attribute_owner_types
-                .iter()
-                .map(|(type_, owner_types)| {
-                    let (min_owner_type, max_owner_type) = min_max_types(&*owner_types);
+        let attribute_owner_types_range: BTreeMap<AttributeType, Bounds<ObjectType>> = attribute_owner_types
+            .iter()
+            .map(|(type_, owner_types)| {
+                let (min_owner_type, max_owner_type) = min_max_types(&*owner_types);
+                (
+                    type_.as_attribute_type(),
                     (
-                        type_.as_attribute_type(),
-                        (
-                            Bound::Included(min_owner_type.as_object_type()),
-                            Bound::Included(max_owner_type.as_object_type()),
-                        ),
-                    )
-                })
-                .collect();
+                        Bound::Included(min_owner_type.as_object_type()),
+                        Bound::Included(max_owner_type.as_object_type()),
+                    ),
+                )
+            })
+            .collect();
 
         let (min_owner_type, max_owner_type) = min_max_types(&*owner_types);
         let owner_type_range =
@@ -239,10 +238,7 @@ impl HasReverseExecutor {
     fn all_has_reverse_chained(
         snapshot: &impl ReadableSnapshot,
         thing_manager: &ThingManager,
-        attribute_type_owner_range: &BTreeMap<
-            AttributeType,
-            (Bound<ObjectType>, Bound<ObjectType>),
-        >,
+        attribute_type_owner_range: &BTreeMap<AttributeType, (Bound<ObjectType>, Bound<ObjectType>)>,
         attribute_values_range: (Bound<Value<'_>>, Bound<Value<'_>>),
     ) -> Result<MultipleTypeHasReverseIterator, Box<ConceptReadError>> {
         let type_manager = thing_manager.type_manager();

--- a/executor/instruction/links_executor.rs
+++ b/executor/instruction/links_executor.rs
@@ -7,9 +7,9 @@
 use std::{
     collections::{BTreeMap, BTreeSet, HashMap},
     fmt, iter,
+    ops::Bound,
     sync::Arc,
 };
-use std::ops::Bound;
 
 use answer::{variable_value::VariableValue, Thing, Type};
 use compiler::{executable::match_::instructions::thing::LinksInstruction, ExecutorVariable};
@@ -177,7 +177,7 @@ impl LinksExecutor {
         match self.iterate_mode {
             TernaryIterateMode::Unbound => {
                 // TODO: we could cache the range byte arrays computed inside the thing_manager, for this case
-                let iterator = thing_manager.get_links_by_relation_type_range(snapshot,  &self.relation_type_range);
+                let iterator = thing_manager.get_links_by_relation_type_range(snapshot, &self.relation_type_range);
                 let as_tuples: LinksUnboundedSortedRelation =
                     iterator.filter_map(filter_for_row).map(links_to_tuple_relation_player_role as _);
                 Ok(TupleIterator::LinksUnbounded(SortedTupleIterator::new(
@@ -235,9 +235,8 @@ impl LinksExecutor {
                 let relation = self.links.relation().as_variable().unwrap().as_position().unwrap();
                 debug_assert!(row.len() > relation.as_usize());
                 let iterator = match row.get(relation) {
-                    &VariableValue::Thing(Thing::Relation(relation)) => {
-                        thing_manager.get_links_by_relation_and_player_type_range(snapshot, relation, &self.player_type_range,)
-                    }
+                    &VariableValue::Thing(Thing::Relation(relation)) => thing_manager
+                        .get_links_by_relation_and_player_type_range(snapshot, relation, &self.player_type_range),
                     _ => unreachable!("Links relation must be a relation."),
                 };
                 let as_tuples: LinksBoundedRelationSortedPlayer =

--- a/executor/instruction/links_executor.rs
+++ b/executor/instruction/links_executor.rs
@@ -18,13 +18,13 @@ use concept::{
         relation::{LinksIterator, Relation, RolePlayer},
         thing_manager::ThingManager,
     },
+    type_::{object_type::ObjectType, relation_type::RelationType},
 };
 use itertools::{kmerge_by, Itertools, KMergeBy, MinMaxResult};
+use typeql::statement::thing::RolePlayer;
+use primitive::Bounds;
 use resource::constants::traversal::CONSTANT_CONCEPT_LIMIT;
-use storage::{
-    key_range::{KeyRange, RangeEnd, RangeStart},
-    snapshot::ReadableSnapshot,
-};
+use storage::snapshot::ReadableSnapshot;
 
 use crate::{
     instruction::{
@@ -48,7 +48,8 @@ pub(crate) struct LinksExecutor {
     tuple_positions: TuplePositions,
 
     relation_player_types: Arc<BTreeMap<Type, Vec<Type>>>, // vecs are in sorted order
-    player_types: Arc<BTreeSet<Type>>,
+    relation_type_range: Bounds<RelationType<'static>>,
+    player_type_range: Bounds<ObjectType<'static>>,
 
     filter_fn: Arc<LinksFilterFn>,
     relation_cache: Option<Vec<Relation>>,
@@ -117,6 +118,13 @@ impl LinksExecutor {
             HashMap::from([(relation, EXTRACT_RELATION), (player, EXTRACT_PLAYER), (role_type, EXTRACT_ROLE)]),
         );
 
+        let relation_type_range = (
+            Bound::Included(relation_player_types.first_key_value().unwrap().0.as_relation_type()),
+            Bound::Included(relation_player_types.last_key_value().unwrap().0.as_relation_type()),
+        );
+        let (min_player_type, max_player_type) = min_max_types(player_types.iter());
+        let player_type_range =
+            (Bound::Included(min_player_type.as_object_type()), Bound::Included(max_player_type.as_object_type()));
         let relation_cache = if iterate_mode == TernaryIterateMode::UnboundInverted {
             let mut cache = Vec::new();
             for type_ in relation_player_types.keys() {
@@ -139,7 +147,8 @@ impl LinksExecutor {
             variable_modes,
             tuple_positions: output_tuple_positions,
             relation_player_types,
-            player_types,
+            relation_type_range,
+            player_type_range,
             filter_fn,
             relation_cache,
             checker,
@@ -167,14 +176,8 @@ impl LinksExecutor {
 
         match self.iterate_mode {
             TernaryIterateMode::Unbound => {
-                let first_from_type = self.relation_player_types.first_key_value().unwrap().0;
-                let last_key_from_type = self.relation_player_types.last_key_value().unwrap().0;
-                let key_range = KeyRange::new_variable_width(
-                    RangeStart::Inclusive(first_from_type.as_relation_type()),
-                    RangeEnd::EndPrefixInclusive(last_key_from_type.as_relation_type()),
-                );
                 // TODO: we could cache the range byte arrays computed inside the thing_manager, for this case
-                let iterator = thing_manager.get_links_by_relation_type_range(snapshot, key_range);
+                let iterator = thing_manager.get_links_by_relation_type_range(snapshot,  &self.relation_type_range);
                 let as_tuples: LinksUnboundedSortedRelation =
                     iterator.filter_map(filter_for_row).map(links_to_tuple_relation_player_role as _);
                 Ok(TupleIterator::LinksUnbounded(SortedTupleIterator::new(
@@ -186,19 +189,13 @@ impl LinksExecutor {
 
             TernaryIterateMode::UnboundInverted => {
                 debug_assert!(self.relation_cache.is_some());
-                let (min_player_type, max_player_type) = min_max_types(&*self.player_types);
-                let player_type_range = KeyRange::new_variable_width(
-                    RangeStart::Inclusive(min_player_type.as_object_type()),
-                    RangeEnd::EndPrefixInclusive(max_player_type.as_object_type()),
-                );
-
-                if let Some(&[relation]) = self.relation_cache.as_deref() {
+                if let Some([relation]) = self.relation_cache.as_deref() {
                     // no heap allocs needed if there is only 1 iterator
                     let iterator = thing_manager.get_links_by_relation_and_player_type_range(
                         snapshot,
                         relation,
                         // TODO: this should be just the types owned by the one instance's type in the cache!
-                        player_type_range,
+                        &self.player_type_range,
                     );
                     let as_tuples: LinksUnboundedSortedPlayerSingle =
                         iterator.filter_map(filter_for_row).map(links_to_tuple_player_relation_role);
@@ -216,7 +213,7 @@ impl LinksExecutor {
                             thing_manager.get_links_by_relation_and_player_type_range(
                                 snapshot,
                                 relation,
-                                player_type_range,
+                                &self.player_type_range,
                             )
                         })
                         .collect_vec();
@@ -237,15 +234,9 @@ impl LinksExecutor {
             TernaryIterateMode::BoundFrom => {
                 let relation = self.links.relation().as_variable().unwrap().as_position().unwrap();
                 debug_assert!(row.len() > relation.as_usize());
-                let (min_player_type, max_player_type) = min_max_types(&*self.player_types);
-                let player_type_range = KeyRange::new_variable_width(
-                    RangeStart::Inclusive(min_player_type.as_object_type()),
-                    RangeEnd::EndPrefixInclusive(max_player_type.as_object_type()),
-                );
-
                 let iterator = match row.get(relation) {
                     &VariableValue::Thing(Thing::Relation(relation)) => {
-                        thing_manager.get_links_by_relation_and_player_type_range(snapshot, relation, player_type_range)
+                        thing_manager.get_links_by_relation_and_player_type_range(snapshot, relation, &self.player_type_range,)
                     }
                     _ => unreachable!("Links relation must be a relation."),
                 };

--- a/executor/instruction/links_executor.rs
+++ b/executor/instruction/links_executor.rs
@@ -9,6 +9,7 @@ use std::{
     fmt, iter,
     sync::Arc,
 };
+use std::ops::Bound;
 
 use answer::{variable_value::VariableValue, Thing, Type};
 use compiler::{executable::match_::instructions::thing::LinksInstruction, ExecutorVariable};
@@ -21,7 +22,6 @@ use concept::{
     type_::{object_type::ObjectType, relation_type::RelationType},
 };
 use itertools::{kmerge_by, Itertools, KMergeBy, MinMaxResult};
-use typeql::statement::thing::RolePlayer;
 use primitive::Bounds;
 use resource::constants::traversal::CONSTANT_CONCEPT_LIMIT;
 use storage::snapshot::ReadableSnapshot;
@@ -48,8 +48,8 @@ pub(crate) struct LinksExecutor {
     tuple_positions: TuplePositions,
 
     relation_player_types: Arc<BTreeMap<Type, Vec<Type>>>, // vecs are in sorted order
-    relation_type_range: Bounds<RelationType<'static>>,
-    player_type_range: Bounds<ObjectType<'static>>,
+    relation_type_range: Bounds<RelationType>,
+    player_type_range: Bounds<ObjectType>,
 
     filter_fn: Arc<LinksFilterFn>,
     relation_cache: Option<Vec<Relation>>,
@@ -193,7 +193,7 @@ impl LinksExecutor {
                     // no heap allocs needed if there is only 1 iterator
                     let iterator = thing_manager.get_links_by_relation_and_player_type_range(
                         snapshot,
-                        relation,
+                        *relation,
                         // TODO: this should be just the types owned by the one instance's type in the cache!
                         &self.player_type_range,
                     );

--- a/executor/instruction/links_reverse_executor.rs
+++ b/executor/instruction/links_reverse_executor.rs
@@ -7,6 +7,7 @@
 use std::{
     collections::{BTreeMap, BTreeSet, HashMap},
     fmt,
+    ops::Bound,
     sync::Arc,
 };
 
@@ -19,13 +20,14 @@ use concept::{
         relation::{LinksIterator, Relation, RolePlayer},
         thing_manager::ThingManager,
     },
+    type_::{object_type::ObjectType, relation_type::RelationType},
 };
 use itertools::{kmerge_by, Itertools, KMergeBy, MinMaxResult};
+use itertools::{Itertools, MinMaxResult};
+use lending_iterator::{kmerge::KMergeBy, AsHkt, LendingIterator, Peekable};
+use primitive::Bounds;
 use resource::constants::traversal::CONSTANT_CONCEPT_LIMIT;
-use storage::{
-    key_range::{KeyRange, RangeEnd, RangeStart},
-    snapshot::ReadableSnapshot,
-};
+use storage::snapshot::ReadableSnapshot;
 
 use crate::{
     instruction::{
@@ -53,7 +55,8 @@ pub(crate) struct LinksReverseExecutor {
     tuple_positions: TuplePositions,
 
     player_relation_types: Arc<BTreeMap<Type, Vec<Type>>>, // vecs are in sorted order
-    relation_types: Arc<BTreeSet<Type>>,
+    player_type_range: Bounds<ObjectType<'static>>,
+    relation_type_range: Bounds<RelationType<'static>>,
 
     filter_fn: Arc<LinksFilterFn>,
     player_cache: Option<Vec<Object>>,
@@ -105,6 +108,17 @@ impl LinksReverseExecutor {
             HashMap::from([(relation, EXTRACT_RELATION), (player, EXTRACT_PLAYER), (role_type, EXTRACT_ROLE)]),
         );
 
+        let player_type_range = (
+            Bound::Included(player_relation_types.first_key_value().unwrap().0.as_object_type()),
+            Bound::Included(player_relation_types.last_key_value().unwrap().0.as_object_type()),
+        );
+
+        let (min_relation_type, max_relation_type) = min_max_types(relation_types.iter());
+        let relation_type_range = (
+            Bound::Included(min_relation_type.as_relation_type()),
+            Bound::Included(max_relation_type.as_relation_type()),
+        );
+
         let player_cache = if iterate_mode == TernaryIterateMode::UnboundInverted {
             let mut cache = Vec::new();
             for type_ in player_relation_types.keys() {
@@ -127,7 +141,8 @@ impl LinksReverseExecutor {
             variable_modes,
             tuple_positions: output_tuple_positions,
             player_relation_types,
-            relation_types,
+            player_type_range,
+            relation_type_range,
             filter_fn,
             player_cache,
             checker,
@@ -155,14 +170,8 @@ impl LinksReverseExecutor {
 
         match self.iterate_mode {
             TernaryIterateMode::Unbound => {
-                let min_player_type = self.player_relation_types.first_key_value().unwrap().0;
-                let max_player_type = self.player_relation_types.last_key_value().unwrap().0;
-                let key_range = KeyRange::new_variable_width(
-                    RangeStart::Inclusive(min_player_type.as_object_type()),
-                    RangeEnd::EndPrefixInclusive(max_player_type.as_object_type()),
-                );
                 // TODO: we could cache the range byte arrays computed inside the thing_manager, for this case
-                let iterator = thing_manager.get_links_reverse_by_player_type_range(snapshot, key_range);
+                let iterator = thing_manager.get_links_reverse_by_player_type_range(snapshot, &self.player_type_range);
                 let as_tuples: LinksReverseUnboundedSortedPlayer =
                     iterator.filter_map(filter_for_row).map(links_to_tuple_player_relation_role);
                 Ok(TupleIterator::LinksReverseUnbounded(SortedTupleIterator::new(
@@ -174,20 +183,13 @@ impl LinksReverseExecutor {
 
             TernaryIterateMode::UnboundInverted => {
                 debug_assert!(self.player_cache.is_some());
-
-                let (min_relation_type, max_relation_type) = min_max_types(&*self.relation_types);
-                let relation_type_range = KeyRange::new_variable_width(
-                    RangeStart::Inclusive(min_relation_type.as_relation_type()),
-                    RangeEnd::EndPrefixInclusive(max_relation_type.as_relation_type()),
-                );
-
-                if let Some(&[player]) = self.player_cache.as_deref() {
+                if let Some([player]) = self.player_cache.as_deref() {
                     // no heap allocs needed if there is only 1 iterator
                     let filtered = thing_manager.get_links_reverse_by_player_and_relation_type_range(
                         snapshot,
                         player,
                         // TODO: this should be just the types owned by the one instance's type in the cache!
-                        relation_type_range,
+                        &self.relation_type_range,
                     );
                     let as_tuples: LinksReverseUnboundedSortedRelationSingle =
                         filtered.filter_map(filter_for_row).map(links_to_tuple_relation_player_role);
@@ -205,7 +207,7 @@ impl LinksReverseExecutor {
                             thing_manager.get_links_reverse_by_player_and_relation_type_range(
                                 snapshot,
                                 relation,
-                                relation_type_range,
+                                &self.relation_type_range,
                             )
                         })
                         .collect_vec();
@@ -226,16 +228,10 @@ impl LinksReverseExecutor {
             TernaryIterateMode::BoundFrom => {
                 let player = self.links.player().as_variable().unwrap().as_position().unwrap();
                 debug_assert!(row.len() > player.as_usize());
-                let (min_relation_type, max_relation_type) = min_max_types(&*self.relation_types);
-                let relation_type_range = KeyRange::new_variable_width(
-                    RangeStart::Inclusive(min_relation_type.as_relation_type()),
-                    RangeEnd::EndPrefixInclusive(max_relation_type.as_relation_type()),
-                );
-
-                let iterator = thing_manager.get_links_reverse_by_player_and_relation_type_range(
+                let mut iterator = thing_manager.get_links_reverse_by_player_and_relation_type_range(
                     snapshot,
                     row.get(player).as_thing().as_object(),
-                    relation_type_range,
+                    &self.relation_type_range,
                 );
                 let as_tuples: LinksReverseBoundedPlayerSortedRelation =
                     iterator.filter_map(filter_for_row).map(links_to_tuple_relation_player_role);

--- a/executor/instruction/links_reverse_executor.rs
+++ b/executor/instruction/links_reverse_executor.rs
@@ -23,8 +23,6 @@ use concept::{
     type_::{object_type::ObjectType, relation_type::RelationType},
 };
 use itertools::{kmerge_by, Itertools, KMergeBy, MinMaxResult};
-use itertools::{Itertools, MinMaxResult};
-use lending_iterator::{kmerge::KMergeBy, AsHkt, LendingIterator, Peekable};
 use primitive::Bounds;
 use resource::constants::traversal::CONSTANT_CONCEPT_LIMIT;
 use storage::snapshot::ReadableSnapshot;
@@ -55,8 +53,8 @@ pub(crate) struct LinksReverseExecutor {
     tuple_positions: TuplePositions,
 
     player_relation_types: Arc<BTreeMap<Type, Vec<Type>>>, // vecs are in sorted order
-    player_type_range: Bounds<ObjectType<'static>>,
-    relation_type_range: Bounds<RelationType<'static>>,
+    player_type_range: Bounds<ObjectType>,
+    relation_type_range: Bounds<RelationType>,
 
     filter_fn: Arc<LinksFilterFn>,
     player_cache: Option<Vec<Object>>,
@@ -187,7 +185,7 @@ impl LinksReverseExecutor {
                     // no heap allocs needed if there is only 1 iterator
                     let filtered = thing_manager.get_links_reverse_by_player_and_relation_type_range(
                         snapshot,
-                        player,
+                        *player,
                         // TODO: this should be just the types owned by the one instance's type in the cache!
                         &self.relation_type_range,
                     );

--- a/executor/instruction/mod.rs
+++ b/executor/instruction/mod.rs
@@ -29,7 +29,7 @@ use ir::{
     },
     pipeline::ParameterRegistry,
 };
-use itertools::Itertools;
+use itertools::{Itertools, MinMaxResult};
 use storage::snapshot::ReadableSnapshot;
 
 use crate::{
@@ -851,5 +851,13 @@ fn get_vertex_value<'a>(
         CheckVertex::Parameter(parameter_id) => {
             VariableValue::Value(parameters.value_unchecked(*parameter_id).as_reference())
         }
+    }
+}
+
+fn min_max_types<'a>(types: impl IntoIterator<Item = &'a Type>) -> (Type, Type) {
+    match types.into_iter().minmax() {
+        MinMaxResult::NoElements => unreachable!("Empty type iterator"),
+        MinMaxResult::OneElement(item) => (item.clone(), item.clone()),
+        MinMaxResult::MinMax(min, max) => (min.clone(), max.clone()),
     }
 }

--- a/executor/tests/execute_comparison_check.rs
+++ b/executor/tests/execute_comparison_check.rs
@@ -14,7 +14,7 @@ use compiler::{
     annotation::{function::EmptyAnnotatedFunctionSignatures, match_inference::infer_types},
     executable::{
         match_::{
-            instructions::{thing::IsaInstruction, CheckInstruction, CheckVertex, ConstraintInstruction, Inputs},
+            instructions::{CheckInstruction, CheckVertex, ConstraintInstruction, Inputs, thing::IsaInstruction},
             planner::{
                 function_plan::ExecutableFunctionRegistry,
                 match_executable::{ExecutionStep, IntersectionStep, MatchExecutable},
@@ -27,8 +27,8 @@ use compiler::{
 use concept::type_::{annotation::AnnotationIndependent, attribute_type::AttributeTypeAnnotation};
 use encoding::value::{label::Label, value::Value, value_type::ValueType};
 use executor::{
-    error::ReadExecutionError, match_executor::MatchExecutor, pipeline::stage::ExecutionContext, profile::QueryProfile,
-    row::MaybeOwnedRow, ExecutionInterrupt,
+    error::ReadExecutionError, ExecutionInterrupt, match_executor::MatchExecutor, pipeline::stage::ExecutionContext,
+    profile::QueryProfile, row::MaybeOwnedRow,
 };
 use ir::{
     pattern::constraint::{Comparator, IsaKind},
@@ -36,7 +36,7 @@ use ir::{
     translation::TranslationContext,
 };
 use lending_iterator::LendingIterator;
-use storage::{durability_client::WALClient, snapshot::CommittableSnapshot, MVCCStorage};
+use storage::{durability_client::WALClient, MVCCStorage, snapshot::CommittableSnapshot};
 use test_utils_concept::{load_managers, setup_concept_storage};
 use test_utils_encoding::create_core_storage;
 

--- a/function/function_manager.rs
+++ b/function/function_manager.rs
@@ -227,8 +227,8 @@ impl FunctionReader {
         snapshot: &impl ReadableSnapshot,
     ) -> Result<Vec<SchemaFunction>, FunctionReadError> {
         snapshot
-            .iterate_range(KeyRange::new_within(
-                RangeStart::Inclusive(DefinitionKey::build_prefix(FunctionDefinition::PREFIX)),
+            .iterate_range(&KeyRange::new_within(
+                DefinitionKey::build_prefix(FunctionDefinition::PREFIX),
                 DefinitionKey::FIXED_WIDTH_ENCODING,
             ))
             .collect_cloned_vec(|key, value| {

--- a/storage/benches/bench_mvcc_storage.rs
+++ b/storage/benches/bench_mvcc_storage.rs
@@ -15,7 +15,7 @@ use pprof::ProfilerGuard;
 use resource::constants::snapshot::{BUFFER_KEY_INLINE, BUFFER_VALUE_INLINE};
 use storage::{
     durability_client::WALClient,
-    key_range::{KeyRange, RangeStart},
+    key_range::KeyRange,
     key_value::{StorageKey, StorageKeyArray, StorageKeyReference},
     keyspace::{KeyspaceId, KeyspaceSet},
     snapshot::{CommittableSnapshot, ReadableSnapshot, WritableSnapshot},

--- a/storage/benches/bench_mvcc_storage.rs
+++ b/storage/benches/bench_mvcc_storage.rs
@@ -70,7 +70,7 @@ fn populate_storage(storage: Arc<MVCCStorage<WALClient>>, keyspace: TestKeyspace
     println!("Keys written: {}", key_count);
     let snapshot = storage.open_snapshot_read();
     let prefix: StorageKey<'_, 48> = StorageKey::Reference(StorageKeyReference::new(keyspace, &[0_u8]));
-    let iterator = snapshot.iterate_range(KeyRange::new_within(RangeStart::Inclusive(prefix), false));
+    let iterator = snapshot.iterate_range(&KeyRange::new_within(prefix, false));
     let count = iterator.collect_cloned_vec(|_, _| ((), ())).unwrap().len();
     println!("Keys confirmed to be written: {}", count);
     count

--- a/storage/iterator.rs
+++ b/storage/iterator.rs
@@ -34,11 +34,12 @@ impl MVCCRangeIterator {
     //
     pub(crate) fn new<D, const PS: usize>(
         storage: &MVCCStorage<D>,
-        range: KeyRange<StorageKey<'_, PS>>,
+        range: &KeyRange<StorageKey<'_, PS>>,
         open_sequence_number: SequenceNumber,
     ) -> Self {
         let keyspace = storage.get_keyspace(range.start().get_value().keyspace_id());
-        let iterator = keyspace.iterate_range(range.map(|key| key.into_bytes(), |fixed_width| fixed_width));
+        let mapped_range = range.map(|key| key.as_bytes(), |fixed_width| fixed_width);
+        let iterator = keyspace.iterate_range(&mapped_range);
         MVCCRangeIterator {
             storage_name: storage.name(),
             keyspace_id: keyspace.id(),

--- a/storage/key_value.rs
+++ b/storage/key_value.rs
@@ -45,7 +45,7 @@ impl<'bytes, const S: usize> StorageKey<'bytes, S> {
     pub fn as_bytes(&self) -> Bytes<'_, S> {
         match self {
             StorageKey::Array(array) => Bytes::Reference(array.byte_array().as_ref()),
-            StorageKey::Reference(ref_) => Bytes::Reference(ref_.byte_ref()),
+            StorageKey::Reference(ref_) => Bytes::Reference(ref_.reference),
         }
     }
 

--- a/storage/key_value.rs
+++ b/storage/key_value.rs
@@ -42,6 +42,13 @@ impl<'bytes, const S: usize> StorageKey<'bytes, S> {
         }
     }
 
+    pub fn as_bytes(&self) -> Bytes<'_, S> {
+        match self {
+            StorageKey::Array(array) => Bytes::Reference(array.byte_array().as_ref()),
+            StorageKey::Reference(ref_) => Bytes::Reference(ref_.byte_ref()),
+        }
+    }
+
     pub fn into_bytes(self) -> Bytes<'bytes, S> {
         match self {
             StorageKey::Array(array) => Bytes::Array(array.into_byte_array()),

--- a/storage/keyspace/iterator.rs
+++ b/storage/keyspace/iterator.rs
@@ -37,8 +37,8 @@ impl KeyspaceRangeIterator {
         // read_opts.set_prefix_same_as_start(true);
 
         let start_prefix = match range.start() {
-            RangeStart::Inclusive(bytes) => Bytes::Reference(bytes.as_reference()),
-            RangeStart::ExcludeFirstWithPrefix(bytes) => Bytes::Reference(bytes.as_reference()),
+            RangeStart::Inclusive(bytes) => Bytes::Reference(bytes.as_ref()),
+            RangeStart::ExcludeFirstWithPrefix(bytes) => Bytes::Reference(bytes.as_ref()),
             RangeStart::ExcludePrefix(bytes) => {
                 let mut cloned = bytes.to_array();
                 cloned.increment().unwrap();

--- a/storage/keyspace/iterator.rs
+++ b/storage/keyspace/iterator.rs
@@ -11,7 +11,7 @@ use lending_iterator::{LendingIterator, Seekable};
 use rocksdb::DB;
 
 use crate::{
-    key_range::{KeyRange, RangeEnd},
+    key_range::{KeyRange, RangeEnd, RangeStart},
     keyspace::{raw_iterator, raw_iterator::DBIterator, Keyspace, KeyspaceError},
 };
 
@@ -31,16 +31,25 @@ enum ContinueCondition {
 impl KeyspaceRangeIterator {
     pub(crate) fn new<'a, const INLINE_BYTES: usize>(
         keyspace: &'a Keyspace,
-        range: KeyRange<Bytes<'a, INLINE_BYTES>>,
+        range: &KeyRange<Bytes<'a, INLINE_BYTES>>,
     ) -> Self {
         // TODO: if self.has_prefix_extractor_for(prefix), we can enable bloom filters
         // read_opts.set_prefix_same_as_start(true);
 
+        let start_prefix = match range.start() {
+            RangeStart::Inclusive(bytes) => Bytes::Reference(bytes.as_reference()),
+            RangeStart::ExcludeFirstWithPrefix(bytes) => Bytes::Reference(bytes.as_reference()),
+            RangeStart::ExcludePrefix(bytes) => {
+                let mut cloned = bytes.to_array();
+                cloned.increment().unwrap();
+                Bytes::Array(cloned)
+            }
+        };
+
         let read_opts = keyspace.new_read_options();
         let kv_storage: &'static DB = unsafe { std::mem::transmute(&keyspace.kv_storage) };
-        let mut iterator =
-            raw_iterator::DBIterator::new_from(kv_storage.raw_iterator_opt(read_opts), range.start().get_value());
-        if range.start().is_exclusive() {
+        let mut iterator = DBIterator::new_from(kv_storage.raw_iterator_opt(read_opts), start_prefix.as_ref());
+        if matches!(range.start(), RangeStart::ExcludeFirstWithPrefix(_)) {
             Self::may_skip_start(&mut iterator, range.start().get_value());
         }
 

--- a/storage/keyspace/keyspace.rs
+++ b/storage/keyspace/keyspace.rs
@@ -45,7 +45,7 @@ fn db_options() -> Options {
     let mut options = Options::default();
     options.create_if_missing(true);
     options.create_missing_column_families(true);
-    options.enable_statistics();
+    // options.enable_statistics();
     // TODO optimise per-keyspace
     options
 }
@@ -252,9 +252,9 @@ impl Keyspace {
     }
 
     // TODO: we should benchmark using iterator pools, which would require changing prefix/range on read options
-    pub(crate) fn iterate_range<'s, const PREFIX_INLINE_SIZE: usize>(
-        &'s self,
-        range: KeyRange<Bytes<'s, PREFIX_INLINE_SIZE>>,
+    pub(crate) fn iterate_range<const PREFIX_INLINE_SIZE: usize>(
+        &self,
+        range: &KeyRange<Bytes<'_, PREFIX_INLINE_SIZE>>,
     ) -> iterator::KeyspaceRangeIterator {
         iterator::KeyspaceRangeIterator::new(self, range)
     }

--- a/storage/snapshot/buffer.rs
+++ b/storage/snapshot/buffer.rs
@@ -189,10 +189,12 @@ impl WriteBuffer {
         } else {
             Bound::Excluded(&*exclusive_end_bytes)
         };
+        let start_as_bound = Self::range_start_as_bound(range_start);
+        let start_bytes = start_as_bound.as_ref().map(|bytes| bytes.as_ref());
         // TODO: we shouldn't have to copy now that we use single-writer semantics
         BufferRangeIterator::new(
             self.writes
-                .range::<[u8], _>((range_start.as_bound().map(|bytes| &**bytes), end))
+                .range::<[u8], _>((start_bytes, end))
                 .map(|(key, val)| (StorageKeyArray::new_raw(self.keyspace_id, key.clone()), val.clone()))
                 .collect::<Vec<_>>(),
         )
@@ -207,9 +209,23 @@ impl WriteBuffer {
         } else {
             Bound::Excluded(&*exclusive_end_bytes)
         };
-        self.writes
-            .range::<[u8], _>((range_start.as_bound().map(|bytes| &**bytes), end))
-            .any(|(_, write)| !write.is_delete())
+        let start_as_bound = Self::range_start_as_bound(range_start);
+        let start_bytes = start_as_bound.as_ref().map(|bytes| bytes.as_ref());
+        self.writes.range::<[u8], _>((start_bytes, end)).any(|(_, write)| !write.is_delete())
+    }
+
+    fn range_start_as_bound<const INLINE: usize>(
+        range_start: RangeStart<Bytes<'_, INLINE>>,
+    ) -> Bound<Bytes<'_, INLINE>> {
+        match range_start {
+            RangeStart::Inclusive(bytes) => Bound::Included(bytes),
+            RangeStart::ExcludeFirstWithPrefix(bytes) => Bound::Excluded(bytes),
+            RangeStart::ExcludePrefix(bytes) => {
+                let mut cloned = bytes.clone().into_array();
+                cloned.increment().unwrap();
+                Bound::Included(Bytes::Array(cloned))
+            }
+        }
     }
 
     fn compute_exclusive_end<const INLINE: usize>(

--- a/storage/snapshot/iterator.rs
+++ b/storage/snapshot/iterator.rs
@@ -230,7 +230,7 @@ impl LendingIterator for SnapshotRangeIterator {
         if self.ready_item_source.is_none() {
             self.find_next_state();
         }
-        match self.ready_item_source.take() {
+        let next = match self.ready_item_source.take() {
             Some(ReadyItemSource::Both) => {
                 // Skip the storage and get the buffered value because they can be different
                 let _ = self.storage_next();
@@ -239,7 +239,8 @@ impl LendingIterator for SnapshotRangeIterator {
             Some(ReadyItemSource::Storage) => self.storage_next(),
             Some(ReadyItemSource::Buffered) => self.buffered_next(),
             None => None,
-        }
+        };
+        next
     }
 }
 

--- a/storage/tests/test_isolation.rs
+++ b/storage/tests/test_isolation.rs
@@ -67,14 +67,14 @@ fn commits_isolated() {
     assert!(get.is_none());
     let prefix: StorageKey<'_, BUFFER_KEY_INLINE> =
         StorageKey::Array(StorageKeyArray::new(Keyspace, ByteArray::copy(&[0x0_u8])));
-    let range = KeyRange::new_within(RangeStart::Inclusive(prefix), false);
-    let retrieved_count = snapshot_2.iterate_range(range.clone()).count();
+    let range = KeyRange::new_within(prefix, false);
+    let retrieved_count = snapshot_2.iterate_range(&range).count();
     assert_eq!(retrieved_count, 2);
 
     let snapshot_3 = storage.open_snapshot_read();
     let get: Option<ByteArray<BUFFER_KEY_INLINE>> = snapshot_3.get(StorageKeyReference::from(&key_3)).unwrap();
     assert!(matches!(get, Some(_value_3)));
-    let retrieved_count = snapshot_3.iterate_range(range.clone()).count();
+    let retrieved_count = snapshot_3.iterate_range(&range).count();
     assert_eq!(retrieved_count, 3);
 }
 
@@ -364,7 +364,7 @@ fn g2_predicate_anti_dependency_cycles() {
     let key_4 = StorageKeyArray::new(Keyspace, ByteArray::copy(&key_4_bytes));
 
     let key_prefix = StorageKeyArray::<BUFFER_KEY_INLINE>::from((Keyspace, [0x0]));
-    let prefix = KeyRange::new_within(RangeStart::Inclusive(StorageKey::Array(key_prefix)), false);
+    let prefix = KeyRange::new_within(StorageKey::Array(key_prefix), false);
     let value_31 = ByteArray::inline([30], 1);
     let value_42 = ByteArray::inline([42], 1);
     let storage_path = create_tmp_dir();
@@ -373,14 +373,14 @@ fn g2_predicate_anti_dependency_cycles() {
     let mut snapshot_1 = storage.clone().open_snapshot_write();
     let mut snapshot_2 = storage.open_snapshot_write();
 
-    let it_1 = snapshot_1.iterate_range(prefix.clone());
+    let it_1 = snapshot_1.iterate_range(&prefix);
     let mut sum_1 = 0;
     for v in it_1.collect_cloned_vec(|_, v| ByteArray::<BUFFER_VALUE_INLINE>::from(v)).unwrap().iter() {
         sum_1 += v[0] as i64;
     }
     assert!(sum_1 == 1);
 
-    let it_2 = snapshot_2.iterate_range(prefix.clone());
+    let it_2 = snapshot_2.iterate_range(&prefix);
     let mut sum_2 = 0;
     for v in it_2.collect_cloned_vec(|_, v| ByteArray::<BUFFER_VALUE_INLINE>::from(v)).unwrap().iter() {
         sum_2 += v[0] as i64;

--- a/storage/tests/test_isolation.rs
+++ b/storage/tests/test_isolation.rs
@@ -13,7 +13,7 @@ use resource::constants::snapshot::{BUFFER_KEY_INLINE, BUFFER_VALUE_INLINE};
 use storage::{
     durability_client::{DurabilityClient, WALClient},
     isolation_manager::IsolationConflict,
-    key_range::{KeyRange, RangeStart},
+    key_range::KeyRange,
     key_value::{StorageKey, StorageKeyArray, StorageKeyReference},
     snapshot::{CommittableSnapshot, ReadableSnapshot, SnapshotError, WritableSnapshot, WriteSnapshot},
     MVCCStorage, StorageCommitError,

--- a/storage/tests/test_snapshot.rs
+++ b/storage/tests/test_snapshot.rs
@@ -11,7 +11,7 @@ use lending_iterator::LendingIterator;
 use logger::result::ResultExt;
 use resource::constants::snapshot::{BUFFER_KEY_INLINE, BUFFER_VALUE_INLINE};
 use storage::{
-    key_range::{KeyRange, RangeStart},
+    key_range::KeyRange,
     key_value::{StorageKey, StorageKeyArray},
     snapshot::{CommittableSnapshot, ReadableSnapshot, WritableSnapshot},
 };

--- a/storage/tests/test_snapshot.rs
+++ b/storage/tests/test_snapshot.rs
@@ -68,7 +68,7 @@ fn snapshot_buffered_put_iterate() {
 
     let key_prefix = StorageKeyArray::<BUFFER_KEY_INLINE>::from((Keyspace, [0x1]));
     let items: Result<Vec<(StorageKeyArray<BUFFER_KEY_INLINE>, ByteArray<BUFFER_VALUE_INLINE>)>, _> = snapshot
-        .iterate_range(KeyRange::new_within(RangeStart::Inclusive(StorageKey::Array(key_prefix)), false))
+        .iterate_range(&KeyRange::new_within(StorageKey::Array(key_prefix), false))
         .collect_cloned_vec(|k, v| (StorageKeyArray::from(k), ByteArray::from(v)));
     assert_eq!(items.unwrap(), vec![(key_2, ByteArray::empty()), (key_3, ByteArray::empty())]);
     snapshot.close_resources();
@@ -97,7 +97,7 @@ fn snapshot_buffered_delete() {
 
     let key_prefix = StorageKeyArray::<BUFFER_KEY_INLINE>::from((Keyspace, [0x1]));
     let items: Vec<(StorageKeyArray<BUFFER_KEY_INLINE>, ByteArray<BUFFER_VALUE_INLINE>)> = snapshot
-        .iterate_range(KeyRange::new_within(RangeStart::Inclusive(StorageKey::Array(key_prefix)), false))
+        .iterate_range(&KeyRange::new_within(StorageKey::Array(key_prefix), false))
         .collect_cloned_vec(|k, v| (StorageKeyArray::from(k), ByteArray::from(v)))
         .unwrap();
     assert_eq!(items, vec![(key_2, ByteArray::empty())]);
@@ -130,7 +130,7 @@ fn snapshot_read_through() {
 
     let key_prefix = StorageKeyArray::<BUFFER_KEY_INLINE>::from((Keyspace, [0x1]));
     let key_values: Vec<(StorageKeyArray<BUFFER_KEY_INLINE>, ByteArray<BUFFER_VALUE_INLINE>)> = snapshot
-        .iterate_range(KeyRange::new_within(RangeStart::Inclusive(StorageKey::Array(key_prefix.clone())), false))
+        .iterate_range(&KeyRange::new_within(StorageKey::Array(key_prefix.clone()), false))
         .collect_cloned_vec(|k, v| (StorageKeyArray::from(k), ByteArray::from(v)))
         .unwrap();
     assert_eq!(
@@ -145,7 +145,7 @@ fn snapshot_read_through() {
     // test delete-iterate read-through
     snapshot.delete(key_2.clone());
     let key_values: Vec<(StorageKeyArray<BUFFER_KEY_INLINE>, ByteArray<BUFFER_VALUE_INLINE>)> = snapshot
-        .iterate_range(KeyRange::new_within(RangeStart::Inclusive(StorageKey::Array(key_prefix)), false))
+        .iterate_range(&KeyRange::new_within(StorageKey::Array(key_prefix), false))
         .collect_cloned_vec(|k, v| (StorageKeyArray::from(k), ByteArray::from(v)))
         .unwrap();
     assert_eq!(key_values, vec![(key_3, ByteArray::empty()), (key_5, ByteArray::empty())]);
@@ -174,11 +174,8 @@ fn snapshot_read_buffered_delete_of_persisted_key() {
         assert_eq!(
             2,
             snapshot
-                .iterate_range(KeyRange::new_within(
-                    RangeStart::Inclusive(StorageKey::Array(StorageKeyArray::new(
-                        Keyspace,
-                        ByteArray::inline([0x0], 1)
-                    ))),
+                .iterate_range(&KeyRange::new_within(
+                    StorageKey::Array(StorageKeyArray::new(Keyspace, ByteArray::inline([0x0], 1))),
                     false
                 ))
                 .count()
@@ -188,11 +185,8 @@ fn snapshot_read_buffered_delete_of_persisted_key() {
         assert_eq!(
             1,
             snapshot
-                .iterate_range(KeyRange::new_within(
-                    RangeStart::Inclusive(StorageKey::Array(StorageKeyArray::new(
-                        Keyspace,
-                        ByteArray::inline([0x0], 1)
-                    ))),
+                .iterate_range(&KeyRange::new_within(
+                    StorageKey::Array(StorageKeyArray::new(Keyspace, ByteArray::inline([0x0], 1))),
                     false
                 ))
                 .count()

--- a/storage/tests/test_storage.rs
+++ b/storage/tests/test_storage.rs
@@ -185,7 +185,7 @@ fn get_put_iterate() {
     let prefix = StorageKeyArray::<BUFFER_VALUE_INLINE>::from((TestKeyspaceSet::Keyspace1, [0x1]));
     let items: Vec<(ByteArray<BUFFER_VALUE_INLINE>, ByteArray<128>)> = storage
         .iterate_keyspace_range(KeyRange::new_within(
-            RangeStart::Inclusive(StorageKey::<BUFFER_VALUE_INLINE>::Reference(StorageKeyReference::from(&prefix))),
+            StorageKey::<BUFFER_VALUE_INLINE>::Reference(StorageKeyReference::from(&prefix)),
             false,
         ))
         .map_static::<(ByteArray<BUFFER_VALUE_INLINE>, ByteArray<128>), _>(|res| {

--- a/storage/tests/test_utils_storage/lib.rs
+++ b/storage/tests/test_utils_storage/lib.rs
@@ -4,8 +4,6 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-pub mod mock_snapshot;
-
 use std::{path::Path, sync::Arc};
 
 use durability::wal::WAL;
@@ -13,6 +11,8 @@ use storage::{
     durability_client::WALClient, keyspace::KeyspaceSet, recovery::checkpoint::Checkpoint, MVCCStorage,
     StorageOpenError,
 };
+
+pub mod mock_snapshot;
 
 #[macro_export]
 macro_rules! test_keyspace_set {

--- a/storage/tests/test_utils_storage/mock_snapshot.rs
+++ b/storage/tests/test_utils_storage/mock_snapshot.rs
@@ -37,13 +37,13 @@ impl ReadableSnapshot for MockSnapshot {
         Err(SnapshotGetError::MockError {})
     }
 
-    fn iterate_range<const PS: usize>(&self, range: KeyRange<StorageKey<'_, PS>>) -> SnapshotRangeIterator {
+    fn iterate_range<const PS: usize>(&self, range: &KeyRange<StorageKey<'_, PS>>) -> SnapshotRangeIterator {
         SnapshotRangeIterator::new_empty()
     }
 
     fn any_in_range<'this, const PS: usize>(
         &'this self,
-        range: KeyRange<StorageKey<'this, PS>>,
+        range: &KeyRange<StorageKey<'this, PS>>,
         buffered_only: bool,
     ) -> bool {
         false
@@ -61,14 +61,14 @@ impl ReadableSnapshot for MockSnapshot {
 
     fn iterate_writes_range<'this, const PS: usize>(
         &'this self,
-        range: KeyRange<StorageKey<'this, PS>>,
+        range: &KeyRange<StorageKey<'this, PS>>,
     ) -> BufferRangeIterator {
         BufferRangeIterator::new_empty()
     }
 
     fn iterate_storage_range<'this, const PS: usize>(
         &'this self,
-        range: KeyRange<StorageKey<'this, PS>>,
+        range: &KeyRange<StorageKey<'this, PS>>,
     ) -> SnapshotRangeIterator {
         SnapshotRangeIterator::new_empty()
     }

--- a/tests/behaviour/steps/concept/thing/has.rs
+++ b/tests/behaviour/steps/concept/thing/has.rs
@@ -222,8 +222,8 @@ async fn object_get_has_is_empty(
         object
             .get_has_unordered(tx.snapshot.as_ref(), &tx.thing_manager)
             .map(|res| {
-                let (attribute, _count) = res.unwrap();
-                attribute
+                let (has, _count) = res.unwrap();
+                has.attribute()
             })
             .collect::<Vec<_>>()
     });
@@ -247,7 +247,8 @@ async fn object_get_has(
         object
             .get_has_unordered(tx.snapshot.as_ref(), &tx.thing_manager)
             .map(|res| {
-                let (attribute, _count) = res.unwrap();
+                let (has, _count) = res.unwrap();
+                let attribute = has.attribute();
                 attribute
             })
             .collect::<Vec<_>>()


### PR DESCRIPTION
## Release notes: product changes

We incorporate more typing information into the storage lookup operations, making them more longer and specific and reducing the range of data that must be retrieved for any traversal operation. This should make future RocksDB bloom filters more effective, and reduce the amount of data that is read even when bloom filters are not available for the prefix. Overall, we expect this to allow TypeDB to scale better, particularly on larger-than-memory workloads.

## Motivation

We implement a feature that is already available in TypeDB 2.x: using the destination type of a connection traversal (say, a 'has') to restrict the range of data that must be searched. This should improve performance and scalability.

## Implementation

We extend the prefixes used to do storage lookups to a consistent length, where possible, of : 
`[connection type][start concept][end concept type prefix]`
instead of
`[connection type][start concept]`. 

This should allow bloom filters to be more effective when they are added, since we are searching for more specialised prefixes that will hit fewer levels in the RocksDB LSM tree.

## Notes

- It is no long entirely clear that adding the `end concept type prefix` is beneficial when the key range we need to scan is a range of prefixes, rather than just within the one prefix: it seems that logical that Rocks bloom filters only work exactly within 1 prefix, as they are used to position iterators in the LSM tree files.
- If we want our iterators to support scanning beyond the initial prefix without missing data, we will need to manually disable prefix filters:
```
Users can only use prefix bloom filter to read inside a specific prefix. If iterator is outside a prefix, the feature needs to be disabled for specific iterators to prevent wrong results:
```

from: https://github.com/facebook/rocksdb/wiki/Prefix-Seek

Thus, in RocksDB, we will need to be careful to make sure that the key range we wish to scan in an iterator has a consistent prefix (`key_range.start()[..bloom_prefix_length] == key_range.end()[..bloom_prefix_length]`)
