### PR TITLE
Planner v0.2

### DIFF
--- a/answer/variable.rs
+++ b/answer/variable.rs
@@ -26,13 +26,21 @@ impl Variable {
 
 impl fmt::Display for Variable {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "${}", self.id)
+        if self.anonymous {
+            write!(f, "$_{}", self.id)
+        } else {
+            write!(f, "${}", self.id)
+        }
     }
 }
 
 impl fmt::Debug for Variable {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "${}", self.id)
+        if self.anonymous {
+            write!(f, "$_{}", self.id)
+        } else {
+            write!(f, "${}", self.id)
+        }
     }
 }
 

--- a/compiler/executable/match_/instructions/mod.rs
+++ b/compiler/executable/match_/instructions/mod.rs
@@ -108,9 +108,34 @@ impl VariableModes {
     pub fn none_inputs(&self) -> bool {
         self.modes.values().all(|mode| mode != &VariableMode::Input)
     }
+
+    pub fn make_var_mapped(&self, mapping: &HashMap<ExecutorVariable, Variable>) -> VarMappedVariableModes {
+        let mut var_mapped_modes = HashMap::new();
+        for (var, mode) in &self.modes {
+            var_mapped_modes.insert(mapping[&var], *mode);
+        }
+        VarMappedVariableModes { modes: var_mapped_modes }
+    }
 }
 
 impl fmt::Display for VariableModes {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        for (key, group) in &self.modes.iter().sorted_by_key(|(_, value)| *value).group_by(|(_, value)| *value) {
+            write!(f, "{key}s=")?;
+            for (var, _) in group {
+                write!(f, "{}, ", var)?;
+            }
+        }
+        Ok(())
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct VarMappedVariableModes {
+    modes: HashMap<Variable, VariableMode>,
+}
+
+impl fmt::Display for VarMappedVariableModes {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         for (key, group) in &self.modes.iter().sorted_by_key(|(_, value)| *value).group_by(|(_, value)| *value) {
             write!(f, "{key}s=")?;

--- a/compiler/executable/match_/planner/match_executable.rs
+++ b/compiler/executable/match_/planner/match_executable.rs
@@ -225,7 +225,9 @@ impl fmt::Display for VarMappedIntersectionStep<'_> {
         write!(
             f,
             "Sorted Iterator Intersection [bound_vars={:?}, output_size={}, sort_by={}]",
-            &self.step.bound_variables, self.step.output_width, self.step.sort_variable
+            &self.step.bound_variables.iter().map(|&v| self.map[&ExecutorVariable::RowPosition(v)]).collect::<Vec<_>>(),
+            self.step.output_width,
+            self.map[&self.step.sort_variable]
         )?;
         for (instruction, modes) in &self.step.instructions {
             let var_mapped_instruction = instruction.clone().map(self.map);

--- a/compiler/executable/match_/planner/mod.rs
+++ b/compiler/executable/match_/planner/mod.rs
@@ -62,8 +62,8 @@ pub fn compile(
     .lower(input_variables.keys().copied(), selected_variables.to_vec(), &assigned_identities, variable_registry)
     .finish(variable_registry);
 
-    println!("Variable names:\n {:#?}", variable_registry.variable_names());
-    println!("Variable positions:\n {:#?}", plan.variable_positions());
+    // println!("Variable names:\n {:#?}", variable_registry.variable_names());
+    // println!("Variable positions:\n {:#?}", plan.variable_positions());
 
     plan
 }

--- a/compiler/executable/match_/planner/plan.rs
+++ b/compiler/executable/match_/planner/plan.rs
@@ -792,9 +792,9 @@ impl PartialCostPlan {
     }
 
     fn heuristic_plan_completion_cost(&self, current_query_size: f64) -> Cost {
-        let remaining_steps = self.remaining_patterns.len() as f64;
-        let interpolation_cost = (OPEN_ITERATOR_RELATIVE_COST + ADVANCE_ITERATOR_RELATIVE_COST * 0.5 * (current_query_size + OLTP_OUTPUT_SIZE_ESTIMATE)) * remaining_steps;
-        Cost { cost: interpolation_cost, io_ratio: OLTP_OUTPUT_SIZE_ESTIMATE }
+        // let remaining_steps = self.remaining_patterns.len() as f64;
+        // let interpolation_cost = (OPEN_ITERATOR_RELATIVE_COST + ADVANCE_ITERATOR_RELATIVE_COST * 0.5 * (current_query_size + OLTP_OUTPUT_SIZE_ESTIMATE)) * remaining_steps;
+        // Cost { cost: interpolation_cost, io_ratio: OLTP_OUTPUT_SIZE_ESTIMATE }
         Cost { cost: 1.0, io_ratio: OLTP_OUTPUT_SIZE_ESTIMATE }
         // Cost::NOOP
     }

--- a/compiler/executable/match_/planner/plan.rs
+++ b/compiler/executable/match_/planner/plan.rs
@@ -735,7 +735,7 @@ impl PartialCostPlan {
                 let projected_cost = cost_including_extension
                     .chain(self.heuristic_plan_completion_cost(extension, graph));
 
-                println!("                Possible choice {:?} = {} join {:?} cost {:?} projected {:?}", extension, graph.elements[&VertexId::Pattern(extension)], join_var, added_cost, projected_cost);
+                // println!("                Possible choice {:?} = {} join {:?} cost {:?} projected {:?}", extension, graph.elements[&VertexId::Pattern(extension)], join_var, added_cost, projected_cost);
 
                 StepExtension {
                     pattern_id: extension,

--- a/compiler/executable/match_/planner/plan.rs
+++ b/compiler/executable/match_/planner/plan.rs
@@ -560,7 +560,7 @@ impl<'a> ConjunctionPlanBuilder<'a> {
     fn beam_search_plan(&self) -> (Vec<VertexId>, HashMap<PatternVertexId, CostMetaData>) {
         let non_restriction_patterns: HashSet<_> = self.graph.pattern_to_variable
             .keys()
-            .filter(|&&p| { !matches![self.graph.elements[&VertexId::Pattern(p)], PlannerVertex::Comparison(_)] })
+            // .filter(|&&p| { !matches![self.graph.elements[&VertexId::Pattern(p)], PlannerVertex::Comparison(_)] })
             .copied().collect(); // Comparisons are maximally pushed down anyway so no need to sort them
         let num_patterns = non_restriction_patterns.len();
 
@@ -795,7 +795,8 @@ impl PartialCostPlan {
         let remaining_steps = self.remaining_patterns.len() as f64;
         let interpolation_cost = (OPEN_ITERATOR_RELATIVE_COST + ADVANCE_ITERATOR_RELATIVE_COST * 0.5 * (current_query_size + OLTP_OUTPUT_SIZE_ESTIMATE)) * remaining_steps;
         Cost { cost: interpolation_cost, io_ratio: OLTP_OUTPUT_SIZE_ESTIMATE }
-      // Cost::NOOP
+        Cost { cost: 1.0, io_ratio: OLTP_OUTPUT_SIZE_ESTIMATE }
+        // Cost::NOOP
     }
 
     fn clone_and_extend_with_continued_step(&self, extension: StepExtension, graph: &Graph<'_>) -> PartialCostPlan {
@@ -884,12 +885,12 @@ impl PartialCostPlan {
 
     fn into_complete_plan(self, graph: &Graph<'_>) -> CompleteCostPlan {
         let mut final_vertex_ordering = self.vertex_ordering.clone();
-        for comparison in graph.pattern_to_variable
-            .keys()
-            .filter(|&&p| { matches![graph.elements[&VertexId::Pattern(p)], PlannerVertex::Comparison(_)] })
-            .copied() {
-            final_vertex_ordering.push(VertexId::Pattern(comparison));
-        }
+        // for comparison in graph.pattern_to_variable
+        //     .keys()
+        //     .filter(|&&p| { matches![graph.elements[&VertexId::Pattern(p)], PlannerVertex::Comparison(_)] })
+        //     .copied() {
+        //     final_vertex_ordering.push(VertexId::Pattern(comparison));
+        // }
         for &pattern in self.ongoing_step.iter() {
             final_vertex_ordering.push(VertexId::Pattern(pattern));
             debug_assert!(!self.vertex_ordering.contains(&VertexId::Pattern(pattern)));

--- a/compiler/executable/match_/planner/vertex/constraint.rs
+++ b/compiler/executable/match_/planner/vertex/constraint.rs
@@ -71,10 +71,11 @@ impl ConstraintVertex<'_> {
         }
     }
 
-    pub(crate) fn can_sort_on(&self, var: VariableVertexId) -> bool {
+    pub(crate) fn can_join_on(&self, var: VariableVertexId) -> bool {
         match self {
             Self::Links(inner) => inner.relation == var || inner.player == var,
-            _ => self.variables().contains(&var),
+            Self::Has(inner) => true,
+            _ => false
         }
     }
 }

--- a/compiler/executable/match_/planner/vertex/constraint.rs
+++ b/compiler/executable/match_/planner/vertex/constraint.rs
@@ -9,7 +9,7 @@ use std::{
     fmt, iter,
     sync::Arc,
 };
-
+use std::fmt::Formatter;
 use answer::{variable::Variable, Type};
 use concept::thing::statistics::Statistics;
 use ir::pattern::constraint::{
@@ -90,6 +90,22 @@ impl ConstraintVertex<'_> {
         match self {
             Self::Links(inner) => inner.relation == var || inner.player == var,
             _ => self.variables().contains(&var),
+        }
+    }
+}
+
+impl<'a> fmt::Display for ConstraintVertex<'a> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        match &self {
+            ConstraintVertex::TypeList(_) => { write!(f, "|TypeId|") } //TODO
+            ConstraintVertex::Iid(_) => { write!(f, "|ThingId|") } //TODO
+            ConstraintVertex::Isa(p) => { write!(f, "|{:?} isa {:?}|", p.isa.thing, p.isa.type_ ) }
+            ConstraintVertex::Has(p) => { write!(f, "|{:?} has {:?}|", p.has.owner(), p.has.attribute()) }
+            ConstraintVertex::Links(p) => { write!(f, "|{:?} links {:?}|", p.links.relation(), p.links.player()) }
+            ConstraintVertex::Sub(_) => { write!(f, "|Sub|") } //TODO
+            ConstraintVertex::Owns(_) => { write!(f, "|Owns|") } //TODO
+            ConstraintVertex::Relates(_) => { write!(f, "|Relates|") } //TODO
+            ConstraintVertex::Plays(_) => { write!(f, "|Plays|") } //TODO
         }
     }
 }
@@ -272,7 +288,7 @@ pub(crate) struct IsaPlanner<'a> {
     isa: &'a Isa<Variable>,
     thing: VariableVertexId,
     type_: Input,
-    unrestricted_expected_size: f64,
+    pub(crate) unrestricted_expected_size: f64,
 }
 
 impl fmt::Debug for IsaPlanner<'_> {
@@ -312,21 +328,22 @@ impl<'a> IsaPlanner<'a> {
         let thing_selectivity = thing.restriction_based_selectivity(inputs);
         f64::max(self.unrestricted_expected_size * thing_selectivity, VariableVertex::OUTPUT_SIZE_MIN)
     }
-}
 
-impl Costed for IsaPlanner<'_> {
-    fn cost_and_metadata(&self, inputs: &[VertexId], graph: &Graph<'_>) -> (Cost, CostMetaData) {
+    pub(crate) fn thing_estimates(&self, inputs: &[VertexId], graph: &Graph<'_>) -> (bool, f64, f64) {
         let thing_id = VertexId::Variable(self.thing);
         let thing = graph.elements()[&thing_id].as_variable().unwrap();
-
         let is_thing_bound = inputs.contains(&thing_id);
+        let thing_size = thing.unrestricted_expected_output_size();
+        let thing_selectivity = thing.restriction_based_selectivity(inputs);
+        (is_thing_bound, thing_size, thing_selectivity)
+    }
+
+    pub(crate) fn type_estimate(&self, inputs: &[VertexId], graph: &Graph<'_>) -> (bool, f64) {
         let is_type_bound = match &self.type_ {
             Input::Fixed => true,
             Input::Variable(var) => inputs.contains(&VertexId::Variable(*var)),
         };
-
-        let thing_size = thing.expected_output_size(inputs);
-        let type_size = match &self.type_ {
+        let num_types = match &self.type_ {
             Input::Fixed => 1.0,
             Input::Variable(var) => {
                 let type_id = VertexId::Variable(*var);
@@ -334,24 +351,34 @@ impl Costed for IsaPlanner<'_> {
                 type_.expected_output_size(inputs)
             }
         };
+        (is_type_bound, num_types)
+    }
 
+    pub(crate) fn output_size_estimate(&self, is_thing_bound: bool, thing_size: f64, thing_selectivity: f64, is_type_bound: bool, num_types: f64) -> f64 {
         let mut scan_size = self.unrestricted_expected_size;
-        scan_size *= thing.restriction_based_selectivity(inputs); // account for restrictions (like iid), which (we assume) can be used to reduce scan size
-        scan_size = f64::max(scan_size, VariableVertex::OUTPUT_SIZE_MIN); // ???
         if is_type_bound {
-            scan_size /= type_size;
-        } // account for narrowed prefix
+            scan_size /= num_types; // account for narrowed prefix
+        }
         if is_thing_bound {
             scan_size /= thing_size;
-        } // account for narrowed prefix
+        } else {
+            scan_size *= thing_selectivity; // account for restrictions (like iid), which (we assume) can be used to reduce scan size
+        }
+        scan_size = f64::max(scan_size, VariableVertex::OUTPUT_SIZE_MIN); // TODO: verify if this is useful (part of previous model)
+        scan_size
+    }
+}
 
+impl Costed for IsaPlanner<'_> {
+    fn cost_and_metadata(&self, inputs: &[VertexId], graph: &Graph<'_>) -> (Cost, CostMetaData) {
+        let (is_thing_bound, thing_size, thing_selectivity) = self.thing_estimates(inputs, graph);
+        let (is_type_bound, num_types) = self.type_estimate(inputs, graph);
+        let scan_size = self.output_size_estimate(is_thing_bound, thing_size, thing_selectivity, is_type_bound, num_types);
         let cost = match is_thing_bound {
             true => 0.0,
             false => OPEN_ITERATOR_RELATIVE_COST + ADVANCE_ITERATOR_RELATIVE_COST * scan_size,
         };
-
         let io_ratio = scan_size;
-
         (Cost { cost, io_ratio }, CostMetaData::Direction(Direction::Canonical))
     }
 }
@@ -361,9 +388,9 @@ pub(crate) struct HasPlanner<'a> {
     has: &'a Has<Variable>,
     pub owner: VariableVertexId,
     pub attribute: VariableVertexId,
-    unbound_typed_expected_size: f64,
-    unbound_typed_expected_size_canonical: f64,
-    unbound_typed_expected_size_reverse: f64,
+    pub unbound_typed_expected_size: f64,
+    pub unbound_typed_expected_size_canonical: f64,
+    pub unbound_typed_expected_size_reverse: f64,
 }
 
 impl fmt::Debug for HasPlanner<'_> {
@@ -423,90 +450,94 @@ impl<'a> HasPlanner<'a> {
         self.has
     }
 
-    fn unbound_direction(&self, graph: &Graph<'_>, inputs: &[VertexId]) -> Direction {
-        if self.unbound_expected_scan_size_canonical(graph, inputs)
-            < self.unbound_expected_scan_size_reverse(graph, inputs)
-        {
-            Direction::Canonical
+    pub(crate) fn owner_estimates(&self, inputs: &[VertexId], graph: &Graph<'_>) -> (bool, f64, f64) {
+        let owner_id = VertexId::Variable(self.owner);
+        let owner = &graph.elements()[&owner_id].as_variable().unwrap();
+        let is_owner_bound = inputs.contains(&owner_id);
+        let owner_size = owner.unrestricted_expected_output_size();
+        let owner_selectivity = owner.restriction_based_selectivity(inputs);
+        (is_owner_bound, owner_size, owner_selectivity)
+    }
+
+    pub(crate) fn attribute_estimates(&self, inputs: &[VertexId], graph: &Graph<'_>) -> (bool, f64, f64) {
+        let attribute_id = VertexId::Variable(self.attribute);
+        let attribute = &graph.elements()[&attribute_id].as_variable().unwrap();
+        let is_attribute_bound = inputs.contains(&attribute_id);
+        let attribute_size = attribute.unrestricted_expected_output_size();
+        let attribute_selectivity = attribute.restriction_based_selectivity(inputs);
+        (is_attribute_bound, attribute_size, attribute_selectivity)
+    }
+
+    pub(crate) fn canonical_scan_size_estimate(&self,
+                                               is_owner_bound: bool,
+                                               owner_size: f64,
+                                               owner_selectivity: f64,
+                                               is_attribute_bound: bool,
+                                               attribute_size: f64,
+    ) -> f64 {
+        let mut scan_size_canonical = self.unbound_typed_expected_size_canonical;
+        if is_owner_bound {
+            scan_size_canonical /= owner_size;
+            if is_attribute_bound {
+                scan_size_canonical /= attribute_size;
+            }
         } else {
-            Direction::Reverse
+            scan_size_canonical *= owner_selectivity;  // restrictions (like iid) apply if var still unbound
         }
+        scan_size_canonical.max(MIN_SCAN_SIZE)
     }
 
-    fn unbound_expected_scan_size(&self, graph: &Graph<'_>, inputs: &[VertexId]) -> f64 {
-        f64::min(
-            self.unbound_expected_scan_size_canonical(graph, inputs),
-            self.unbound_expected_scan_size_reverse(graph, inputs),
-        )
+
+    pub(crate) fn reverse_scan_size_estimate(&self,
+                                             is_owner_bound: bool,
+                                             owner_size: f64,
+                                             is_attribute_bound: bool,
+                                             attribute_size: f64,
+                                             attribute_selectivity: f64
+    ) -> f64 {
+        let mut scan_size_reverse = self.unbound_typed_expected_size_reverse;
+        if is_attribute_bound {
+            scan_size_reverse /= attribute_size;
+            if is_owner_bound {
+                scan_size_reverse /= owner_size;
+            }
+        } else {
+            scan_size_reverse *= attribute_selectivity; // restrictions (like iid) apply if var still unbound
+        }
+        scan_size_reverse.max(MIN_SCAN_SIZE)
     }
 
-    fn unbound_expected_scan_size_canonical(&self, graph: &Graph<'_>, inputs: &[VertexId]) -> f64 {
-        let owner = &graph.elements()[&VertexId::Variable(self.attribute)].as_variable().unwrap();
-        self.unbound_typed_expected_size_canonical * owner.restriction_based_selectivity(inputs)
-    }
-
-    fn unbound_expected_scan_size_reverse(&self, graph: &Graph<'_>, inputs: &[VertexId]) -> f64 {
-        let attribute = &graph.elements()[&VertexId::Variable(self.attribute)].as_variable().unwrap();
-        self.unbound_typed_expected_size_reverse * attribute.restriction_based_selectivity(inputs)
-    }
-
-    fn expected_output_size(&self, graph: &Graph<'_>, inputs: &[VertexId]) -> f64 {
-        // get selectivity of attribute and multiply it by the expected size based on types
-        let attribute = &graph.elements()[&VertexId::Variable(self.attribute)].as_variable().unwrap();
-        let owner = &graph.elements()[&VertexId::Variable(self.owner)].as_variable().unwrap();
-        let expected_size = self.unbound_typed_expected_size
-            * attribute.restriction_based_selectivity(inputs)
-            * owner.restriction_based_selectivity(inputs);
-        f64::max(expected_size, VariableVertex::OUTPUT_SIZE_MIN)
+    pub(crate) fn output_size_estimate(&self,
+                                       is_owner_bound: bool,
+                                       owner_size: f64,
+                                       owner_selectivity: f64,
+                                       is_attribute_bound: bool,
+                                       attribute_size: f64,
+                                       attribute_selectivity: f64
+    ) -> f64 {
+        let mut scan_size = self.unbound_typed_expected_size;
+        if is_owner_bound {
+            scan_size /= owner_size;
+        } else {
+            scan_size *= owner_selectivity;
+        }
+        if is_attribute_bound {
+            scan_size /= attribute_size;
+        } else {
+            scan_size *= attribute_selectivity;
+        }
+        scan_size
     }
 }
 
 impl Costed for HasPlanner<'_> {
     fn cost_and_metadata(&self, inputs: &[VertexId], graph: &Graph<'_>) -> (Cost, CostMetaData) {
-        let owner_id = VertexId::Variable(self.owner);
-        let owner = &graph.elements()[&owner_id].as_variable().unwrap();
+        let (is_owner_bound, owner_size, owner_selectivity) = self.owner_estimates(inputs, graph);
+        let (is_attribute_bound, attribute_size, attribute_selectivity) = self.attribute_estimates(inputs, graph);
 
-        let attribute_id = VertexId::Variable(self.attribute);
-        let attribute = &graph.elements()[&attribute_id].as_variable().unwrap();
-
-        let is_owner_bound = inputs.contains(&owner_id);
-        let is_attribute_bound = inputs.contains(&attribute_id);
-
-        let owner_size = owner.expected_output_size(inputs);
-        let attribute_size = attribute.expected_output_size(inputs);
-
-        let mut scan_size_canonical = self.unbound_typed_expected_size_canonical;
-        if is_owner_bound {
-            scan_size_canonical /= owner_size; // accounts for bound prefix
-            if is_attribute_bound {
-                scan_size_canonical /= attribute_size; // accounts for bound prefix
-            }
-        } else {
-            scan_size_canonical *= owner.restriction_based_selectivity(inputs); // account for restrictions (like iid)
-        }
-        scan_size_canonical = scan_size_canonical.max(MIN_SCAN_SIZE);
-
-        let mut scan_size_reverse = self.unbound_typed_expected_size_reverse;
-        if is_attribute_bound {
-            scan_size_reverse /= attribute_size; // accounts for bound prefix
-            if is_owner_bound {
-                scan_size_reverse /= owner_size; // accounts for bound prefix
-            }
-        } else {
-            // account for restrictions (like ==)
-            scan_size_reverse *= attribute.restriction_based_selectivity(inputs);
-        }
-        scan_size_reverse = scan_size_reverse.max(MIN_SCAN_SIZE);
-
-        let mut io_ratio = self.unbound_typed_expected_size;
-        if is_owner_bound {
-            io_ratio /= owner_size;
-        }
-        if is_attribute_bound {
-            io_ratio /= attribute_size;
-        }
-        io_ratio *= owner.restriction_based_selectivity(inputs) * attribute.restriction_based_selectivity(inputs);
-
+        let scan_size_canonical = self.canonical_scan_size_estimate(is_owner_bound, owner_size, owner_selectivity, is_attribute_bound, attribute_size,);
+        let scan_size_reverse= self.reverse_scan_size_estimate(is_owner_bound, owner_size, is_attribute_bound, attribute_size, attribute_selectivity);
+        let mut io_ratio = self.output_size_estimate(is_owner_bound, owner_size, owner_selectivity, is_attribute_bound, attribute_size, attribute_selectivity);
         let cost: f64;
         let direction: Direction;
 
@@ -527,7 +558,7 @@ pub(crate) struct LinksPlanner<'a> {
     pub relation: VariableVertexId,
     pub player: VariableVertexId,
     pub role: VariableVertexId,
-    unbound_typed_expected_size: f64,
+    pub(crate) unbound_typed_expected_size: f64,
     unbound_typed_expected_size_canonical: f64,
     unbound_typed_expected_size_reverse: f64,
 }
@@ -614,63 +645,31 @@ impl<'a> LinksPlanner<'a> {
         self.links
     }
 
-    pub(crate) fn unbound_direction(&self, graph: &Graph<'_>, inputs: &[VertexId]) -> Direction {
-        if self.unbound_expected_scan_size_canonical(graph, inputs)
-            < self.unbound_expected_scan_size_reverse(graph, inputs)
-        {
-            Direction::Canonical
-        } else {
-            Direction::Reverse
-        }
-    }
-
-    fn unbound_expected_scan_size(&self, graph: &Graph<'_>, inputs: &[VertexId]) -> f64 {
-        f64::max(
-            f64::min(
-                self.unbound_expected_scan_size_canonical(graph, inputs),
-                self.unbound_expected_scan_size_reverse(graph, inputs),
-            ),
-            VariableVertex::OUTPUT_SIZE_MIN,
-        )
-    }
-
-    fn unbound_expected_scan_size_canonical(&self, graph: &Graph<'_>, inputs: &[VertexId]) -> f64 {
-        let relation = &graph.elements()[&VertexId::Variable(self.relation)].as_variable().unwrap();
-        self.unbound_typed_expected_size_canonical * relation.restriction_based_selectivity(inputs)
-    }
-
-    fn unbound_expected_scan_size_reverse(&self, graph: &Graph<'_>, inputs: &[VertexId]) -> f64 {
-        let player = &graph.elements()[&VertexId::Variable(self.player)].as_variable().unwrap();
-        self.unbound_typed_expected_size_reverse * player.restriction_based_selectivity(inputs)
-    }
-
-    fn expected_output_size(&self, graph: &Graph<'_>, inputs: &[VertexId]) -> f64 {
-        // get selectivity of attribute and multiply it by the expected size based on types
-        let player = &graph.elements()[&VertexId::Variable(self.player)].as_variable().unwrap();
-        let relation = &graph.elements()[&VertexId::Variable(self.relation)].as_variable().unwrap();
-        f64::max(
-            self.unbound_typed_expected_size
-                * player.restriction_based_selectivity(inputs)
-                * relation.restriction_based_selectivity(inputs),
-            VariableVertex::OUTPUT_SIZE_MIN,
-        )
-    }
-}
-
-impl Costed for LinksPlanner<'_> {
-    fn cost_and_metadata(&self, inputs: &[VertexId], graph: &Graph<'_>) -> (Cost, CostMetaData) {
+    pub(crate) fn relation_estimates(&self, inputs: &[VertexId], graph: &Graph<'_>) -> (bool, f64, f64) {
         let relation_id = VertexId::Variable(self.relation);
         let relation = &graph.elements()[&relation_id].as_variable().unwrap();
+        let is_relation_bound = inputs.contains(&relation_id);
+        let relation_size = relation.unrestricted_expected_output_size();
+        let relation_selectivity = relation.restriction_based_selectivity(inputs);
+        (is_relation_bound, relation_size, relation_selectivity)
+    }
 
+    pub(crate) fn player_estimates(&self, inputs: &[VertexId], graph: &Graph<'_>) -> (bool, f64, f64) {
         let player_id = VertexId::Variable(self.player);
         let player = &graph.elements()[&player_id].as_variable().unwrap();
-
-        let is_relation_bound = inputs.contains(&relation_id);
         let is_player_bound = inputs.contains(&player_id);
+        let player_size = player.unrestricted_expected_output_size();
+        let player_selectivity = player.restriction_based_selectivity(inputs);
+        (is_player_bound, player_size, player_selectivity)
+    }
 
-        let relation_size = relation.expected_output_size(inputs);
-        let player_size = player.expected_output_size(inputs);
-
+    pub(crate) fn canonical_scan_size_estimate(&self,
+                                               is_relation_bound: bool,
+                                               relation_size: f64,
+                                               relation_selectivity: f64,
+                                               is_player_bound: bool,
+                                               player_size: f64,
+    ) -> f64 {
         let mut scan_size_canonical = self.unbound_typed_expected_size_canonical;
         if is_relation_bound {
             scan_size_canonical /= relation_size;
@@ -678,11 +677,19 @@ impl Costed for LinksPlanner<'_> {
                 scan_size_canonical /= player_size;
             }
         } else {
-            scan_size_canonical *= relation.restriction_based_selectivity(inputs);
-            // account for restrictions (like iid)
+            scan_size_canonical *= relation_selectivity;  // restrictions (like iid) apply if var still unbound
         }
-        scan_size_canonical = scan_size_canonical.max(MIN_SCAN_SIZE);
+        scan_size_canonical.max(MIN_SCAN_SIZE)
+    }
 
+
+    pub(crate) fn reverse_scan_size_estimate(&self,
+                                               is_relation_bound: bool,
+                                               relation_size: f64,
+                                               is_player_bound: bool,
+                                               player_size: f64,
+                                               player_selectivity: f64
+    ) -> f64 {
         let mut scan_size_reverse = self.unbound_typed_expected_size_reverse;
         if is_player_bound {
             scan_size_reverse /= player_size;
@@ -690,19 +697,42 @@ impl Costed for LinksPlanner<'_> {
                 scan_size_reverse /= relation_size;
             }
         } else {
-            scan_size_reverse *= player.restriction_based_selectivity(inputs); // account for restrictions (like iid)
+            scan_size_reverse *= player_selectivity; // restrictions (like iid) apply if var still unbound
         }
-        scan_size_reverse = scan_size_reverse.max(MIN_SCAN_SIZE);
+        scan_size_reverse.max(MIN_SCAN_SIZE)
+    }
 
-        let mut io_ratio = self.unbound_typed_expected_size;
+    pub(crate) fn output_size_estimate(&self,
+                                       is_relation_bound: bool,
+                                       relation_size: f64,
+                                       relation_selectivity: f64,
+                                       is_player_bound: bool,
+                                       player_size: f64,
+                                       player_selectivity: f64
+    ) -> f64 {
+        let mut scan_size = self.unbound_typed_expected_size;
         if is_relation_bound {
-            io_ratio /= relation_size;
+            scan_size /= relation_size;
+        } else {
+            scan_size *= relation_selectivity;
         }
         if is_player_bound {
-            io_ratio /= player_size;
+            scan_size /= player_size;
+        } else {
+            scan_size *= player_selectivity;
         }
-        io_ratio *= relation.restriction_based_selectivity(inputs) * player.restriction_based_selectivity(inputs);
+        scan_size
+    }
+}
 
+impl Costed for LinksPlanner<'_> {
+    fn cost_and_metadata(&self, inputs: &[VertexId], graph: &Graph<'_>) -> (Cost, CostMetaData) {
+        let (is_relation_bound, relation_size, relation_selectivity) = self.relation_estimates(inputs, graph);
+        let (is_player_bound, player_size, player_selectivity) = self.player_estimates(inputs, graph);
+
+        let scan_size_canonical = self.canonical_scan_size_estimate(is_relation_bound, relation_size, relation_selectivity, is_player_bound, player_size,);
+        let scan_size_reverse= self.reverse_scan_size_estimate(is_relation_bound, relation_size, is_player_bound, player_size, player_selectivity);
+        let mut io_ratio = self.output_size_estimate(is_relation_bound, relation_size, relation_selectivity, is_player_bound, player_size, player_selectivity);
         let cost: f64;
         let direction: Direction;
 
@@ -825,7 +855,6 @@ pub(crate) struct SubPlanner<'a> {
     sub: &'a Sub<Variable>,
     type_: Input,
     supertype: Input,
-    unbound_direction: Direction,
 }
 
 impl<'a> SubPlanner<'a> {
@@ -838,7 +867,6 @@ impl<'a> SubPlanner<'a> {
             sub,
             type_: Input::from_vertex(sub.subtype(), variable_index),
             supertype: Input::from_vertex(sub.supertype(), variable_index),
-            unbound_direction: Direction::Reverse,
         }
     }
 
@@ -853,7 +881,7 @@ impl<'a> SubPlanner<'a> {
 
 impl Costed for SubPlanner<'_> {
     fn cost_and_metadata(&self, _: &[VertexId], _: &Graph<'_>) -> (Cost, CostMetaData) {
-        (Cost::in_mem_complex_with_ratio(1.0), CostMetaData::Direction(Direction::Canonical))
+        (Cost::in_mem_complex_with_ratio(1.0), CostMetaData::Direction(Direction::Reverse))
     }
 }
 
@@ -862,7 +890,6 @@ pub(crate) struct OwnsPlanner<'a> {
     owns: &'a Owns<Variable>,
     owner: Input,
     attribute: Input,
-    unbound_direction: Direction,
 }
 
 impl<'a> OwnsPlanner<'a> {
@@ -874,7 +901,7 @@ impl<'a> OwnsPlanner<'a> {
     ) -> Self {
         let owner = Input::from_vertex(owns.owner(), variable_index);
         let attribute = Input::from_vertex(owns.attribute(), variable_index);
-        Self { owns, owner, attribute, unbound_direction: Direction::Canonical }
+        Self { owns, owner, attribute }
     }
 
     fn variables(&self) -> impl Iterator<Item = VariableVertexId> {
@@ -897,7 +924,6 @@ pub(crate) struct RelatesPlanner<'a> {
     relates: &'a Relates<Variable>,
     relation: Input,
     role_type: Input,
-    unbound_direction: Direction,
 }
 
 impl<'a> RelatesPlanner<'a> {
@@ -909,7 +935,7 @@ impl<'a> RelatesPlanner<'a> {
     ) -> Self {
         let relation = Input::from_vertex(relates.relation(), variable_index);
         let role_type = Input::from_vertex(relates.role_type(), variable_index);
-        Self { relates, relation, role_type, unbound_direction: Direction::Canonical }
+        Self { relates, relation, role_type }
     }
 
     fn variables(&self) -> impl Iterator<Item = VariableVertexId> {
@@ -932,7 +958,6 @@ pub(crate) struct PlaysPlanner<'a> {
     plays: &'a Plays<Variable>,
     player: Input,
     role_type: Input,
-    unbound_direction: Direction,
 }
 
 impl<'a> PlaysPlanner<'a> {
@@ -944,7 +969,7 @@ impl<'a> PlaysPlanner<'a> {
     ) -> Self {
         let player = Input::from_vertex(plays.player(), variable_index);
         let role_type = Input::from_vertex(plays.role_type(), variable_index);
-        Self { plays, player, role_type, unbound_direction: Direction::Canonical }
+        Self { plays, player, role_type }
     }
 
     fn variables(&self) -> impl Iterator<Item = VariableVertexId> {

--- a/compiler/executable/match_/planner/vertex/constraint.rs
+++ b/compiler/executable/match_/planner/vertex/constraint.rs
@@ -54,21 +54,6 @@ impl ConstraintVertex<'_> {
         true // always valid
     }
 
-    pub(crate) fn unbound_direction(&self, graph: &Graph<'_>) -> Direction {
-        match self {
-            Self::TypeList(_) => Direction::Canonical,
-            Self::Iid(_) => Direction::Canonical,
-            Self::Isa(_) => Direction::Canonical,
-            Self::Has(inner) => inner.unbound_direction(graph, &[]),
-            Self::Links(inner) => inner.unbound_direction(graph, &[]),
-            Self::IndexedRelation(inner) => inner.unbound_direction(graph, &[]),
-            Self::Sub(inner) => inner.unbound_direction,
-            Self::Owns(inner) => inner.unbound_direction,
-            Self::Relates(inner) => inner.unbound_direction,
-            Self::Plays(inner) => inner.unbound_direction,
-        }
-    }
-
     pub(crate) fn variables(&self) -> Box<dyn Iterator<Item = VariableVertexId> + '_> {
         match self {
             Self::TypeList(inner) => Box::new(inner.variables()),
@@ -106,6 +91,7 @@ impl<'a> fmt::Display for ConstraintVertex<'a> {
             ConstraintVertex::Owns(_) => { write!(f, "|Owns|") } //TODO
             ConstraintVertex::Relates(_) => { write!(f, "|Relates|") } //TODO
             ConstraintVertex::Plays(_) => { write!(f, "|Plays|") } //TODO
+            ConstraintVertex::IndexedRelation(_) => {  write!(f, "|Relation Index|") }
         }
     }
 }

--- a/compiler/executable/match_/planner/vertex/mod.rs
+++ b/compiler/executable/match_/planner/vertex/mod.rs
@@ -4,11 +4,8 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-use std::{
-    collections::{HashMap, HashSet},
-    iter,
-};
-
+use std::{collections::{HashMap, HashSet}, fmt, iter};
+use std::fmt::Formatter;
 use answer::{variable::Variable, Type};
 use concept::thing::statistics::Statistics;
 use ir::pattern::{
@@ -28,8 +25,8 @@ use crate::{
 pub(super) mod constraint;
 pub(super) mod variable;
 
-const OPEN_ITERATOR_RELATIVE_COST: f64 = 5.0;
-const ADVANCE_ITERATOR_RELATIVE_COST: f64 = 1.0;
+pub(super) const OPEN_ITERATOR_RELATIVE_COST: f64 = 5.0;
+pub(super) const ADVANCE_ITERATOR_RELATIVE_COST: f64 = 1.0;
 
 const _REGEX_EXPECTED_CHECKS_PER_MATCH: f64 = 2.0;
 const _CONTAINS_EXPECTED_CHECKS_PER_MATCH: f64 = 2.0;
@@ -116,6 +113,21 @@ impl PlannerVertex<'_> {
 pub(crate) struct Cost {
     pub cost: f64, // per input
     pub io_ratio: f64,
+}
+
+impl<'a> fmt::Display for PlannerVertex<'a> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        match &self {
+            PlannerVertex::Variable(v) => { write!(f, "|Var {}|", v.variable())}
+            PlannerVertex::Constraint(v) => { write!(f, "{}", v) }
+            PlannerVertex::Is(_) => { write!(f, "|Is|") } //TODO
+            PlannerVertex::Comparison(v) => { write!(f, "|{:?} {:?} {:?}|", v.lhs, v.comparison, v.rhs) }
+            PlannerVertex::Expression(v) => { write!(f, "|Expr of {:?}|", v.expression.variables) }
+            PlannerVertex::FunctionCall(_) => { write!(f, "|Fun Call|") } //TODO
+            PlannerVertex::Negation(_) => { write!(f, "|Negation|") } //TODO
+            PlannerVertex::Disjunction(_) => { write!(f, "|Disjunction|") } //TODO
+        }
+    }
 }
 
 impl Cost {

--- a/compiler/executable/match_/planner/vertex/variable.rs
+++ b/compiler/executable/match_/planner/vertex/variable.rs
@@ -273,7 +273,7 @@ impl ThingPlanner {
 
     fn restriction_based_selectivity(&self, inputs: &[VertexId]) -> f64 {
         // decrease selectivity whenever we have any matching restrictions
-        let bias: f64 = 2.0;
+        let bias: f64 = 1.0; // TODO: why???
         let selectivity = if self
             .restriction_exact
             .iter()

--- a/compiler/executable/match_/planner/vertex/variable.rs
+++ b/compiler/executable/match_/planner/vertex/variable.rs
@@ -30,7 +30,7 @@ pub(crate) enum VariableVertex {
 impl VariableVertex {
     const RESTRICTION_NONE: f64 = 1.0;
     const SELECTIVITY_MIN: f64 = 0.000001;
-    pub(crate) const OUTPUT_SIZE_MIN: f64 = 1.0;
+    pub(crate) const OUTPUT_SIZE_MIN: f64 = 1.0; // TODO: investigate
 
     pub(crate) fn expected_output_size(&self, inputs: &[VertexId]) -> f64 {
         let unrestricted_size = match self {
@@ -40,6 +40,16 @@ impl VariableVertex {
             Self::Value(_) => 1.0,
         };
         f64::max(unrestricted_size * self.restriction_based_selectivity(inputs), Self::OUTPUT_SIZE_MIN)
+    }
+
+    pub(crate) fn unrestricted_expected_output_size(&self) -> f64 {
+        let unrestricted_size = match self {
+            Self::Input(_) => 1.0,
+            Self::Type(inner) => inner.unrestricted_expected_size,
+            Self::Thing(inner) => inner.unrestricted_expected_size,
+            Self::Value(_) => 1.0,
+        };
+        f64::max(unrestricted_size, Self::OUTPUT_SIZE_MIN)
     }
 
     pub(crate) fn restriction_based_selectivity(&self, inputs: &[VertexId]) -> f64 {
@@ -174,7 +184,7 @@ impl TypePlanner {
 pub(crate) struct ThingPlanner {
     variable: Variable,
     binding: Option<PatternVertexId>,
-    unrestricted_expected_size: f64,
+    pub unrestricted_expected_size: f64,
     unrestricted_expected_attribute_types: usize,
 
     restriction_exact: HashSet<VariableVertexId>, // IID or exact Type + Value
@@ -199,7 +209,7 @@ impl ThingPlanner {
         type_annotations: &TypeAnnotations,
         statistics: &Statistics,
     ) -> Self {
-        let mut unrestricted_expected_size: f64 = 0.0;
+        let mut unrestricted_expected_size: f64 = 1.0;
         let mut unrestricted_expected_attribute_types: usize = 0;
         for type_ in type_annotations
             .vertex_annotations_of(&Vertex::Variable(variable))

--- a/executor/pipeline/reduce.rs
+++ b/executor/pipeline/reduce.rs
@@ -52,8 +52,10 @@ where
             Ok(rows) => rows,
             Err(err) => return Err((err, context)),
         };
-        let profile = context.profile.profile_stage(|| String::from("Reduce (no-op)"), executable_id);
-        let step_profile = profile.extend_or_get(0, || String::from("Reduction (no-op)"));
+        // we can't time the reduce over the iterator because we either need to measure an extremely granular operation
+        //  or double count the previous stage's operations
+        let profile = context.profile.profile_stage(|| String::from("Reduce (untimed)"), executable_id);
+        let step_profile = profile.extend_or_get(0, || String::from("Reduction (untimed)"));
         let measurement = step_profile.start_measurement();
         measurement.end(&step_profile, 1, rows.len() as u64);
         Ok((WrittenRowsIterator::new(rows), context))

--- a/executor/pipeline/reduce.rs
+++ b/executor/pipeline/reduce.rs
@@ -47,13 +47,14 @@ where
         let Self { previous, executable, .. } = self;
         let (previous_iterator, context) = previous.into_iterator(interrupt)?;
 
-        let profile = context.profile.profile_stage(|| String::from("Reduce"), executable.executable_id);
-        let step_profile = profile.extend_or_get(0, || String::from("Reduction"));
-        let measurement = step_profile.start_measurement();
+        let executable_id = executable.executable_id;
         let rows = match reduce_iterator(&context, executable, previous_iterator) {
             Ok(rows) => rows,
             Err(err) => return Err((err, context)),
         };
+        let profile = context.profile.profile_stage(|| String::from("Reduce (no-op)"), executable_id);
+        let step_profile = profile.extend_or_get(0, || String::from("Reduction (no-op)"));
+        let measurement = step_profile.start_measurement();
         measurement.end(&step_profile, 1, rows.len() as u64);
         Ok((WrittenRowsIterator::new(rows), context))
     }

--- a/executor/read/immediate_executor.rs
+++ b/executor/read/immediate_executor.rs
@@ -233,11 +233,12 @@ impl IntersectionExecutor {
             while !batch.is_full() && self.compute_next_row(context)? {
                 batch.append(|mut row| self.write_next_row_into(&mut row));
             }
+            measurement.end(&self.profile, 1, batch.len() as u64);
             Some(batch)
         } else {
+            measurement.end(&self.profile, 0, 0);
             None
         };
-        measurement.end(&self.profile, 1, output.as_ref().map(|batch| batch.len()).unwrap_or(0) as u64);
         Ok(output)
     }
 

--- a/executor/read/pattern_executor.rs
+++ b/executor/read/pattern_executor.rs
@@ -5,6 +5,7 @@
  */
 
 use std::ops::DerefMut;
+use std::time::Instant;
 
 use compiler::VariablePosition;
 use lending_iterator::LendingIterator;
@@ -67,10 +68,12 @@ impl PatternExecutor {
         tabled_functions: &mut TabledFunctions,
         suspensions: &mut QueryPatternSuspensions,
     ) -> Result<Option<FixedBatch>, ReadExecutionError> {
+        let start = Instant::now();
         let _suspension_count_before = suspensions.record_nested_pattern_entry();
         let result = self.batch_continue(context, interrupt, tabled_functions, suspensions);
         let _suspension_count_after = suspensions.record_nested_pattern_exit();
         // debug_assert!(state_after == state_before); // TODO: Enable once we figure out retries at the calls. // As long as compute_next_batch is only called for the entry.
+        println!("Match executor micros: {}", Instant::now().duration_since(start).as_micros());
         result
     }
 

--- a/ir/pattern/constraint.rs
+++ b/ir/pattern/constraint.rs
@@ -1155,8 +1155,8 @@ impl<ID: IrID> fmt::Display for Is<ID> {
 #[derive(Debug, Clone, Eq, PartialEq, Hash)]
 pub struct Isa<ID> {
     kind: IsaKind,
-    thing: Vertex<ID>,
-    type_: Vertex<ID>,
+    pub thing: Vertex<ID>,
+    pub type_: Vertex<ID>,
 }
 
 impl<ID: IrID> Isa<ID> {

--- a/query/query_manager.rs
+++ b/query/query_manager.rs
@@ -115,8 +115,8 @@ impl QueryManager {
                 )
                 .map_err(|err| QueryError::Annotation { typedb_source: err })?;
 
-                // apply_transformations(snapshot.as_ref(), type_manager, &mut annotated_pipeline)
-                //     .map_err(|err| QueryError::Transformation { typedb_source: err })?;
+                apply_transformations(snapshot.as_ref(), type_manager, &mut annotated_pipeline)
+                    .map_err(|err| QueryError::Transformation { typedb_source: err })?;
 
                 let AnnotatedPipeline { annotated_preamble, annotated_stages, annotated_fetch } = annotated_pipeline;
                 // 3: Compile


### PR DESCRIPTION
## Main Improvements

### Printing and log tracing
* Improved Display and Debug prints
* Log tracing for query profiler now prints variables (instead of positions)
* Added log tracing for query planning

### Query planning
* Support for Relation indexes
* Hash checks during planning
   * trivial permutations of the "same" plan are ignored.
   * "same" means produces the same variables with the same cost
* Make planner more deterministic
   * trivial plan elements are now decided upon determinstically, freeing the planner to consider only the more "heavy-weight" choices.
* Various bug fixes (joins in lowering)
   
## Future work
* Improve focus on "difficult bits" in planner
* Integrate dynamic planning approach (see postgres) + allow for non-linear plans and execution (DAGs are all the hype now)