### PR TITLE
Iterator pools

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,10 +9,6 @@ features = {}
 	edition = "2021"
 	version = "0.0.0"
 
-[profile.profiling]
-       inherits = "release"
-       debug = true
-
 [dev-dependencies]
 
 	[dev-dependencies.steps]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,10 @@ features = {}
 	edition = "2021"
 	version = "0.0.0"
 
+[profile.profiling]
+       inherits = "release"
+       debug = true
+
 [dev-dependencies]
 
 	[dev-dependencies.steps]

--- a/compiler/executable/insert/executable.rs
+++ b/compiler/executable/insert/executable.rs
@@ -4,7 +4,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use answer::variable::Variable;
 use encoding::graph::type_::Kind;

--- a/compiler/executable/insert/executable.rs
+++ b/compiler/executable/insert/executable.rs
@@ -4,7 +4,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 
 use answer::variable::Variable;
 use encoding::graph::type_::Kind;

--- a/concept/thing/statistics.rs
+++ b/concept/thing/statistics.rs
@@ -34,6 +34,7 @@ use storage::{
     snapshot::{buffer::OperationsBuffer, write::Write},
     MVCCStorage,
 };
+use storage::keyspace::IteratorPool;
 use storage::key_value::StorageKeyReference;
 
 use crate::{
@@ -425,7 +426,7 @@ fn write_to_delta<D>(
                 }));
 
             if check_storage {
-                if storage.get::<0>(write_key, commit_sequence_number.previous())?.is_some() {
+                if storage.get::<0>(&IteratorPool::new(), write_key, commit_sequence_number.previous())?.is_some() {
                     // exists in storage before PUT is committed
                     Ok(0)
                 } else {

--- a/concept/thing/statistics.rs
+++ b/concept/thing/statistics.rs
@@ -22,20 +22,19 @@ use encoding::graph::{
     Typed,
 };
 use error::typedb_error;
-use resource::constants::database::STATISTICS_DURABLE_WRITE_CHANGE_PERCENT;
+use resource::constants::{database::STATISTICS_DURABLE_WRITE_CHANGE_PERCENT, snapshot::BUFFER_KEY_INLINE};
 use serde::{Deserialize, Serialize};
 use storage::{
     durability_client::{DurabilityClient, DurabilityClientError, DurabilityRecord, UnsequencedDurabilityRecord},
     isolation_manager::CommitType,
     iterator::MVCCReadError,
-    key_value::StorageKeyArray,
+    key_value::{StorageKeyArray, StorageKeyReference},
+    keyspace::IteratorPool,
     recovery::commit_recovery::{load_commit_data_from, RecoveryCommitStatus, StorageRecoveryError},
     sequence_number::SequenceNumber,
     snapshot::{buffer::OperationsBuffer, write::Write},
     MVCCStorage,
 };
-use storage::keyspace::IteratorPool;
-use storage::key_value::StorageKeyReference;
 
 use crate::{
     thing::{attribute::Attribute, entity::Entity, object::Object, relation::Relation, ThingAPI},
@@ -387,7 +386,7 @@ impl Statistics {
 }
 
 fn write_to_delta<D>(
-    write_key: &StorageKeyArray<40>,
+    write_key: &StorageKeyArray<{ BUFFER_KEY_INLINE }>,
     write: &Write,
     open_sequence_number: SequenceNumber,
     commit_sequence_number: SequenceNumber,

--- a/durability/wal.rs
+++ b/durability/wal.rs
@@ -109,8 +109,8 @@ impl WAL {
         DurabilitySequenceNumber::from(self.next_sequence_number.load(Ordering::Relaxed) - 1)
     }
 
-    pub fn request_sync(&self) -> mpsc::Receiver<()> {
-        self.fsync_thread.subscribe_to_next_sync()
+    pub fn request_sync(&self, ack_waits_for_sync: bool) -> mpsc::Receiver<()> {
+        self.fsync_thread.schedule_next_sync_may_subscribe(ack_waits_for_sync)
     }
 }
 
@@ -517,7 +517,7 @@ impl Iterator for FileRecordIterator<'_> {
 pub struct FsyncThreadContext {
     files: Arc<RwLock<Files>>,
     shutting_down: AtomicBool,
-    signalling: [Mutex<Vec<mpsc::Sender<()>>>; 2],
+    signalling: [Mutex<Vec<Option<mpsc::Sender<()>>>>; 2],
     current_signal: AtomicU8,
 }
 
@@ -538,7 +538,7 @@ impl FsyncThread {
         Self { handle: None, context: Arc::new(context) }
     }
 
-    fn subscribe_to_next_sync(&self) -> mpsc::Receiver<()> {
+    fn schedule_next_sync_may_subscribe(&self, subscribe: bool) -> mpsc::Receiver<()> {
         let (sender, recv) = mpsc::channel();
         let mut vec = self
             .context
@@ -547,7 +547,12 @@ impl FsyncThread {
             .unwrap()
             .lock()
             .unwrap();
-        vec.push(sender);
+        if subscribe {
+            vec.push(Some(sender));
+        } else {
+            vec.push(None);
+            sender.send(()).unwrap_or_log();
+        }
         recv
     }
 
@@ -580,9 +585,10 @@ impl FsyncThread {
         let mut vec = vec_lock.unwrap();
         if !vec.is_empty() {
             context.files.write().unwrap().sync_all();
-            while let Some(sender) = vec.pop() {
-                sender.send(()).unwrap_or_log(); // TODO
-                drop(sender)
+            while let Some(sender_opt) = vec.pop() {
+                if let Some(sender) = sender_opt {
+                    sender.send(()).unwrap_or_log(); // TODO
+                }
             }
         }
     }

--- a/durability/wal.rs
+++ b/durability/wal.rs
@@ -551,7 +551,7 @@ impl FsyncThread {
             vec.push(Some(sender));
         } else {
             vec.push(None);
-            sender.send(()).unwrap_or_log();
+            sender.send(()).unwrap();
         }
         recv
     }
@@ -587,7 +587,7 @@ impl FsyncThread {
             context.files.write().unwrap().sync_all();
             while let Some(sender_opt) = vec.pop() {
                 if let Some(sender) = sender_opt {
-                    sender.send(()).unwrap_or_log(); // TODO
+                    sender.send(()).unwrap();
                 }
             }
         }

--- a/encoding/encoding.rs
+++ b/encoding/encoding.rs
@@ -93,7 +93,6 @@ impl KeyspaceSet for EncodingKeyspace {
         // Enable if we wanted to check bloom filter usage, cache hits, etc.
         // options.enable_statistics();
         // options.set_stats_dump_period_sec(100);
-        // options.set_statistics_level(StatsLevel::All);
 
         options.create_if_missing(true);
         options.create_missing_column_families(true);

--- a/encoding/encoding.rs
+++ b/encoding/encoding.rs
@@ -7,10 +7,8 @@
 #![deny(elided_lifetimes_in_paths)]
 #![deny(unused_must_use)]
 
+use bytes::{util::MB, Bytes};
 use rocksdb::{BlockBasedIndexType, BlockBasedOptions, DBCompressionType, SliceTransform};
-
-use bytes::Bytes;
-use bytes::util::MB;
 use storage::{
     key_value::StorageKey,
     keyspace::{KeyspaceId, KeyspaceSet},
@@ -52,7 +50,6 @@ pub enum EncodingKeyspace {
     /// LinksIndex prefix: [1: prefix][11: player 1][2: rel type id][3: player 2 type]
     OptimisedPrefix17,
 
-
     /// Keyspace optimised for 25 byte prefix seeks:
     /// Has Reverse prefix for Long attribute vertices: [1: prefix][21: from][3: to type]
     OptimisedPrefix25,
@@ -66,7 +63,8 @@ impl KeyspaceSet for EncodingKeyspace {
             Self::OptimisedPrefix16,
             Self::OptimisedPrefix17,
             Self::OptimisedPrefix25,
-        ].into_iter()
+        ]
+        .into_iter()
     }
 
     fn id(&self) -> KeyspaceId {
@@ -96,11 +94,11 @@ impl KeyspaceSet for EncodingKeyspace {
         // options.enable_statistics();
         // options.set_stats_dump_period_sec(100);
         // options.set_statistics_level(StatsLevel::All);
-        
+
         options.create_if_missing(true);
         options.create_missing_column_families(true);
         options.set_max_background_jobs(10);
-        options.set_target_file_size_base(64  * MB);
+        options.set_target_file_size_base(64 * MB);
         options.set_write_buffer_size(64 * MB as usize);
         options.set_max_write_buffer_size_to_maintain(0);
         options.set_max_write_buffer_number(2);

--- a/encoding/graph/thing/edge.rs
+++ b/encoding/graph/thing/edge.rs
@@ -172,7 +172,6 @@ pub struct ThingEdgeHasReverse {
 }
 
 impl ThingEdgeHasReverse {
-
     const PREFIX: Prefix = Prefix::EdgeHasReverse;
     pub const FIXED_WIDTH_ENCODING: bool = Self::PREFIX.fixed_width_keys();
 
@@ -210,14 +209,14 @@ impl ThingEdgeHasReverse {
     }
 
     pub fn prefix_from_prefix_long(
-        from_prefix: Prefix
+        from_prefix: Prefix,
     ) -> StorageKey<'static, { ThingEdgeHasReverse::LENGTH_PREFIX_FROM_PREFIX }> {
         Self::prefix_from_prefix(from_prefix, Self::keyspace_for_is_short(false))
     }
 
     fn prefix_from_prefix(
         from_prefix: Prefix,
-        keyspace: EncodingKeyspace
+        keyspace: EncodingKeyspace,
     ) -> StorageKey<'static, { ThingEdgeHasReverse::LENGTH_PREFIX_FROM_PREFIX }> {
         let mut bytes = ByteArray::zeros(Self::LENGTH_PREFIX_FROM_PREFIX);
         bytes[Self::INDEX_PREFIX] = Self::PREFIX.prefix_id().byte;
@@ -236,7 +235,10 @@ impl ThingEdgeHasReverse {
         bytes[Self::INDEX_PREFIX + 1..from_prefix_end].copy_from_slice(&Prefix::VertexAttribute.prefix_id().to_bytes());
         let from_type_id_end = from_prefix_end + TypeID::LENGTH;
         bytes[from_prefix_end..from_type_id_end].copy_from_slice(&from_type_id.to_bytes());
-        StorageKey::new_owned(Self::keyspace_for_is_short(AttributeVertex::is_category_short_encoding(from_type_value_type_category)), bytes)
+        StorageKey::new_owned(
+            Self::keyspace_for_is_short(AttributeVertex::is_category_short_encoding(from_type_value_type_category)),
+            bytes,
+        )
     }
 
     pub fn prefix_from_attribute_vertex_prefix(

--- a/encoding/graph/thing/mod.rs
+++ b/encoding/graph/thing/mod.rs
@@ -34,7 +34,6 @@ const fn max(lhs: usize, rhs: usize) -> usize {
 pub const THING_VERTEX_MAX_LENGTH: usize = max(ObjectVertex::LENGTH, AttributeVertex::MAX_LENGTH);
 
 pub trait ThingVertex: Prefixed<BUFFER_KEY_INLINE> + Typed<BUFFER_KEY_INLINE> + Keyable<BUFFER_KEY_INLINE> {
-
     fn decode(bytes: &[u8]) -> Self;
 
     fn build_prefix_prefix(prefix: Prefix, keyspace: EncodingKeyspace) -> StorageKey<'static, { PrefixID::LENGTH }> {
@@ -44,7 +43,11 @@ pub trait ThingVertex: Prefixed<BUFFER_KEY_INLINE> + Typed<BUFFER_KEY_INLINE> + 
         StorageKey::new(keyspace, Bytes::Array(array))
     }
 
-    fn build_prefix_type(prefix: Prefix, type_id: TypeID, keyspace: EncodingKeyspace) -> StorageKey<'static, THING_VERTEX_LENGTH_PREFIX_TYPE> {
+    fn build_prefix_type(
+        prefix: Prefix,
+        type_id: TypeID,
+        keyspace: EncodingKeyspace,
+    ) -> StorageKey<'static, THING_VERTEX_LENGTH_PREFIX_TYPE> {
         debug_assert!(matches!(prefix, Prefix::VertexEntity | Prefix::VertexRelation | Prefix::VertexAttribute));
         let mut array = ByteArray::zeros(THING_VERTEX_LENGTH_PREFIX_TYPE);
         Self::write_prefix_type(array.as_mut(), prefix, type_id);

--- a/encoding/graph/thing/vertex_generator.rs
+++ b/encoding/graph/thing/vertex_generator.rs
@@ -12,11 +12,10 @@ use std::sync::{
 use bytes::{byte_array::ByteArray, Bytes};
 use storage::{
     key_range::KeyRange,
-    key_value::StorageKey,
+    key_value::{StorageKey, StorageKeyReference},
     snapshot::{iterator::SnapshotIteratorError, ReadableSnapshot, WritableSnapshot},
     MVCCKey, MVCCStorage,
 };
-use storage::key_value::StorageKeyReference;
 
 use super::vertex_attribute::{
     BooleanAttributeID, DateAttributeID, DateTimeAttributeID, DateTimeTZAttributeID, DecimalAttributeID,
@@ -39,7 +38,7 @@ use crate::{
         date_time_tz_bytes::DateTimeTZBytes, decimal_bytes::DecimalBytes, double_bytes::DoubleBytes,
         duration_bytes::DurationBytes, long_bytes::LongBytes, string_bytes::StringBytes, struct_bytes::StructBytes,
     },
-    AsBytes, Keyable, Prefixed,
+    AsBytes, Keyable,
 };
 
 #[derive(Debug)]
@@ -105,7 +104,9 @@ impl ThingVertexGenerator {
             bytes::util::increment(&mut max_object_id).unwrap();
             let next_storage_key: StorageKey<'_, { ObjectVertex::LENGTH }> =
                 StorageKey::new_ref(ObjectVertex::KEYSPACE, &max_object_id);
-            if let Some(prev_bytes) = storage.get_prev_raw(next_storage_key.as_reference(), |key, _| Vec::from(key.key())) {
+            if let Some(prev_bytes) =
+                storage.get_prev_raw(next_storage_key.as_reference(), |key, _| Vec::from(key.key()))
+            {
                 if ObjectVertex::is_entity_vertex(StorageKeyReference::new(ObjectVertex::KEYSPACE, &prev_bytes)) {
                     let object_vertex = ObjectVertex::decode(&prev_bytes);
                     if object_vertex.type_id_() == TypeID::new(type_id) {
@@ -120,7 +121,9 @@ impl ThingVertexGenerator {
             bytes::util::increment(&mut max_object_id).unwrap();
             let next_storage_key: StorageKey<'_, { ObjectVertex::LENGTH }> =
                 StorageKey::new_ref(ObjectVertex::KEYSPACE, &max_object_id);
-            if let Some(prev_bytes) = storage.get_prev_raw(next_storage_key.as_reference(), |key, _| Vec::from(key.key())) {
+            if let Some(prev_bytes) =
+                storage.get_prev_raw(next_storage_key.as_reference(), |key, _| Vec::from(key.key()))
+            {
                 if ObjectVertex::is_relation_vertex(StorageKeyReference::new(ObjectVertex::KEYSPACE, &prev_bytes)) {
                     let object_vertex = ObjectVertex::decode(&prev_bytes);
                     if object_vertex.type_id_() == TypeID::new(type_id) {

--- a/encoding/graph/thing/vertex_object.rs
+++ b/encoding/graph/thing/vertex_object.rs
@@ -8,11 +8,7 @@ use std::{fmt, mem, ops::Range};
 
 use bytes::{byte_array::ByteArray, util::HexBytesFormatter, Bytes};
 use resource::constants::snapshot::BUFFER_KEY_INLINE;
-use storage::{
-    key_value::{StorageKey, StorageKeyArray},
-    keyspace::KeyspaceSet,
-};
-use storage::key_value::StorageKeyReference;
+use storage::{key_value::StorageKeyReference, keyspace::KeyspaceSet};
 
 use crate::{
     graph::{

--- a/encoding/graph/type_/vertex.rs
+++ b/encoding/graph/type_/vertex.rs
@@ -148,7 +148,8 @@ pub trait PrefixedTypeVertexEncoding: TypeVertexEncoding {
     }
 
     fn is_decodable_from_key(key: &StorageKeyArray<BUFFER_KEY_INLINE>) -> bool {
-        key.keyspace_id() == EncodingKeyspace::DefaultOptimisedPrefix11.id() && Self::is_decodable_from(Bytes::Reference(key.bytes()))
+        key.keyspace_id() == EncodingKeyspace::DefaultOptimisedPrefix11.id()
+            && Self::is_decodable_from(Bytes::Reference(key.bytes()))
     }
 
     fn is_decodable_from(bytes: Bytes<'_, BUFFER_KEY_INLINE>) -> bool {

--- a/encoding/value/long_bytes.rs
+++ b/encoding/value/long_bytes.rs
@@ -36,7 +36,7 @@ impl LongBytes {
 }
 
 impl InlineEncodableAttributeID for LongBytes {
-    const ENCODED_LENGTH_ID: ValueEncodingLength= ValueEncodingLength::Short;
+    const ENCODED_LENGTH_ID: ValueEncodingLength = ValueEncodingLength::Short;
     const VALUE_TYPE: ValueType = ValueType::Long;
 
     fn bytes_ref(&self) -> &[u8] {

--- a/executor/instruction/has_reverse_executor.rs
+++ b/executor/instruction/has_reverse_executor.rs
@@ -19,7 +19,7 @@ use concept::{
     type_::{attribute_type::AttributeType, object_type::ObjectType},
 };
 use encoding::value::value::Value;
-use itertools::{kmerge_by, Itertools, KMergeBy, MinMaxResult};
+use itertools::{kmerge_by, Itertools, KMergeBy};
 use primitive::Bounds;
 use resource::constants::traversal::CONSTANT_CONCEPT_LIMIT;
 use storage::snapshot::ReadableSnapshot;

--- a/executor/instruction/links_reverse_executor.rs
+++ b/executor/instruction/links_reverse_executor.rs
@@ -226,7 +226,7 @@ impl LinksReverseExecutor {
             TernaryIterateMode::BoundFrom => {
                 let player = self.links.player().as_variable().unwrap().as_position().unwrap();
                 debug_assert!(row.len() > player.as_usize());
-                let mut iterator = thing_manager.get_links_reverse_by_player_and_relation_type_range(
+                let iterator = thing_manager.get_links_reverse_by_player_and_relation_type_range(
                     snapshot,
                     row.get(player).as_thing().as_object(),
                     &self.relation_type_range,

--- a/executor/tests/BUILD
+++ b/executor/tests/BUILD
@@ -69,6 +69,7 @@ rust_test(
     srcs = ["writes.rs"],
     deps = deps + [
         "//query:query",
+        "//function:function",
     ],
 )
 

--- a/executor/tests/BUILD
+++ b/executor/tests/BUILD
@@ -64,6 +64,15 @@ rust_test(
 )
 
 rust_test(
+    name = "test_writes",
+    crate_root = "writes.rs",
+    srcs = ["writes.rs"],
+    deps = deps + [
+        "//query:query",
+    ],
+)
+
+rust_test(
     name = "test_execute_expression",
     crate_root = "execute_expression.rs",
     srcs = ["execute_expression.rs"],

--- a/executor/tests/BUILD
+++ b/executor/tests/BUILD
@@ -64,16 +64,6 @@ rust_test(
 )
 
 rust_test(
-    name = "test_writes",
-    crate_root = "writes.rs",
-    srcs = ["writes.rs"],
-    deps = deps + [
-        "//query:query",
-        "//function:function",
-    ],
-)
-
-rust_test(
     name = "test_execute_expression",
     crate_root = "execute_expression.rs",
     srcs = ["execute_expression.rs"],

--- a/executor/tests/writes.rs
+++ b/executor/tests/writes.rs
@@ -7,8 +7,6 @@
 use std::{
     collections::{BTreeMap, HashMap},
     sync::Arc,
-    thread,
-    time::Duration,
     vec,
 };
 
@@ -23,7 +21,6 @@ use concept::{
     type_::{object_type::ObjectType, type_manager::TypeManager, Ordering, OwnerAPI, PlayerAPI},
 };
 use encoding::{
-    graph::definition::definition_key_generator::DefinitionKeyGenerator,
     value::{label::Label, value::Value, value_type::ValueType},
 };
 use executor::{
@@ -38,14 +35,12 @@ use executor::{
     write::WriteError,
     ExecutionInterrupt,
 };
-use function::function_manager::FunctionManager;
 use ir::{
     pipeline::{function_signature::HashMapFunctionSignatureIndex, ParameterRegistry},
     translation::TranslationContext,
 };
 use itertools::Itertools;
 use lending_iterator::{AsHkt, AsNarrowingIterator, LendingIterator};
-use query::{query_cache::QueryCache, query_manager::QueryManager};
 use storage::{
     durability_client::WALClient,
     snapshot::{CommittableSnapshot, WritableSnapshot, WriteSnapshot},
@@ -178,8 +173,6 @@ fn execute_insert<Snapshot: WritableSnapshot + 'static>(
         &EmptyAnnotatedFunctionSignatures,
     )
     .unwrap();
-
-    let variable_registry = Arc::new(translation_context.variable_registry);
 
     let insert_plan = compiler::executable::insert::executable::compile(
         block.conjunction().constraints(),
@@ -542,72 +535,4 @@ fn delete_has() {
     let snapshot = storage.clone().open_snapshot_read();
     assert_eq!(0, p10.as_thing().as_object().get_has_unordered(&snapshot, &thing_manager).count());
     snapshot.close_resources()
-}
-
-#[test]
-fn lots_of_inserts() {
-    let schema = typeql::parse_query(
-        r#"
-    define
-      entity ITEM,
-        owns I_ID,
-        owns I_IM_ID,
-        owns I_NAME,
-        owns I_PRICE,
-        owns I_DATA;
-
-      attribute I_ID, value long;
-      attribute I_IM_ID, value long;
-      attribute I_NAME, value string;
-      attribute I_PRICE, value double;
-      attribute I_DATA, value string;
-    "#,
-    )
-    .unwrap()
-    .into_schema();
-    let (_tmp_dir, mut storage) = create_core_storage();
-    setup_concept_storage(&mut storage);
-
-    let qm = QueryManager::new(Some(Arc::new(QueryCache::new(0))));
-    let function_manager = FunctionManager::new(Arc::new(DefinitionKeyGenerator::new()), None);
-    let schema_number = {
-        let (type_manager, thing_manager) = load_managers(storage.clone(), None);
-        let mut snapshot = storage.clone().open_snapshot_schema();
-        qm.execute_schema(&mut snapshot, &type_manager, &thing_manager, &function_manager, schema).unwrap();
-        snapshot.commit().unwrap().unwrap()
-    };
-    let (type_manager, thing_manager) = load_managers(storage.clone(), Some(schema_number));
-    let function_manager = FunctionManager::new(type_manager.definition_key_generator().clone(), None);
-
-    let p = 2512537;
-    let q = 2515411;
-    let mut at = p;
-
-    for _ in 0..2000 {
-        let mut snapshot = storage.clone().open_snapshot_write();
-        let i_id = (at + p) % q;
-        let i_im_id = (i_id + p) % q;
-        let i_name = (i_im_id + p) % q;
-        let i_price = (i_name + p) % q;
-        let i_data = (i_price + p) % q;
-        at = (i_price + p) % q;
-
-        let insert = format!(
-            r#"
-            insert
-            $item isa ITEM,
-            has I_ID {i_id}, has I_IM_ID {i_im_id}, has I_NAME "{i_name}",
-            has I_PRICE {i_price}, has I_DATA "{i_data}";
-        "#
-        );
-        let insert_parsed = typeql::parse_query(insert.as_str()).unwrap().into_pipeline();
-        let pipeline = qm
-            .prepare_write_pipeline(snapshot, &type_manager, thing_manager.clone(), &function_manager, &insert_parsed)
-            .unwrap();
-        let (mut iterator, ctx) = pipeline.into_rows_iterator(ExecutionInterrupt::new_uninterruptible()).unwrap();
-        iterator.collect_owned().unwrap();
-        snapshot = Arc::into_inner(ctx.snapshot).unwrap();
-        snapshot.commit().unwrap();
-    }
-    println!("Done");
 }

--- a/executor/tests/writes.rs
+++ b/executor/tests/writes.rs
@@ -22,8 +22,10 @@ use concept::{
     thing::{object::ObjectAPI, relation::Relation, thing_manager::ThingManager},
     type_::{object_type::ObjectType, type_manager::TypeManager, Ordering, OwnerAPI, PlayerAPI},
 };
-use encoding::graph::definition::definition_key_generator::DefinitionKeyGenerator;
-use encoding::value::{label::Label, value::Value, value_type::ValueType};
+use encoding::{
+    graph::definition::definition_key_generator::DefinitionKeyGenerator,
+    value::{label::Label, value::Value, value_type::ValueType},
+};
 use executor::{
     pipeline::{
         delete::DeleteStageExecutor,
@@ -43,8 +45,7 @@ use ir::{
 };
 use itertools::Itertools;
 use lending_iterator::{AsHkt, AsNarrowingIterator, LendingIterator};
-use query::query_cache::QueryCache;
-use query::query_manager::QueryManager;
+use query::{query_cache::QueryCache, query_manager::QueryManager};
 use storage::{
     durability_client::WALClient,
     snapshot::{CommittableSnapshot, WritableSnapshot, WriteSnapshot},
@@ -367,7 +368,7 @@ fn relation() {
         execute_insert(snapshot, type_manager.clone(), thing_manager.clone(), query_str, &[], vec![vec![]]).unwrap();
     snapshot.commit().unwrap();
 
-    let snapshot = storage.open_snapshot_read();
+    let snapshot = storage.clone().open_snapshot_read();
     let person_type = type_manager.get_entity_type(&snapshot, &PERSON_LABEL).unwrap().unwrap();
     let group_type = type_manager.get_entity_type(&snapshot, &GROUP_LABEL).unwrap().unwrap();
     let membership_type = type_manager.get_relation_type(&snapshot, &MEMBERSHIP_LABEL).unwrap().unwrap();
@@ -415,7 +416,7 @@ fn relation_with_inferred_roles() {
         execute_insert(snapshot, type_manager.clone(), thing_manager.clone(), query_str, &[], vec![vec![]]).unwrap();
     snapshot.commit().unwrap();
 
-    let snapshot = storage.open_snapshot_read();
+    let snapshot = storage.clone().open_snapshot_read();
     let person_type = type_manager.get_entity_type(&snapshot, &PERSON_LABEL).unwrap().unwrap();
     let group_type = type_manager.get_entity_type(&snapshot, &GROUP_LABEL).unwrap().unwrap();
     let membership_type = type_manager.get_relation_type(&snapshot, &MEMBERSHIP_LABEL).unwrap().unwrap();

--- a/executor/tests/writes.rs
+++ b/executor/tests/writes.rs
@@ -7,6 +7,8 @@
 use std::{
     collections::{BTreeMap, HashMap},
     sync::Arc,
+    thread,
+    time::Duration,
     vec,
 };
 
@@ -20,6 +22,7 @@ use concept::{
     thing::{object::ObjectAPI, relation::Relation, thing_manager::ThingManager},
     type_::{object_type::ObjectType, type_manager::TypeManager, Ordering, OwnerAPI, PlayerAPI},
 };
+use encoding::graph::definition::definition_key_generator::DefinitionKeyGenerator;
 use encoding::value::{label::Label, value::Value, value_type::ValueType};
 use executor::{
     pipeline::{
@@ -33,12 +36,15 @@ use executor::{
     write::WriteError,
     ExecutionInterrupt,
 };
+use function::function_manager::FunctionManager;
 use ir::{
     pipeline::{function_signature::HashMapFunctionSignatureIndex, ParameterRegistry},
     translation::TranslationContext,
 };
 use itertools::Itertools;
 use lending_iterator::{AsHkt, AsNarrowingIterator, LendingIterator};
+use query::query_cache::QueryCache;
+use query::query_manager::QueryManager;
 use storage::{
     durability_client::WALClient,
     snapshot::{CommittableSnapshot, WritableSnapshot, WriteSnapshot},
@@ -157,7 +163,7 @@ fn execute_insert<Snapshot: WritableSnapshot + 'static>(
     let input_row_format = input_row_var_names
         .iter()
         .enumerate()
-        .map(|(i, v)| (translation_context.get_variable(v).unwrap(), VariablePosition::new(i as u32)))
+        .map(|(i, v)| (translation_context.get_variable(*v).unwrap(), VariablePosition::new(i as u32)))
         .collect::<HashMap<_, _>>();
 
     let variable_registry = &translation_context.variable_registry;
@@ -261,7 +267,7 @@ fn execute_delete<Snapshot: WritableSnapshot + 'static>(
     let input_row_format = input_row_var_names
         .iter()
         .enumerate()
-        .map(|(i, v)| (translation_context.get_variable(v).unwrap(), VariablePosition::new(i as u32)))
+        .map(|(i, v)| (translation_context.get_variable(*v).unwrap(), VariablePosition::new(i as u32)))
         .collect::<HashMap<_, _>>();
 
     let delete_plan = compiler::executable::delete::executable::compile(
@@ -535,4 +541,72 @@ fn delete_has() {
     let snapshot = storage.clone().open_snapshot_read();
     assert_eq!(0, p10.as_thing().as_object().get_has_unordered(&snapshot, &thing_manager).count());
     snapshot.close_resources()
+}
+
+#[test]
+fn lots_of_inserts() {
+    let schema = typeql::parse_query(
+        r#"
+    define
+      entity ITEM,
+        owns I_ID,
+        owns I_IM_ID,
+        owns I_NAME,
+        owns I_PRICE,
+        owns I_DATA;
+
+      attribute I_ID, value long;
+      attribute I_IM_ID, value long;
+      attribute I_NAME, value string;
+      attribute I_PRICE, value double;
+      attribute I_DATA, value string;
+    "#,
+    )
+    .unwrap()
+    .into_schema();
+    let (_tmp_dir, mut storage) = create_core_storage();
+    setup_concept_storage(&mut storage);
+
+    let qm = QueryManager::new(Some(Arc::new(QueryCache::new(0))));
+    let function_manager = FunctionManager::new(Arc::new(DefinitionKeyGenerator::new()), None);
+    let schema_number = {
+        let (type_manager, thing_manager) = load_managers(storage.clone(), None);
+        let mut snapshot = storage.clone().open_snapshot_schema();
+        qm.execute_schema(&mut snapshot, &type_manager, &thing_manager, &function_manager, schema).unwrap();
+        snapshot.commit().unwrap().unwrap()
+    };
+    let (type_manager, thing_manager) = load_managers(storage.clone(), Some(schema_number));
+    let function_manager = FunctionManager::new(type_manager.definition_key_generator().clone(), None);
+
+    let p = 2512537;
+    let q = 2515411;
+    let mut at = p;
+
+    for _ in 0..2000 {
+        let mut snapshot = storage.clone().open_snapshot_write();
+        let i_id = (at + p) % q;
+        let i_im_id = (i_id + p) % q;
+        let i_name = (i_im_id + p) % q;
+        let i_price = (i_name + p) % q;
+        let i_data = (i_price + p) % q;
+        at = (i_price + p) % q;
+
+        let insert = format!(
+            r#"
+            insert
+            $item isa ITEM,
+            has I_ID {i_id}, has I_IM_ID {i_im_id}, has I_NAME "{i_name}",
+            has I_PRICE {i_price}, has I_DATA "{i_data}";
+        "#
+        );
+        let insert_parsed = typeql::parse_query(insert.as_str()).unwrap().into_pipeline();
+        let pipeline = qm
+            .prepare_write_pipeline(snapshot, &type_manager, thing_manager.clone(), &function_manager, &insert_parsed)
+            .unwrap();
+        let (mut iterator, ctx) = pipeline.into_rows_iterator(ExecutionInterrupt::new_uninterruptible()).unwrap();
+        iterator.collect_owned().unwrap();
+        snapshot = Arc::into_inner(ctx.snapshot).unwrap();
+        snapshot.commit().unwrap();
+    }
+    println!("Done");
 }

--- a/executor/tests/writes.rs
+++ b/executor/tests/writes.rs
@@ -20,9 +20,7 @@ use concept::{
     thing::{object::ObjectAPI, relation::Relation, thing_manager::ThingManager},
     type_::{object_type::ObjectType, type_manager::TypeManager, Ordering, OwnerAPI, PlayerAPI},
 };
-use encoding::{
-    value::{label::Label, value::Value, value_type::ValueType},
-};
+use encoding::value::{label::Label, value::Value, value_type::ValueType};
 use executor::{
     pipeline::{
         delete::DeleteStageExecutor,

--- a/function/function_manager.rs
+++ b/function/function_manager.rs
@@ -40,7 +40,7 @@ use itertools::Itertools;
 use primitive::maybe_owns::MaybeOwns;
 use resource::constants::snapshot::BUFFER_VALUE_INLINE;
 use storage::{
-    key_range::{KeyRange, RangeStart},
+    key_range::KeyRange,
     snapshot::{ReadableSnapshot, WritableSnapshot},
 };
 

--- a/ir/tests/structural_equality.rs
+++ b/ir/tests/structural_equality.rs
@@ -24,7 +24,7 @@ fn test_function_equivalence() {
     let parsed_function = typeql::parse_definition_function(function).unwrap();
 
     let function_ir =
-        translate_typeql_function(&MockSnapshot {}, &HashMapFunctionSignatureIndex::empty(), &parsed_function).unwrap();
+        translate_typeql_function(&MockSnapshot::new(), &HashMapFunctionSignatureIndex::empty(), &parsed_function).unwrap();
 
     let hash = function_ir.hash();
     let equals_self = function_ir.equals(&function_ir);
@@ -38,7 +38,7 @@ fn test_function_equivalence() {
     let parsed_alpha_equivalent_function = typeql::parse_definition_function(alpha_equivalent_function).unwrap();
 
     let alpha_equivalent_function_ir = translate_typeql_function(
-        &MockSnapshot {},
+        &MockSnapshot::new(),
         &HashMapFunctionSignatureIndex::empty(),
         &parsed_alpha_equivalent_function,
     )
@@ -61,7 +61,7 @@ fn test_function_non_equivalence() {
         return sum($salary);
     ";
     let function_ir = translate_typeql_function(
-        &MockSnapshot {},
+        &MockSnapshot::new(),
         &HashMapFunctionSignatureIndex::empty(),
         &typeql::parse_definition_function(function).unwrap(),
     )
@@ -73,7 +73,7 @@ fn test_function_non_equivalence() {
         return sum($salary);
     ";
     let different_1_ir = translate_typeql_function(
-        &MockSnapshot {},
+        &MockSnapshot::new(),
         &HashMapFunctionSignatureIndex::empty(),
         &typeql::parse_definition_function(different_1).unwrap(),
     )
@@ -87,7 +87,7 @@ fn test_function_non_equivalence() {
         return sum($salary);
     ";
     let different_2_ir = translate_typeql_function(
-        &MockSnapshot {},
+        &MockSnapshot::new(),
         &HashMapFunctionSignatureIndex::empty(),
         &typeql::parse_definition_function(different_2).unwrap(),
     )
@@ -101,7 +101,7 @@ fn test_function_non_equivalence() {
         return sum($salary);
     ";
     let different_3_ir = translate_typeql_function(
-        &MockSnapshot {},
+        &MockSnapshot::new(),
         &HashMapFunctionSignatureIndex::empty(),
         &typeql::parse_definition_function(different_3).unwrap(),
     )
@@ -116,7 +116,7 @@ fn test_function_non_equivalence() {
         return sum($salary);
     ";
     let different_4_ir = translate_typeql_function(
-        &MockSnapshot {},
+        &MockSnapshot::new(),
         &HashMapFunctionSignatureIndex::empty(),
         &typeql::parse_definition_function(different_4).unwrap(),
     )
@@ -153,7 +153,7 @@ fetch {
 };
 ";
     let TranslatedPipeline { translated_preamble, translated_stages, translated_fetch, .. } = translate_pipeline(
-        &MockSnapshot {},
+        &MockSnapshot::new(),
         &HashMapFunctionSignatureIndex::empty(),
         &typeql::parse_query(pipeline).unwrap().into_pipeline(),
     )
@@ -191,7 +191,7 @@ fetch {
         translated_fetch: equivalent_translated_fetch,
         ..
     } = translate_pipeline(
-        &MockSnapshot {},
+        &MockSnapshot::new(),
         &HashMapFunctionSignatureIndex::empty(),
         &typeql::parse_query(structurally_equivalent_pipeline).unwrap().into_pipeline(),
     )
@@ -231,7 +231,7 @@ fetch {
   'my-key': { $ol.* }
 };";
     let TranslatedPipeline { translated_preamble, translated_stages, translated_fetch, .. } = translate_pipeline(
-        &MockSnapshot {},
+        &MockSnapshot::new(),
         &HashMapFunctionSignatureIndex::empty(),
         &typeql::parse_query(pipeline).unwrap().into_pipeline(),
     )
@@ -268,7 +268,7 @@ fetch {
         translated_fetch: different_translated_fetch,
         ..
     } = translate_pipeline(
-        &MockSnapshot {},
+        &MockSnapshot::new(),
         &HashMapFunctionSignatureIndex::empty(),
         &typeql::parse_query(different).unwrap().into_pipeline(),
     )
@@ -287,7 +287,7 @@ fetch {
 fn test_anonymous_non_equivalence() {
     let query = "match $x relates $_ as parent;";
     let TranslatedPipeline { translated_stages, .. } = translate_pipeline(
-        &MockSnapshot {},
+        &MockSnapshot::new(),
         &HashMapFunctionSignatureIndex::empty(),
         &typeql::parse_query(query).unwrap().into_pipeline(),
     )
@@ -296,7 +296,7 @@ fn test_anonymous_non_equivalence() {
 
     let non_equivalent_query = "match $x relates $role as parent;";
     let TranslatedPipeline { translated_stages: different_translated_stages, .. } = translate_pipeline(
-        &MockSnapshot {},
+        &MockSnapshot::new(),
         &HashMapFunctionSignatureIndex::empty(),
         &typeql::parse_query(non_equivalent_query).unwrap().into_pipeline(),
     )

--- a/resource/constants.rs
+++ b/resource/constants.rs
@@ -38,7 +38,7 @@ pub mod storage {
     pub const TIMELINE_WINDOW_SIZE: usize = 100;
     pub const WAL_SYNC_INTERVAL_MICROSECONDS: u64 = 1000;
     pub const WATERMARK_WAIT_INTERVAL_MICROSECONDS: u64 = 50;
-    pub const WAIT_FOR_SYNC: bool = true;
+    pub const COMMIT_WAIT_FOR_FSYNC: bool = true;
 
     pub const ROCKSDB_CACHE_SIZE_MB: u64 = 1000;
 }

--- a/resource/constants.rs
+++ b/resource/constants.rs
@@ -36,9 +36,10 @@ pub mod snapshot {
 
 pub mod storage {
     pub const TIMELINE_WINDOW_SIZE: usize = 100;
-    pub const WAL_SYNC_INTERVAL_MICROSECONDS: u64 = 1_000;
+    pub const WAL_SYNC_INTERVAL_MICROSECONDS: u64 = 1000;
     pub const WATERMARK_WAIT_INTERVAL_MICROSECONDS: u64 = 50;
-    
+    pub const WAIT_FOR_SYNC: bool = true;
+
     pub const ROCKSDB_CACHE_SIZE_MB: u64 = 1000;
 }
 

--- a/resource/constants.rs
+++ b/resource/constants.rs
@@ -36,7 +36,7 @@ pub mod snapshot {
 
 pub mod storage {
     pub const TIMELINE_WINDOW_SIZE: usize = 100;
-    pub const WAL_SYNC_INTERVAL_MICROSECONDS: u64 = 1000;
+    pub const WAL_SYNC_INTERVAL_MICROSECONDS: u64 = 1_000;
     pub const WATERMARK_WAIT_INTERVAL_MICROSECONDS: u64 = 50;
     
     pub const ROCKSDB_CACHE_SIZE_MB: u64 = 1000;

--- a/server/service/transaction_service.rs
+++ b/server/service/transaction_service.rs
@@ -425,29 +425,35 @@ impl TransactionService {
 
         let transaction = match transaction_type {
             typedb_protocol::transaction::Type::Read => {
-                let transaction = spawn_blocking(move ||
+                let transaction = spawn_blocking(move || {
                     TransactionRead::open(database, transaction_options).map_err(|typedb_source| {
                         TransactionServiceError::TransactionFailed { typedb_source }.into_error_message().into_status()
                     })
-                ).await.unwrap()?;
+                })
+                .await
+                .unwrap()?;
                 Transaction::Read(transaction)
             }
             typedb_protocol::transaction::Type::Write => {
-                let transaction = spawn_blocking(move ||
+                let transaction = spawn_blocking(move || {
                     TransactionWrite::open(database, transaction_options).map_err(|typedb_source| {
                         TransactionServiceError::TransactionFailed { typedb_source }.into_error_message().into_status()
                     })
-                ).await.unwrap()?;
+                })
+                .await
+                .unwrap()?;
                 Transaction::Write(transaction)
             }
             typedb_protocol::transaction::Type::Schema => {
-                let transaction = spawn_blocking(move ||
+                let transaction = spawn_blocking(move || {
                     TransactionSchema::open(database, transaction_options).map_err(|typedb_source| {
                         TransactionServiceError::TransactionFailed { typedb_source }.into_error_message().into_status()
                     })
-                ).await.unwrap()?;
+                })
+                .await
+                .unwrap()?;
                 Transaction::Schema(transaction)
-            },
+            }
         };
         self.transaction = Some(transaction);
         self.is_open = true;
@@ -486,7 +492,9 @@ impl TransactionService {
                 transaction.commit().map_err(|err| {
                     TransactionServiceError::DataCommitFailed { typedb_source: err }.into_error_message().into_status()
                 })
-            }).await.unwrap(),
+            })
+            .await
+            .unwrap(),
             Transaction::Schema(transaction) => transaction.commit().map_err(|typedb_source| {
                 TransactionServiceError::SchemaCommitFailed { typedb_source }.into_error_message().into_status()
             }),

--- a/storage/durability_client.rs
+++ b/storage/durability_client.rs
@@ -141,7 +141,8 @@ impl WALClient {
 
 impl DurabilityClient for WALClient {
     fn request_sync(&self) -> mpsc::Receiver<()> {
-        self.wal.request_sync()
+        let WAIT_FOR_SYNC = true;
+        self.wal.request_sync(WAIT_FOR_SYNC)
     }
 
     fn register_record_type<Record: DurabilityRecord>(&mut self) {

--- a/storage/durability_client.rs
+++ b/storage/durability_client.rs
@@ -13,6 +13,7 @@ use std::{
 use durability::{wal::WAL, DurabilityRecordType, DurabilityService, DurabilityServiceError, RawRecord};
 use error::typedb_error;
 use itertools::Itertools;
+use resource::constants::storage::WAIT_FOR_SYNC;
 
 use crate::sequence_number::SequenceNumber;
 
@@ -141,7 +142,6 @@ impl WALClient {
 
 impl DurabilityClient for WALClient {
     fn request_sync(&self) -> mpsc::Receiver<()> {
-        let WAIT_FOR_SYNC = true;
         self.wal.request_sync(WAIT_FOR_SYNC)
     }
 

--- a/storage/durability_client.rs
+++ b/storage/durability_client.rs
@@ -13,7 +13,7 @@ use std::{
 use durability::{wal::WAL, DurabilityRecordType, DurabilityService, DurabilityServiceError, RawRecord};
 use error::typedb_error;
 use itertools::Itertools;
-use resource::constants::storage::WAIT_FOR_SYNC;
+use resource::constants::storage::COMMIT_WAIT_FOR_FSYNC;
 
 use crate::sequence_number::SequenceNumber;
 
@@ -142,7 +142,7 @@ impl WALClient {
 
 impl DurabilityClient for WALClient {
     fn request_sync(&self) -> mpsc::Receiver<()> {
-        self.wal.request_sync(WAIT_FOR_SYNC)
+        self.wal.request_sync(COMMIT_WAIT_FOR_FSYNC)
     }
 
     fn register_record_type<Record: DurabilityRecord>(&mut self) {

--- a/storage/iterator.rs
+++ b/storage/iterator.rs
@@ -13,10 +13,9 @@ use super::{MVCCKey, MVCCStorage, StorageOperation, MVCC_KEY_INLINE_SIZE};
 use crate::{
     key_range::KeyRange,
     key_value::{StorageKey, StorageKeyReference},
-    keyspace::{iterator::KeyspaceRangeIterator, KeyspaceError, KeyspaceId},
+    keyspace::{iterator::KeyspaceRangeIterator, IteratorPool, KeyspaceError, KeyspaceId},
     sequence_number::SequenceNumber,
 };
-use crate::keyspace::IteratorPool;
 
 pub(crate) struct MVCCRangeIterator {
     storage_name: Arc<String>,

--- a/storage/iterator.rs
+++ b/storage/iterator.rs
@@ -16,6 +16,7 @@ use crate::{
     keyspace::{iterator::KeyspaceRangeIterator, KeyspaceError, KeyspaceId},
     sequence_number::SequenceNumber,
 };
+use crate::keyspace::IteratorPool;
 
 pub(crate) struct MVCCRangeIterator {
     storage_name: Arc<String>,
@@ -34,12 +35,13 @@ impl MVCCRangeIterator {
     //
     pub(crate) fn new<D, const PS: usize>(
         storage: &MVCCStorage<D>,
+        iterpool: &IteratorPool,
         range: &KeyRange<StorageKey<'_, PS>>,
         open_sequence_number: SequenceNumber,
     ) -> Self {
         let keyspace = storage.get_keyspace(range.start().get_value().keyspace_id());
         let mapped_range = range.map(|key| key.as_bytes(), |fixed_width| fixed_width);
-        let iterator = keyspace.iterate_range(&mapped_range);
+        let iterator = keyspace.iterate_range(iterpool, &mapped_range);
         MVCCRangeIterator {
             storage_name: storage.name(),
             keyspace_id: keyspace.id(),

--- a/storage/keyspace/iterator.rs
+++ b/storage/keyspace/iterator.rs
@@ -47,6 +47,9 @@ impl KeyspaceRangeIterator {
             }
         };
 
+        // if keyspace.name() == "OptimisedPrefix15" {
+        //     println!("Opening iterator in keyspace 'OptimisedPrefix15' for prefix length {}: {}", start_prefix.len(), start_prefix);
+        // }
         let mut iterator = raw_iterator::DBIterator::new_from(iterpool.get_iterator(keyspace), start_prefix.as_ref());
         if matches!(range.start(), RangeStart::ExcludeFirstWithPrefix(_)) {
             Self::may_skip_start(&mut iterator, range.start().get_value());

--- a/storage/keyspace/iterator.rs
+++ b/storage/keyspace/iterator.rs
@@ -14,6 +14,7 @@ use crate::{
     key_range::{KeyRange, RangeEnd, RangeStart},
     keyspace::{raw_iterator, raw_iterator::DBIterator, Keyspace, KeyspaceError},
 };
+use crate::keyspace::IteratorPool;
 
 pub struct KeyspaceRangeIterator {
     iterator: DBIterator,
@@ -31,6 +32,7 @@ enum ContinueCondition {
 impl KeyspaceRangeIterator {
     pub(crate) fn new<'a, const INLINE_BYTES: usize>(
         keyspace: &'a Keyspace,
+        iterpool: &IteratorPool,
         range: &KeyRange<Bytes<'a, INLINE_BYTES>>,
     ) -> Self {
         // TODO: if self.has_prefix_extractor_for(prefix), we can enable bloom filters
@@ -48,7 +50,7 @@ impl KeyspaceRangeIterator {
 
         let read_opts = keyspace.new_read_options();
         let kv_storage: &'static DB = unsafe { std::mem::transmute(&keyspace.kv_storage) };
-        let mut iterator = DBIterator::new_from(kv_storage.raw_iterator_opt(read_opts), start_prefix.as_ref());
+        let mut iterator = DBIterator::new_from(iterpool.get_iterator(keyspace), start_prefix.as_ref());
         if matches!(range.start(), RangeStart::ExcludeFirstWithPrefix(_)) {
             Self::may_skip_start(&mut iterator, range.start().get_value());
         }

--- a/storage/keyspace/iterator.rs
+++ b/storage/keyspace/iterator.rs
@@ -12,9 +12,8 @@ use rocksdb::DB;
 
 use crate::{
     key_range::{KeyRange, RangeEnd, RangeStart},
-    keyspace::{raw_iterator, raw_iterator::DBIterator, Keyspace, KeyspaceError},
+    keyspace::{raw_iterator, raw_iterator::DBIterator, IteratorPool, Keyspace, KeyspaceError},
 };
-use crate::keyspace::IteratorPool;
 
 pub struct KeyspaceRangeIterator {
     iterator: DBIterator,
@@ -48,9 +47,7 @@ impl KeyspaceRangeIterator {
             }
         };
 
-        let read_opts = keyspace.new_read_options();
-        let kv_storage: &'static DB = unsafe { std::mem::transmute(&keyspace.kv_storage) };
-        let mut iterator = DBIterator::new_from(iterpool.get_iterator(keyspace), start_prefix.as_ref());
+        let mut iterator = raw_iterator::DBIterator::new_from(iterpool.get_iterator(keyspace), start_prefix.as_ref());
         if matches!(range.start(), RangeStart::ExcludeFirstWithPrefix(_)) {
             Self::may_skip_start(&mut iterator, range.start().get_value());
         }

--- a/storage/keyspace/iterator.rs
+++ b/storage/keyspace/iterator.rs
@@ -8,7 +8,6 @@ use std::cmp::Ordering;
 
 use bytes::{byte_array::ByteArray, Bytes};
 use lending_iterator::{LendingIterator, Seekable};
-use rocksdb::DB;
 
 use crate::{
     key_range::{KeyRange, RangeEnd, RangeStart},
@@ -47,9 +46,6 @@ impl KeyspaceRangeIterator {
             }
         };
 
-        // if keyspace.name() == "OptimisedPrefix15" {
-        //     println!("Opening iterator in keyspace 'OptimisedPrefix15' for prefix length {}: {}", start_prefix.len(), start_prefix);
-        // }
         let mut iterator = raw_iterator::DBIterator::new_from(iterpool.get_iterator(keyspace), start_prefix.as_ref());
         if matches!(range.start(), RangeStart::ExcludeFirstWithPrefix(_)) {
             Self::may_skip_start(&mut iterator, range.start().get_value());

--- a/storage/keyspace/keyspace.rs
+++ b/storage/keyspace/keyspace.rs
@@ -196,7 +196,10 @@ impl Keyspace {
     }
 
     pub(super) fn new_read_options(&self) -> ReadOptions {
-        ReadOptions::default()
+        let mut options = ReadOptions::default();
+        options.set_async_io(true);
+        options.set_total_order_seek(false);
+        options
     }
 
     pub(crate) fn id(&self) -> KeyspaceId {

--- a/storage/keyspace/keyspace.rs
+++ b/storage/keyspace/keyspace.rs
@@ -18,7 +18,7 @@ use serde::{Deserialize, Serialize};
 use bytes::util::MB;
 use resource::constants::storage::ROCKSDB_CACHE_SIZE_MB;
 
-use super::iterator;
+use super::{iterator, IteratorPool};
 use crate::{key_range::KeyRange, write_batches::WriteBatches};
 
 #[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
@@ -235,9 +235,10 @@ impl Keyspace {
     // TODO: we should benchmark using iterator pools, which would require changing prefix/range on read options
     pub(crate) fn iterate_range<const PREFIX_INLINE_SIZE: usize>(
         &self,
+        iterpool: &IteratorPool,
         range: &KeyRange<Bytes<'_, PREFIX_INLINE_SIZE>>,
     ) -> iterator::KeyspaceRangeIterator {
-        iterator::KeyspaceRangeIterator::new(self, range)
+        iterator::KeyspaceRangeIterator::new(self, iterpool, range)
     }
 
     pub(crate) fn write(&self, write_batch: WriteBatch) -> Result<(), KeyspaceError> {

--- a/storage/keyspace/keyspace.rs
+++ b/storage/keyspace/keyspace.rs
@@ -196,7 +196,6 @@ impl Keyspace {
 
     pub(super) fn new_read_options(&self) -> ReadOptions {
         let mut options = ReadOptions::default();
-        options.set_async_io(true);
         options.set_total_order_seek(false);
         options
     }

--- a/storage/keyspace/keyspace.rs
+++ b/storage/keyspace/keyspace.rs
@@ -11,12 +11,11 @@ use std::{
     sync::Arc,
 };
 
-use bytes::Bytes;
+use bytes::{util::MB, Bytes};
 use itertools::Itertools;
+use resource::constants::storage::ROCKSDB_CACHE_SIZE_MB;
 use rocksdb::{checkpoint::Checkpoint, IteratorMode, Options, ReadOptions, WriteBatch, WriteOptions, DB};
 use serde::{Deserialize, Serialize};
-use bytes::util::MB;
-use resource::constants::storage::ROCKSDB_CACHE_SIZE_MB;
 
 use super::{iterator, IteratorPool};
 use crate::{key_range::KeyRange, write_batches::WriteBatches};

--- a/storage/keyspace/mod.rs
+++ b/storage/keyspace/mod.rs
@@ -6,7 +6,7 @@
 
 pub(crate) use keyspace::{Keyspace, KeyspaceCheckpointError, KeyspaceError, Keyspaces, KEYSPACE_MAXIMUM_COUNT};
 pub use keyspace::{KeyspaceDeleteError, KeyspaceId, KeyspaceOpenError, KeyspaceSet, KeyspaceValidationError};
-use rocksdb::{DB, DBRawIterator};
+use rocksdb::{DBRawIterator, DB};
 
 use crate::snapshot::pool::{PoolRecycleGuard, Poolable, SinglePool};
 
@@ -21,9 +21,7 @@ pub struct IteratorPool {
 }
 impl IteratorPool {
     pub fn new() -> Self {
-        let pools_per_keyspace = std::array::from_fn(|i| {
-            SinglePool::new()
-        });
+        let pools_per_keyspace = std::array::from_fn(|i| SinglePool::new());
         Self { pools_per_keyspace }
     }
     fn get_iterator(&self, keyspace: &Keyspace) -> PoolRecycleGuard<DBRawIterator<'static>> {

--- a/storage/keyspace/mod.rs
+++ b/storage/keyspace/mod.rs
@@ -19,11 +19,13 @@ impl Poolable for DBRawIterator<'static> {}
 pub struct IteratorPool {
     pools_per_keyspace: [SinglePool<DBRawIterator<'static>>; KEYSPACE_MAXIMUM_COUNT],
 }
+
 impl IteratorPool {
     pub fn new() -> Self {
-        let pools_per_keyspace = std::array::from_fn(|i| SinglePool::new());
+        let pools_per_keyspace = std::array::from_fn(|_| SinglePool::new());
         Self { pools_per_keyspace }
     }
+
     fn get_iterator(&self, keyspace: &Keyspace) -> PoolRecycleGuard<DBRawIterator<'static>> {
         self.pools_per_keyspace[keyspace.id().0 as usize].get_or_create(|| {
             let kv_storage: &'static DB = unsafe { std::mem::transmute(&keyspace.kv_storage) };

--- a/storage/keyspace/mod.rs
+++ b/storage/keyspace/mod.rs
@@ -6,7 +6,31 @@
 
 pub(crate) use keyspace::{Keyspace, KeyspaceCheckpointError, KeyspaceError, Keyspaces, KEYSPACE_MAXIMUM_COUNT};
 pub use keyspace::{KeyspaceDeleteError, KeyspaceId, KeyspaceOpenError, KeyspaceSet, KeyspaceValidationError};
+use rocksdb::DBRawIterator;
+
+use crate::snapshot::pool::{PoolRecycleGuard, Poolable, SinglePool};
 
 pub mod iterator;
 mod keyspace;
 mod raw_iterator;
+
+impl<'a> Poolable for DBRawIterator<'a> {}
+
+pub(crate) struct IteratorPool<'snapshot> {
+    pools_per_keyspace: [SinglePool<DBRawIterator<'snapshot>>; KEYSPACE_MAXIMUM_COUNT],
+}
+impl<'snapshot> IteratorPool<'snapshot> {
+    pub(crate) fn new() -> Self {
+        let pools_per_keyspace = std::array::from_fn(|i| {
+            SinglePool::new()
+            // let pool: fn(&Keyspace) -> DBRawIterator<'a> = SinglePool::new(Self::create_iterator);
+            // pool
+        });
+        Self { pools_per_keyspace }
+    }
+    fn get_iterator(&self, keyspace: &'snapshot Keyspace) -> PoolRecycleGuard<'_, DBRawIterator<'snapshot>> {
+        self.pools_per_keyspace[keyspace.id().0 as usize].get_or_create(|| {
+            keyspace.kv_storage.raw_iterator_opt(keyspace.new_read_options()) // It is safe to read later RocksDB snapshots since our MVCC will
+        })
+    }
+}

--- a/storage/keyspace/raw_iterator.rs
+++ b/storage/keyspace/raw_iterator.rs
@@ -74,19 +74,9 @@ impl LendingIterator for DBIterator {
 
 impl Seekable<[u8]> for DBIterator {
     fn seek(&mut self, key: &[u8]) {
-        if let Some(item) = self.peek() {
-            match compare_key(item, key) {
-                Ordering::Less => {
-                    self.item.take();
-                    self.iterator.seek(key);
-                    self.item = peek_item(&self.iterator); // repopulate `item` to prevent advancing the underlying iterator
-                }
-                Ordering::Equal => (),
-                Ordering::Greater => {
-                    // TODO: seeking backward could be a no-op or an error or illegal state??
-                }
-            }
-        }
+        self.item.take();
+        self.iterator.seek(key);
+        self.item = peek_item(&self.iterator); // repopulate `item` to prevent advancing the underlying iterator
     }
 
     fn compare_key(&self, item: &Self::Item<'_>, key: &[u8]) -> Ordering {

--- a/storage/keyspace/raw_iterator.rs
+++ b/storage/keyspace/raw_iterator.rs
@@ -8,6 +8,7 @@ use std::{cmp::Ordering, mem::transmute};
 
 use lending_iterator::{LendingIterator, Seekable};
 use rocksdb::DBRawIterator;
+
 use crate::snapshot::pool::PoolRecycleGuard;
 
 type KeyValue<'a> = Result<(&'a [u8], &'a [u8]), rocksdb::Error>;

--- a/storage/snapshot/mod.rs
+++ b/storage/snapshot/mod.rs
@@ -12,5 +12,6 @@ pub use snapshot::{
 pub mod buffer;
 pub mod iterator;
 pub mod lock;
+pub(crate) mod pool;
 mod snapshot;
 pub mod write;

--- a/storage/snapshot/pool.rs
+++ b/storage/snapshot/pool.rs
@@ -4,9 +4,10 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-use std::{ops::Deref, sync::Mutex};
-use std::ops::DerefMut;
-use std::sync::Arc;
+use std::{
+    ops::{Deref, DerefMut},
+    sync::{Arc, Mutex},
+};
 
 pub trait Poolable {}
 
@@ -54,13 +55,11 @@ impl<T: Poolable> Deref for PoolRecycleGuard<T> {
     }
 }
 
-
 impl<T: Poolable> DerefMut for PoolRecycleGuard<T> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         self.item.as_mut().unwrap()
     }
 }
-
 
 impl<T: Poolable> Drop for PoolRecycleGuard<T> {
     fn drop(&mut self) {

--- a/storage/snapshot/pool.rs
+++ b/storage/snapshot/pool.rs
@@ -1,0 +1,55 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+use std::{ops::Deref, sync::Mutex};
+
+pub trait Poolable {}
+
+pub struct SinglePool<T: Poolable> {
+    pool: Mutex<Vec<T>>,
+}
+
+impl<T: Poolable> SinglePool<T> {
+    pub fn new() -> Self {
+        Self { pool: Mutex::new(Vec::new()) }
+    }
+
+    pub fn get_or_create(&self, default: impl FnOnce() -> T) -> PoolRecycleGuard<'_, T> {
+        let mut unlocked = self.pool.try_lock().unwrap();
+        if let Some(item) = unlocked.pop() {
+            PoolRecycleGuard { item: Some(item), pool: self }
+        } else {
+            drop(unlocked);
+            PoolRecycleGuard { item: Some(default()), pool: self }
+        }
+    }
+
+    fn recycle(&self, item: T) {
+        let mut unlocked = self.pool.try_lock().unwrap();
+        unlocked.push(item);
+    }
+}
+
+pub struct PoolRecycleGuard<'pool, T: Poolable> {
+    item: Option<T>,
+    pool: &'pool SinglePool<T>,
+}
+
+impl<'pool, T: Poolable> Deref for PoolRecycleGuard<'pool, T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        self.item.as_ref().unwrap()
+    }
+}
+
+impl<'pool, T: Poolable> Drop for PoolRecycleGuard<'pool, T> {
+    fn drop(&mut self) {
+        debug_assert!(self.item.is_some());
+        let item = self.item.take().unwrap();
+        self.pool.recycle(item)
+    }
+}

--- a/storage/snapshot/snapshot.rs
+++ b/storage/snapshot/snapshot.rs
@@ -17,6 +17,7 @@ use crate::{
     iterator::MVCCReadError,
     key_range::KeyRange,
     key_value::{StorageKey, StorageKeyArray, StorageKeyReference},
+    keyspace::IteratorPool,
     sequence_number::SequenceNumber,
     snapshot::{
         buffer::{BufferRangeIterator, OperationsBuffer},
@@ -187,6 +188,7 @@ where
 pub struct ReadSnapshot<D> {
     storage: Arc<MVCCStorage<D>>,
     open_sequence_number: SequenceNumber,
+    iterator_pool: IteratorPool<'static>,
 }
 
 impl<D: fmt::Debug> fmt::Debug for ReadSnapshot<D> {
@@ -198,7 +200,7 @@ impl<D: fmt::Debug> fmt::Debug for ReadSnapshot<D> {
 impl<D> ReadSnapshot<D> {
     pub(crate) fn new(storage: Arc<MVCCStorage<D>>, open_sequence_number: SequenceNumber) -> Self {
         // Note: for serialisability, we would need to register the open transaction to the IsolationManager
-        ReadSnapshot { storage, open_sequence_number }
+        ReadSnapshot { storage, open_sequence_number, iterator_pool: IteratorPool::new() }
     }
 
     pub fn close_resources(self) {}

--- a/storage/snapshot/snapshot.rs
+++ b/storage/snapshot/snapshot.rs
@@ -266,7 +266,7 @@ impl<D> ReadableSnapshot for ReadSnapshot<D> {
 pub struct WriteSnapshot<D> {
     operations: OperationsBuffer,
     open_sequence_number: SequenceNumber,
-    iterator_pool: IteratorPool, // Must be declared & dropped before storage
+    iterator_pool: IteratorPool, // Pool must be declared & dropped before storage
     storage: Arc<MVCCStorage<D>>,
 }
 

--- a/storage/snapshot/snapshot.rs
+++ b/storage/snapshot/snapshot.rs
@@ -73,10 +73,7 @@ pub trait ReadableSnapshot {
 
     fn iterate_writes_range<const PS: usize>(&self, range: &KeyRange<StorageKey<'_, PS>>) -> BufferRangeIterator;
 
-    fn iterate_storage_range<const PS: usize>(
-        &self,
-        range: &KeyRange<StorageKey<'_, PS>>,
-    ) -> SnapshotRangeIterator;
+    fn iterate_storage_range<const PS: usize>(&self, range: &KeyRange<StorageKey<'_, PS>>) -> SnapshotRangeIterator;
 
     fn iterator_pool(&self) -> &IteratorPool;
 }
@@ -238,7 +235,8 @@ impl<D> ReadableSnapshot for ReadSnapshot<D> {
     }
 
     fn any_in_range<const PS: usize>(&self, range: &KeyRange<StorageKey<'_, PS>>, buffered_only: bool) -> bool {
-        !buffered_only && self.storage.iterate_range(self.iterator_pool(), range, self.open_sequence_number).next().is_some()
+        !buffered_only
+            && self.storage.iterate_range(self.iterator_pool(), range, self.open_sequence_number).next().is_some()
     }
 
     fn get_write(&self, _: StorageKeyReference<'_>) -> Option<&Write> {

--- a/storage/storage.rs
+++ b/storage/storage.rs
@@ -44,6 +44,7 @@ use crate::{
     sequence_number::SequenceNumber,
     snapshot::{write::Write, CommittableSnapshot, ReadSnapshot, SchemaSnapshot, WriteSnapshot},
 };
+use crate::key_range::RangeStart;
 
 pub mod durability_client;
 pub mod error;
@@ -358,7 +359,7 @@ impl<Durability> MVCCStorage<Durability> {
         let key = key.into();
         let mut iterator = self.iterate_range(
             iterator_pool,
-            &KeyRange::new_within(RangeStart::Inclusive(StorageKey::<0>::Reference(key)), false),
+            &KeyRange::new_within(StorageKey::<0>::Reference(key), false),
             open_sequence_number,
         );
         loop {

--- a/storage/storage.rs
+++ b/storage/storage.rs
@@ -34,7 +34,8 @@ use crate::{
     key_range::KeyRange,
     key_value::{StorageKey, StorageKeyReference},
     keyspace::{
-        iterator::KeyspaceRangeIterator, Keyspace, KeyspaceError, KeyspaceId, KeyspaceOpenError, KeyspaceSet, Keyspaces,
+        iterator::KeyspaceRangeIterator, IteratorPool, Keyspace, KeyspaceError, KeyspaceId, KeyspaceOpenError,
+        KeyspaceSet, Keyspaces,
     },
     recovery::{
         checkpoint::{Checkpoint, CheckpointCreateError, CheckpointLoadError},
@@ -43,7 +44,6 @@ use crate::{
     sequence_number::SequenceNumber,
     snapshot::{write::Write, CommittableSnapshot, ReadSnapshot, SchemaSnapshot, WriteSnapshot},
 };
-use crate::keyspace::IteratorPool;
 
 pub mod durability_client;
 pub mod error;

--- a/storage/storage.rs
+++ b/storage/storage.rs
@@ -609,6 +609,7 @@ mod tests {
         write_batches::WriteBatches,
         MVCCStorage,
     };
+    use crate::keyspace::IteratorPool;
 
     macro_rules! test_keyspace_set {
         {$($variant:ident => $id:literal : $name: literal),* $(,)?} => {
@@ -670,6 +671,6 @@ mod tests {
         let storage =
             MVCCStorage::<WALClient>::load::<TestKeyspaceSet>("storage", &storage_path, durability_client, &None)
                 .unwrap();
-        assert_eq!(storage.get::<0>(&key_2, seq).unwrap().unwrap(), ByteArray::empty());
+        assert_eq!(storage.get::<0>(&IteratorPool::new(), &key_2, seq).unwrap().unwrap(), ByteArray::empty());
     }
 }

--- a/storage/storage.rs
+++ b/storage/storage.rs
@@ -44,7 +44,6 @@ use crate::{
     sequence_number::SequenceNumber,
     snapshot::{write::Write, CommittableSnapshot, ReadSnapshot, SchemaSnapshot, WriteSnapshot},
 };
-use crate::key_range::RangeStart;
 
 pub mod durability_client;
 pub mod error;

--- a/storage/storage.rs
+++ b/storage/storage.rs
@@ -43,6 +43,7 @@ use crate::{
     sequence_number::SequenceNumber,
     snapshot::{write::Write, CommittableSnapshot, ReadSnapshot, SchemaSnapshot, WriteSnapshot},
 };
+use crate::keyspace::IteratorPool;
 
 pub mod durability_client;
 pub mod error;
@@ -275,12 +276,12 @@ impl<Durability> MVCCStorage<Durability> {
                 let wrapped = StorageKeyReference::new_raw(buffer.keyspace_id, key);
                 if known_to_exist {
                     debug_assert!(self
-                        .get::<0>(wrapped, snapshot.open_sequence_number())
+                        .get::<0>(snapshot.iterator_pool(), wrapped, snapshot.open_sequence_number())
                         .is_ok_and(|opt| opt.is_some()));
                     reinsert.store(false, Ordering::Release);
                 } else {
                     let existing_stored = self
-                        .get::<BUFFER_VALUE_INLINE>(wrapped, snapshot.open_sequence_number())?
+                        .get::<BUFFER_VALUE_INLINE>(snapshot.iterator_pool(), wrapped, snapshot.open_sequence_number())?
                         .is_some_and(|reference| &reference == value);
                     reinsert.store(!existing_stored, Ordering::Release);
                 }
@@ -337,14 +338,16 @@ impl<Durability> MVCCStorage<Durability> {
 
     pub fn get<'a, const INLINE_BYTES: usize>(
         &self,
+        iterator_pool: &IteratorPool,
         key: impl Into<StorageKeyReference<'a>>,
         open_sequence_number: SequenceNumber,
     ) -> Result<Option<ByteArray<INLINE_BYTES>>, MVCCReadError> {
-        self.get_mapped(key, open_sequence_number, |byte_ref| ByteArray::from(byte_ref))
+        self.get_mapped(iterator_pool, key, open_sequence_number, |byte_ref| ByteArray::from(byte_ref))
     }
 
-    pub fn get_mapped<'a, Mapper, V>(
+    pub fn get_mapped<'a, 'pool, Mapper, V>(
         &self,
+        iterator_pool: &IteratorPool,
         key: impl Into<StorageKeyReference<'a>>,
         open_sequence_number: SequenceNumber,
         mapper: Mapper,
@@ -353,8 +356,11 @@ impl<Durability> MVCCStorage<Durability> {
         Mapper: Fn(&[u8]) -> V,
     {
         let key = key.into();
-        let mut iterator =
-            self.iterate_range(&KeyRange::new_within(StorageKey::<0>::Reference(key), false), open_sequence_number);
+        let mut iterator = self.iterate_range(
+            iterator_pool,
+            &KeyRange::new_within(RangeStart::Inclusive(StorageKey::<0>::Reference(key)), false),
+            open_sequence_number,
+        );
         loop {
             match iterator.next().transpose()? {
                 None => return Ok(None),
@@ -366,10 +372,11 @@ impl<Durability> MVCCStorage<Durability> {
 
     pub(crate) fn iterate_range<'this, const PS: usize>(
         &'this self,
+        iterpool: &IteratorPool,
         range: &KeyRange<StorageKey<'this, PS>>,
         open_sequence_number: SequenceNumber,
     ) -> MVCCRangeIterator {
-        MVCCRangeIterator::new(self, range, open_sequence_number)
+        MVCCRangeIterator::new(self, iterpool, range, open_sequence_number)
     }
 
     pub fn snapshot_watermark(&self) -> SequenceNumber {
@@ -421,11 +428,12 @@ impl<Durability> MVCCStorage<Durability> {
 
     pub fn iterate_keyspace_range<'this, const PREFIX_INLINE: usize>(
         &'this self,
+        iterator_pool: &IteratorPool,
         range: KeyRange<StorageKey<'this, PREFIX_INLINE>>,
     ) -> KeyspaceRangeIterator {
         self.keyspaces
             .get(range.start().get_value().keyspace_id())
-            .iterate_range(&range.map(|k| k.as_bytes(), |fixed| fixed))
+            .iterate_range(iterator_pool, &range.map(|k| k.as_bytes(), |fixed| fixed))
     }
 
     pub fn reset(&mut self) -> Result<(), StorageResetError>

--- a/storage/tests/test_utils_storage/mock_snapshot.rs
+++ b/storage/tests/test_utils_storage/mock_snapshot.rs
@@ -15,8 +15,17 @@ use storage::{
         buffer::BufferRangeIterator, iterator::SnapshotRangeIterator, write::Write, ReadableSnapshot, SnapshotGetError,
     },
 };
+use storage::keyspace::IteratorPool;
 
-pub struct MockSnapshot {}
+pub struct MockSnapshot {
+    iterator_pool: IteratorPool,
+}
+
+impl MockSnapshot {
+    pub fn new() -> Self {
+        Self { iterator_pool : IteratorPool::new() }
+    }
+}
 
 impl ReadableSnapshot for MockSnapshot {
     fn open_sequence_number(&self) -> SequenceNumber {
@@ -71,5 +80,9 @@ impl ReadableSnapshot for MockSnapshot {
         range: &KeyRange<StorageKey<'this, PS>>,
     ) -> SnapshotRangeIterator {
         SnapshotRangeIterator::new_empty()
+    }
+
+    fn iterator_pool(&self) -> &IteratorPool {
+        &self.iterator_pool
     }
 }


### PR DESCRIPTION
## Release notes: product changes

Optimise storage-layer iterator creation and deletion using iterator pools, one per transaction. This helps improve benchmark performance by 2-8%.

## Motivation

Optimise performance by re-using iterators.

## Implementation

Implement an iterator pool per-snapshot. The pool is provided to the storage layer methods that would normally open iterators internally, such as `MVCCStorage::get()`, which actually performs a seek under the hood.
