### PR TITLE
IID constraint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2905,6 +2905,7 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 name = "structural_equality"
 version = "0.0.0"
 dependencies = [
+ "paste",
  "serde",
  "typeql",
 ]
@@ -3421,7 +3422,7 @@ checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
 [[package]]
 name = "typeql"
 version = "0.0.0"
-source = "git+https://github.com/typedb/typeql?rev=0be38cbab19da7d6b2549ad5aa1248fc811bc4e0#0be38cbab19da7d6b2549ad5aa1248fc811bc4e0"
+source = "git+https://github.com/typedb/typeql?rev=a839354d9633794d989fc15b3e41bb85e202f761#a839354d9633794d989fc15b3e41bb85e202f761"
 dependencies = [
  "chrono",
  "itertools 0.10.5",

--- a/common/bytes/byte_array.rs
+++ b/common/bytes/byte_array.rs
@@ -151,7 +151,7 @@ impl<const BYTES: usize> ByteArrayInline<BYTES> {
         Self::checked_build(data, 0, total_length as u8)
     }
 
-    fn new(bytes: [u8; BYTES], length: usize) -> Self {
+    pub fn new(bytes: [u8; BYTES], length: usize) -> Self {
         Self::checked_build(bytes, 0, length as u8)
     }
 

--- a/common/error/Cargo.toml
+++ b/common/error/Cargo.toml
@@ -16,7 +16,7 @@ features = {}
 
 	[dependencies.typeql]
 		features = []
-		rev = "0be38cbab19da7d6b2549ad5aa1248fc811bc4e0"
+		rev = "a839354d9633794d989fc15b3e41bb85e202f761"
 		git = "https://github.com/typedb/typeql"
 		default-features = false
 

--- a/common/structural_equality/BUILD
+++ b/common/structural_equality/BUILD
@@ -17,7 +17,10 @@ rust_library(
         "@typeql//rust:typeql",
 
         "@crates//:serde",
-    ]
+    ],
+    proc_macro_deps = [
+        "@crates//:paste",
+    ],
 )
 
 checkstyle_test(

--- a/common/structural_equality/Cargo.toml
+++ b/common/structural_equality/Cargo.toml
@@ -21,7 +21,12 @@ features = {}
 
 	[dependencies.typeql]
 		features = []
-		rev = "0be38cbab19da7d6b2549ad5aa1248fc811bc4e0"
+		rev = "a839354d9633794d989fc15b3e41bb85e202f761"
 		git = "https://github.com/typedb/typeql"
+		default-features = false
+
+	[dependencies.paste]
+		features = []
+		version = "1.0.15"
 		default-features = false
 

--- a/common/structural_equality/typeql_structural_equality.rs
+++ b/common/structural_equality/typeql_structural_equality.rs
@@ -19,17 +19,11 @@ use crate::{ordered_hash_combine, StructuralEquality};
 
 impl StructuralEquality for Variable {
     fn hash(&self) -> u64 {
-        &mem::discriminant(self).hash()
+        mem::discriminant(self).hash()
             ^ match self {
-                Variable::Anonymous { optional, .. } => {
-                    if optional.is_some() {
-                        0
-                    } else {
-                        1
-                    }
-                }
+                Variable::Anonymous { optional, .. } => optional.is_none() as u64,
                 Variable::Named { ident, optional, .. } => {
-                    ordered_hash_combine(ident.as_str().hash(), if optional.is_some() { 0 } else { 1 })
+                    ordered_hash_combine(ident.as_str().hash(), optional.is_none() as u64)
                 }
             }
     }

--- a/compiler/Cargo.toml
+++ b/compiler/Cargo.toml
@@ -43,7 +43,7 @@ features = {}
 
 	[dependencies.typeql]
 		features = []
-		rev = "0be38cbab19da7d6b2549ad5aa1248fc811bc4e0"
+		rev = "a839354d9633794d989fc15b3e41bb85e202f761"
 		git = "https://github.com/typedb/typeql"
 		default-features = false
 

--- a/compiler/annotation/type_seeder.rs
+++ b/compiler/annotation/type_seeder.rs
@@ -97,6 +97,7 @@ impl<'this, Snapshot: ReadableSnapshot> TypeGraphSeedingContext<'this, Snapshot>
             .constraints()
             .iter()
             .flat_map(|constraint| constraint.vertices())
+            .filter(|vertex| !vertex.is_parameter())
             .unique()
             .all(|vertex| graph.vertices.contains_key(vertex)));
 
@@ -1637,7 +1638,7 @@ pub mod tests {
         let (_tmp_dir, storage) = setup_storage();
         let (type_manager, thing_manager) = managers();
 
-        let ((type_animal, type_cat, type_dog), (type_name, type_catname, type_dogname), (type_fears, _, _)) =
+        let ((_type_animal, type_cat, type_dog), (_type_name, type_catname, type_dogname), (type_fears, _, _)) =
             setup_types(storage.clone().open_snapshot_write(), &type_manager, &thing_manager);
 
         // Case 1: $a has $n;

--- a/compiler/annotation/type_seeder.rs
+++ b/compiler/annotation/type_seeder.rs
@@ -230,6 +230,7 @@ impl<'this, Snapshot: ReadableSnapshot> TypeGraphSeedingContext<'this, Snapshot>
                 Constraint::FunctionCallBinding(c) => c.apply(self, vertices)?,
                 Constraint::RoleName(c) => c.apply(self, vertices)?,
                 Constraint::Value(c) => c.apply(self, vertices)?,
+                | Constraint::Iid(_)
                 | Constraint::Is(_)
                 | Constraint::Sub(_)
                 | Constraint::Isa(_)
@@ -392,6 +393,7 @@ impl<'this, Snapshot: ReadableSnapshot> TypeGraphSeedingContext<'this, Snapshot>
             Constraint::Owns(owns) => self.try_propagating_vertex_annotation_impl(owns, vertices)?,
             Constraint::Relates(relates) => self.try_propagating_vertex_annotation_impl(relates, vertices)?,
             Constraint::Plays(plays) => self.try_propagating_vertex_annotation_impl(plays, vertices)?,
+            | Constraint::Iid(_)
             | Constraint::ExpressionBinding(_)
             | Constraint::FunctionCallBinding(_)
             | Constraint::RoleName(_)
@@ -514,6 +516,7 @@ impl<'this, Snapshot: ReadableSnapshot> TypeGraphSeedingContext<'this, Snapshot>
                 Constraint::Owns(owns) => edges.push(self.seed_edge(constraint, owns, vertices)?),
                 Constraint::Relates(relates) => edges.push(self.seed_edge(constraint, relates, vertices)?),
                 Constraint::Plays(plays) => edges.push(self.seed_edge(constraint, plays, vertices)?),
+                | Constraint::Iid(_)
                 | Constraint::RoleName(_)
                 | Constraint::Label(_)
                 | Constraint::Kind(_)

--- a/compiler/executable/delete/executable.rs
+++ b/compiler/executable/delete/executable.rs
@@ -73,6 +73,7 @@ pub fn compile(
                 };
                 connection_deletes.push(ConnectionInstruction::Links(Links { relation, player, role }));
             }
+            Constraint::Iid(_) => todo!("should we be able to delete by IID?"),
             | Constraint::Isa(_)
             | Constraint::Kind(_)
             | Constraint::Label(_)

--- a/compiler/executable/insert/type_check.rs
+++ b/compiler/executable/insert/type_check.rs
@@ -34,7 +34,8 @@ pub fn check_annotations(
 ) -> Result<(), TypeInferenceError> {
     for constraint in block.conjunction().constraints() {
         match constraint {
-            Constraint::Isa(_) => (), // Nothing to do
+            Constraint::Isa(_) => (),             // Nothing to do
+            Constraint::Iid(_) => unreachable!(), // iid in insert should have been rejected by now
             Constraint::Has(has) => {
                 validate_has_insertable(
                     snapshot,

--- a/compiler/executable/match_/instructions/thing.rs
+++ b/compiler/executable/match_/instructions/thing.rs
@@ -6,7 +6,7 @@
 
 use std::{
     collections::{BTreeMap, BTreeSet, HashMap},
-    fmt::{Display, Formatter},
+    fmt,
     sync::Arc,
 };
 
@@ -55,8 +55,8 @@ impl<ID: IrID> IsaInstruction<ID> {
     }
 }
 
-impl<ID: IrID> Display for IsaInstruction<ID> {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+impl<ID: IrID> fmt::Display for IsaInstruction<ID> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "[{}] filter {}", &self.isa, DisplayVec::new(&self.checks))
     }
 }
@@ -95,8 +95,8 @@ impl<ID: IrID> IsaReverseInstruction<ID> {
     }
 }
 
-impl<ID: IrID> Display for IsaReverseInstruction<ID> {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+impl<ID: IrID> fmt::Display for IsaReverseInstruction<ID> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "Reverse[{}] filter {}", &self.isa, DisplayVec::new(&self.checks))
     }
 }
@@ -147,8 +147,8 @@ impl<ID: IrID> HasInstruction<ID> {
     }
 }
 
-impl<ID: IrID> Display for HasInstruction<ID> {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+impl<ID: IrID> fmt::Display for HasInstruction<ID> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "[{}] filter {}", &self.has, DisplayVec::new(&self.checks))
     }
 }
@@ -198,8 +198,8 @@ impl<ID: IrID> HasReverseInstruction<ID> {
     }
 }
 
-impl<ID: IrID> Display for HasReverseInstruction<ID> {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+impl<ID: IrID> fmt::Display for HasReverseInstruction<ID> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "Reverse[{}] filter {}", &self.has, DisplayVec::new(&self.checks))
     }
 }
@@ -257,8 +257,8 @@ impl<ID: IrID> LinksInstruction<ID> {
     }
 }
 
-impl<ID: IrID> Display for LinksInstruction<ID> {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+impl<ID: IrID> fmt::Display for LinksInstruction<ID> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "[{}] filter {}", &self.links, DisplayVec::new(&self.checks))
     }
 }
@@ -316,8 +316,8 @@ impl<ID: IrID> LinksReverseInstruction<ID> {
     }
 }
 
-impl<ID: IrID> Display for LinksReverseInstruction<ID> {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+impl<ID: IrID> fmt::Display for LinksReverseInstruction<ID> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "Reverse[{}] filter {}", &self.links, DisplayVec::new(&self.checks))
     }
 }

--- a/compiler/executable/match_/instructions/thing.rs
+++ b/compiler/executable/match_/instructions/thing.rs
@@ -30,7 +30,7 @@ pub struct IidInstruction<ID> {
 
 impl IidInstruction<Variable> {
     pub fn new(iid: Iid<Variable>, type_annotations: &TypeAnnotations) -> Self {
-        let types = type_annotations.vertex_annotations_of(&iid.var()).unwrap().clone();
+        let types = type_annotations.vertex_annotations_of(iid.var()).unwrap().clone();
         Self { iid, types, checks: Vec::new() }
     }
 }

--- a/compiler/executable/match_/planner/mod.rs
+++ b/compiler/executable/match_/planner/mod.rs
@@ -333,7 +333,7 @@ impl MatchExecutableBuilder {
 
     /// inject the check as an optimisation into previously built steps
     fn inline_as_optimisation(&mut self, variables: &[Variable], check: &CheckInstruction<ExecutorVariable>) -> bool {
-        if !matches!(check, &CheckInstruction::Comparison { .. }) {
+        if !matches!(check, CheckInstruction::Comparison { .. } | CheckInstruction::Iid { .. }) {
             // TODO: inject IID check as well
             return false;
         }

--- a/compiler/executable/match_/planner/plan.rs
+++ b/compiler/executable/match_/planner/plan.rs
@@ -425,6 +425,8 @@ impl<'a> ConjunctionPlanBuilder<'a> {
     fn register_iid(&mut self, iid: &'a Iid<Variable>) {
         let planner =
             IidPlanner::from_constraint(iid, &self.graph.variable_index, self.type_annotations, self.statistics);
+        // TODO not setting exact bound for the var here as the checker can't currently take advantage of that
+        //      so the cost would be misleading the planner
         self.graph.push_constraint(ConstraintVertex::Iid(planner));
     }
 

--- a/compiler/executable/match_/planner/plan.rs
+++ b/compiler/executable/match_/planner/plan.rs
@@ -16,7 +16,7 @@ use ir::{
     pattern::{
         conjunction::Conjunction,
         constraint::{
-            Comparator, Comparison, Constraint, ExpressionBinding, FunctionCallBinding, Has, Is, Isa, Kind, Label,
+            Comparator, Comparison, Constraint, ExpressionBinding, FunctionCallBinding, Has, Iid, Is, Isa, Kind, Label,
             Links, Owns, Plays, Relates, RoleName, Sub, Value,
         },
         nested_pattern::NestedPattern,
@@ -32,8 +32,8 @@ use crate::{
     executable::match_::{
         instructions::{
             thing::{
-                HasInstruction, HasReverseInstruction, IsaInstruction, IsaReverseInstruction, LinksInstruction,
-                LinksReverseInstruction,
+                HasInstruction, HasReverseInstruction, IidInstruction, IsaInstruction, IsaReverseInstruction,
+                LinksInstruction, LinksReverseInstruction,
             },
             type_::{
                 OwnsInstruction, OwnsReverseInstruction, PlaysInstruction, PlaysReverseInstruction, RelatesInstruction,
@@ -44,8 +44,8 @@ use crate::{
         planner::{
             vertex::{
                 constraint::{
-                    ConstraintVertex, HasPlanner, IsaPlanner, LinksPlanner, OwnsPlanner, PlaysPlanner, RelatesPlanner,
-                    SubPlanner, TypeListPlanner,
+                    ConstraintVertex, HasPlanner, IidPlanner, IsaPlanner, LinksPlanner, OwnsPlanner, PlaysPlanner,
+                    RelatesPlanner, SubPlanner, TypeListPlanner,
                 },
                 variable::{InputPlanner, ThingPlanner, TypePlanner, ValuePlanner, VariableVertex},
                 ComparisonPlanner, Costed, Direction, DisjunctionPlanner, ElementCost, ExpressionPlanner,
@@ -355,6 +355,7 @@ impl<'a> ConjunctionPlanBuilder<'a> {
                 Constraint::Plays(plays) => self.register_plays(plays),
 
                 Constraint::Isa(isa) => self.register_isa(isa),
+                Constraint::Iid(iid) => self.register_iid(iid),
                 Constraint::Has(has) => self.register_has(has),
                 Constraint::Links(links) => self.register_links(links),
 
@@ -419,6 +420,12 @@ impl<'a> ConjunctionPlanBuilder<'a> {
         let planner =
             IsaPlanner::from_constraint(isa, &self.graph.variable_index, self.type_annotations, self.statistics);
         self.graph.push_constraint(ConstraintVertex::Isa(planner));
+    }
+
+    fn register_iid(&mut self, iid: &'a Iid<Variable>) {
+        let planner =
+            IidPlanner::from_constraint(iid, &self.graph.variable_index, self.type_annotations, self.statistics);
+        self.graph.push_constraint(ConstraintVertex::Iid(planner));
     }
 
     fn register_has(&mut self, has: &'a Has<Variable>) {
@@ -991,6 +998,13 @@ impl ConjunctionPlan<'_> {
                 match_builder.push_instruction(var, instruction);
             }
 
+            ConstraintVertex::Iid(iid) => {
+                let var = iid.iid().var().as_variable().unwrap();
+                let instruction =
+                    ConstraintInstruction::Iid(IidInstruction::new(iid.iid().clone(), self.type_annotations));
+                match_builder.push_instruction(var, instruction);
+            }
+
             ConstraintVertex::Sub(planner) => {
                 let sub = planner.sub();
                 binary!((with sub_kind) subtype sub supertype, Sub(SubInstruction), SubReverse(SubReverseInstruction))
@@ -1097,6 +1111,12 @@ impl ConjunctionPlan<'_> {
             ConstraintVertex::TypeList(type_list) => {
                 let var = type_list.constraint().var();
                 let instruction = type_list.lower_check();
+                match_builder.push_check(&[var], instruction.map(match_builder.position_mapping()));
+            }
+
+            ConstraintVertex::Iid(iid) => {
+                let var = iid.iid().var().as_variable().unwrap();
+                let instruction = CheckInstruction::Iid { var, iid: iid.iid().iid().as_parameter().unwrap() };
                 match_builder.push_check(&[var], instruction.map(match_builder.position_mapping()));
             }
 

--- a/concept/thing/thing_manager.rs
+++ b/concept/thing/thing_manager.rs
@@ -182,6 +182,18 @@ impl ThingManager {
         self.get_instances_in(snapshot, object_type)
     }
 
+    pub fn instance_exists<'a>(
+        &self,
+        snapshot: &impl ReadableSnapshot,
+        instance: impl ThingAPI<'a>,
+    ) -> Result<bool, Box<ConceptReadError>> {
+        let storage_key = instance.into_vertex().into_storage_key();
+        snapshot
+            .get::<BUFFER_KEY_INLINE>(storage_key.as_reference())
+            .map(|value| value.is_some())
+            .map_err(|error| Box::new(ConceptReadError::SnapshotGet { source: error }))
+    }
+
     pub(crate) fn get_relations_roles<'o>(
         &self,
         snapshot: &impl ReadableSnapshot,

--- a/database/Cargo.toml
+++ b/database/Cargo.toml
@@ -88,7 +88,7 @@ features = {}
 
 	[dependencies.typeql]
 		features = []
-		rev = "0be38cbab19da7d6b2549ad5aa1248fc811bc4e0"
+		rev = "a839354d9633794d989fc15b3e41bb85e202f761"
 		git = "https://github.com/typedb/typeql"
 		default-features = false
 

--- a/dependencies/typedb/repositories.bzl
+++ b/dependencies/typedb/repositories.bzl
@@ -21,8 +21,8 @@ def typedb_dependencies():
 def typeql():
     git_repository(
         name = "typeql",
-        remote = "https://github.com/typedb/typeql",
-        commit = "0be38cbab19da7d6b2549ad5aa1248fc811bc4e0",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @typeql
+        remote = "https://github.com/dmitrii-ubskii/typeql",
+        commit = "a839354d9633794d989fc15b3e41bb85e202f761",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @typeql
     )
 
 def typedb_common():
@@ -42,6 +42,6 @@ def typedb_protocol():
 def typedb_behaviour():
     git_repository(
         name = "typedb_behaviour",
-        remote = "https://github.com/typedb/typedb-behaviour",
-        commit = "3e43fc4dfdc0e2a7513a429f375d75dcb3f3188f",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @typedb_behaviour
+        remote = "https://github.com/dmitrii-ubskii/typedb-behaviour",
+        commit = "5be15bd16cc7d367c62bf18fabdeb1b461fb9d48",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @typedb_behaviour
     )

--- a/dependencies/typedb/repositories.bzl
+++ b/dependencies/typedb/repositories.bzl
@@ -21,8 +21,8 @@ def typedb_dependencies():
 def typeql():
     git_repository(
         name = "typeql",
-        remote = "https://github.com/dmitrii-ubskii/typeql",
-        commit = "a839354d9633794d989fc15b3e41bb85e202f761",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @typeql
+        remote = "https://github.com/typedb/typeql",
+        commit = "7b5404c7f098dcea34bfdaaee384abfe8ecf90d1",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @typeql
     )
 
 def typedb_common():
@@ -42,6 +42,6 @@ def typedb_protocol():
 def typedb_behaviour():
     git_repository(
         name = "typedb_behaviour",
-        remote = "https://github.com/dmitrii-ubskii/typedb-behaviour",
-        commit = "5be15bd16cc7d367c62bf18fabdeb1b461fb9d48",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @typedb_behaviour
+        remote = "https://github.com/typedb/typedb-behaviour",
+        commit = "d6236c340a61553d8eb2805461ef00fc6de1a6de",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @typedb_behaviour
     )

--- a/encoding/graph/thing/mod.rs
+++ b/encoding/graph/thing/mod.rs
@@ -31,7 +31,7 @@ const fn max(lhs: usize, rhs: usize) -> usize {
     }
 }
 
-pub const THING_VERTEX_MAX_LENGTH: usize = max(ObjectVertex::LENGTH, AttributeVertex::MAX_LENGTH) + 1;
+pub const THING_VERTEX_MAX_LENGTH: usize = max(ObjectVertex::LENGTH, AttributeVertex::MAX_LENGTH);
 
 pub trait ThingVertex<'a>:
     Prefixed<'a, BUFFER_KEY_INLINE> + Typed<'a, BUFFER_KEY_INLINE> + Keyable<'a, BUFFER_KEY_INLINE>

--- a/encoding/graph/thing/mod.rs
+++ b/encoding/graph/thing/mod.rs
@@ -8,6 +8,7 @@ use bytes::{byte_array::ByteArray, Bytes};
 use resource::constants::snapshot::BUFFER_KEY_INLINE;
 use storage::key_value::StorageKey;
 
+use self::{vertex_attribute::AttributeVertex, vertex_object::ObjectVertex};
 use crate::{
     graph::{type_::vertex::TypeID, Typed},
     layout::prefix::{Prefix, PrefixID},
@@ -21,6 +22,16 @@ pub mod vertex_generator;
 pub mod vertex_object;
 
 const THING_VERTEX_LENGTH_PREFIX_TYPE: usize = PrefixID::LENGTH + TypeID::LENGTH;
+
+const fn max(lhs: usize, rhs: usize) -> usize {
+    if lhs < rhs {
+        rhs
+    } else {
+        lhs
+    }
+}
+
+pub const THING_VERTEX_MAX_LENGTH: usize = max(ObjectVertex::LENGTH, AttributeVertex::MAX_LENGTH) + 1;
 
 pub trait ThingVertex<'a>: Prefixed<'a, BUFFER_KEY_INLINE> + Typed<'a, BUFFER_KEY_INLINE> {
     const KEYSPACE: EncodingKeyspace = EncodingKeyspace::Data;

--- a/encoding/graph/thing/mod.rs
+++ b/encoding/graph/thing/mod.rs
@@ -33,7 +33,9 @@ const fn max(lhs: usize, rhs: usize) -> usize {
 
 pub const THING_VERTEX_MAX_LENGTH: usize = max(ObjectVertex::LENGTH, AttributeVertex::MAX_LENGTH) + 1;
 
-pub trait ThingVertex<'a>: Prefixed<'a, BUFFER_KEY_INLINE> + Typed<'a, BUFFER_KEY_INLINE> {
+pub trait ThingVertex<'a>:
+    Prefixed<'a, BUFFER_KEY_INLINE> + Typed<'a, BUFFER_KEY_INLINE> + Keyable<'a, BUFFER_KEY_INLINE>
+{
     const KEYSPACE: EncodingKeyspace = EncodingKeyspace::Data;
 
     fn new(bytes: Bytes<'a, BUFFER_KEY_INLINE>) -> Self;

--- a/encoding/graph/thing/mod.rs
+++ b/encoding/graph/thing/mod.rs
@@ -12,7 +12,7 @@ use self::{vertex_attribute::AttributeVertex, vertex_object::ObjectVertex};
 use crate::{
     graph::{type_::vertex::TypeID, Typed},
     layout::prefix::{Prefix, PrefixID},
-    EncodingKeyspace, Prefixed,
+    EncodingKeyspace, Keyable, Prefixed,
 };
 
 pub mod edge;

--- a/encoding/graph/thing/vertex_attribute.rs
+++ b/encoding/graph/thing/vertex_attribute.rs
@@ -23,6 +23,7 @@ use crate::{
         Typed,
     },
     layout::prefix::Prefix,
+    layout::prefix::PrefixID,
     value::{
         boolean_bytes::BooleanBytes,
         date_bytes::DateBytes,
@@ -48,6 +49,7 @@ pub struct AttributeVertex<'a> {
 
 impl<'a> AttributeVertex<'a> {
     pub const PREFIX: Prefix = Prefix::VertexAttribute;
+    pub const MAX_LENGTH: usize = PrefixID::LENGTH + TypeID::LENGTH + ValueEncodingLength::LONG_LENGTH;
 
     pub fn new(bytes: Bytes<'a, BUFFER_KEY_INLINE>) -> Self {
         debug_assert!(bytes[Self::RANGE_PREFIX] == Self::PREFIX.prefix_id().bytes);

--- a/encoding/graph/thing/vertex_attribute.rs
+++ b/encoding/graph/thing/vertex_attribute.rs
@@ -65,6 +65,13 @@ impl<'a> AttributeVertex<'a> {
         Self::new(Bytes::Array(bytes))
     }
 
+    pub fn try_from_bytes(bytes: &'a [u8]) -> Option<Self> {
+        if !Self::is_attribute_bytes(bytes) {
+            return None;
+        }
+        Some(Self::new(Bytes::reference(bytes)))
+    }
+
     pub fn build_prefix_for_value(
         type_id: TypeID,
         value: Value<'_>,
@@ -91,9 +98,11 @@ impl<'a> AttributeVertex<'a> {
     }
 
     pub fn is_attribute_vertex(storage_key: StorageKeyReference<'_>) -> bool {
-        storage_key.keyspace_id() == Self::KEYSPACE.id()
-            && !storage_key.bytes().is_empty()
-            && storage_key.bytes()[Self::RANGE_PREFIX] == Prefix::VertexAttribute.prefix_id().bytes()
+        storage_key.keyspace_id() == Self::KEYSPACE.id() && Self::is_attribute_bytes(storage_key.bytes())
+    }
+
+    fn is_attribute_bytes(bytes: &[u8]) -> bool {
+        !bytes.is_empty() && bytes[Self::RANGE_PREFIX] == Prefix::VertexAttribute.prefix_id().bytes()
     }
 
     pub fn value_type_category(&self) -> ValueTypeCategory {

--- a/encoding/graph/thing/vertex_object.rs
+++ b/encoding/graph/thing/vertex_object.rs
@@ -49,6 +49,18 @@ impl<'a> ObjectVertex<'a> {
         ObjectVertex { bytes: Bytes::Array(array) }
     }
 
+    pub fn try_from_bytes(bytes: &'a [u8]) -> Option<Self> {
+        if bytes.len() != Self::LENGTH {
+            return None;
+        }
+        let prefix = &bytes[..1];
+        if prefix != Prefix::VertexEntity.prefix_id().bytes() && prefix != Prefix::VertexRelation.prefix_id().bytes() {
+            return None;
+        }
+        // all byte patterns beyond the prefix are valid for object vertices
+        Some(Self::new(Bytes::reference(bytes)))
+    }
+
     pub fn is_entity_vertex(storage_key: StorageKeyReference<'_>) -> bool {
         storage_key.keyspace_id() == Self::KEYSPACE.id()
             && storage_key.bytes().len() == Self::LENGTH

--- a/encoding/value/value_struct.rs
+++ b/encoding/value/value_struct.rs
@@ -298,8 +298,8 @@ impl StructIndexEntry<'static> {
 impl<'a> StructIndexEntry<'a> {
     const STRING_FIELD_LENGTH: usize = 17;
     const STRING_FIELD_HASHID_LENGTH: usize = 9;
-    const STRING_FIELD_HASHED_PREFIX_LENGTH: usize = { Self::STRING_FIELD_LENGTH - Self::STRING_FIELD_HASHID_LENGTH };
-    const STRING_FIELD_INLINE_LENGTH: usize = { Self::STRING_FIELD_LENGTH - 1 };
+    const STRING_FIELD_HASHED_PREFIX_LENGTH: usize = Self::STRING_FIELD_LENGTH - Self::STRING_FIELD_HASHID_LENGTH;
+    const STRING_FIELD_INLINE_LENGTH: usize = Self::STRING_FIELD_LENGTH - 1;
 
     fn encode_string_into<const INLINE_SIZE: usize>(
         snapshot: &impl ReadableSnapshot,

--- a/executor/BUILD
+++ b/executor/BUILD
@@ -17,6 +17,7 @@ rust_library(
     ], exclude=["tests/**"]),
     deps = [
         "//answer",
+        "//common/bytes",
         "//common/error",
         "//common/lending_iterator",
         "//common/logger",

--- a/executor/Cargo.toml
+++ b/executor/Cargo.toml
@@ -24,11 +24,6 @@ features = {}
 		features = []
 		default-features = false
 
-	[dev-dependencies.bytes]
-		path = "../common/bytes"
-		features = []
-		default-features = false
-
 	[dev-dependencies.query]
 		path = "../query"
 		features = []
@@ -106,9 +101,14 @@ features = {}
 		features = []
 		default-features = false
 
+	[dependencies.bytes]
+		path = "../common/bytes"
+		features = []
+		default-features = false
+
 	[dependencies.typeql]
 		features = []
-		rev = "0be38cbab19da7d6b2549ad5aa1248fc811bc4e0"
+		rev = "a839354d9633794d989fc15b3e41bb85e202f761"
 		git = "https://github.com/typedb/typeql"
 		default-features = false
 

--- a/executor/instruction/has_executor.rs
+++ b/executor/instruction/has_executor.rs
@@ -7,7 +7,7 @@
 use std::{
     cmp::Ordering,
     collections::{BTreeMap, BTreeSet, HashMap},
-    fmt::{Display, Formatter},
+    fmt,
     sync::Arc,
 };
 
@@ -250,8 +250,8 @@ impl HasExecutor {
     }
 }
 
-impl Display for HasExecutor {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+impl fmt::Display for HasExecutor {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         writeln!(f, "[{}], mode={}", &self.has, &self.iterate_mode)
     }
 }

--- a/executor/instruction/has_reverse_executor.rs
+++ b/executor/instruction/has_reverse_executor.rs
@@ -7,7 +7,7 @@
 use std::{
     cmp::Ordering,
     collections::{BTreeMap, BTreeSet, Bound, HashMap},
-    fmt::{Display, Formatter},
+    fmt,
     sync::{Arc, OnceLock},
     vec,
 };
@@ -247,8 +247,8 @@ impl HasReverseExecutor {
         Ok(AsLendingIterator::new(iterators).flatten())
     }
 }
-impl Display for HasReverseExecutor {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+impl fmt::Display for HasReverseExecutor {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         writeln!(f, "Reverse[{}], mode={}", &self.has, &self.iterate_mode)
     }
 }

--- a/executor/instruction/iid_executor.rs
+++ b/executor/instruction/iid_executor.rs
@@ -1,0 +1,136 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+use std::{
+    collections::{BTreeSet, HashMap},
+    sync::Arc,
+};
+
+use answer::{variable_value::VariableValue, Type};
+use compiler::{executable::match_::instructions::thing::IidInstruction, ExecutorVariable};
+use concept::{
+    error::ConceptReadError,
+    thing::{attribute::Attribute, object::Object, ThingAPI},
+};
+use encoding::graph::thing::{vertex_attribute::AttributeVertex, vertex_object::ObjectVertex};
+use ir::pattern::constraint::Iid;
+use lending_iterator::{
+    adaptors::{Map, TryFilter},
+    AsHkt, AsNarrowingIterator, LendingIterator,
+};
+use storage::snapshot::ReadableSnapshot;
+
+use crate::{
+    instruction::{
+        iterator::{SortedTupleIterator, TupleIterator},
+        tuple::{Tuple, TuplePositions, TupleResult},
+        Checker, FilterFn, VariableModes,
+    },
+    pipeline::stage::ExecutionContext,
+    row::MaybeOwnedRow,
+};
+
+pub(crate) struct IidExecutor {
+    iid: Iid<ExecutorVariable>,
+    variable_modes: VariableModes,
+    tuple_positions: TuplePositions,
+    filter_fn: Arc<IidFilterFn>,
+    checker: Checker<AsHkt![VariableValue<'_>]>,
+}
+
+pub(crate) type IidToTupleFn = for<'a> fn(Result<VariableValue<'a>, Box<ConceptReadError>>) -> TupleResult<'a>;
+
+pub(super) type IidTupleIterator<I> = Map<
+    TryFilter<I, Box<IidFilterFn>, AsHkt![VariableValue<'_>], Box<ConceptReadError>>,
+    IidToTupleFn,
+    AsHkt![TupleResult<'_>],
+>;
+
+pub(super) type IidFilterFn = FilterFn<AsHkt![VariableValue<'_>]>;
+
+pub(crate) type IidIterator = IidTupleIterator<
+    AsNarrowingIterator<
+        <Option<Result<VariableValue<'static>, Box<ConceptReadError>>> as IntoIterator>::IntoIter,
+        Result<AsHkt![VariableValue<'_>], Box<ConceptReadError>>,
+    >,
+>;
+
+type IidVariableValueExtractor = for<'a, 'b> fn(&'a VariableValue<'b>) -> VariableValue<'a>;
+
+pub(super) const EXTRACT_LHS: IidVariableValueExtractor = |lhs| lhs.as_reference();
+
+fn iid_to_tuple(res: Result<VariableValue<'_>, Box<ConceptReadError>>) -> Result<Tuple<'_>, Box<ConceptReadError>> {
+    match res {
+        Ok(value) => Ok(Tuple::Single([value])),
+        Err(err) => Err(err),
+    }
+}
+
+impl IidExecutor {
+    pub(crate) fn new(
+        iid: IidInstruction<ExecutorVariable>,
+        variable_modes: VariableModes,
+        _sort_by: ExecutorVariable,
+    ) -> Self {
+        let IidInstruction { iid, types, checks } = iid;
+
+        let var = iid.var().as_variable().unwrap();
+        let output_tuple_positions = TuplePositions::Single([Some(var)]);
+        let checker = Checker::<VariableValue<'_>>::new(checks, HashMap::from_iter([(var, EXTRACT_LHS)]));
+
+        let filter_fn: Arc<IidFilterFn> = Arc::new(move |res| match res {
+            Ok(value) => Ok(types.contains(&value.as_thing().type_())),
+            Err(err) => Err(err.clone()),
+        });
+
+        Self { iid, variable_modes, tuple_positions: output_tuple_positions, filter_fn, checker }
+    }
+
+    pub(crate) fn get_iterator(
+        &self,
+        context: &ExecutionContext<impl ReadableSnapshot + 'static>,
+        row: MaybeOwnedRow<'_>,
+    ) -> Result<TupleIterator, Box<ConceptReadError>> {
+        let filter = self.filter_fn.clone();
+        let check = self.checker.filter_for_row(context, &row);
+        let filter_for_row: Box<IidFilterFn> = Box::new(move |item| match filter(item) {
+            Ok(true) => check(item),
+            fail => fail,
+        });
+
+        let iid_parameter = self.iid.iid().as_parameter().unwrap();
+        let bytes = context.parameters().iid(iid_parameter).unwrap();
+        eprintln!("[{}:{}] bytes = {:x?}", file!(), line!(), bytes);
+
+        let snapshot = &**context.snapshot();
+        let thing_manager = context.thing_manager();
+
+        let instance = if let Some(object) = ObjectVertex::try_from_bytes(bytes) {
+            let object = Object::new(object);
+            thing_manager
+                .instance_exists(snapshot, object.as_reference())
+                .map(move |exists| exists.then_some(VariableValue::Thing(object.into_owned().into())))
+        } else if let Some(attribute) = AttributeVertex::try_from_bytes(bytes) {
+            let attribute = Attribute::new(attribute);
+            thing_manager
+                .instance_exists(snapshot, attribute.as_reference())
+                .map(move |exists| exists.then_some(VariableValue::Thing(attribute.into_owned().into())))
+        } else {
+            Ok(None)
+        };
+
+        fn as_tuples<T>(it: T) -> Map<T, IidToTupleFn, AsHkt![TupleResult<'_>]>
+        where
+            T: for<'a> LendingIterator<Item<'a> = Result<VariableValue<'a>, Box<ConceptReadError>>>,
+        {
+            it.map::<TupleResult<'_>, IidToTupleFn>(iid_to_tuple)
+        }
+
+        let iterator = AsNarrowingIterator::new(instance.transpose());
+        let as_tuples = as_tuples(iterator.try_filter::<_, IidFilterFn, VariableValue<'_>, _>(filter_for_row));
+        Ok(TupleIterator::Iid(SortedTupleIterator::new(as_tuples, self.tuple_positions.clone(), &self.variable_modes)))
+    }
+}

--- a/executor/instruction/iid_executor.rs
+++ b/executor/instruction/iid_executor.rs
@@ -100,7 +100,6 @@ impl IidExecutor {
 
         let iid_parameter = self.iid.iid().as_parameter().unwrap();
         let bytes = context.parameters().iid(iid_parameter).unwrap();
-        eprintln!("[{}:{}] bytes = {:x?}", file!(), line!(), bytes);
 
         let snapshot = &**context.snapshot();
         let thing_manager = context.thing_manager();

--- a/executor/instruction/iid_executor.rs
+++ b/executor/instruction/iid_executor.rs
@@ -98,11 +98,11 @@ impl IidExecutor {
             fail => fail,
         });
 
-        let iid_parameter = self.iid.iid().as_parameter().unwrap();
-        let bytes = context.parameters().iid(iid_parameter).unwrap();
-
         let snapshot = &**context.snapshot();
         let thing_manager = context.thing_manager();
+
+        let iid_parameter = self.iid.iid().as_parameter().unwrap();
+        let bytes = context.parameters().iid(iid_parameter).unwrap();
 
         let instance = if let Some(object) = ObjectVertex::try_from_bytes(bytes) {
             let object = Object::new(object);

--- a/executor/instruction/iid_executor.rs
+++ b/executor/instruction/iid_executor.rs
@@ -4,12 +4,9 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-use std::{
-    collections::{BTreeSet, HashMap},
-    sync::Arc,
-};
+use std::{collections::HashMap, fmt, sync::Arc};
 
-use answer::{variable_value::VariableValue, Type};
+use answer::variable_value::VariableValue;
 use compiler::{executable::match_::instructions::thing::IidInstruction, ExecutorVariable};
 use concept::{
     error::ConceptReadError,
@@ -132,5 +129,11 @@ impl IidExecutor {
         let iterator = AsNarrowingIterator::new(instance.transpose());
         let as_tuples = as_tuples(iterator.try_filter::<_, IidFilterFn, VariableValue<'_>, _>(filter_for_row));
         Ok(TupleIterator::Iid(SortedTupleIterator::new(as_tuples, self.tuple_positions.clone(), &self.variable_modes)))
+    }
+}
+
+impl fmt::Display for IidExecutor {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        writeln!(f, "{}", &self.iid)
     }
 }

--- a/executor/instruction/is_executor.rs
+++ b/executor/instruction/is_executor.rs
@@ -19,11 +19,10 @@ use lending_iterator::{
 };
 use storage::snapshot::ReadableSnapshot;
 
-use super::tuple::Tuple;
 use crate::{
     instruction::{
         iterator::{SortedTupleIterator, TupleIterator},
-        tuple::{TuplePositions, TupleResult},
+        tuple::{Tuple, TuplePositions, TupleResult},
         Checker, FilterFn, VariableModes,
     },
     pipeline::stage::ExecutionContext,

--- a/executor/instruction/isa_executor.rs
+++ b/executor/instruction/isa_executor.rs
@@ -50,25 +50,6 @@ pub(crate) struct IsaExecutor {
     checker: Checker<(AsHkt![Thing<'_>], Type)>,
 }
 
-#[allow(clippy::large_enum_variant)]
-pub(crate) enum SingleTypeIsaIterator {
-    Entity(MapToThingType<InstanceIterator<AsHkt![Entity<'_>]>, EntityToThingTypeFn>),
-    Relation(MapToThingType<InstanceIterator<AsHkt![Relation<'_>]>, RelationToThingTypeFn>),
-    Attribute(MapToThingType<AttributeIterator<InstanceIterator<AsHkt![Attribute<'_>]>>, AttributeToThingTypeFn>),
-}
-
-impl LendingIterator for SingleTypeIsaIterator {
-    type Item<'a> = Result<(Thing<'a>, Type), Box<ConceptReadError>>;
-
-    fn next(&mut self) -> Option<Self::Item<'_>> {
-        match self {
-            SingleTypeIsaIterator::Entity(inner) => inner.next(),
-            SingleTypeIsaIterator::Relation(inner) => inner.next(),
-            SingleTypeIsaIterator::Attribute(inner) => inner.next(),
-        }
-    }
-}
-
 type MapToThingType<I, F> = Map<I, F, Result<(AsHkt![Thing<'_>], Type), Box<ConceptReadError>>>;
 type EntityToThingTypeFn =
     for<'a> fn(Result<Entity<'a>, Box<ConceptReadError>>) -> Result<(Thing<'a>, Type), Box<ConceptReadError>>;
@@ -106,10 +87,8 @@ type ThingWithTypes<I> = Map<
     Result<(AsHkt![Thing<'_>], Type), Box<ConceptReadError>>,
 >;
 
-pub(super) type IsaUnboundedSortedTypeSingle = IsaTupleIterator<SingleTypeIsaIterator>;
 pub(super) type IsaUnboundedSortedTypeMerged = IsaTupleIterator<MultipleTypeIsaIterator>;
 
-pub(super) type IsaUnboundedSortedThingSingle = IsaTupleIterator<SingleTypeIsaIterator>;
 pub(super) type IsaUnboundedSortedThingMerged = IsaTupleIterator<MultipleTypeIsaIterator>;
 
 pub(super) type IsaBoundedSortedType =

--- a/executor/instruction/iterator.rs
+++ b/executor/instruction/iterator.rs
@@ -25,6 +25,7 @@ use crate::{
             HasReverseBoundedSortedOwner, HasReverseUnboundedSortedAttribute, HasReverseUnboundedSortedOwnerMerged,
             HasReverseUnboundedSortedOwnerSingle,
         },
+        iid_executor::IidIterator,
         is_executor::IsIterator,
         isa_executor::{IsaBoundedSortedType, IsaUnboundedSortedThing},
         isa_reverse_executor::{IsaReverseBoundedSortedThing, IsaReverseUnboundedSortedType},
@@ -94,6 +95,7 @@ dispatch_tuple_iterator! {
 #[allow(clippy::large_enum_variant)]
 pub(crate) enum TupleIterator {
     Is(SortedTupleIterator<IsIterator>),
+    Iid(SortedTupleIterator<IidIterator>),
     Type(SortedTupleIterator<TypeIterator>),
 
     SubUnbounded(SortedTupleIterator<SubUnboundedSortedSub>),

--- a/executor/instruction/iterator.rs
+++ b/executor/instruction/iterator.rs
@@ -26,14 +26,8 @@ use crate::{
             HasReverseUnboundedSortedOwnerSingle,
         },
         is_executor::IsIterator,
-        isa_executor::{
-            IsaBoundedSortedType, IsaUnboundedSortedThingMerged, IsaUnboundedSortedThingSingle,
-            IsaUnboundedSortedTypeMerged, IsaUnboundedSortedTypeSingle,
-        },
-        isa_reverse_executor::{
-            IsaReverseBoundedSortedThing, IsaReverseUnboundedSortedThingMerged, IsaReverseUnboundedSortedThingSingle,
-            IsaReverseUnboundedSortedTypeMerged, IsaReverseUnboundedSortedTypeSingle,
-        },
+        isa_executor::{IsaBoundedSortedType, IsaUnboundedSortedThing},
+        isa_reverse_executor::{IsaReverseBoundedSortedThing, IsaReverseUnboundedSortedType},
         links_executor::{
             LinksBoundedRelationPlayer, LinksBoundedRelationSortedPlayer, LinksUnboundedSortedPlayerMerged,
             LinksUnboundedSortedPlayerSingle, LinksUnboundedSortedRelation,
@@ -126,16 +120,10 @@ pub(crate) enum TupleIterator {
     PlaysReverseUnbounded(SortedTupleIterator<PlaysReverseUnboundedSortedRole>),
     PlaysReverseBounded(SortedTupleIterator<PlaysReverseBoundedSortedPlayer>),
 
-    IsaUnboundedSingle(SortedTupleIterator<IsaUnboundedSortedThingSingle>),
-    IsaUnboundedMerged(SortedTupleIterator<IsaUnboundedSortedThingMerged>),
-    IsaUnboundedInvertedSingle(SortedTupleIterator<IsaUnboundedSortedTypeSingle>),
-    IsaUnboundedInvertedMerged(SortedTupleIterator<IsaUnboundedSortedTypeMerged>),
+    IsaUnbounded(SortedTupleIterator<IsaUnboundedSortedThing>),
     IsaBounded(SortedTupleIterator<IsaBoundedSortedType>),
 
-    IsaReverseUnboundedSingle(SortedTupleIterator<IsaReverseUnboundedSortedTypeSingle>),
-    IsaReverseUnboundedMerged(SortedTupleIterator<IsaReverseUnboundedSortedTypeMerged>),
-    IsaReverseUnboundedInvertedSingle(SortedTupleIterator<IsaReverseUnboundedSortedThingSingle>),
-    IsaReverseUnboundedInvertedMerged(SortedTupleIterator<IsaReverseUnboundedSortedThingMerged>),
+    IsaReverseUnbounded(SortedTupleIterator<IsaReverseUnboundedSortedType>),
     IsaReverseBounded(SortedTupleIterator<IsaReverseBoundedSortedThing>),
 
     HasUnbounded(SortedTupleIterator<HasUnboundedSortedOwner>),

--- a/executor/instruction/mod.rs
+++ b/executor/instruction/mod.rs
@@ -15,10 +15,13 @@ use compiler::{
 };
 use concept::{
     error::ConceptReadError,
-    thing::{object::ObjectAPI, thing_manager::ThingManager},
+    thing::{object::ObjectAPI, thing_manager::ThingManager, ThingAPI},
     type_::{OwnerAPI, PlayerAPI},
 };
-use encoding::value::{value::Value, ValueEncodable};
+use encoding::{
+    value::{value::Value, ValueEncodable},
+    AsBytes,
+};
 use ir::{
     pattern::{
         constraint::{Comparator, IsaKind, SubKind},
@@ -215,6 +218,7 @@ impl fmt::Display for InstructionExecutor {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             InstructionExecutor::Is(inner) => fmt::Display::fmt(inner, f),
+            InstructionExecutor::Iid(inner) => fmt::Display::fmt(inner, f),
             InstructionExecutor::TypeList(inner) => fmt::Display::fmt(inner, f),
             InstructionExecutor::Sub(inner) => fmt::Display::fmt(inner, f),
             InstructionExecutor::SubReverse(inner) => fmt::Display::fmt(inner, f),
@@ -515,9 +519,9 @@ impl<T: Hkt> Checker<T> {
                         let value = var(value);
                         match value {
                             VariableValue::Thing(thing) => match thing {
-                                Thing::Entity(entity) => Ok(iid.bytes() == entity.vertex().bytes().bytes()),
-                                Thing::Relation(relation) => Ok(iid.bytes() == relation.vertex().bytes().bytes()),
-                                Thing::Attribute(attribute) => Ok(iid.bytes() == attribute.vertex().bytes().bytes()),
+                                Thing::Entity(entity) => Ok(&*iid == entity.vertex().bytes().bytes()),
+                                Thing::Relation(relation) => Ok(&*iid == relation.vertex().bytes().bytes()),
+                                Thing::Attribute(attribute) => Ok(&*iid == attribute.vertex().bytes().bytes()),
                             },
                             VariableValue::Empty => Ok(false),
                             VariableValue::Type(_) => Ok(false),

--- a/executor/instruction/mod.rs
+++ b/executor/instruction/mod.rs
@@ -33,9 +33,9 @@ use storage::snapshot::ReadableSnapshot;
 use crate::{
     instruction::{
         function_call_binding_executor::FunctionCallBindingIteratorExecutor, has_executor::HasExecutor,
-        has_reverse_executor::HasReverseExecutor, is_executor::IsExecutor, isa_executor::IsaExecutor,
-        isa_reverse_executor::IsaReverseExecutor, iterator::TupleIterator, links_executor::LinksExecutor,
-        links_reverse_executor::LinksReverseExecutor, owns_executor::OwnsExecutor,
+        has_reverse_executor::HasReverseExecutor, iid_executor::IidExecutor, is_executor::IsExecutor,
+        isa_executor::IsaExecutor, isa_reverse_executor::IsaReverseExecutor, iterator::TupleIterator,
+        links_executor::LinksExecutor, links_reverse_executor::LinksReverseExecutor, owns_executor::OwnsExecutor,
         owns_reverse_executor::OwnsReverseExecutor, plays_executor::PlaysExecutor,
         plays_reverse_executor::PlaysReverseExecutor, relates_executor::RelatesExecutor,
         relates_reverse_executor::RelatesReverseExecutor, sub_executor::SubExecutor,
@@ -48,6 +48,7 @@ use crate::{
 mod function_call_binding_executor;
 mod has_executor;
 mod has_reverse_executor;
+mod iid_executor;
 mod is_executor;
 mod isa_executor;
 mod isa_reverse_executor;
@@ -69,6 +70,7 @@ pub(crate) const TYPES_EMPTY: Vec<Type> = Vec::new();
 
 pub(crate) enum InstructionExecutor {
     Is(IsExecutor),
+    Iid(IidExecutor),
     TypeList(TypeListExecutor),
 
     Sub(SubExecutor),
@@ -106,6 +108,7 @@ impl InstructionExecutor {
     ) -> Result<Self, Box<ConceptReadError>> {
         match instruction {
             ConstraintInstruction::Is(is) => Ok(Self::Is(IsExecutor::new(is, variable_modes, sort_by))),
+            ConstraintInstruction::Iid(iid) => Ok(Self::Iid(IidExecutor::new(iid, variable_modes, sort_by))),
             ConstraintInstruction::TypeList(type_) => {
                 Ok(Self::TypeList(TypeListExecutor::new(type_, variable_modes, sort_by)))
             }
@@ -164,6 +167,7 @@ impl InstructionExecutor {
     ) -> Result<TupleIterator, Box<ConceptReadError>> {
         match self {
             Self::Is(executor) => executor.get_iterator(context, row),
+            Self::Iid(executor) => executor.get_iterator(context, row),
             Self::TypeList(executor) => executor.get_iterator(context, row),
             Self::Sub(executor) => executor.get_iterator(context, row),
             Self::SubReverse(executor) => executor.get_iterator(context, row),

--- a/executor/instruction/plays_executor.rs
+++ b/executor/instruction/plays_executor.rs
@@ -6,8 +6,7 @@
 
 use std::{
     collections::{BTreeMap, BTreeSet, HashMap},
-    fmt::{Display, Formatter},
-    iter,
+    fmt, iter,
     sync::Arc,
     vec,
 };
@@ -209,8 +208,8 @@ impl PlaysExecutor {
     }
 }
 
-impl Display for PlaysExecutor {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+impl fmt::Display for PlaysExecutor {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         writeln!(f, "[{}], mode={}", &self.plays, &self.iterate_mode)
     }
 }

--- a/executor/instruction/plays_reverse_executor.rs
+++ b/executor/instruction/plays_reverse_executor.rs
@@ -6,8 +6,7 @@
 
 use std::{
     collections::{BTreeMap, BTreeSet, HashMap},
-    fmt::{Display, Formatter},
-    iter,
+    fmt, iter,
     sync::Arc,
     vec,
 };
@@ -190,8 +189,8 @@ impl PlaysReverseExecutor {
     }
 }
 
-impl Display for PlaysReverseExecutor {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+impl fmt::Display for PlaysReverseExecutor {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         writeln!(f, "Reverse[{}], mode={}", &self.plays, &self.iterate_mode)
     }
 }

--- a/executor/instruction/relates_reverse_executor.rs
+++ b/executor/instruction/relates_reverse_executor.rs
@@ -6,8 +6,7 @@
 
 use std::{
     collections::{BTreeMap, BTreeSet, HashMap},
-    fmt::{Display, Formatter},
-    iter,
+    fmt, iter,
     sync::Arc,
     vec,
 };
@@ -190,8 +189,8 @@ impl RelatesReverseExecutor {
     }
 }
 
-impl Display for RelatesReverseExecutor {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+impl fmt::Display for RelatesReverseExecutor {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         writeln!(f, "Reverse[{}], mode={}", &self.relates, &self.iterate_mode)
     }
 }

--- a/function/Cargo.toml
+++ b/function/Cargo.toml
@@ -93,7 +93,7 @@ features = {}
 
 	[dependencies.typeql]
 		features = []
-		rev = "0be38cbab19da7d6b2549ad5aa1248fc811bc4e0"
+		rev = "a839354d9633794d989fc15b3e41bb85e202f761"
 		git = "https://github.com/typedb/typeql"
 		default-features = false
 

--- a/ir/BUILD
+++ b/ir/BUILD
@@ -20,6 +20,7 @@ rust_library(
     ]),
     deps = [
         "//answer",
+        "//common/bytes",
         "//common/primitive",
         "//common/structural_equality",
         "//common/error",

--- a/ir/Cargo.toml
+++ b/ir/Cargo.toml
@@ -19,11 +19,6 @@ features = {}
 		features = []
 		default-features = false
 
-	[dev-dependencies.bytes]
-		path = "../common/bytes"
-		features = []
-		default-features = false
-
 	[dev-dependencies.test_utils_storage]
 		path = "../storage/tests"
 		features = []
@@ -86,9 +81,14 @@ features = {}
 		features = []
 		default-features = false
 
+	[dependencies.bytes]
+		path = "../common/bytes"
+		features = []
+		default-features = false
+
 	[dependencies.typeql]
 		features = []
-		rev = "0be38cbab19da7d6b2549ad5aa1248fc811bc4e0"
+		rev = "a839354d9633794d989fc15b3e41bb85e202f761"
 		git = "https://github.com/typedb/typeql"
 		default-features = false
 

--- a/ir/pattern/constraint.rs
+++ b/ir/pattern/constraint.rs
@@ -1003,8 +1003,8 @@ impl StructuralEquality for SubKind {
     }
 }
 
-impl Display for SubKind {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+impl fmt::Display for SubKind {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::Exact => write!(f, "!"),
             // This is not a great Display implementation since there is no symbol to read this variant
@@ -1245,8 +1245,8 @@ impl StructuralEquality for IsaKind {
     }
 }
 
-impl Display for IsaKind {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+impl fmt::Display for IsaKind {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::Exact => write!(f, "!"),
             // This is not a great Display implementation since there is no symbol to read this variant
@@ -1603,8 +1603,8 @@ impl StructuralEquality for Comparator {
     }
 }
 
-impl Display for Comparator {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+impl fmt::Display for Comparator {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::Equal => write!(f, "{}", typeql::token::Comparator::Eq),
             Self::NotEqual => write!(f, "{}", typeql::token::Comparator::Neq),

--- a/ir/pattern/constraint.rs
+++ b/ir/pattern/constraint.rs
@@ -7,7 +7,6 @@
 use std::{
     collections::HashMap,
     fmt,
-    fmt::{Display, Formatter},
     hash::{DefaultHasher, Hasher},
     mem,
     ops::Deref,

--- a/ir/pattern/constraint.rs
+++ b/ir/pattern/constraint.rs
@@ -21,7 +21,7 @@ use crate::{
         expression::{ExpressionDefinitionError, ExpressionTree},
         function_call::FunctionCall,
         variable_category::VariableCategory,
-        IrID, ScopeId, ValueType, Vertex,
+        IrID, ParameterID, ScopeId, ValueType, Vertex,
     },
     pipeline::{block::BlockBuilderContext, function_signature::FunctionSignature, ParameterRegistry},
     RepresentationError,
@@ -198,6 +198,16 @@ impl<'cx, 'reg> ConstraintsBuilder<'cx, 'reg> {
 
         let constraint = self.constraints.add_constraint(isa);
         Ok(constraint.as_isa().unwrap())
+    }
+
+    pub fn add_iid(&mut self, var: Variable, iid: ParameterID) -> Result<&Iid<Variable>, Box<RepresentationError>> {
+        let iid = Iid::new(var, iid);
+
+        debug_assert!(self.context.is_variable_available(self.constraints.scope, var));
+        self.context.set_variable_category(var, VariableCategory::Thing, iid.clone().into())?;
+
+        let constraint = self.constraints.add_constraint(iid);
+        Ok(constraint.as_iid().unwrap())
     }
 
     pub fn add_has(
@@ -447,6 +457,7 @@ pub enum Constraint<ID> {
     RoleName(RoleName<ID>),
     Sub(Sub<ID>),
     Isa(Isa<ID>),
+    Iid(Iid<ID>),
     Links(Links<ID>),
     Has(Has<ID>),
     ExpressionBinding(ExpressionBinding<ID>),
@@ -467,6 +478,7 @@ impl<ID: IrID> Constraint<ID> {
             Constraint::RoleName(_) => "role-name",
             Constraint::Sub(_) => typeql::token::Keyword::Sub.as_str(),
             Constraint::Isa(_) => typeql::token::Keyword::Isa.as_str(),
+            Constraint::Iid(_) => typeql::token::Keyword::IID.as_str(),
             Constraint::Links(_) => typeql::token::Keyword::Links.as_str(),
             Constraint::Has(_) => typeql::token::Keyword::Has.as_str(),
             Constraint::ExpressionBinding(_) => typeql::token::Comparator::Eq.as_str(),
@@ -487,6 +499,7 @@ impl<ID: IrID> Constraint<ID> {
             Constraint::RoleName(role_name) => Box::new(role_name.ids()),
             Constraint::Sub(sub) => Box::new(sub.ids()),
             Constraint::Isa(isa) => Box::new(isa.ids()),
+            Constraint::Iid(iid) => Box::new(iid.ids()),
             Constraint::Links(rp) => Box::new(rp.ids()),
             Constraint::Has(has) => Box::new(has.ids()),
             Constraint::ExpressionBinding(binding) => Box::new(binding.ids_assigned()),
@@ -507,6 +520,7 @@ impl<ID: IrID> Constraint<ID> {
             Constraint::RoleName(role_name) => Box::new(role_name.vertices()),
             Constraint::Sub(sub) => Box::new(sub.vertices()),
             Constraint::Isa(isa) => Box::new(isa.vertices()),
+            Constraint::Iid(iid) => Box::new(iid.vertices()),
             Constraint::Links(rp) => Box::new(rp.vertices()),
             Constraint::Has(has) => Box::new(has.vertices()),
             Constraint::ExpressionBinding(binding) => Box::new(binding.vertices_assigned()),
@@ -530,6 +544,7 @@ impl<ID: IrID> Constraint<ID> {
             Self::RoleName(role_name) => role_name.ids_foreach(function),
             Self::Sub(sub) => sub.ids_foreach(function),
             Self::Isa(isa) => isa.ids_foreach(function),
+            Self::Iid(iid) => iid.ids_foreach(function),
             Self::Links(rp) => rp.ids_foreach(function),
             Self::Has(has) => has.ids_foreach(function),
             Self::ExpressionBinding(binding) => binding.ids_foreach(function),
@@ -550,6 +565,7 @@ impl<ID: IrID> Constraint<ID> {
             Self::RoleName(inner) => Constraint::RoleName(inner.map(mapping)),
             Self::Sub(inner) => Constraint::Sub(inner.map(mapping)),
             Self::Isa(inner) => Constraint::Isa(inner.map(mapping)),
+            Self::Iid(inner) => Constraint::Iid(inner.map(mapping)),
             Self::Links(inner) => Constraint::Links(inner.map(mapping)),
             Self::Has(inner) => Constraint::Has(inner.map(mapping)),
             Self::ExpressionBinding(inner) => todo!(),
@@ -620,6 +636,13 @@ impl<ID: IrID> Constraint<ID> {
     pub(crate) fn as_isa(&self) -> Option<&Isa<ID>> {
         match self {
             Constraint::Isa(isa) => Some(isa),
+            _ => None,
+        }
+    }
+
+    pub(crate) fn as_iid(&self) -> Option<&Iid<ID>> {
+        match self {
+            Constraint::Iid(iid) => Some(iid),
             _ => None,
         }
     }
@@ -698,6 +721,7 @@ impl<ID: StructuralEquality + Ord> StructuralEquality for Constraint<ID> {
                 Self::RoleName(inner) => inner.hash(),
                 Self::Sub(inner) => inner.hash(),
                 Self::Isa(inner) => inner.hash(),
+                Self::Iid(inner) => inner.hash(),
                 Self::Links(inner) => inner.hash(),
                 Self::Has(inner) => inner.hash(),
                 Self::ExpressionBinding(inner) => inner.hash(),
@@ -718,6 +742,7 @@ impl<ID: StructuralEquality + Ord> StructuralEquality for Constraint<ID> {
             (Self::RoleName(inner), Self::RoleName(other_inner)) => inner.equals(other_inner),
             (Self::Sub(inner), Self::Sub(other_inner)) => inner.equals(other_inner),
             (Self::Isa(inner), Self::Isa(other_inner)) => inner.equals(other_inner),
+            (Self::Iid(inner), Self::Iid(other_inner)) => inner.equals(other_inner),
             (Self::Links(inner), Self::Links(other_inner)) => inner.equals(other_inner),
             (Self::Has(inner), Self::Has(other_inner)) => inner.equals(other_inner),
             (Self::ExpressionBinding(inner), Self::ExpressionBinding(other_inner)) => inner.equals(other_inner),
@@ -734,6 +759,7 @@ impl<ID: StructuralEquality + Ord> StructuralEquality for Constraint<ID> {
             | (Self::RoleName { .. }, _)
             | (Self::Sub { .. }, _)
             | (Self::Isa { .. }, _)
+            | (Self::Iid { .. }, _)
             | (Self::Links { .. }, _)
             | (Self::Has { .. }, _)
             | (Self::ExpressionBinding { .. }, _)
@@ -756,6 +782,7 @@ impl<ID: IrID> fmt::Display for Constraint<ID> {
             Self::RoleName(constraint) => fmt::Display::fmt(constraint, f),
             Self::Sub(constraint) => fmt::Display::fmt(constraint, f),
             Self::Isa(constraint) => fmt::Display::fmt(constraint, f),
+            Self::Iid(constraint) => fmt::Display::fmt(constraint, f),
             Self::Links(constraint) => fmt::Display::fmt(constraint, f),
             Self::Has(constraint) => fmt::Display::fmt(constraint, f),
             Self::ExpressionBinding(constraint) => fmt::Display::fmt(constraint, f),
@@ -1215,7 +1242,7 @@ impl<ID: StructuralEquality> StructuralEquality for Isa<ID> {
 
 impl<ID: IrID> fmt::Display for Isa<ID> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{} isa {}", self.thing, self.type_)
+        write!(f, "{} {}{} {}", self.thing, typeql::token::Keyword::Isa, self.kind, self.type_)
     }
 }
 
@@ -1251,6 +1278,70 @@ impl fmt::Display for IsaKind {
             // This is not a great Display implementation since there is no symbol to read this variant
             Self::Subtype => write!(f, ""),
         }
+    }
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Hash)]
+pub struct Iid<ID> {
+    var: Vertex<ID>,
+    iid: Vertex<ID>,
+}
+
+impl<ID: IrID> Iid<ID> {
+    pub fn new(var: ID, iid: ParameterID) -> Self {
+        Self { var: Vertex::Variable(var), iid: Vertex::Parameter(iid) }
+    }
+
+    pub fn var(&self) -> &Vertex<ID> {
+        &self.var
+    }
+
+    pub fn iid(&self) -> &Vertex<ID> {
+        &self.iid
+    }
+
+    pub fn ids(&self) -> impl Iterator<Item = ID> + Sized {
+        self.var.as_variable().into_iter()
+    }
+
+    pub fn vertices(&self) -> impl Iterator<Item = &Vertex<ID>> + Sized {
+        [&self.var, &self.iid].into_iter()
+    }
+
+    pub fn ids_foreach<F>(&self, mut function: F)
+    where
+        F: FnMut(ID, ConstraintIDSide),
+    {
+        self.var.as_variable().inspect(|&id| function(id, ConstraintIDSide::Left));
+    }
+
+    pub fn map<T: IrID>(self, mapping: &HashMap<ID, T>) -> Iid<T> {
+        Iid { var: self.var.map(mapping), iid: self.iid.map(mapping) }
+    }
+}
+
+impl<ID: IrID> From<Iid<ID>> for Constraint<ID> {
+    fn from(val: Iid<ID>) -> Self {
+        Constraint::Iid(val)
+    }
+}
+
+impl<ID: StructuralEquality> StructuralEquality for Iid<ID> {
+    fn hash(&self) -> u64 {
+        let mut hasher = DefaultHasher::new();
+        self.var.hash_into(&mut hasher);
+        self.iid.hash_into(&mut hasher);
+        hasher.finish()
+    }
+
+    fn equals(&self, other: &Self) -> bool {
+        self.var.equals(&other.var) && self.iid.equals(&other.iid)
+    }
+}
+
+impl<ID: IrID> fmt::Display for Iid<ID> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{} iid {}", self.var, self.iid)
     }
 }
 
@@ -1332,7 +1423,7 @@ impl<ID: StructuralEquality> StructuralEquality for Links<ID> {
 
 impl<ID: IrID> fmt::Display for Links<ID> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{} rp {} (role: {})", self.relation, self.player, self.role_type)
+        write!(f, "{} links {} (role: {})", self.relation, self.player, self.role_type)
     }
 }
 

--- a/ir/pattern/mod.rs
+++ b/ir/pattern/mod.rs
@@ -159,13 +159,20 @@ impl<ID: fmt::Debug> fmt::Display for Vertex<ID> {
 }
 
 #[derive(Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
-pub struct ParameterID {
-    pub id: usize,
+pub enum ParameterID {
+    Value(usize),
+    Iid(usize),
+    FetchKey(usize),
 }
 
 impl StructuralEquality for ParameterID {
     fn hash(&self) -> u64 {
-        StructuralEquality::hash(&self.id)
+        let id = match *self {
+            ParameterID::Value(id) => id,
+            ParameterID::Iid(id) => id,
+            ParameterID::FetchKey(id) => id,
+        };
+        StructuralEquality::hash(&id)
     }
 
     fn equals(&self, other: &Self) -> bool {
@@ -175,7 +182,14 @@ impl StructuralEquality for ParameterID {
 
 impl fmt::Debug for ParameterID {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "Param[{}]", self.id)
+        write!(f, "Param[")?;
+        match self {
+            ParameterID::Value(id) => write!(f, "Value({id})")?,
+            ParameterID::Iid(id) => write!(f, "IID({id})")?,
+            ParameterID::FetchKey(id) => write!(f, "FetchKey({id})")?,
+        }
+        write!(f, "]")?;
+        Ok(())
     }
 }
 

--- a/ir/translation/constraints.rs
+++ b/ir/translation/constraints.rs
@@ -372,18 +372,21 @@ fn add_typeql_isa(
     Ok(())
 }
 
-fn parse_iid(iid: &str) -> ByteArray<THING_VERTEX_MAX_LENGTH> {
+fn parse_iid(mut iid: &str) -> ByteArray<THING_VERTEX_MAX_LENGTH> {
     fn from_hex(c: u8) -> u8 {
         // relying on the fact that typeql ensures only hex digits
         match c {
             b'0'..=b'9' => c - b'0',
-            b'a'..=b'f' => c - b'a',
-            b'A'..=b'F' => c - b'A',
+            b'a'..=b'f' => c - b'a' + 10,
+            b'A'..=b'F' => c - b'A' + 10,
             _ => unreachable!(),
         }
     }
+
+    iid = &iid["0x".len()..];
+
     let mut bytes = [0u8; THING_VERTEX_MAX_LENGTH];
-    for (i, (hi, lo)) in iid.bytes().skip(2).tuples().enumerate() {
+    for (i, (hi, lo)) in iid.bytes().tuples().enumerate() {
         bytes[i] = (from_hex(hi) << 4) + from_hex(lo);
     }
     let len = iid.as_bytes().len() / 2;

--- a/query/Cargo.toml
+++ b/query/Cargo.toml
@@ -118,7 +118,7 @@ features = {}
 
 	[dependencies.typeql]
 		features = []
-		rev = "0be38cbab19da7d6b2549ad5aa1248fc811bc4e0"
+		rev = "a839354d9633794d989fc15b3e41bb85e202f761"
 		git = "https://github.com/typedb/typeql"
 		default-features = false
 

--- a/query/tests/define.rs
+++ b/query/tests/define.rs
@@ -4,9 +4,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-use std::sync::Arc;
-
-use query::{query_cache::QueryCache, query_manager::QueryManager};
+use query::query_manager::QueryManager;
 use storage::snapshot::CommittableSnapshot;
 use test_utils_concept::{load_managers, setup_concept_storage};
 use test_utils_encoding::create_core_storage;

--- a/query/tests/define.rs
+++ b/query/tests/define.rs
@@ -4,7 +4,9 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-use query::query_manager::QueryManager;
+use std::sync::Arc;
+
+use query::{query_cache::QueryCache, query_manager::QueryManager};
 use storage::snapshot::CommittableSnapshot;
 use test_utils_concept::{load_managers, setup_concept_storage};
 use test_utils_encoding::create_core_storage;

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -71,7 +71,7 @@ features = {}
 
 	[dependencies.typeql]
 		features = []
-		rev = "0be38cbab19da7d6b2549ad5aa1248fc811bc4e0"
+		rev = "a839354d9633794d989fc15b3e41bb85e202f761"
 		git = "https://github.com/typedb/typeql"
 		default-features = false
 

--- a/tests/behaviour/steps/Cargo.toml
+++ b/tests/behaviour/steps/Cargo.toml
@@ -81,7 +81,7 @@ features = {}
 
 	[dependencies.typeql]
 		features = []
-		rev = "0be38cbab19da7d6b2549ad5aa1248fc811bc4e0"
+		rev = "a839354d9633794d989fc15b3e41bb85e202f761"
 		git = "https://github.com/typedb/typeql"
 		default-features = false
 

--- a/tests/behaviour/steps/query_answer_context.rs
+++ b/tests/behaviour/steps/query_answer_context.rs
@@ -32,14 +32,14 @@ macro_rules! with_rows_answer {
 }
 pub(crate) use with_rows_answer;
 
-#[expect(unused_macros, reason="added for symmetry")]
+#[expect(unused_macros, reason = "added for symmetry")]
 macro_rules! with_documents_answer {
     ($context:ident, |$answer:ident| $expr:expr) => {
         let $answer = $context.query_answer.as_ref().unwrap().as_documents();
         $expr
     };
 }
-#[expect(unused_imports, reason="added for symmetry")]
+#[expect(unused_imports, reason = "added for symmetry")]
 pub(crate) use with_documents_answer;
 
 impl QueryAnswer {

--- a/tests/behaviour/steps/query_answer_context.rs
+++ b/tests/behaviour/steps/query_answer_context.rs
@@ -32,22 +32,25 @@ macro_rules! with_rows_answer {
 }
 pub(crate) use with_rows_answer;
 
+#[expect(unused_macros, reason="added for symmetry")]
 macro_rules! with_documents_answer {
     ($context:ident, |$answer:ident| $expr:expr) => {
         let $answer = $context.query_answer.as_ref().unwrap().as_documents();
         $expr
     };
 }
+#[expect(unused_imports, reason="added for symmetry")]
+pub(crate) use with_documents_answer;
 
 impl QueryAnswer {
-    pub fn as_rows(&self) -> &Vec<HashMap<String, VariableValue<'static>>> {
+    pub fn as_rows(&self) -> &[HashMap<String, VariableValue<'static>>] {
         match self {
             Self::ConceptRows(rows) => rows,
             Self::ConceptDocuments(..) => panic!("Expected ConceptRows, got ConceptDocuments"),
         }
     }
 
-    pub fn as_documents(&self) -> &Vec<ConceptDocument> {
+    pub fn as_documents(&self) -> &[ConceptDocument] {
         match self {
             Self::ConceptRows(..) => {
                 panic!("Expected ConceptDocuments, got ConceptRows")
@@ -56,7 +59,7 @@ impl QueryAnswer {
         }
     }
 
-    pub fn as_documents_parameters(&self) -> &Arc<ParameterRegistry> {
+    pub fn as_documents_parameters(&self) -> &ParameterRegistry {
         match self {
             Self::ConceptRows(..) => {
                 panic!("Expected ConceptDocuments, got ConceptRows")
@@ -93,7 +96,7 @@ impl QueryAnswer {
         snapshot: &impl ReadableSnapshot,
         type_manager: &TypeManager,
         thing_manager: &ThingManager,
-        parameters: &Arc<ParameterRegistry>,
+        parameters: &ParameterRegistry,
         node: &DocumentNode,
     ) -> JSON {
         match &node {
@@ -116,7 +119,7 @@ impl QueryAnswer {
         snapshot: &impl ReadableSnapshot,
         type_manager: &TypeManager,
         thing_manager: &ThingManager,
-        parameters: &Arc<ParameterRegistry>,
+        parameters: &ParameterRegistry,
         document_map: &DocumentMap,
     ) -> HashMap<Cow<'static, str>, JSON> {
         match document_map {


### PR DESCRIPTION
## Release notes: product changes

We add support for IID constraints in `match` clauses.

Example:
```
match $x iid 0x1E001A0000000012345678;
```

## Motivation

## Implementation
