### PR TITLE
Fix greedy planner to sort on correct vars

### DIFF
--- a/compiler/executable/match_/planner/plan.rs
+++ b/compiler/executable/match_/planner/plan.rs
@@ -591,6 +591,23 @@ impl<'a> ConjunctionPlanBuilder<'a> {
                 produced_at_this_stage
                     .extend(element.variables().filter(|&var| !ordering.contains(&VertexId::Variable(var))));
 
+                if sort_variable.is_none() {
+                    let constraint = element.as_constraint().unwrap();
+                    if constraint.unbound_direction(&self.graph) == Direction::Canonical {
+                        if let Some(candidate_sort_variable) = constraint.variables().next() {
+                            if produced_at_this_stage.contains(&candidate_sort_variable) {
+                                sort_variable = Some(candidate_sort_variable);
+                            }
+                        }
+                    } else {
+                        if let Some(candidate_sort_variable) = constraint.variables().nth(1) {
+                            if produced_at_this_stage.contains(&candidate_sort_variable) {
+                                sort_variable = Some(candidate_sort_variable);
+                            }
+                        }
+                    }
+                }
+
                 ordering.push(next);
                 open_set.remove(&next);
             } else {

--- a/compiler/executable/match_/planner/vertex/mod.rs
+++ b/compiler/executable/match_/planner/vertex/mod.rs
@@ -187,7 +187,7 @@ pub(super) trait Costed {
     fn cost(
         &self,
         inputs: &[VertexId],
-        intersection_variable: Option<VariableVertexId>,
+        sort_variable: Option<VariableVertexId>,
         graph: &Graph<'_>,
     ) -> ElementCost;
 }


### PR DESCRIPTION
## Motivation

Currently, the greedy planner picks a plan in form of an ordering of constraints and variables. An added constraint *produces* variables if it relates those variables and they haven't been added to the plan at an earlier stage. 

The greedy planner picks constraints based on their "minimal" cost for a directional lookup, that may sort on either of one or more variables that the constraint relates. However, it does not record which variable the lookup should be sorted on. This means, as it stands, produced variables are added in random order after their constraint to the ordered plan.

This PR aims to ensure that we sort on the variable for the appropriate direction, by adding them first.

## Implementation

The previous implementation already had a notion of `sort_variable` (renamed from `intersection_variable` since, in general, its really just the sort variable for the step; moreover, the greedy plan essentially never picks interesting intersections as it doesn't look ahead; and produced variables are always cheaper to add.)

We simply set this `sort_variable` to be the variable corresponding to the constraints direction.


