### PR TITLE
Introduce PostHog diagnostics and correct server shutdown

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -35,8 +35,11 @@ rust_binary(
         "//resource",
         "//server",
 
+        "@crates//:clap",
         "@crates//:tokio",
-        "@crates//:clap"
+    ],
+    compile_data = [
+        ":VERSION",
     ],
 )
 

--- a/diagnostics/diagnostics_manager.rs
+++ b/diagnostics/diagnostics_manager.rs
@@ -6,9 +6,10 @@
 
 use std::{collections::HashSet, future::Future, hash::Hash, sync::Arc};
 
-use resource::constants::{database::INTERNAL_DATABASE_PREFIX};
+use resource::constants::database::INTERNAL_DATABASE_PREFIX;
 use tonic::Status;
 use tonic_types::StatusExt;
+use concurrency::TokioIntervalRunner;
 
 use crate::{
     metrics::{ActionKind, DatabaseMetrics, LoadKind},

--- a/diagnostics/diagnostics_manager.rs
+++ b/diagnostics/diagnostics_manager.rs
@@ -9,7 +9,6 @@ use std::{collections::HashSet, future::Future, hash::Hash, sync::Arc};
 use resource::constants::database::INTERNAL_DATABASE_PREFIX;
 use tonic::Status;
 use tonic_types::StatusExt;
-use concurrency::TokioIntervalRunner;
 
 use crate::{
     metrics::{ActionKind, DatabaseMetrics, LoadKind},

--- a/diagnostics/diagnostics_manager.rs
+++ b/diagnostics/diagnostics_manager.rs
@@ -6,7 +6,7 @@
 
 use std::{collections::HashSet, future::Future, hash::Hash, sync::Arc};
 
-use resource::constants::{database::INTERNAL_DATABASE_PREFIX, diagnostics::REPORTING_URI};
+use resource::constants::{database::INTERNAL_DATABASE_PREFIX};
 use tonic::Status;
 use tonic_types::StatusExt;
 
@@ -51,7 +51,7 @@ impl DiagnosticsManager {
         let reporter = if is_development_mode {
             None
         } else {
-            Some(Reporter::new(deployment_id, diagnostics.clone(), REPORTING_URI, data_directory, is_reporting_enabled))
+            Some(Reporter::new(deployment_id, diagnostics.clone(), data_directory, is_reporting_enabled))
         };
 
         let monitoring_server = if is_monitoring_enabled {

--- a/diagnostics/lib.rs
+++ b/diagnostics/lib.rs
@@ -15,7 +15,7 @@ use std::{
 };
 
 use error::TypeDBError;
-use serde_json::Value as JSONValue;
+use serde_json::{json, Value as JSONValue};
 use xxhash_rust::xxh3::Xxh3;
 
 use crate::metrics::{
@@ -120,14 +120,14 @@ impl Diagnostics {
         self.lock_error_metrics_write().values_mut().for_each(|metrics| metrics.take_snapshot());
     }
 
-    pub fn to_reporting_json_against_snapshot(&self) -> JSONValue {
+    pub fn to_service_reporting_json_against_snapshot(&self) -> JSONValue {
         match self.is_full_reporting {
-            true => self.to_full_reporting_json(),
-            false => self.to_minimal_reporting_json(),
+            true => self.to_full_service_reporting_json(),
+            false => self.to_minimal_service_reporting_json(),
         }
     }
 
-    fn to_full_reporting_json(&self) -> JSONValue {
+    fn to_full_service_reporting_json(&self) -> JSONValue {
         let mut diagnostics = self.server_properties.to_reporting_json();
 
         diagnostics["server"] = self.server_metrics.to_json();
@@ -144,7 +144,7 @@ impl Diagnostics {
         let actions = self
             .lock_action_metrics_read()
             .iter()
-            .map(|(database_hash, metrics)| metrics.to_reporting_json(database_hash))
+            .map(|(database_hash, metrics)| metrics.to_service_reporting_json(database_hash))
             .flatten()
             .collect();
         diagnostics["actions"] = JSONValue::Array(actions);
@@ -160,7 +160,7 @@ impl Diagnostics {
         diagnostics
     }
 
-    fn to_minimal_reporting_json(&self) -> JSONValue {
+    fn to_minimal_service_reporting_json(&self) -> JSONValue {
         let mut diagnostics = self.server_properties.to_reporting_json();
         diagnostics["server"] = self.server_metrics.to_reporting_minimal_json();
         diagnostics
@@ -247,6 +247,19 @@ impl Diagnostics {
             if user_errors_data.len() > user_errors_data_header_length { user_errors_data } else { String::new() },
         ]
         .join("\n")
+    }
+
+    pub fn to_posthog_reporting_json_against_snapshot(&self, api_key: &str) -> JSONValue {
+        let deployment_id = self.server_properties.deployment_id();
+        let batch: Vec<_> = self
+            .lock_action_metrics_read()
+            .iter()
+            .map(|(database_hash, metrics)| metrics.to_posthog_reporting_json(deployment_id, database_hash))
+            .collect();
+        json!({
+            "api_key": api_key,
+            "batch": batch,
+        })
     }
 
     fn hash_database(database_name: impl AsRef<str> + Hash) -> DatabaseHash {

--- a/diagnostics/lib.rs
+++ b/diagnostics/lib.rs
@@ -14,7 +14,7 @@ use std::{
     sync::{Mutex, MutexGuard, RwLock, RwLockReadGuard, RwLockWriteGuard},
 };
 
-use error::TypeDBError;
+use error::{typedb_error, TypeDBError};
 use serde_json::{json, Value as JSONValue};
 use xxhash_rust::xxh3::Xxh3;
 
@@ -264,7 +264,9 @@ impl Diagnostics {
         let mut batch: Vec<_> = self
             .lock_action_metrics_read()
             .iter()
-            .map(|(database_hash, metrics)| metrics.to_posthog_reporting_json(database_hash, common_properties.clone()))
+            .filter_map(|(database_hash, metrics)| {
+                metrics.to_posthog_reporting_json(database_hash, common_properties.clone())
+            })
             .collect();
         if batch.is_empty() {
             batch.push(ActionMetrics::empty_posthog_reporting_json(common_properties));

--- a/diagnostics/metrics.rs
+++ b/diagnostics/metrics.rs
@@ -525,7 +525,7 @@ impl ActionMetrics {
         &self,
         database_hash: &DatabaseHashOpt,
         mut properties: JSONMap<String, JSONValue>,
-    ) -> JSONValue {
+    ) -> Option<JSONValue> {
         let mut event = JSONMap::new();
 
         let mut any_actions = false;
@@ -548,9 +548,9 @@ impl ActionMetrics {
             }
 
             event.insert("properties".to_string(), json!(properties));
-            json!(event)
+            Some(json!(event))
         } else {
-            json!(event)
+            None
         }
     }
 

--- a/diagnostics/metrics.rs
+++ b/diagnostics/metrics.rs
@@ -531,11 +531,11 @@ impl ActionMetrics {
         let mut any_actions = false;
 
         for kind in self.actions.keys() {
-            let total = self.get_posthog_successful_delta(kind) + self.get_posthog_failed_delta(kind);
-            if total == 0 {
+            let successful = self.get_posthog_successful_delta(kind);
+            if successful == 0 {
                 continue;
             }
-            properties.insert(kind.to_posthog_event_name().to_string(), json!(total));
+            properties.insert(kind.to_posthog_event_name().to_string(), json!(successful));
             any_actions = true;
         }
 
@@ -907,27 +907,27 @@ impl ActionKind {
 
     pub fn to_posthog_event_name(&self) -> &'static str {
         match self {
-            ActionKind::ConnectionOpen => "connections_opened",
-            ActionKind::ServersAll => "all_servers_retrieved",
-            ActionKind::UsersContains => "users_presence_checked",
-            ActionKind::UsersCreate => "users_created",
-            ActionKind::UsersUpdate => "users_updated",
-            ActionKind::UsersDelete => "users_deleted",
-            ActionKind::UsersAll => "all_users_retrieved",
-            ActionKind::UsersGet => "users_retrieved",
-            ActionKind::Authenticate => "authentications_performed",
-            ActionKind::DatabasesContains => "databases_presence_checked",
-            ActionKind::DatabasesCreate => "databases_created",
-            ActionKind::DatabasesGet => "databases_retrieved",
-            ActionKind::DatabasesAll => "all_databases_retrieved",
-            ActionKind::DatabaseSchema => "database_schemas_retrieved",
-            ActionKind::DatabaseTypeSchema => "database_type_schemas_retrieved",
-            ActionKind::DatabaseDelete => "databases_deleted",
-            ActionKind::TransactionOpen => "transactions_opened",
-            ActionKind::TransactionClose => "transactions_closed",
-            ActionKind::TransactionCommit => "transactions_committed",
-            ActionKind::TransactionRollback => "transactions_rolled_back",
-            ActionKind::TransactionQuery => "queries_executed",
+            ActionKind::ConnectionOpen => "connection_opens",
+            ActionKind::ServersAll => "server_alls",
+            ActionKind::UsersContains => "user_containses",
+            ActionKind::UsersCreate => "user_creates",
+            ActionKind::UsersUpdate => "user_updates",
+            ActionKind::UsersDelete => "user_deletes",
+            ActionKind::UsersAll => "user_alls",
+            ActionKind::UsersGet => "user_gets",
+            ActionKind::Authenticate => "authenticates",
+            ActionKind::DatabasesContains => "database_containses",
+            ActionKind::DatabasesCreate => "database_creates",
+            ActionKind::DatabasesGet => "database_gets",
+            ActionKind::DatabasesAll => "database_alls",
+            ActionKind::DatabaseSchema => "database_schemas",
+            ActionKind::DatabaseTypeSchema => "database_type_schemas",
+            ActionKind::DatabaseDelete => "databases_deletes",
+            ActionKind::TransactionOpen => "transaction_opens",
+            ActionKind::TransactionClose => "transaction_closes",
+            ActionKind::TransactionCommit => "transaction_commits",
+            ActionKind::TransactionRollback => "transaction_rollbacks",
+            ActionKind::TransactionQuery => "transaction_queries",
         }
     }
 }

--- a/diagnostics/monitoring_server.rs
+++ b/diagnostics/monitoring_server.rs
@@ -41,9 +41,13 @@ impl MonitoringServer {
                 }
             });
 
-            let server = Server::bind(&addr).serve(make_svc);
-            if let Err(e) = server.await {
-                eprintln!("Monitoring server error: {}", e);
+            match Server::try_bind(&addr) {
+                Ok(server) => {
+                    if let Err(e) = server.serve(make_svc).await {
+                        eprintln!("Diagnostics monitoring server error: {}", e);
+                    }
+                }
+                Err(e) => eprintln!("Diagnostics monitoring server setup error for {}: {}", addr, e),
             }
         });
     }

--- a/diagnostics/reporter.rs
+++ b/diagnostics/reporter.rs
@@ -16,23 +16,26 @@ use std::{
         Arc, Mutex,
     },
     thread,
-    time::{Duration, SystemTime, UNIX_EPOCH},
+    time::{Duration, Instant, UNIX_EPOCH},
 };
 
 use chrono::{DateTime, Timelike, Utc};
 use concurrency::{IntervalRunner, TokioIntervalRunner};
 use hyper::{
+    client::HttpConnector,
     header::{HeaderValue, CONNECTION, CONTENT_TYPE},
     Body, Client, Method, Request,
 };
-use hyper::client::HttpConnector;
 use hyper_rustls::{HttpsConnector, HttpsConnectorBuilder};
 use logger::{debug, trace};
 use resource::constants::{
     common::SECONDS_IN_MINUTE,
-    diagnostics::{DISABLED_REPORTING_FILE_NAME, REPORT_INTERVAL, REPORT_ONCE_DELAY},
+    diagnostics::{
+        DISABLED_REPORTING_FILE_NAME, POSTHOG_API_KEY, POSTHOG_BATCH_REPORTING_URI, REPORT_INITIAL_RETRY_DELAY,
+        REPORT_INTERVAL, REPORT_MAX_RETRY_NUM, REPORT_ONCE_DELAY, REPORT_RETRY_DELAY_EXPONENTIAL_MULTIPLIER,
+        SERVICE_REPORTING_URI,
+    },
 };
-use resource::constants::diagnostics::{POSTHOG_API_KEY, POSTHOG_BATCH_REPORTING_URI, SERVICE_REPORTING_URI};
 
 use crate::{hash_string_consistently, Diagnostics};
 
@@ -80,8 +83,9 @@ impl Reporter {
                     Self::report(diagnostics).await;
                 }
             },
-            REPORT_INTERVAL,
-            self.calculate_initial_delay(),
+            Duration::from_secs(15),
+            Duration::from_secs(15),
+            true,
         );
         *self._reporting_job.lock().expect("Expected reporting job exclusive lock acquisition") = Some(reporting_job);
     }
@@ -93,7 +97,7 @@ impl Reporter {
             let data_directory = self.data_directory.clone();
 
             tokio::spawn(async move {
-                tokio::time::sleep(Duration::from_secs(20)).await;
+                tokio::time::sleep(Duration::from_secs(20)).await; // TODO: Return constant
                 if Self::report(diagnostics).await {
                     Self::save_disabled_reporting_file(&data_directory);
                 }
@@ -101,101 +105,95 @@ impl Reporter {
         }
     }
 
-    fn calculate_initial_delay(&self) -> Duration {
-        let report_interval_secs = REPORT_INTERVAL.as_secs();
-        assert!(report_interval_secs == 3600, "Modify the algorithm if you change the interval!");
-
-        let current_minute = Utc::now().minute() as u64;
-        let scheduled_minute =
-            hash_string_consistently(&self.deployment_id) % (report_interval_secs / SECONDS_IN_MINUTE);
-
-        let delay_secs = if current_minute > scheduled_minute {
-            report_interval_secs - (current_minute + scheduled_minute) * SECONDS_IN_MINUTE
-        } else {
-            (scheduled_minute - current_minute) * SECONDS_IN_MINUTE
-        };
-        Duration::from_secs(delay_secs)
-    }
-
     async fn report(diagnostics: Arc<Diagnostics>) -> bool {
-        println!("REPORT!"); // TODO: Remove
-        let service_task = Self::report_diagnostics_service(diagnostics.clone(), SERVICE_REPORTING_URI);
-        let posthog_task = Self::report_posthog(diagnostics.clone(), POSTHOG_BATCH_REPORTING_URI, POSTHOG_API_KEY);
+        let service_task = Self::report_diagnostics_service(diagnostics.clone());
+        let posthog_task = Self::report_posthog(diagnostics.clone());
         let (is_service_reported, is_posthog_reported) = tokio::join!(service_task, posthog_task);
-
-        diagnostics.take_snapshot();
-
-        // TODO: Redo
-        if !is_service_reported {
-            println!("Service diagnostics not reported, consider additional logic!");
-        }
-        if !is_posthog_reported {
-            println!("Posthog diagnostics not reported, consider additional logic!");
-        }
-        is_posthog_reported && is_service_reported
+        is_service_reported && is_posthog_reported
     }
 
-    async fn report_diagnostics_service(diagnostics: Arc<Diagnostics>, reporting_uri: &'static str) -> bool {
-        let diagnostics_json = diagnostics.to_service_reporting_json_against_snapshot().to_string();
-
-        // TODO: return
-        // let request = hyper::Request::post(reporting_uri)
-        //     .header(CONTENT_TYPE, "application/json")
-        //     .header(CONNECTION, "close")
-        //     .body(Body::from(diagnostics_json))
-        //     .expect("Failed to construct the request");
+    async fn report_diagnostics_service(diagnostics: Arc<Diagnostics>) -> bool {
+        // let diagnostics_json = diagnostics.to_service_reporting_json_against_snapshot();
+        // let is_reported = Self::send_request(
+        //     diagnostics_json.to_string(),
+        //     ReportingEndpoint::DiagnosticsService.get_uri(),
+        // ).await;
         //
-        // match Self::new_https_client().request(request).await {
-        //     Ok(response) => {
-        //         if response.status().is_success() {
-        //             true
-        //         } else {
-        //             trace!("Failed to push diagnostics to {}: {}", reporting_uri, response.status());
-        //             false
-        //         }
-        //     }
-        //     Err(e) => {
-        //         trace!("Failed to push diagnostics to {}: {}", reporting_uri, e);
-        //         false
-        //     }
+        // // The request is sent once, so it's fine to take a snapshot lossy with a small delay
+        // if is_reported {
+        //     println!("Service reporting is successful. Taking a snapshot...");
+        //     trace!("Service reporting is successful. Taking a snapshot...");
+        //     diagnostics.take_service_snapshot();
         // }
-        true
+        // is_reported
+        true // TODO: return the main code
     }
 
-    async fn report_posthog(diagnostics: Arc<Diagnostics>, reporting_uri: &'static str, api_key: &'static str) -> bool {
-        let events_json = diagnostics.to_posthog_reporting_json_against_snapshot(api_key).to_string();
+    async fn report_posthog(diagnostics: Arc<Diagnostics>) -> bool {
+        let events_json = diagnostics.to_posthog_reporting_json_against_snapshot(POSTHOG_API_KEY);
+        diagnostics.take_posthog_snapshot();
         println!("Posthog events: {events_json}");
 
-        let request = Request::post(reporting_uri)
+        let is_reported =
+            Self::send_request_with_retries(events_json.to_string(), ReportingEndpoint::PostHog.get_uri()).await;
+
+        // The request is sent with retries, and we don't want to lose posthog data. The snapshot
+        // is taken right after the json creation, but can be restored to preserve the not sent data
+        // for the next reporting action
+        if !is_reported {
+            println!("PostHog reporting is not successful. Restoring the snapshot...");
+            trace!("PostHog reporting is not successful. Restoring the snapshot...");
+            diagnostics.restore_posthog_snapshot();
+        }
+        is_reported
+    }
+
+    async fn send_request_with_retries(request_body: String, uri: &'static str) -> bool {
+        let mut retries_num = 0;
+        let mut delay = REPORT_INITIAL_RETRY_DELAY;
+
+        while retries_num < REPORT_MAX_RETRY_NUM {
+            if Self::send_request(request_body.clone(), uri).await {
+                return true;
+            }
+
+            println!("Retrying to send diagnostics data to {} after {:?}...", uri, delay);
+            trace!("Retrying to send diagnostics data to {} after {:?}...", uri, delay);
+            tokio::time::sleep(delay).await;
+            retries_num += 1;
+            delay *= REPORT_RETRY_DELAY_EXPONENTIAL_MULTIPLIER.pow(retries_num);
+        }
+
+        println!("Max reporting retries reached for {}.", uri);
+        trace!("Max reporting retries reached for {}.", uri);
+        false
+    }
+
+    async fn send_request(body: String, uri: &'static str) -> bool {
+        let request = Request::post(uri)
             .header(CONTENT_TYPE, "application/json")
             .header(CONNECTION, "close")
-            .body(Body::from(events_json.to_string()))
+            .body(Body::from(body))
             .expect("Failed to construct the request");
 
         match Self::new_https_client().request(request).await {
             Ok(response) => {
                 if response.status().is_success() {
-                    println!("POSTHOG success!");
+                    println!("Successfully sent diagnostics data to {}", uri);
+                    trace!("Successfully sent diagnostics data to {}", uri);
                     true
                 } else {
-                    println!("Failed to send a posthog batch to {}: {}", reporting_uri, response.status());
-                    trace!("Failed to send a posthog batch to {}: {}", reporting_uri, response.status());
+                    println!("Failed to send diagnostics data to {}: {}", uri, response.status());
+                    trace!("Failed to send diagnostics data to {}: {}", uri, response.status());
                     false
                 }
             }
             Err(e) => {
-                println!("Failed to send a posthog batch to {}: {}", reporting_uri, e);
-                trace!("Failed to send a posthog batch to {}: {}", reporting_uri, e);
+                println!("Failed to send diagnostics data to {}: {}", uri, e);
+                trace!("Failed to send diagnostics data to {}: {}", uri, e);
                 false
             }
         }
-    }
-
-    pub async fn shutdown(&self) {
-        if !self.is_enabled {
-            return;
-        }
-        // TODO: implement final sending on shutdown
     }
 
     fn new_https_client() -> Client<HttpsConnector<HttpConnector>> {
@@ -217,8 +215,41 @@ impl Reporter {
 
     fn delete_disabled_reporting_file_if_exists(data_directory: &PathBuf) {
         let disabled_reporting_file = data_directory.join(DISABLED_REPORTING_FILE_NAME);
-        if let Err(e) = fs::remove_file(&disabled_reporting_file) {
-            debug!("Failed to delete disabled reporting file: {}", e);
+        if fs::exists(&disabled_reporting_file).unwrap_or(false) {
+            if let Err(e) = fs::remove_file(&disabled_reporting_file) {
+                debug!("Failed to delete disabled reporting file: {}", e);
+            }
+        }
+    }
+
+    fn calculate_initial_delay(&self) -> Duration {
+        let report_interval_secs = REPORT_INTERVAL.as_secs();
+        assert!(report_interval_secs == 3600, "Modify the algorithm if you change the interval!");
+
+        let current_minute = Utc::now().minute() as u64;
+        let scheduled_minute =
+            hash_string_consistently(&self.deployment_id) % (report_interval_secs / SECONDS_IN_MINUTE);
+
+        let delay_secs = if current_minute > scheduled_minute {
+            report_interval_secs - (current_minute + scheduled_minute) * SECONDS_IN_MINUTE
+        } else {
+            (scheduled_minute - current_minute) * SECONDS_IN_MINUTE
+        };
+        Duration::from_secs(delay_secs)
+    }
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
+enum ReportingEndpoint {
+    DiagnosticsService,
+    PostHog,
+}
+
+impl ReportingEndpoint {
+    pub(crate) fn get_uri(&self) -> &'static str {
+        match self {
+            ReportingEndpoint::DiagnosticsService => SERVICE_REPORTING_URI,
+            ReportingEndpoint::PostHog => POSTHOG_BATCH_REPORTING_URI,
         }
     }
 }

--- a/diagnostics/version.rs
+++ b/diagnostics/version.rs
@@ -4,4 +4,4 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-pub const JSON_API_VERSION: u64 = 1;
+pub const SERVICE_API_VERSION: u64 = 1;

--- a/main.rs
+++ b/main.rs
@@ -18,6 +18,7 @@ use server::parameters::{
 };
 
 const DISTRIBUTION: &str = "TypeDB CE";
+const VERSION: &str = include_str!("VERSION");
 
 #[tokio::main]
 async fn main() {
@@ -30,7 +31,7 @@ async fn main() {
     let deployment_id = None;
     let config = get_configuration(cli_args);
 
-    let open_result = server::typedb::Server::open(config, DISTRIBUTION, deployment_id).await;
+    let open_result = server::typedb::Server::open(config, DISTRIBUTION, VERSION, deployment_id).await;
 
     let result = open_result.unwrap().serve().await;
     match result {

--- a/main.rs
+++ b/main.rs
@@ -50,7 +50,7 @@ fn get_configuration(cli_args: CLIArgs) -> Config {
     let diagnostics_config = DiagnosticsConfig {
         is_monitoring_enabled: cli_args.diagnostics_monitoring_enable,
         monitoring_port: cli_args.diagnostics_monitoring_port,
-        is_service_reporting_enabled: cli_args.diagnostics_reporting_metrics,
+        is_reporting_enabled: cli_args.diagnostics_reporting_metrics,
     };
     let data_dir = cli_args.storage_data.map(|dir| PathBuf::from_str(dir.as_str()).unwrap());
     Config::customised(

--- a/main.rs
+++ b/main.rs
@@ -53,7 +53,13 @@ fn get_configuration(cli_args: CLIArgs) -> Config {
         is_service_reporting_enabled: cli_args.diagnostics_reporting_metrics,
     };
     let data_dir = cli_args.storage_data.map(|dir| PathBuf::from_str(dir.as_str()).unwrap());
-    Config::customised(cli_args.server_address, Some(encryption_config), Some(diagnostics_config), data_dir, cli_args.development_mode_enabled)
+    Config::customised(
+        cli_args.server_address,
+        Some(encryption_config),
+        Some(diagnostics_config),
+        data_dir,
+        cli_args.development_mode_enabled,
+    )
 }
 
 fn print_ascii_logo() {

--- a/resource/BUILD
+++ b/resource/BUILD
@@ -14,7 +14,6 @@ rust_library(
     ]),
     compile_data = [
         "typedb-ascii.txt",
-        "//:VERSION",
     ],
 )
 

--- a/resource/constants.rs
+++ b/resource/constants.rs
@@ -17,8 +17,6 @@ pub mod server {
 
     pub const ASCII_LOGO: &str = include_str!("typedb-ascii.txt");
 
-    pub const VERSION: &str = include_str!("../VERSION");
-
     pub const GRPC_CONNECTION_KEEPALIVE: Duration = Duration::from_secs(2 * SECONDS_IN_HOUR);
 
     pub const DEFAULT_TRANSACTION_TIMEOUT_MILLIS: u64 = Duration::from_secs(5 * SECONDS_IN_MINUTE).as_millis() as u64;
@@ -115,5 +113,10 @@ pub mod diagnostics {
 
     pub const REPORT_INTERVAL: Duration = Duration::from_secs(1 * SECONDS_IN_HOUR);
     pub const REPORT_ONCE_DELAY: Duration = Duration::from_secs(1 * SECONDS_IN_HOUR);
+
+    pub const REPORT_INITIAL_RETRY_DELAY: Duration = Duration::from_millis(500);
+    pub const REPORT_RETRY_DELAY_EXPONENTIAL_MULTIPLIER: u32 = 3;
+    pub const REPORT_MAX_RETRY_NUM: u32 = 3;
+
     pub const DISABLED_REPORTING_FILE_NAME: &str = "_reporting_disabled";
 }

--- a/resource/constants.rs
+++ b/resource/constants.rs
@@ -108,7 +108,11 @@ pub mod diagnostics {
 
     pub const UNKNOWN_STR: &'static str = "Unknown";
 
-    pub const REPORTING_URI: &str = "https://diagnostics.typedb.com/";
+    pub const SERVICE_REPORTING_URI: &str = "https://diagnostics.typedb.com/";
+    pub const POSTHOG_BATCH_REPORTING_URI: &str = "https://us.i.posthog.com/batch/";
+    // The key is read-only and safe to expose
+    pub const POSTHOG_API_KEY: &str = "phc_kee7J4vlLnef61l6krVU8Fg5B6tYIgSEVOyW7yxwLSk"; // TODO: update to prod
+
     pub const REPORT_INTERVAL: Duration = Duration::from_secs(1 * SECONDS_IN_HOUR);
     pub const REPORT_ONCE_DELAY: Duration = Duration::from_secs(1 * SECONDS_IN_HOUR);
     pub const DISABLED_REPORTING_FILE_NAME: &str = "_reporting_disabled";

--- a/resource/constants.rs
+++ b/resource/constants.rs
@@ -108,14 +108,14 @@ pub mod diagnostics {
 
     pub const SERVICE_REPORTING_URI: &str = "https://diagnostics.typedb.com/";
     pub const POSTHOG_BATCH_REPORTING_URI: &str = "https://us.i.posthog.com/batch/";
-    // The key is read-only and safe to expose
-    pub const POSTHOG_API_KEY: &str = "phc_kee7J4vlLnef61l6krVU8Fg5B6tYIgSEVOyW7yxwLSk"; // TODO: update to prod
+    // The key is write-only and safe to expose
+    pub const POSTHOG_API_KEY: &str = "phc_pYoyROZCtNDL8obeJfLZ8cP0UKzIAxmd0JcQQ03i07T";
 
     pub const REPORT_INTERVAL: Duration = Duration::from_secs(1 * SECONDS_IN_HOUR);
     pub const REPORT_ONCE_DELAY: Duration = Duration::from_secs(1 * SECONDS_IN_HOUR);
 
     pub const REPORT_INITIAL_RETRY_DELAY: Duration = Duration::from_millis(500);
-    pub const REPORT_RETRY_DELAY_EXPONENTIAL_MULTIPLIER: u32 = 3;
+    pub const REPORT_RETRY_DELAY_EXPONENTIAL_MULTIPLIER: u32 = 2;
     pub const REPORT_MAX_RETRY_NUM: u32 = 3;
 
     pub const DISABLED_REPORTING_FILE_NAME: &str = "_reporting_disabled";

--- a/server/parameters/cli.rs
+++ b/server/parameters/cli.rs
@@ -4,6 +4,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 use std::net::SocketAddr;
+
 use clap::{ArgAction, Parser};
 use resource::constants::server::MONITORING_DEFAULT_PORT;
 
@@ -11,7 +12,6 @@ use resource::constants::server::MONITORING_DEFAULT_PORT;
 #[derive(Parser, Debug)]
 #[command(version, about, long_about = None)]
 pub struct CLIArgs {
-
     /// Server host and port, eg., 0.0.0.0:1729
     #[arg(long = "server.address")]
     pub server_address: Option<String>,

--- a/server/parameters/config.rs
+++ b/server/parameters/config.rs
@@ -9,8 +9,9 @@ use std::{
     path::{Path, PathBuf},
     str::FromStr,
 };
-use tokio::net::lookup_host;
+
 use resource::constants::server::{DEFAULT_ADDRESS, DEFAULT_DATA_DIR, MONITORING_DEFAULT_PORT};
+use tokio::net::lookup_host;
 
 #[derive(Debug)]
 pub struct Config {

--- a/server/parameters/config.rs
+++ b/server/parameters/config.rs
@@ -127,7 +127,7 @@ pub(crate) struct StorageConfig {
 pub struct DiagnosticsConfig {
     pub is_monitoring_enabled: bool,
     pub monitoring_port: u16,
-    pub is_service_reporting_enabled: bool,
+    pub is_reporting_enabled: bool,
 }
 
 impl DiagnosticsConfig {
@@ -135,7 +135,7 @@ impl DiagnosticsConfig {
         Self {
             is_monitoring_enabled: true,
             monitoring_port: MONITORING_DEFAULT_PORT,
-            is_service_reporting_enabled: true,
+            is_reporting_enabled: true,
         }
     }
 }

--- a/server/typedb.rs
+++ b/server/typedb.rs
@@ -152,7 +152,7 @@ impl Server {
             distribution.to_owned(),
             version.to_owned(),
             storage_directory,
-            config.is_service_reporting_enabled,
+            config.is_reporting_enabled,
         );
 
         DiagnosticsManager::new(diagnostics, config.monitoring_port, config.is_monitoring_enabled, is_development_mode)

--- a/server/typedb.rs
+++ b/server/typedb.rs
@@ -4,19 +4,19 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-use std::{fs, io, path::PathBuf, sync::Arc};
-use std::net::SocketAddr;
+use std::{fs, io, net::SocketAddr, path::PathBuf, sync::Arc};
+
 use concurrency::IntervalRunner;
 use database::{database_manager::DatabaseManager, DatabaseOpenError};
 use diagnostics::{diagnostics_manager::DiagnosticsManager, Diagnostics};
 use error::typedb_error;
 use rand::Rng;
-use tokio::net::lookup_host;
 use resource::constants::server::{
     DATABASE_METRICS_UPDATE_INTERVAL, GRPC_CONNECTION_KEEPALIVE, SERVER_ID_ALPHABET, SERVER_ID_FILE_NAME,
     SERVER_ID_LENGTH,
 };
 use system::initialise_system_database;
+use tokio::net::lookup_host;
 use tonic::transport::{Certificate, Identity, ServerTlsConfig};
 use user::{initialise_default_user, user_manager::UserManager};
 

--- a/tests/behaviour/steps/connection/mod.rs
+++ b/tests/behaviour/steps/connection/mod.rs
@@ -21,6 +21,7 @@ mod database;
 mod transaction;
 
 const DISTRIBUTION: &str = "TypeDB CE TEST";
+const VERSION: &str = "0.0.0";
 static TYPEDB: OnceCell<(TempDir, Arc<Mutex<typedb::Server>>)> = OnceCell::const_new();
 
 #[apply(generic_step)]
@@ -30,7 +31,7 @@ pub async fn typedb_starts(context: &mut Context) {
         .get_or_init(|| async {
             let server_dir = create_tmp_dir();
             let config = Config::new_with_data_directory(server_dir.as_ref(), true);
-            let server = typedb::Server::open(config, DISTRIBUTION, None).await.unwrap();
+            let server = typedb::Server::open(config, DISTRIBUTION, VERSION, None).await.unwrap();
             (server_dir, Arc::new(Mutex::new(server)))
         })
         .await;


### PR DESCRIPTION
## Release notes: product changes
### Diagnostics
We add PostHog diagnostics events reporting for gathering usage data about users' journeys through TypeDB and enhance the user experience after connecting it with other metrics collected in PostHog. 
The reporting configuration remains the same: the `--diagnostics.reporting.metrics` flag controls both the old (Service diagnostics) and the new (PostHog) reporting, letting a user disable everything in one action.

There are two groups of events sent:
* server usage: hourly heartbeats with deployment/server IDs and the version of the server, can optionally contain information about actions performed without connection to a specific database (opened connection, created user, etc.);
* database usage:  optional event (can be not sent if there is nothing to send), similar to the optional server usage action metrics, but regarding a specific database (created database, opened transaction, executed query). 

The format of the events is the following:
* If nothing happened for the past hour:
```
{
  "batch": [
    {
      "event": "server_usage",
      "properties": {
        "distinct_id": "ARUTFWVJ3MIOJJ50",
        "server_id": "ARUTFWVJ3MIOJJ50",
        "version": "3.0.0-alpha-10"
      }
    }
  ]
}
```
* If anything happened for the past hour for multiple databases:
```
{
  "batch": [
    {
      "event": "database_usage",
      "properties": {
        "distinct_id": "ARUTFWVJ3MIOJJ50",
        "server_id": "ARUTFWVJ3MIOJJ50",
        "version": "3.0.0-alpha-10",
        "databases_presence_checked": 80,
        "databases_created": 81,
        "queries_executed": 237,
        "databases_deleted": 80,
        "transactions_opened": 133,
        "transactions_committed": 57,
        "database": 95615005977010740
      }
    },
    {
      "event": "server_usage",
      "properties": {
        "distinct_id": "ARUTFWVJ3MIOJJ50",
        "server_id": "ARUTFWVJ3MIOJJ50",
        "version": "3.0.0-alpha-10",
        "all_users_retrieved": 79,
        "all_databases_retrieved": 271,
        "connections_opened": 248,
        "authentications_performed": 988
      }
    },
    {
      "event": "database_usage",
      "properties": {
        "distinct_id": "ARUTFWVJ3MIOJJ50",
        "server_id": "ARUTFWVJ3MIOJJ50",
        "version": "3.0.0-alpha-10",
        "databases_deleted": 1,
        "transactions_opened": 2,
        "transactions_committed": 1,
        "databases_presence_checked": 4,
        "databases_created": 1,
        "database": 3619243786487231000
      }
    },
    {
      "event": "database_usage",
      "properties": {
        "distinct_id": "ARUTFWVJ3MIOJJ50",
        "server_id": "ARUTFWVJ3MIOJJ50",
        "version": "3.0.0-alpha-10",
        "databases_created": 1,
        "database": 3244421341483603000
      }
    },
    {
      "event": "database_usage",
      "properties": {
        "distinct_id": "ARUTFWVJ3MIOJJ50",
        "server_id": "ARUTFWVJ3MIOJJ50",
        "version": "3.0.0-alpha-10",
        "databases_presence_checked": 4,
        "database": 2857950145998399500
      }
    },
    {
      "event": "database_usage",
      "properties": {
        "distinct_id": "ARUTFWVJ3MIOJJ50",
        "server_id": "ARUTFWVJ3MIOJJ50",
        "version": "3.0.0-alpha-10",
        "databases_deleted": 1,
        "databases_presence_checked": 1,
        "databases_created": 1,
        "database": 5191865013595434000
      }
    }
  ]
}
```

### Server shutdown
Now, the server is correctly shut down when using `CTRL-C`signal, awaiting for all the background tasks and printing pretty and informative messages:
```
Running TypeDB CE 3.0.0-alpha-10.
Ready!
^C
Received a CTRL-C signal. Shutting down...
Exited.
```
Additionally, we add a feature of sending diagnostics (both types) on server shutdown (if enabled).

## Motivation
Integration with PostHog for management's queries aimed at exploring the quality of the user experience.

## Implementation
### Diagnostics
We introduce two `ReportingEndpoint`s:
* Service / DiagnosticsService (the old one);
* PostHog (the new one).

PostHog reporting is an extension to the already existing `diagnostics/Reporter`. 
The metrics we are interested in are partially `server properties`, `server metrics` (version), and `action metrics`.
Its reporting is controlled by the same mechanisms from the main `report` method.

However, we want this data to be a little more precise, sustainable, and consistent through time (it's acceptable to lose some as it's just diagnostics). So the main differences from diagnostics are:
* Small retries for the event reporting (3 attempts with small increasing timeouts between them);
* These retries introduce a higher delay between creating a diagnostics report and making a snapshot (to take action metrics' diffs every hour). Considering that we'd like to make it less lossy, we use a special, a little more memory-greedy approach of snapshotting: get a json -> take a snapshot -> try sending it -> if not successful, give up and restore the snapshot from its backup. 

With this approach, we achieve the same rule of "if could not send in this hour, combine this data with the data from the next hour on the next attempt", but with an additional retry logic with better precision. 
**This approach is implemented only for PostHog reporting**. Can be extended to the service diagnostics in the future if we like it. 

The shutdown diagnostics reporting does not collide with the regular hourly reporting. The key points of the current naive implementations are:
* If we sent a snapshot of diagnostics a second before the shutdown, we still send an "empty" batch. Is not considered a serious problem for simplicity.
* If we are in the process of waiting for reporting timeouts (currently, its' 500ms, 1s, 4s -> 5.5s in total), we will wait for them to finish as they ignore the drop processing. Again, it doesn't sound too bad now, but it's something to be fixed in the future.

### Shutting down
We discovered (by trying the shut down feature for diagnostics) that we don't actually trigger any `Drop`s because we don't currently shut down our Server's tonic/tokio tasks. Now, it's fixed by using `tokio::signal::ctrl_c()`. 