### PR TITLE
Validate user input to the 'user repository' module

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3134,6 +3134,7 @@ dependencies = [
  "compiler",
  "concept",
  "database",
+ "error",
  "executor",
  "function",
  "lending_iterator",

--- a/server/authenticator.rs
+++ b/server/authenticator.rs
@@ -32,14 +32,21 @@ impl Authenticator {
         let password_metadata = metadata.get(AUTHENTICATOR_PASSWORD_FIELD).map(|u| u.to_str());
         match (username_metadata, password_metadata) {
             (Some(Ok(username)), Some(Ok(password))) => match self.user_manager.get(username) {
-                Some((_, Credential::PasswordType { password_hash })) => {
-                    if password_hash.matches(password) {
-                        Ok(req)
-                    } else {
-                        Err(Status::unauthenticated(ERROR_INVALID_CREDENTIAL))
+                Ok(get_result) => {
+                    match get_result {
+                        Some((_, Credential::PasswordType { password_hash })) => {
+                            if password_hash.matches(password) {
+                                Ok(req)
+                            } else {
+                                Err(Status::unauthenticated(ERROR_INVALID_CREDENTIAL))
+                            }
+                        }
+                        None => Err(Status::unauthenticated(ERROR_INVALID_CREDENTIAL)),
                     }
                 }
-                None => Err(Status::unauthenticated(ERROR_INVALID_CREDENTIAL)),
+                Err(_) => {
+                    Err(Status::unauthenticated(ERROR_INVALID_CREDENTIAL))
+                }
             },
             _ => {
                 Err(Status::unauthenticated(ERROR_CREDENTIAL_NOT_SUPPLIED))

--- a/system/BUILD
+++ b/system/BUILD
@@ -19,6 +19,7 @@ rust_library(
         "//compiler",
         "//concept",
         "//database",
+        "//common/error",
         "//executor",
         "//function",
         "//query",

--- a/system/Cargo.toml
+++ b/system/Cargo.toml
@@ -34,6 +34,11 @@ features = {}
 		features = []
 		default-features = false
 
+	[dependencies.error]
+		path = "../common/error"
+		features = []
+		default-features = false
+
 	[dependencies.uuid]
 		features = ["default", "fast-rng", "rng", "serde", "std", "v4"]
 		version = "1.11.0"

--- a/system/repositories.rs
+++ b/system/repositories.rs
@@ -37,9 +37,9 @@ pub mod user_repository {
         users
     }
 
-    pub fn get(tx: TransactionRead<WALClient>, username: &str) -> Result<Option<(User, Credential)>, QueryError> {
+    pub fn get(tx: TransactionRead<WALClient>, username: &str) -> Result<Option<(User, Credential)>, SystemDBError> {
         if !is_valid_typeql_value(username) {
-            return Err(QueryError::IllegalQueryInput {});
+            return Err(SystemDBError::IllegalQueryInput {});
         }
         let unexpected_error_msg = "An unexpected error occurred when attempting to retrieve a user";
         let query = parse_query(
@@ -71,9 +71,9 @@ pub mod user_repository {
         query_manager: &QueryManager,
         user: &User,
         credential: &Credential,
-    ) -> (Result<(), QueryError>, Arc<WriteSnapshot<WALClient>>) {
+    ) -> (Result<(), SystemDBError>, Arc<WriteSnapshot<WALClient>>) {
         if !is_valid_typeql_value(&user.name) {
-            return (Err(QueryError::IllegalQueryInput {}), Arc::new(snapshot));
+            return (Err(SystemDBError::IllegalQueryInput {}), Arc::new(snapshot));
         }
         let unexpected_error_msg = "An unexpected error occurred when attempting to create a new user";
         let query = match credential {
@@ -125,9 +125,9 @@ pub mod user_repository {
         function_manager: &FunctionManager,
         query_manager: &QueryManager,
         username: &str,
-    ) -> (Result<(), QueryError>, Arc<WriteSnapshot<WALClient>>) {
+    ) -> (Result<(), SystemDBError>, Arc<WriteSnapshot<WALClient>>) {
         if !is_valid_typeql_value(username) {
-            return (Err(QueryError::IllegalQueryInput {}), Arc::new(snapshot));
+            return (Err(SystemDBError::IllegalQueryInput {}), Arc::new(snapshot));
         }
         let unexpected_error_msg = "An unexpected error occurred when attempting to delete a user";
         let query = parse_query(
@@ -150,7 +150,7 @@ pub mod user_repository {
     }
 
     typedb_error!(
-        pub QueryError(component = "System database", prefix = "SDB") {
+        pub SystemDBError(component = "System database", prefix = "SDB") {
             IllegalQueryInput(1, "The specified input contains one or more illegal character(s)"),
         }
     );

--- a/system/repositories.rs
+++ b/system/repositories.rs
@@ -8,7 +8,7 @@ pub const SCHEMA: &str = include_str!("schema.tql");
 
 pub mod user_repository {
     use std::{collections::HashMap, sync::Arc};
-
+    use typeql::common::identifier::is_valid_identifier;
     use answer::variable_value::VariableValue;
     use concept::{thing::thing_manager, type_::type_manager::TypeManager};
     use database::transaction::{TransactionRead, TransactionWrite};
@@ -25,6 +25,7 @@ pub mod user_repository {
             query_util::{execute_read_pipeline, execute_write_pipeline},
         },
     };
+    use error::typedb_error;
 
     pub fn list(tx: TransactionRead<WALClient>) -> Vec<User> {
         let unexpected_error_msg = "An unexpected error occurred when acquiring the list of users";
@@ -36,7 +37,10 @@ pub mod user_repository {
         users
     }
 
-    pub fn get(tx: TransactionRead<WALClient>, username: &str) -> Option<(User, Credential)> {
+    pub fn get(tx: TransactionRead<WALClient>, username: &str) -> Result<Option<(User, Credential)>, QueryError> {
+        if !is_valid_typeql_value(username) {
+            return Err(QueryError::IllegalQueryInput {});
+        }
         let unexpected_error_msg = "An unexpected error occurred when attempting to retrieve a user";
         let query = parse_query(
             format!(
@@ -53,9 +57,9 @@ pub mod user_repository {
         if !rows.is_empty() {
             let row = rows.pop().expect(unexpected_error_msg);
             let hash = get_string(&tx, &row, "h");
-            Some((User::new(username.to_string()), Credential::PasswordType { password_hash: PasswordHash::new(hash) }))
+            Ok(Some((User::new(username.to_string()), Credential::PasswordType { password_hash: PasswordHash::new(hash) })))
         } else {
-            None
+            Ok(None)
         }
     }
 
@@ -67,7 +71,10 @@ pub mod user_repository {
         query_manager: &QueryManager,
         user: &User,
         credential: &Credential,
-    ) -> Arc<WriteSnapshot<WALClient>> {
+    ) -> (Result<(), QueryError>, Arc<WriteSnapshot<WALClient>>) {
+        if !is_valid_typeql_value(&user.name) {
+            return (Err(QueryError::IllegalQueryInput {}), Arc::new(snapshot));
+        }
         let unexpected_error_msg = "An unexpected error occurred when attempting to create a new user";
         let query = match credential {
             Credential::PasswordType { password_hash: PasswordHash { value: hash } } => {
@@ -88,7 +95,7 @@ pub mod user_repository {
         };
         let (_, snapshot) =
             execute_write_pipeline(snapshot, type_manager, thing_manager, function_manager, query_manager, &query.into_pipeline());
-        snapshot
+        (Ok(()), snapshot)
     }
 
     pub fn update(
@@ -118,7 +125,10 @@ pub mod user_repository {
         function_manager: &FunctionManager,
         query_manager: &QueryManager,
         username: &str,
-    ) -> Arc<WriteSnapshot<WALClient>> {
+    ) -> (Result<(), QueryError>, Arc<WriteSnapshot<WALClient>>) {
+        if !is_valid_typeql_value(username) {
+            return (Err(QueryError::IllegalQueryInput {}), Arc::new(snapshot));
+        }
         let unexpected_error_msg = "An unexpected error occurred when attempting to delete a user";
         let query = parse_query(
             format!(
@@ -132,6 +142,16 @@ pub mod user_repository {
         .expect(unexpected_error_msg);
         let (_, snapshot) =
             execute_write_pipeline(snapshot, type_manager, thing_manager, function_manager, query_manager, &query.into_pipeline());
-        snapshot
+        (Ok(()), snapshot)
     }
+
+    pub fn is_valid_typeql_value(value: &str) -> bool {
+        is_valid_identifier(value)
+    }
+
+    typedb_error!(
+        pub QueryError(component = "System database", prefix = "SDB") {
+            IllegalQueryInput(1, "The specified input contains one or more illegal character(s)"),
+        }
+    );
 }

--- a/system/util.rs
+++ b/system/util.rs
@@ -84,7 +84,7 @@ pub mod transaction_util {
                 query_manager,
                 database,
                 transaction_options,
-            } = TransactionWrite::open(self.database.clone(), TransactionOptions::default()).unwrap(); // TODO
+            } = TransactionWrite::open(self.database.clone(), TransactionOptions::default()).unwrap();
             let (rows, snapshot) = fn_(
                 snapshot,
                 type_manager.clone(),

--- a/user/errors.rs
+++ b/user/errors.rs
@@ -7,8 +7,15 @@
 use error::typedb_error;
 
 typedb_error!(
+    pub UserGetError(component = "User create", prefix = "USC") {
+        QueryExecutionError(1, "User get query could not be executed"),
+    }
+);
+
+typedb_error!(
     pub UserCreateError(component = "User create", prefix = "USC") {
-        Unexpected(1, "An unexpected error has occurred in the process of creating a new user"),
+        QueryExecutionError(1, "User create query could not be executed"),
+        Unexpected(2, "An unexpected error has occurred in the process of creating a new user"),
     }
 );
 
@@ -21,6 +28,7 @@ typedb_error!(
 typedb_error!(
     pub UserDeleteError(component = "User delete", prefix = "USD") {
         DefaultUserCannotBeDeleted(1, "Default user cannot be deleted"),
-        Unexpected(2, "An unexpected error has occurred in the process of deleting a user"),
+        QueryExecutionError(2, "User delete query could not be executed"),
+        Unexpected(3, "An unexpected error has occurred in the process of deleting a user"),
     }
 );

--- a/user/errors.rs
+++ b/user/errors.rs
@@ -8,13 +8,13 @@ use error::typedb_error;
 
 typedb_error!(
     pub UserGetError(component = "User create", prefix = "USC") {
-        QueryExecutionError(1, "User get query could not be executed"),
+        IllegalUsername(1, "Supplied username contains illegal character(s)"),
     }
 );
 
 typedb_error!(
     pub UserCreateError(component = "User create", prefix = "USC") {
-        QueryExecutionError(1, "User create query could not be executed"),
+        IllegalUsername(1, "Supplied username contains illegal character(s)"),
         Unexpected(2, "An unexpected error has occurred in the process of creating a new user"),
     }
 );
@@ -28,7 +28,7 @@ typedb_error!(
 typedb_error!(
     pub UserDeleteError(component = "User delete", prefix = "USD") {
         DefaultUserCannotBeDeleted(1, "Default user cannot be deleted"),
-        QueryExecutionError(2, "User delete query could not be executed"),
+        IllegalUsername(2, "Supplied username contains illegal character(s)"),
         Unexpected(3, "An unexpected error has occurred in the process of deleting a user"),
     }
 );

--- a/user/lib.rs
+++ b/user/lib.rs
@@ -14,7 +14,7 @@ pub mod errors;
 pub mod user_manager;
 
 pub fn initialise_default_user(user_manager: &UserManager) {
-    if !user_manager.contains(DEFAULT_USER_NAME) {
+    if !user_manager.contains(DEFAULT_USER_NAME).expect("An unexpected error occurred when checking for the existence of default user") {
         user_manager
             .create(
                 &User::new(DEFAULT_USER_NAME.to_string()),

--- a/user/user_manager.rs
+++ b/user/user_manager.rs
@@ -34,7 +34,7 @@ impl UserManager {
 
     pub fn get(&self, username: &str) -> Result<Option<(User, Credential)>, UserGetError> {
         self.transaction_util.read_transaction(|tx|
-            user_repository::get(tx, username).map_err(|e| UserGetError::QueryExecutionError {})
+            user_repository::get(tx, username).map_err(|_query_error| UserGetError::IllegalUsername {})
         )
     }
 
@@ -57,8 +57,8 @@ impl UserManager {
             });
         match create_result {
             Ok(Ok(())) => { Ok(()) }
-            Ok(Err(_)) => { Err( UserCreateError::QueryExecutionError {}) }
-            Err(_) => { Err(UserCreateError::QueryExecutionError {}) }
+            Ok(Err(_query_error)) => { Err( UserCreateError::IllegalUsername {}) }
+            Err(_) => { Err(UserCreateError::IllegalUsername {}) }
         }
     }
 
@@ -101,8 +101,8 @@ impl UserManager {
             });
         match delete_result {
             Ok(Ok(())) => { Ok(()) }
-            Ok(Err(_)) => { Err( UserDeleteError::QueryExecutionError {}) }
-            Err(_) => { Err(UserDeleteError::QueryExecutionError {}) }
+            Ok(Err(_query_error)) => { Err( UserDeleteError::IllegalUsername {}) }
+            Err(_commit_error) => { Err(UserDeleteError::Unexpected {}) }
         }
     }
 }

--- a/user/user_manager.rs
+++ b/user/user_manager.rs
@@ -58,7 +58,7 @@ impl UserManager {
         match create_result {
             Ok(Ok(())) => { Ok(()) }
             Ok(Err(_query_error)) => { Err( UserCreateError::IllegalUsername {}) }
-            Err(_) => { Err(UserCreateError::IllegalUsername {}) }
+            Err(_commit_error) => { Err(UserCreateError::Unexpected {}) }
         }
     }
 


### PR DESCRIPTION
## Release notes: product changes
Validate input to 'user repository'  methods by restricting the value such that it must be a valid TypeQL identifier.

## Motivation
The validation is done mainly to prevent TypeQL injection into the system database by a malicious attacker.

## Implementation
- Validate the supplied username into the various methods in the `user_repository` module , make sure it is a valid TypeQL identifier