### PR TITLE
Add server address CLI argument

### DIFF
--- a/main.rs
+++ b/main.rs
@@ -52,7 +52,7 @@ fn get_configuration(cli_args: CLIArgs) -> Config {
         is_service_reporting_enabled: cli_args.diagnostics_reporting_metrics,
     };
     let data_dir = cli_args.storage_data.map(|dir| PathBuf::from_str(dir.as_str()).unwrap());
-    Config::customised(Some(encryption_config), Some(diagnostics_config), data_dir, cli_args.development_mode_enabled)
+    Config::customised(cli_args.server_address, Some(encryption_config), Some(diagnostics_config), data_dir, cli_args.development_mode_enabled)
 }
 
 fn print_ascii_logo() {

--- a/main.rs
+++ b/main.rs
@@ -16,7 +16,6 @@ use server::parameters::{
     cli::CLIArgs,
     config::{Config, DiagnosticsConfig, EncryptionConfig},
 };
-use tokio::net::lookup_host;
 
 const DISTRIBUTION: &str = "TypeDB CE";
 
@@ -29,7 +28,7 @@ async fn main() {
     initialise_logging_global();
 
     let deployment_id = None;
-    let config = get_configuration(cli_args).await;
+    let config = get_configuration(cli_args);
 
     let open_result = server::typedb::Server::open(config, DISTRIBUTION, deployment_id).await;
 
@@ -40,7 +39,7 @@ async fn main() {
     }
 }
 
-async fn get_configuration(cli_args: CLIArgs) -> Config {
+fn get_configuration(cli_args: CLIArgs) -> Config {
     let encryption_config = EncryptionConfig {
         enabled: cli_args.server_encryption_enabled,
         cert: cli_args.server_encryption_cert.map(|path| PathBuf::from_str(path.as_str()).unwrap()),

--- a/main.rs
+++ b/main.rs
@@ -16,6 +16,7 @@ use server::parameters::{
     cli::CLIArgs,
     config::{Config, DiagnosticsConfig, EncryptionConfig},
 };
+use tokio::net::lookup_host;
 
 const DISTRIBUTION: &str = "TypeDB CE";
 
@@ -28,7 +29,7 @@ async fn main() {
     initialise_logging_global();
 
     let deployment_id = None;
-    let config = get_configuration(cli_args);
+    let config = get_configuration(cli_args).await;
 
     let open_result = server::typedb::Server::open(config, DISTRIBUTION, deployment_id).await;
 
@@ -39,7 +40,7 @@ async fn main() {
     }
 }
 
-fn get_configuration(cli_args: CLIArgs) -> Config {
+async fn get_configuration(cli_args: CLIArgs) -> Config {
     let encryption_config = EncryptionConfig {
         enabled: cli_args.server_encryption_enabled,
         cert: cli_args.server_encryption_cert.map(|path| PathBuf::from_str(path.as_str()).unwrap()),

--- a/server/parameters/cli.rs
+++ b/server/parameters/cli.rs
@@ -3,7 +3,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
-
+use std::net::SocketAddr;
 use clap::{ArgAction, Parser};
 use resource::constants::server::MONITORING_DEFAULT_PORT;
 
@@ -11,6 +11,11 @@ use resource::constants::server::MONITORING_DEFAULT_PORT;
 #[derive(Parser, Debug)]
 #[command(version, about, long_about = None)]
 pub struct CLIArgs {
+
+    /// Server host and port, eg., 0.0.0.0:1729
+    #[arg(long = "server.address")]
+    pub server_address: Option<SocketAddr>,
+
     /// Enable/disable in-flight encryption. Specify to enable, or leave out to disable
     #[arg(long = "server.encryption.enabled")]
     pub server_encryption_enabled: bool,

--- a/server/parameters/cli.rs
+++ b/server/parameters/cli.rs
@@ -14,7 +14,7 @@ pub struct CLIArgs {
 
     /// Server host and port, eg., 0.0.0.0:1729
     #[arg(long = "server.address")]
-    pub server_address: Option<SocketAddr>,
+    pub server_address: Option<String>,
 
     /// Enable/disable in-flight encryption. Specify to enable, or leave out to disable
     #[arg(long = "server.encryption.enabled")]

--- a/server/parameters/config.rs
+++ b/server/parameters/config.rs
@@ -41,23 +41,25 @@ impl Config {
     }
 
     pub fn new_with_encryption_config(encryption_config: EncryptionConfig, is_development_mode: bool) -> Self {
-        Self::customised(Some(encryption_config), None, None, is_development_mode)
+        Self::customised(None, Some(encryption_config), None, None, is_development_mode)
     }
 
     pub fn new_with_diagnostics_config(diagnostics_config: DiagnosticsConfig, is_development_mode: bool) -> Self {
-        Self::customised(None, Some(diagnostics_config), None, is_development_mode)
+        Self::customised(None, None, Some(diagnostics_config), None, is_development_mode)
     }
 
     pub fn new_with_data_directory(data_directory: &Path, is_development_mode: bool) -> Self {
-        Self::customised(None, None, Some(data_directory.to_path_buf()), is_development_mode)
+        Self::customised(None, None, None, Some(data_directory.to_path_buf()), is_development_mode)
     }
 
     pub fn customised(
+        server_address: Option<SocketAddr>,
         encryption_config: Option<EncryptionConfig>,
         diagnostics_config: Option<DiagnosticsConfig>,
         data_directory: Option<PathBuf>,
         is_development_mode: bool,
     ) -> Self {
+        let server_address = server_address.unwrap_or_else(|| SocketAddr::from_str(DEFAULT_ADDRESS).unwrap());
         let encryption_config = encryption_config.unwrap_or_else(|| EncryptionConfig::default());
         let diagnostics_config = diagnostics_config.unwrap_or_else(|| DiagnosticsConfig::default());
         let data_directory = data_directory.map(|dir| dir.to_path_buf()).unwrap_or_else(|| {
@@ -69,7 +71,7 @@ impl Config {
         let is_development_mode = ServerConfig::IS_DEVELOPMENT_MODE_FORCED || is_development_mode;
         Self {
             server: ServerConfig {
-                address: SocketAddr::from_str(DEFAULT_ADDRESS).unwrap(),
+                address: server_address,
                 encryption: encryption_config,
                 diagnostics: diagnostics_config,
                 is_development_mode,

--- a/server/parameters/config.rs
+++ b/server/parameters/config.rs
@@ -9,7 +9,7 @@ use std::{
     path::{Path, PathBuf},
     str::FromStr,
 };
-
+use tokio::net::lookup_host;
 use resource::constants::server::{DEFAULT_ADDRESS, MONITORING_DEFAULT_PORT};
 
 #[derive(Debug)]
@@ -31,7 +31,7 @@ impl Config {
             .unwrap_or(std::env::current_dir().unwrap());
         Self {
             server: ServerConfig {
-                address: SocketAddr::from_str(DEFAULT_ADDRESS).unwrap(),
+                address: DEFAULT_ADDRESS.to_string(),
                 encryption: EncryptionConfig::default(),
                 diagnostics: DiagnosticsConfig::default(),
                 is_development_mode: ServerConfig::IS_DEVELOPMENT_MODE_FORCED,
@@ -53,13 +53,13 @@ impl Config {
     }
 
     pub fn customised(
-        server_address: Option<SocketAddr>,
+        server_address: Option<String>,
         encryption_config: Option<EncryptionConfig>,
         diagnostics_config: Option<DiagnosticsConfig>,
         data_directory: Option<PathBuf>,
         is_development_mode: bool,
     ) -> Self {
-        let server_address = server_address.unwrap_or_else(|| SocketAddr::from_str(DEFAULT_ADDRESS).unwrap());
+        let server_address = server_address.unwrap_or_else(|| DEFAULT_ADDRESS.to_string());
         let encryption_config = encryption_config.unwrap_or_else(|| EncryptionConfig::default());
         let diagnostics_config = diagnostics_config.unwrap_or_else(|| DiagnosticsConfig::default());
         let data_directory = data_directory.map(|dir| dir.to_path_buf()).unwrap_or_else(|| {
@@ -83,7 +83,7 @@ impl Config {
 
 #[derive(Debug)]
 pub(crate) struct ServerConfig {
-    pub(crate) address: SocketAddr,
+    pub(crate) address: String,
     pub(crate) encryption: EncryptionConfig,
     pub(crate) diagnostics: DiagnosticsConfig,
 

--- a/server/typedb.rs
+++ b/server/typedb.rs
@@ -5,12 +5,13 @@
  */
 
 use std::{fs, io, path::PathBuf, sync::Arc};
-
+use std::net::SocketAddr;
 use concurrency::IntervalRunner;
 use database::{database_manager::DatabaseManager, DatabaseOpenError};
 use diagnostics::{diagnostics_manager::DiagnosticsManager, Diagnostics};
 use error::typedb_error;
 use rand::Rng;
+use tokio::net::lookup_host;
 use resource::constants::server::{
     DATABASE_METRICS_UPDATE_INTERVAL, GRPC_CONNECTION_KEEPALIVE, SERVER_ID_ALPHABET, SERVER_ID_FILE_NAME,
     SERVER_ID_LENGTH, VERSION,
@@ -31,6 +32,7 @@ pub struct Server {
     id: String,
     deployment_id: String,
     distribution: &'static str,
+    address: SocketAddr,
     data_directory: PathBuf,
     user_manager: Arc<UserManager>,
     authenticator_cache: Arc<AuthenticatorCache>,
@@ -54,7 +56,7 @@ impl Server {
         let server_config = &config.server;
         let server_id = Self::initialise_server_id(storage_directory)?;
         let deployment_id = deployment_id.unwrap_or(server_id.clone());
-
+        let server_address = resolve_address(server_config.address.clone()).await;
         let mut diagnostics_manager = Arc::new(Self::initialise_diagnostics(
             deployment_id.clone(),
             server_id.clone(),
@@ -71,7 +73,7 @@ impl Server {
         initialise_default_user(&user_manager);
 
         let typedb_service = TypeDBService::new(
-            &config.server.address,
+            &server_address,
             database_manager.clone(),
             user_manager.clone(),
             authenticator_cache.clone(),
@@ -85,6 +87,7 @@ impl Server {
             id: server_id,
             deployment_id,
             distribution,
+            address: server_address,
             data_directory: storage_directory.to_owned(),
             user_manager,
             authenticator_cache,
@@ -114,7 +117,7 @@ impl Server {
         Self::create_tonic_server(&self.config.server.encryption)
             .layer(&authenticator)
             .add_service(service)
-            .serve(self.config.server.address)
+            .serve(self.address)
             .await
     }
 
@@ -226,6 +229,14 @@ fn synchronize_database_metrics(diagnostics_manager: Arc<DiagnosticsManager>, da
         .map(|database| database.get_metrics())
         .collect();
     diagnostics_manager.submit_database_metrics(metrics);
+}
+
+async fn resolve_address(address: String) -> SocketAddr {
+    lookup_host(address.clone())
+        .await
+        .unwrap()
+        .next()
+        .expect(format!("Unable to map address '{}' to any IP address", address).as_str())
 }
 
 typedb_error!(

--- a/server/typedb.rs
+++ b/server/typedb.rs
@@ -236,7 +236,7 @@ async fn resolve_address(address: String) -> SocketAddr {
         .await
         .unwrap()
         .next()
-        .expect(format!("Unable to map address '{}' to any IP address", address).as_str())
+        .expect(format!("Unable to map address '{}' to any IP addresses", address).as_str())
 }
 
 typedb_error!(


### PR DESCRIPTION
## Release notes: product changes
Make server address configurable through command line argument.

## Motivation
User will want to configure the server listen address.

## Implementation
- Add server address command line argument
