### PR TITLE
Optimize statistics update routine

### DIFF
--- a/concept/thing/statistics.rs
+++ b/concept/thing/statistics.rs
@@ -121,8 +121,9 @@ impl Statistics {
         }
 
         // make it a little more likely that we capture concurrent commits
-        let load_start =
-            DurabilitySequenceNumber::new(self.sequence_number.number().saturating_sub(Self::COMMIT_CONTEXT_SIZE));
+        let load_start = DurabilitySequenceNumber::new(
+            self.sequence_number.number().saturating_sub(Self::COMMIT_CONTEXT_SIZE).max(1),
+        );
 
         let mut data_commits = BTreeMap::new();
         for (seq, status) in load_commit_data_from(load_start, storage.durability())

--- a/database/transaction.rs
+++ b/database/transaction.rs
@@ -308,7 +308,7 @@ impl<D: DurabilityClient> TransactionSchema<D> {
             .map_err(|typedb_source| StatisticsError { typedb_source })?;
         // 2. flush statistics to WAL, guaranteeing a version of statistics is in WAL before schema can change
         thing_statistics
-            .durably_write(&self.database.storage)
+            .durably_write(self.database.storage.durability())
             .map_err(|typedb_source| StatisticsError { typedb_source })?;
 
         let sequence_number = snapshot.commit().map_err(|typedb_source| SnapshotError { typedb_source })?;


### PR DESCRIPTION
## Release notes: product changes

We improve the performance of `Statistics::may_synchronise` by reducing the amount of storage accesses

- use the `reinsert` flag rather than `known_to_exist`, as the former takes into account the state of the storage at time of commit,
- load a context of 8 commits from WAL to increase the chances concurrent writes can be resolved without checking storage,
- check loaded commit data before accessing storage in case there is enough information to determine the delta.

## Motivation

## Implementation
