### PR TITLE
Fix default data directory location

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -49,7 +49,9 @@ empty_directories = [
 ]
 
 binary_permissions = pkg_attributes(mode = "0744")
-other_permissions = {} # These don't seem to work.
+other_permissions = {
+    "server/data": "0755",
+}
 
 alias(
     name = "typedb_console_artifact",

--- a/resource/constants.rs
+++ b/resource/constants.rs
@@ -44,6 +44,7 @@ pub mod server {
     pub const DEFAULT_ADDRESS: &str = "0.0.0.0:1729";
     pub const DEFAULT_USER_NAME: &str = "admin";
     pub const DEFAULT_USER_PASSWORD: &str = "password";
+    pub const DEFAULT_DATA_DIR: &str = "data";
 
     pub const SYSTEM_FILE_PREFIX: &str = "_";
 }

--- a/server/parameters/config.rs
+++ b/server/parameters/config.rs
@@ -10,7 +10,7 @@ use std::{
     str::FromStr,
 };
 
-use resource::constants::server::{DEFAULT_ADDRESS, MONITORING_DEFAULT_PORT};
+use resource::constants::server::{DEFAULT_ADDRESS, DEFAULT_DATA_DIR, MONITORING_DEFAULT_PORT};
 
 #[derive(Debug)]
 pub struct Config {
@@ -36,7 +36,7 @@ impl Config {
                 diagnostics: DiagnosticsConfig::default(),
                 is_development_mode: ServerConfig::IS_DEVELOPMENT_MODE_FORCED,
             },
-            storage: StorageConfig { data: typedb_dir_or_current.join(PathBuf::from_str("server/data").unwrap()) },
+            storage: StorageConfig { data: typedb_dir_or_current.join(PathBuf::from_str(DEFAULT_DATA_DIR).unwrap()) },
         }
     }
 
@@ -64,7 +64,7 @@ impl Config {
             let typedb_dir_or_current = std::env::current_exe()
                 .map(|path| path.parent().unwrap().to_path_buf())
                 .unwrap_or(std::env::current_dir().unwrap());
-            typedb_dir_or_current.join(PathBuf::from_str("server/data").unwrap())
+            typedb_dir_or_current.join(PathBuf::from_str(DEFAULT_DATA_DIR).unwrap())
         });
         let is_development_mode = ServerConfig::IS_DEVELOPMENT_MODE_FORCED || is_development_mode;
         Self {

--- a/server/typedb.rs
+++ b/server/typedb.rs
@@ -49,7 +49,6 @@ impl Server {
     ) -> Result<Self, ServerOpenError> {
         let storage_directory = &config.storage.data;
         Self::initialise_storage_directory(storage_directory)?;
-        println!("Storage directory: {:?}", storage_directory);
 
         let server_config = &config.server;
         let server_id = Self::initialise_server_id(storage_directory)?;


### PR DESCRIPTION
## Release notes: product changes
Fix data directory location, to be correctly placed in `./server/data` instead of `./server/server/data`.

## Motivation
The default data directory was wrong

## Implementation
- Make the default data directory path a constant
- Update the default data directory, to be relative to the `./{distribution-dir}/server` directory rather than `./{distribution-dir}`
- Remove debug print where we print data