### PR TITLE
Iterator pooling for snapshots

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,10 +9,6 @@ features = {}
 	edition = "2021"
 	version = "0.0.0"
 
-[profile.profiling]
-       inherits = "release"
-       debug = true
-
 [dev-dependencies]
 
 	[dev-dependencies.steps]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,10 @@ features = {}
 	edition = "2021"
 	version = "0.0.0"
 
+[profile.profiling]
+       inherits = "release"
+       debug = true
+
 [dev-dependencies]
 
 	[dev-dependencies.steps]

--- a/concept/thing/statistics.rs
+++ b/concept/thing/statistics.rs
@@ -34,6 +34,7 @@ use storage::{
     snapshot::{buffer::OperationsBuffer, write::Write},
     MVCCStorage,
 };
+use storage::keyspace::IteratorPool;
 
 use crate::{
     thing::{attribute::Attribute, entity::Entity, object::Object, relation::Relation, ThingAPI},
@@ -439,7 +440,7 @@ fn write_to_delta<D>(
                 }));
 
             if check_storage {
-                if storage.get::<0>(write_key, commit_sequence_number.previous())?.is_some() {
+                if storage.get::<0>(&IteratorPool::new(), write_key, commit_sequence_number.previous())?.is_some() {
                     // exists in storage before PUT is committed
                     Ok(0)
                 } else {

--- a/concept/thing/statistics.rs
+++ b/concept/thing/statistics.rs
@@ -29,12 +29,12 @@ use storage::{
     isolation_manager::CommitType,
     iterator::MVCCReadError,
     key_value::StorageKeyReference,
+    keyspace::IteratorPool,
     recovery::commit_recovery::{load_commit_data_from, RecoveryCommitStatus, StorageRecoveryError},
     sequence_number::SequenceNumber,
     snapshot::{buffer::OperationsBuffer, write::Write},
     MVCCStorage,
 };
-use storage::keyspace::IteratorPool;
 
 use crate::{
     thing::{attribute::Attribute, entity::Entity, object::Object, relation::Relation, ThingAPI},

--- a/durability/wal.rs
+++ b/durability/wal.rs
@@ -551,7 +551,7 @@ impl FsyncThread {
             vec.push(Some(sender));
         } else {
             vec.push(None);
-            sender.send(()).unwrap_or_log();
+            sender.send(()).unwrap();
         }
         recv
     }
@@ -587,7 +587,7 @@ impl FsyncThread {
             context.files.write().unwrap().sync_all();
             while let Some(sender_opt) = vec.pop() {
                 if let Some(sender) = sender_opt {
-                    sender.send(()).unwrap_or_log(); // TODO
+                    sender.send(()).unwrap();
                 }
             }
         }

--- a/executor/tests/BUILD
+++ b/executor/tests/BUILD
@@ -69,6 +69,7 @@ rust_test(
     srcs = ["writes.rs"],
     deps = deps + [
         "//query:query",
+        "//function:function",
     ],
 )
 

--- a/executor/tests/BUILD
+++ b/executor/tests/BUILD
@@ -64,6 +64,15 @@ rust_test(
 )
 
 rust_test(
+    name = "test_writes",
+    crate_root = "writes.rs",
+    srcs = ["writes.rs"],
+    deps = deps + [
+        "//query:query",
+    ],
+)
+
+rust_test(
     name = "test_execute_expression",
     crate_root = "execute_expression.rs",
     srcs = ["execute_expression.rs"],

--- a/executor/tests/BUILD
+++ b/executor/tests/BUILD
@@ -64,16 +64,6 @@ rust_test(
 )
 
 rust_test(
-    name = "test_writes",
-    crate_root = "writes.rs",
-    srcs = ["writes.rs"],
-    deps = deps + [
-        "//query:query",
-        "//function:function",
-    ],
-)
-
-rust_test(
     name = "test_execute_expression",
     crate_root = "execute_expression.rs",
     srcs = ["execute_expression.rs"],

--- a/executor/tests/writes.rs
+++ b/executor/tests/writes.rs
@@ -22,8 +22,10 @@ use concept::{
     thing::{object::ObjectAPI, relation::Relation, thing_manager::ThingManager},
     type_::{object_type::ObjectType, type_manager::TypeManager, Ordering, OwnerAPI, PlayerAPI},
 };
-use encoding::graph::definition::definition_key_generator::DefinitionKeyGenerator;
-use encoding::value::{label::Label, value::Value, value_type::ValueType};
+use encoding::{
+    graph::definition::definition_key_generator::DefinitionKeyGenerator,
+    value::{label::Label, value::Value, value_type::ValueType},
+};
 use executor::{
     pipeline::{
         delete::DeleteStageExecutor,
@@ -42,8 +44,7 @@ use ir::{
     translation::TranslationContext,
 };
 use lending_iterator::{AsHkt, AsNarrowingIterator, LendingIterator};
-use query::query_cache::QueryCache;
-use query::query_manager::QueryManager;
+use query::{query_cache::QueryCache, query_manager::QueryManager};
 use storage::{
     durability_client::WALClient,
     snapshot::{CommittableSnapshot, WritableSnapshot, WriteSnapshot},
@@ -366,7 +367,7 @@ fn relation() {
         execute_insert(snapshot, type_manager.clone(), thing_manager.clone(), query_str, &[], vec![vec![]]).unwrap();
     snapshot.commit().unwrap();
 
-    let snapshot = storage.open_snapshot_read();
+    let snapshot = storage.clone().open_snapshot_read();
     let person_type = type_manager.get_entity_type(&snapshot, &PERSON_LABEL).unwrap().unwrap();
     let group_type = type_manager.get_entity_type(&snapshot, &GROUP_LABEL).unwrap().unwrap();
     let membership_type = type_manager.get_relation_type(&snapshot, &MEMBERSHIP_LABEL).unwrap().unwrap();
@@ -420,7 +421,7 @@ fn relation_with_inferred_roles() {
         execute_insert(snapshot, type_manager.clone(), thing_manager.clone(), query_str, &[], vec![vec![]]).unwrap();
     snapshot.commit().unwrap();
 
-    let snapshot = storage.open_snapshot_read();
+    let snapshot = storage.clone().open_snapshot_read();
     let person_type = type_manager.get_entity_type(&snapshot, &PERSON_LABEL).unwrap().unwrap();
     let group_type = type_manager.get_entity_type(&snapshot, &GROUP_LABEL).unwrap().unwrap();
     let membership_type = type_manager.get_relation_type(&snapshot, &MEMBERSHIP_LABEL).unwrap().unwrap();

--- a/executor/tests/writes.rs
+++ b/executor/tests/writes.rs
@@ -7,6 +7,8 @@
 use std::{
     collections::{BTreeMap, HashMap},
     sync::Arc,
+    thread,
+    time::Duration,
     vec,
 };
 
@@ -20,6 +22,7 @@ use concept::{
     thing::{object::ObjectAPI, relation::Relation, thing_manager::ThingManager},
     type_::{object_type::ObjectType, type_manager::TypeManager, Ordering, OwnerAPI, PlayerAPI},
 };
+use encoding::graph::definition::definition_key_generator::DefinitionKeyGenerator;
 use encoding::value::{label::Label, value::Value, value_type::ValueType};
 use executor::{
     pipeline::{
@@ -33,11 +36,14 @@ use executor::{
     write::WriteError,
     ExecutionInterrupt,
 };
+use function::function_manager::FunctionManager;
 use ir::{
     pipeline::{function_signature::HashMapFunctionSignatureIndex, ParameterRegistry},
     translation::TranslationContext,
 };
 use lending_iterator::{AsHkt, AsNarrowingIterator, LendingIterator};
+use query::query_cache::QueryCache;
+use query::query_manager::QueryManager;
 use storage::{
     durability_client::WALClient,
     snapshot::{CommittableSnapshot, WritableSnapshot, WriteSnapshot},
@@ -156,7 +162,7 @@ fn execute_insert<Snapshot: WritableSnapshot + 'static>(
     let input_row_format = input_row_var_names
         .iter()
         .enumerate()
-        .map(|(i, v)| (translation_context.get_variable(v).unwrap(), VariablePosition::new(i as u32)))
+        .map(|(i, v)| (translation_context.get_variable(*v).unwrap(), VariablePosition::new(i as u32)))
         .collect::<HashMap<_, _>>();
 
     let variable_registry = &translation_context.variable_registry;
@@ -260,7 +266,7 @@ fn execute_delete<Snapshot: WritableSnapshot + 'static>(
     let input_row_format = input_row_var_names
         .iter()
         .enumerate()
-        .map(|(i, v)| (translation_context.get_variable(v).unwrap(), VariablePosition::new(i as u32)))
+        .map(|(i, v)| (translation_context.get_variable(*v).unwrap(), VariablePosition::new(i as u32)))
         .collect::<HashMap<_, _>>();
 
     let delete_plan = compiler::executable::delete::executable::compile(
@@ -546,4 +552,72 @@ fn delete_has() {
     let snapshot = storage.clone().open_snapshot_read();
     assert_eq!(0, p10.as_thing().as_object().get_has_unordered(&snapshot, &thing_manager).count());
     snapshot.close_resources()
+}
+
+#[test]
+fn lots_of_inserts() {
+    let schema = typeql::parse_query(
+        r#"
+    define
+      entity ITEM,
+        owns I_ID,
+        owns I_IM_ID,
+        owns I_NAME,
+        owns I_PRICE,
+        owns I_DATA;
+
+      attribute I_ID, value long;
+      attribute I_IM_ID, value long;
+      attribute I_NAME, value string;
+      attribute I_PRICE, value double;
+      attribute I_DATA, value string;
+    "#,
+    )
+    .unwrap()
+    .into_schema();
+    let (_tmp_dir, mut storage) = create_core_storage();
+    setup_concept_storage(&mut storage);
+
+    let qm = QueryManager::new(Some(Arc::new(QueryCache::new(0))));
+    let function_manager = FunctionManager::new(Arc::new(DefinitionKeyGenerator::new()), None);
+    let schema_number = {
+        let (type_manager, thing_manager) = load_managers(storage.clone(), None);
+        let mut snapshot = storage.clone().open_snapshot_schema();
+        qm.execute_schema(&mut snapshot, &type_manager, &thing_manager, &function_manager, schema).unwrap();
+        snapshot.commit().unwrap().unwrap()
+    };
+    let (type_manager, thing_manager) = load_managers(storage.clone(), Some(schema_number));
+    let function_manager = FunctionManager::new(type_manager.definition_key_generator().clone(), None);
+
+    let p = 2512537;
+    let q = 2515411;
+    let mut at = p;
+
+    for _ in 0..2000 {
+        let mut snapshot = storage.clone().open_snapshot_write();
+        let i_id = (at + p) % q;
+        let i_im_id = (i_id + p) % q;
+        let i_name = (i_im_id + p) % q;
+        let i_price = (i_name + p) % q;
+        let i_data = (i_price + p) % q;
+        at = (i_price + p) % q;
+
+        let insert = format!(
+            r#"
+            insert
+            $item isa ITEM,
+            has I_ID {i_id}, has I_IM_ID {i_im_id}, has I_NAME "{i_name}",
+            has I_PRICE {i_price}, has I_DATA "{i_data}";
+        "#
+        );
+        let insert_parsed = typeql::parse_query(insert.as_str()).unwrap().into_pipeline();
+        let pipeline = qm
+            .prepare_write_pipeline(snapshot, &type_manager, thing_manager.clone(), &function_manager, &insert_parsed)
+            .unwrap();
+        let (mut iterator, ctx) = pipeline.into_rows_iterator(ExecutionInterrupt::new_uninterruptible()).unwrap();
+        iterator.collect_owned().unwrap();
+        snapshot = Arc::into_inner(ctx.snapshot).unwrap();
+        snapshot.commit().unwrap();
+    }
+    println!("Done");
 }

--- a/resource/constants.rs
+++ b/resource/constants.rs
@@ -36,7 +36,7 @@ pub mod snapshot {
 
 pub mod storage {
     pub const TIMELINE_WINDOW_SIZE: usize = 100;
-    pub const WAL_SYNC_INTERVAL_MICROSECONDS: u64 = 1000;
+    pub const WAL_SYNC_INTERVAL_MICROSECONDS: u64 = 1_000;
     pub const WATERMARK_WAIT_INTERVAL_MICROSECONDS: u64 = 50;
 }
 

--- a/resource/constants.rs
+++ b/resource/constants.rs
@@ -36,8 +36,9 @@ pub mod snapshot {
 
 pub mod storage {
     pub const TIMELINE_WINDOW_SIZE: usize = 100;
-    pub const WAL_SYNC_INTERVAL_MICROSECONDS: u64 = 1_000;
+    pub const WAL_SYNC_INTERVAL_MICROSECONDS: u64 = 1000;
     pub const WATERMARK_WAIT_INTERVAL_MICROSECONDS: u64 = 50;
+    pub const WAIT_FOR_SYNC: bool = true;
 }
 
 pub mod encoding {

--- a/storage/durability_client.rs
+++ b/storage/durability_client.rs
@@ -141,7 +141,8 @@ impl WALClient {
 
 impl DurabilityClient for WALClient {
     fn request_sync(&self) -> mpsc::Receiver<()> {
-        self.wal.request_sync()
+        let WAIT_FOR_SYNC = true;
+        self.wal.request_sync(WAIT_FOR_SYNC)
     }
 
     fn register_record_type<Record: DurabilityRecord>(&mut self) {

--- a/storage/durability_client.rs
+++ b/storage/durability_client.rs
@@ -13,6 +13,7 @@ use std::{
 use durability::{wal::WAL, DurabilityRecordType, DurabilityService, DurabilityServiceError, RawRecord};
 use error::typedb_error;
 use itertools::Itertools;
+use resource::constants::storage::WAIT_FOR_SYNC;
 
 use crate::sequence_number::SequenceNumber;
 
@@ -141,7 +142,6 @@ impl WALClient {
 
 impl DurabilityClient for WALClient {
     fn request_sync(&self) -> mpsc::Receiver<()> {
-        let WAIT_FOR_SYNC = true;
         self.wal.request_sync(WAIT_FOR_SYNC)
     }
 

--- a/storage/iterator.rs
+++ b/storage/iterator.rs
@@ -16,6 +16,7 @@ use crate::{
     keyspace::{iterator::KeyspaceRangeIterator, KeyspaceError, KeyspaceId},
     sequence_number::SequenceNumber,
 };
+use crate::keyspace::IteratorPool;
 
 pub(crate) struct MVCCRangeIterator {
     storage_name: Arc<String>,
@@ -34,11 +35,12 @@ impl MVCCRangeIterator {
     //
     pub(crate) fn new<D, const PS: usize>(
         storage: &MVCCStorage<D>,
+        iterpool: &IteratorPool,
         range: KeyRange<StorageKey<'_, PS>>,
         open_sequence_number: SequenceNumber,
     ) -> Self {
         let keyspace = storage.get_keyspace(range.start().get_value().keyspace_id());
-        let iterator = keyspace.iterate_range(range.map(|key| key.into_bytes(), |fixed_width| fixed_width));
+        let iterator = keyspace.iterate_range(iterpool, range.map(|key| key.into_bytes(), |fixed_width| fixed_width));
         MVCCRangeIterator {
             storage_name: storage.name(),
             keyspace_id: keyspace.id(),

--- a/storage/iterator.rs
+++ b/storage/iterator.rs
@@ -13,10 +13,9 @@ use super::{MVCCKey, MVCCStorage, StorageOperation, MVCC_KEY_INLINE_SIZE};
 use crate::{
     key_range::KeyRange,
     key_value::{StorageKey, StorageKeyArray, StorageKeyReference},
-    keyspace::{iterator::KeyspaceRangeIterator, KeyspaceError, KeyspaceId},
+    keyspace::{iterator::KeyspaceRangeIterator, IteratorPool, KeyspaceError, KeyspaceId},
     sequence_number::SequenceNumber,
 };
-use crate::keyspace::IteratorPool;
 
 pub(crate) struct MVCCRangeIterator {
     storage_name: Arc<String>,

--- a/storage/keyspace/iterator.rs
+++ b/storage/keyspace/iterator.rs
@@ -12,9 +12,8 @@ use rocksdb::DB;
 
 use crate::{
     key_range::{KeyRange, RangeEnd},
-    keyspace::{raw_iterator, raw_iterator::DBIterator, Keyspace, KeyspaceError},
+    keyspace::{raw_iterator, raw_iterator::DBIterator, IteratorPool, Keyspace, KeyspaceError},
 };
-use crate::keyspace::IteratorPool;
 
 pub struct KeyspaceRangeIterator {
     iterator: DBIterator,
@@ -37,9 +36,6 @@ impl KeyspaceRangeIterator {
     ) -> Self {
         // TODO: if self.has_prefix_extractor_for(prefix), we can enable bloom filters
         // read_opts.set_prefix_same_as_start(true);
-
-        let read_opts = keyspace.new_read_options();
-        let kv_storage: &'static DB = unsafe { std::mem::transmute(&keyspace.kv_storage) };
         let mut iterator =
             raw_iterator::DBIterator::new_from(iterpool.get_iterator(keyspace), range.start().get_value());
         if range.start().is_exclusive() {

--- a/storage/keyspace/keyspace.rs
+++ b/storage/keyspace/keyspace.rs
@@ -16,7 +16,7 @@ use itertools::Itertools;
 use rocksdb::{checkpoint::Checkpoint, IteratorMode, Options, ReadOptions, WriteBatch, WriteOptions, DB};
 use serde::{Deserialize, Serialize};
 
-use super::iterator;
+use super::{iterator, IteratorPool};
 use crate::{key_range::KeyRange, write_batches::WriteBatches};
 
 #[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
@@ -254,9 +254,10 @@ impl Keyspace {
     // TODO: we should benchmark using iterator pools, which would require changing prefix/range on read options
     pub(crate) fn iterate_range<'s, const PREFIX_INLINE_SIZE: usize>(
         &'s self,
+        iterpool: &IteratorPool,
         range: KeyRange<Bytes<'s, PREFIX_INLINE_SIZE>>,
     ) -> iterator::KeyspaceRangeIterator {
-        iterator::KeyspaceRangeIterator::new(self, range)
+        iterator::KeyspaceRangeIterator::new(self, iterpool, range)
     }
 
     pub(crate) fn write(&self, write_batch: WriteBatch) -> Result<(), KeyspaceError> {

--- a/storage/keyspace/mod.rs
+++ b/storage/keyspace/mod.rs
@@ -6,7 +6,7 @@
 
 pub(crate) use keyspace::{Keyspace, KeyspaceCheckpointError, KeyspaceError, Keyspaces, KEYSPACE_MAXIMUM_COUNT};
 pub use keyspace::{KeyspaceDeleteError, KeyspaceId, KeyspaceOpenError, KeyspaceSet, KeyspaceValidationError};
-use rocksdb::{DB, DBRawIterator};
+use rocksdb::{DBRawIterator, DB};
 
 use crate::snapshot::pool::{PoolRecycleGuard, Poolable, SinglePool};
 
@@ -21,9 +21,7 @@ pub struct IteratorPool {
 }
 impl IteratorPool {
     pub fn new() -> Self {
-        let pools_per_keyspace = std::array::from_fn(|i| {
-            SinglePool::new()
-        });
+        let pools_per_keyspace = std::array::from_fn(|i| SinglePool::new());
         Self { pools_per_keyspace }
     }
     fn get_iterator(&self, keyspace: &Keyspace) -> PoolRecycleGuard<DBRawIterator<'static>> {

--- a/storage/keyspace/mod.rs
+++ b/storage/keyspace/mod.rs
@@ -6,7 +6,31 @@
 
 pub(crate) use keyspace::{Keyspace, KeyspaceCheckpointError, KeyspaceError, Keyspaces, KEYSPACE_MAXIMUM_COUNT};
 pub use keyspace::{KeyspaceDeleteError, KeyspaceId, KeyspaceOpenError, KeyspaceSet, KeyspaceValidationError};
+use rocksdb::DBRawIterator;
+
+use crate::snapshot::pool::{PoolRecycleGuard, Poolable, SinglePool};
 
 pub mod iterator;
 mod keyspace;
 mod raw_iterator;
+
+impl<'a> Poolable for DBRawIterator<'a> {}
+
+pub(crate) struct IteratorPool<'snapshot> {
+    pools_per_keyspace: [SinglePool<DBRawIterator<'snapshot>>; KEYSPACE_MAXIMUM_COUNT],
+}
+impl<'snapshot> IteratorPool<'snapshot> {
+    pub(crate) fn new() -> Self {
+        let pools_per_keyspace = std::array::from_fn(|i| {
+            SinglePool::new()
+            // let pool: fn(&Keyspace) -> DBRawIterator<'a> = SinglePool::new(Self::create_iterator);
+            // pool
+        });
+        Self { pools_per_keyspace }
+    }
+    fn get_iterator(&self, keyspace: &'snapshot Keyspace) -> PoolRecycleGuard<'_, DBRawIterator<'snapshot>> {
+        self.pools_per_keyspace[keyspace.id().0 as usize].get_or_create(|| {
+            keyspace.kv_storage.raw_iterator_opt(keyspace.new_read_options()) // It is safe to read later RocksDB snapshots since our MVCC will
+        })
+    }
+}

--- a/storage/keyspace/raw_iterator.rs
+++ b/storage/keyspace/raw_iterator.rs
@@ -74,19 +74,9 @@ impl LendingIterator for DBIterator {
 
 impl Seekable<[u8]> for DBIterator {
     fn seek(&mut self, key: &[u8]) {
-        if let Some(item) = self.peek() {
-            match compare_key(item, key) {
-                Ordering::Less => {
-                    self.item.take();
-                    self.iterator.seek(key);
-                    self.item = peek_item(&self.iterator); // repopulate `item` to prevent advancing the underlying iterator
-                }
-                Ordering::Equal => (),
-                Ordering::Greater => {
-                    // TODO: seeking backward could be a no-op or an error or illegal state??
-                }
-            }
-        }
+        self.item.take();
+        self.iterator.seek(key);
+        self.item = peek_item(&self.iterator); // repopulate `item` to prevent advancing the underlying iterator
     }
 
     fn compare_key(&self, item: &Self::Item<'_>, key: &[u8]) -> Ordering {

--- a/storage/keyspace/raw_iterator.rs
+++ b/storage/keyspace/raw_iterator.rs
@@ -8,6 +8,7 @@ use std::{cmp::Ordering, mem::transmute};
 
 use lending_iterator::{LendingIterator, Seekable};
 use rocksdb::DBRawIterator;
+
 use crate::snapshot::pool::PoolRecycleGuard;
 
 type KeyValue<'a> = Result<(&'a [u8], &'a [u8]), rocksdb::Error>;

--- a/storage/snapshot/mod.rs
+++ b/storage/snapshot/mod.rs
@@ -12,5 +12,6 @@ pub use snapshot::{
 pub mod buffer;
 pub mod iterator;
 pub mod lock;
+pub(crate) mod pool;
 mod snapshot;
 pub mod write;

--- a/storage/snapshot/pool.rs
+++ b/storage/snapshot/pool.rs
@@ -4,9 +4,10 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-use std::{ops::Deref, sync::Mutex};
-use std::ops::DerefMut;
-use std::sync::Arc;
+use std::{
+    ops::{Deref, DerefMut},
+    sync::{Arc, Mutex},
+};
 
 pub trait Poolable {}
 
@@ -54,13 +55,11 @@ impl<T: Poolable> Deref for PoolRecycleGuard<T> {
     }
 }
 
-
 impl<T: Poolable> DerefMut for PoolRecycleGuard<T> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         self.item.as_mut().unwrap()
     }
 }
-
 
 impl<T: Poolable> Drop for PoolRecycleGuard<T> {
     fn drop(&mut self) {

--- a/storage/snapshot/pool.rs
+++ b/storage/snapshot/pool.rs
@@ -1,0 +1,55 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+use std::{ops::Deref, sync::Mutex};
+
+pub trait Poolable {}
+
+pub struct SinglePool<T: Poolable> {
+    pool: Mutex<Vec<T>>,
+}
+
+impl<T: Poolable> SinglePool<T> {
+    pub fn new() -> Self {
+        Self { pool: Mutex::new(Vec::new()) }
+    }
+
+    pub fn get_or_create(&self, default: impl FnOnce() -> T) -> PoolRecycleGuard<'_, T> {
+        let mut unlocked = self.pool.try_lock().unwrap();
+        if let Some(item) = unlocked.pop() {
+            PoolRecycleGuard { item: Some(item), pool: self }
+        } else {
+            drop(unlocked);
+            PoolRecycleGuard { item: Some(default()), pool: self }
+        }
+    }
+
+    fn recycle(&self, item: T) {
+        let mut unlocked = self.pool.try_lock().unwrap();
+        unlocked.push(item);
+    }
+}
+
+pub struct PoolRecycleGuard<'pool, T: Poolable> {
+    item: Option<T>,
+    pool: &'pool SinglePool<T>,
+}
+
+impl<'pool, T: Poolable> Deref for PoolRecycleGuard<'pool, T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        self.item.as_ref().unwrap()
+    }
+}
+
+impl<'pool, T: Poolable> Drop for PoolRecycleGuard<'pool, T> {
+    fn drop(&mut self) {
+        debug_assert!(self.item.is_some());
+        let item = self.item.take().unwrap();
+        self.pool.recycle(item)
+    }
+}

--- a/storage/snapshot/snapshot.rs
+++ b/storage/snapshot/snapshot.rs
@@ -17,6 +17,7 @@ use crate::{
     iterator::MVCCReadError,
     key_range::KeyRange,
     key_value::{StorageKey, StorageKeyArray, StorageKeyReference},
+    keyspace::IteratorPool,
     sequence_number::SequenceNumber,
     snapshot::{
         buffer::{BufferRangeIterator, OperationsBuffer},
@@ -197,6 +198,7 @@ where
 pub struct ReadSnapshot<D> {
     storage: Arc<MVCCStorage<D>>,
     open_sequence_number: SequenceNumber,
+    iterator_pool: IteratorPool<'static>,
 }
 
 impl<D: fmt::Debug> fmt::Debug for ReadSnapshot<D> {
@@ -208,7 +210,7 @@ impl<D: fmt::Debug> fmt::Debug for ReadSnapshot<D> {
 impl<D> ReadSnapshot<D> {
     pub(crate) fn new(storage: Arc<MVCCStorage<D>>, open_sequence_number: SequenceNumber) -> Self {
         // Note: for serialisability, we would need to register the open transaction to the IsolationManager
-        ReadSnapshot { storage, open_sequence_number }
+        ReadSnapshot { storage, open_sequence_number, iterator_pool: IteratorPool::new() }
     }
 
     pub fn close_resources(self) {}

--- a/storage/snapshot/snapshot.rs
+++ b/storage/snapshot/snapshot.rs
@@ -198,9 +198,9 @@ where
 }
 
 pub struct ReadSnapshot<D> {
-    storage: Arc<MVCCStorage<D>>,
     open_sequence_number: SequenceNumber,
-    iterator_pool: IteratorPool,
+    iterator_pool: IteratorPool, // Must be declared & dropped before storage
+    storage: Arc<MVCCStorage<D>>,
 }
 
 impl<D: fmt::Debug> fmt::Debug for ReadSnapshot<D> {
@@ -227,7 +227,9 @@ impl<D> ReadableSnapshot for ReadSnapshot<D> {
         &self,
         key: StorageKeyReference<'_>,
     ) -> Result<Option<ByteArray<INLINE_BYTES>>, SnapshotGetError> {
-        self.storage.get(self.iterator_pool(), key, self.open_sequence_number).map_err(|error| SnapshotGetError::MVCCRead { source: error })
+        self.storage
+            .get(self.iterator_pool(), key, self.open_sequence_number)
+            .map_err(|error| SnapshotGetError::MVCCRead { source: error })
     }
 
     fn get_last_existing<const INLINE_BYTES: usize>(
@@ -250,7 +252,8 @@ impl<D> ReadableSnapshot for ReadSnapshot<D> {
         range: KeyRange<StorageKey<'this, PS>>,
         buffered_only: bool,
     ) -> bool {
-        !buffered_only && self.storage.iterate_range(self.iterator_pool(), range, self.open_sequence_number).next().is_some()
+        !buffered_only
+            && self.storage.iterate_range(self.iterator_pool(), range, self.open_sequence_number).next().is_some()
     }
 
     fn get_write(&self, _: StorageKeyReference<'_>) -> Option<&Write> {
@@ -282,10 +285,10 @@ impl<D> ReadableSnapshot for ReadSnapshot<D> {
 }
 
 pub struct WriteSnapshot<D> {
-    storage: Arc<MVCCStorage<D>>,
     operations: OperationsBuffer,
     open_sequence_number: SequenceNumber,
-    iterator_pool: IteratorPool,
+    iterator_pool: IteratorPool, // Must be declared & dropped before storage
+    storage: Arc<MVCCStorage<D>>,
 }
 
 impl<D: fmt::Debug> fmt::Debug for WriteSnapshot<D> {
@@ -297,7 +300,12 @@ impl<D: fmt::Debug> fmt::Debug for WriteSnapshot<D> {
 impl<D> WriteSnapshot<D> {
     pub(crate) fn new(storage: Arc<MVCCStorage<D>>, open_sequence_number: SequenceNumber) -> Self {
         storage.isolation_manager.opened_for_read(open_sequence_number);
-        WriteSnapshot { storage, operations: OperationsBuffer::new(), open_sequence_number, iterator_pool: IteratorPool::new() }
+        WriteSnapshot {
+            storage,
+            operations: OperationsBuffer::new(),
+            open_sequence_number,
+            iterator_pool: IteratorPool::new(),
+        }
     }
 
     pub fn new_with_operations(
@@ -436,10 +444,10 @@ impl<D: DurabilityClient> CommittableSnapshot<D> for WriteSnapshot<D> {
 }
 
 pub struct SchemaSnapshot<D> {
-    storage: Arc<MVCCStorage<D>>,
     operations: OperationsBuffer,
     open_sequence_number: SequenceNumber,
-    iterator_pool: IteratorPool,
+    iterator_pool: IteratorPool, // Must be declared & dropped before storage
+    storage: Arc<MVCCStorage<D>>,
 }
 
 impl<D: fmt::Debug> fmt::Debug for SchemaSnapshot<D> {
@@ -451,7 +459,12 @@ impl<D: fmt::Debug> fmt::Debug for SchemaSnapshot<D> {
 impl<D> SchemaSnapshot<D> {
     pub(crate) fn new(storage: Arc<MVCCStorage<D>>, open_sequence_number: SequenceNumber) -> Self {
         storage.isolation_manager.opened_for_read(open_sequence_number);
-        SchemaSnapshot { storage, operations: OperationsBuffer::new(), open_sequence_number, iterator_pool: IteratorPool::new() }
+        SchemaSnapshot {
+            storage,
+            operations: OperationsBuffer::new(),
+            open_sequence_number,
+            iterator_pool: IteratorPool::new(),
+        }
     }
 
     pub fn new_with_operations(

--- a/storage/snapshot/snapshot.rs
+++ b/storage/snapshot/snapshot.rs
@@ -287,7 +287,7 @@ impl<D> ReadableSnapshot for ReadSnapshot<D> {
 pub struct WriteSnapshot<D> {
     operations: OperationsBuffer,
     open_sequence_number: SequenceNumber,
-    iterator_pool: IteratorPool, // Must be declared & dropped before storage
+    iterator_pool: IteratorPool, // Pool must be declared & dropped before storage
     storage: Arc<MVCCStorage<D>>,
 }
 

--- a/storage/storage.rs
+++ b/storage/storage.rs
@@ -34,7 +34,8 @@ use crate::{
     key_range::{KeyRange, RangeStart},
     key_value::{StorageKey, StorageKeyReference},
     keyspace::{
-        iterator::KeyspaceRangeIterator, Keyspace, KeyspaceError, KeyspaceId, KeyspaceOpenError, KeyspaceSet, Keyspaces,
+        iterator::KeyspaceRangeIterator, IteratorPool, Keyspace, KeyspaceError, KeyspaceId, KeyspaceOpenError,
+        KeyspaceSet, Keyspaces,
     },
     recovery::{
         checkpoint::{Checkpoint, CheckpointCreateError, CheckpointLoadError},
@@ -43,7 +44,6 @@ use crate::{
     sequence_number::SequenceNumber,
     snapshot::{write::Write, CommittableSnapshot, ReadSnapshot, SchemaSnapshot, WriteSnapshot},
 };
-use crate::keyspace::IteratorPool;
 
 pub mod durability_client;
 pub mod error;


### PR DESCRIPTION
(Do not merge till we confirm the performance on TPCC loading. It currently looks 2x slower)

## Release notes: product changes
Introduces an iterator pool to reduce costs of creating & dropping rocked iterators. 
