### PR TITLE
Hide the system database

### DIFF
--- a/database/database.rs
+++ b/database/database.rs
@@ -467,6 +467,7 @@ typedb_error!(
 typedb_error!(
     pub DatabaseCreateError(component = "Database create", prefix = "DBC") {
         InvalidName(1, "Cannot create database since '{name}' is not a valid database name.", name: String),
+        InternalDatabaseCreationProhibited(2, "Creating an internal database is prohibited"),
     }
 );
 
@@ -476,6 +477,7 @@ typedb_error!(
         InUse(2, "Cannot delete database since it is in use."),
         StorageDelete(3, "Error while deleting storage resources.", ( typedb_source: StorageDeleteError )),
         DirectoryDelete(4, "Error deleting directory.", ( source: Arc<io::Error> )),
+        InternalDatabaseDeletionProhibited(5, "Deleting an internal database is prohibited"),
     }
 );
 

--- a/database/database_manager.rs
+++ b/database/database_manager.rs
@@ -16,7 +16,12 @@ use storage::durability_client::WALClient;
 
 use crate::{database::DatabaseCreateError, Database, DatabaseDeleteError, DatabaseOpenError, DatabaseResetError};
 
-pub const INTERNAL_DATABASE_PREFIX: &str = "_";
+#[macro_export]
+macro_rules! internal_database_prefix {
+    () => {
+        "_"
+    };
+}
 
 #[derive(Debug)]
 pub struct DatabaseManager {
@@ -149,7 +154,7 @@ impl DatabaseManager {
     }
 
     pub fn is_internal_database(name: &str) -> bool {
-        name.starts_with(INTERNAL_DATABASE_PREFIX)
+        name.starts_with(internal_database_prefix!())
     }
 
 }

--- a/system/lib.rs
+++ b/system/lib.rs
@@ -13,21 +13,25 @@ use std::{fmt::format, sync::Arc};
 use database::{database_manager::DatabaseManager, Database};
 use storage::durability_client::WALClient;
 use typeql;
-
+use database::database_manager::INTERNAL_DATABASE_PREFIX;
 use crate::{repositories::SCHEMA, util::transaction_util::TransactionUtil};
 
-const SYSTEM_DB: &str = "system";
+fn get_system_database_name() -> String {
+    format!("{}system", INTERNAL_DATABASE_PREFIX)
+}
 
 pub fn initialise_system_database(database_manager: &DatabaseManager) -> Arc<Database<WALClient>> {
-    match database_manager.database(SYSTEM_DB) {
+    let system_db_name = get_system_database_name();
+    let system_db_name = system_db_name.as_str();
+    match database_manager.database_unrestricted(system_db_name) {
         Some(db) => db,
         None => {
             database_manager
-                .create_database(SYSTEM_DB)
-                .expect(format!("Unable to create the {} database.", SYSTEM_DB).as_str());
+                .create_database_unrestricted(system_db_name)
+                .expect(format!("Unable to create the {} database.", system_db_name).as_str());
             let db = database_manager
-                .database(SYSTEM_DB)
-                .expect(format!("The {} database could not be found.", SYSTEM_DB).as_str());
+                .database_unrestricted(system_db_name)
+                .expect(format!("The {} database could not be found.", system_db_name).as_str());
             let tx_util = TransactionUtil::new(db.clone());
             tx_util
                 .schema_transaction(|snapshot, type_mgr, thing_mgr, fn_mgr, query_mgr| {
@@ -35,20 +39,20 @@ pub fn initialise_system_database(database_manager: &DatabaseManager) -> Arc<Dat
                         .expect(
                             format!(
                                 "Unexpected error occurred when parsing the schema for the {} database.",
-                                SYSTEM_DB
+                                system_db_name
                             )
                             .as_str(),
                         )
                         .into_schema();
                     query_mgr.execute_schema(snapshot, type_mgr, thing_mgr, query).expect(
-                        format!("Unexpected error occurred when defining the schema for the {} database.", SYSTEM_DB)
+                        format!("Unexpected error occurred when defining the schema for the {} database.", system_db_name)
                             .as_str(),
                     );
                 })
                 .expect(
                     format!(
                         "Unexpected error occurred when committing the schema transaction for {} database.",
-                        SYSTEM_DB
+                        system_db_name
                     )
                     .as_str(),
                 );

--- a/system/lib.rs
+++ b/system/lib.rs
@@ -13,25 +13,21 @@ use std::{fmt::format, sync::Arc};
 use database::{database_manager::DatabaseManager, Database};
 use storage::durability_client::WALClient;
 use typeql;
-use database::database_manager::INTERNAL_DATABASE_PREFIX;
+use database::internal_database_prefix;
 use crate::{repositories::SCHEMA, util::transaction_util::TransactionUtil};
 
-fn get_system_database_name() -> String {
-    format!("{}system", INTERNAL_DATABASE_PREFIX)
-}
+const SYSTEM_DB: &'static str = concat!(internal_database_prefix!(), "system");
 
 pub fn initialise_system_database(database_manager: &DatabaseManager) -> Arc<Database<WALClient>> {
-    let system_db_name = get_system_database_name();
-    let system_db_name = system_db_name.as_str();
-    match database_manager.database_unrestricted(system_db_name) {
+    match database_manager.database_unrestricted(SYSTEM_DB) {
         Some(db) => db,
         None => {
             database_manager
-                .create_database_unrestricted(system_db_name)
-                .expect(format!("Unable to create the {} database.", system_db_name).as_str());
+                .create_database_unrestricted(SYSTEM_DB)
+                .expect(format!("Unable to create the {} database.", SYSTEM_DB).as_str());
             let db = database_manager
-                .database_unrestricted(system_db_name)
-                .expect(format!("The {} database could not be found.", system_db_name).as_str());
+                .database_unrestricted(SYSTEM_DB)
+                .expect(format!("The {} database could not be found.", SYSTEM_DB).as_str());
             let tx_util = TransactionUtil::new(db.clone());
             tx_util
                 .schema_transaction(|snapshot, type_mgr, thing_mgr, fn_mgr, query_mgr| {
@@ -39,20 +35,20 @@ pub fn initialise_system_database(database_manager: &DatabaseManager) -> Arc<Dat
                         .expect(
                             format!(
                                 "Unexpected error occurred when parsing the schema for the {} database.",
-                                system_db_name
+                                SYSTEM_DB
                             )
                             .as_str(),
                         )
                         .into_schema();
                     query_mgr.execute_schema(snapshot, type_mgr, thing_mgr, query).expect(
-                        format!("Unexpected error occurred when defining the schema for the {} database.", system_db_name)
+                        format!("Unexpected error occurred when defining the schema for the {} database.", SYSTEM_DB)
                             .as_str(),
                     );
                 })
                 .expect(
                     format!(
                         "Unexpected error occurred when committing the schema transaction for {} database.",
-                        system_db_name
+                        SYSTEM_DB
                     )
                     .as_str(),
                 );


### PR DESCRIPTION
## Release notes: product changes
Prevent user access to any internal databases (ie., any database whose name is prefixed with `_`) through the database manager.

## Motivation
Add the ability for the server to create databases that is not accessible by user for internal purposes, such as storing user accounts and possibly other internal configurations

## Implementation
- Prevent access to internal databases through the database manager