### PR TITLE
Frugal type seeder

### DIFF
--- a/compiler/annotation/match_inference.rs
+++ b/compiler/annotation/match_inference.rs
@@ -267,34 +267,22 @@ impl<'this> TypeInferenceEdge<'this> {
         initial_left_to_right: BTreeMap<TypeAnnotation, BTreeSet<TypeAnnotation>>,
         initial_right_to_left: BTreeMap<TypeAnnotation, BTreeSet<TypeAnnotation>>,
     ) -> TypeInferenceEdge<'this> {
-        // The final left_to_right & right_to_left sets must be consistent with each other. i.e.
-        //      left_to_right.keys() == union(right_to_left.values()) AND
-        //      right_to_left.keys() == union(left_to_right.values())
+        // The left_to_right & right_to_left sets must be consistent with each other. i.e.
+        //   They must contain the same set of edges.
         // This is a pre-condition to the type-inference loop.
-        let mut left_to_right = initial_left_to_right;
-        let mut right_to_left = initial_right_to_left;
-        let left_types = Self::intersect_first_keys_with_union_of_second_values(&left_to_right, &right_to_left);
-        let right_types = Self::intersect_first_keys_with_union_of_second_values(&right_to_left, &left_to_right);
-        Self::prune_keys_not_in_first_and_values_not_in_second(&mut left_to_right, &left_types, &right_types);
-        Self::prune_keys_not_in_first_and_values_not_in_second(&mut right_to_left, &right_types, &left_types);
-        TypeInferenceEdge { constraint, left, right, left_to_right, right_to_left }
-    }
-
-    fn intersect_first_keys_with_union_of_second_values(
-        keys_from: &BTreeMap<TypeAnnotation, BTreeSet<TypeAnnotation>>,
-        values_from: &BTreeMap<TypeAnnotation, BTreeSet<TypeAnnotation>>,
-    ) -> BTreeSet<TypeAnnotation> {
-        values_from.values().flatten().filter(|v| keys_from.contains_key(v)).cloned().collect()
-    }
-
-    fn prune_keys_not_in_first_and_values_not_in_second(
-        prune_from: &mut BTreeMap<TypeAnnotation, BTreeSet<TypeAnnotation>>,
-        allowed_keys: &BTreeSet<TypeAnnotation>,
-        allowed_values: &BTreeSet<TypeAnnotation>,
-    ) {
-        prune_from.retain(|type_, _| allowed_keys.contains(type_));
-        for v in prune_from.values_mut() {
-            v.retain(|type_| allowed_values.contains(type_));
+        // This is currently true by construction.
+        debug_assert!(initial_left_to_right
+            .iter()
+            .all(|(u, vs)| vs.iter().all(|v| initial_right_to_left.get(v).unwrap().contains(u))));
+        debug_assert!(initial_right_to_left
+            .iter()
+            .all(|(u, vs)| vs.iter().all(|v| initial_left_to_right.get(v).unwrap().contains(u))));
+        TypeInferenceEdge {
+            constraint,
+            left,
+            right,
+            left_to_right: initial_left_to_right,
+            right_to_left: initial_right_to_left,
         }
     }
 

--- a/compiler/annotation/match_inference.rs
+++ b/compiler/annotation/match_inference.rs
@@ -237,7 +237,7 @@ impl<'this> TypeInferenceGraph<'this> {
         });
 
         vertices.into_iter().for_each(|(variable, types)| {
-            vertex_annotations.entry(variable).or_insert_with(|| Arc::new(types.into_iter().collect()));
+            vertex_annotations.entry(variable).or_insert_with(|| Arc::new(types));
         });
 
         chain(

--- a/compiler/annotation/type_seeder.rs
+++ b/compiler/annotation/type_seeder.rs
@@ -99,7 +99,8 @@ impl<'this, Snapshot: ReadableSnapshot> TypeGraphSeedingContext<'this, Snapshot>
             .flat_map(|constraint| constraint.vertices())
             .filter(|vertex| !vertex.is_parameter())
             .unique()
-            .all(|vertex| graph.vertices.contains_key(vertex)));
+            .all(|vertex| vertex.is_parameter() ||  graph.vertices.contains_key(vertex))
+        );
 
         Ok(graph)
     }

--- a/compiler/annotation/type_seeder.rs
+++ b/compiler/annotation/type_seeder.rs
@@ -784,15 +784,16 @@ trait BinaryConstraint {
         allowed_right_types: &BTreeSet<TypeAnnotation>,
     ) -> Result<BTreeMap<TypeAnnotation, BTreeSet<TypeAnnotation>>, Box<ConceptReadError>> {
         let mut left_to_right = BTreeMap::new();
-        #[cfg(debug_assertions)]
-        let (left_is_thing, right_is_thing) = self.check_for_thing_vars(seeder);
-        debug_assert!(!left_is_thing || left_types.iter().all(|t| seeder.is_not_abstract(t).unwrap()));
-        debug_assert!(!right_is_thing || allowed_right_types.iter().all(|t| seeder.is_not_abstract(t).unwrap()));
+        #[cfg(debug_assertions)]{
+            let (left_is_thing, right_is_thing) = self.check_for_thing_vars(seeder);
+            debug_assert!(!left_is_thing || left_types.iter().all(|t| seeder.is_not_abstract(t).unwrap()));
+            debug_assert!(!right_is_thing || allowed_right_types.iter().all(|t| seeder.is_not_abstract(t).unwrap()));
+        }
         for left_type in left_types {
             let mut right_annotations = BTreeSet::new();
             self.annotate_left_to_right_for_type(seeder, left_type, &mut right_annotations)?;
             right_annotations.retain(|type_| allowed_right_types.contains(type_));
-            debug_assert!(!right_is_thing || right_annotations.iter().all(|t| seeder.is_not_abstract(t).unwrap()));
+            debug_assert!(!self.check_for_thing_vars(seeder).1 || right_annotations.iter().all(|t| seeder.is_not_abstract(t).unwrap()));
             if !right_annotations.is_empty() {
                 left_to_right.insert(left_type.clone(), right_annotations);
             }
@@ -807,14 +808,16 @@ trait BinaryConstraint {
         allowed_left_types: &BTreeSet<TypeAnnotation>,
     ) -> Result<BTreeMap<TypeAnnotation, BTreeSet<TypeAnnotation>>, Box<ConceptReadError>> {
         let mut right_to_left = BTreeMap::new();
-        let (left_is_thing, right_is_thing) = self.check_for_thing_vars(seeder);
-        debug_assert!(!right_is_thing || right_types.iter().all(|t| seeder.is_not_abstract(t).unwrap()));
-        debug_assert!(!left_is_thing || allowed_left_types.iter().all(|t| seeder.is_not_abstract(t).unwrap()));
+        #[cfg(debug_assertions)]{
+            let (left_is_thing, right_is_thing) = self.check_for_thing_vars(seeder);
+            debug_assert!(!right_is_thing || right_types.iter().all(|t| seeder.is_not_abstract(t).unwrap()));
+            debug_assert!(!left_is_thing || allowed_left_types.iter().all(|t| seeder.is_not_abstract(t).unwrap()));
+        }
         for right_type in right_types {
             let mut left_annotations = BTreeSet::new();
             self.annotate_right_to_left_for_type(seeder, right_type, &mut left_annotations)?;
             left_annotations.retain(|type_| allowed_left_types.contains(type_));
-            debug_assert!(!left_is_thing || left_annotations.iter().all(|t| seeder.is_not_abstract(t).unwrap()));
+            debug_assert!(!self.check_for_thing_vars(seeder).0 || left_annotations.iter().all(|t| seeder.is_not_abstract(t).unwrap()));
             if !left_annotations.is_empty() {
                 right_to_left.insert(right_type.clone(), left_annotations);
             }

--- a/compiler/annotation/type_seeder.rs
+++ b/compiler/annotation/type_seeder.rs
@@ -1353,41 +1353,20 @@ impl BinaryConstraint for Comparison<Variable> {
 
     fn annotate_left_to_right_for_type(
         &self,
-        seeder: &TypeGraphSeedingContext<'_, impl ReadableSnapshot>,
-        left_type: &TypeAnnotation,
-        collector: &mut BTreeSet<TypeAnnotation>,
+        _seeder: &TypeGraphSeedingContext<'_, impl ReadableSnapshot>,
+        _left_type: &TypeAnnotation,
+        _collector: &mut BTreeSet<TypeAnnotation>,
     ) -> Result<(), Box<ConceptReadError>> {
-        unreachable!();
-        let left_value_type = match left_type {
-            TypeAnnotation::Attribute(attribute) => {
-                attribute.get_value_type_without_source(seeder.snapshot, seeder.type_manager)?
-            }
-            _ => return Ok(()), // It can't be another type => Do nothing and let type-inference clean it up
-        };
-        if let Some(value_type) = left_value_type {
-            let comparable_types = ValueTypeCategory::comparable_categories(value_type.category());
-            for subattr in seeder.type_manager.get_attribute_types(seeder.snapshot)?.iter() {
-                if let Some(subvaluetype) =
-                    subattr.get_value_type_without_source(seeder.snapshot, seeder.type_manager)?
-                {
-                    if comparable_types.contains(&subvaluetype.category()) {
-                        collector.insert(TypeAnnotation::Attribute(subattr.clone()));
-                    }
-                }
-            }
-        }
-        Ok(())
+        unreachable!()
     }
 
     fn annotate_right_to_left_for_type(
         &self,
-        seeder: &TypeGraphSeedingContext<'_, impl ReadableSnapshot>,
-        right_type: &TypeAnnotation,
-        collector: &mut BTreeSet<TypeAnnotation>,
+        _seeder: &TypeGraphSeedingContext<'_, impl ReadableSnapshot>,
+        _right_type: &TypeAnnotation,
+        _collector: &mut BTreeSet<TypeAnnotation>,
     ) -> Result<(), Box<ConceptReadError>> {
-        unreachable!();
-
-        Ok(())
+        unreachable!()
     }
 }
 


### PR DESCRIPTION
## Release notes: product changes
Optimises parts of the type seeder to avoid unnecessary effort.

## Motivation

## Implementation
* `left_to_right` and `right_to_left` in `TypeInferenceEdge` are consistent & exclude abstract by construction.
* Vertex annotations are no longer propagated across comparison edges.
* Implements a custom edge seeder for Comparison to avoid collecting too many attribute types.
* 
