### PR TITLE
Add concept document streaming from write queries

### DIFF
--- a/common/primitive/either.rs
+++ b/common/primitive/either.rs
@@ -4,6 +4,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
+// TODO: Why don't we use itertools::Either?
 #[derive(Debug)]
 pub enum Either<F, S> {
     First(F),

--- a/server/parameters/config.rs
+++ b/server/parameters/config.rs
@@ -132,11 +132,7 @@ pub struct DiagnosticsConfig {
 
 impl DiagnosticsConfig {
     pub fn enabled() -> Self {
-        Self {
-            is_monitoring_enabled: true,
-            monitoring_port: MONITORING_DEFAULT_PORT,
-            is_reporting_enabled: true,
-        }
+        Self { is_monitoring_enabled: true, monitoring_port: MONITORING_DEFAULT_PORT, is_reporting_enabled: true }
     }
 }
 


### PR DESCRIPTION
## Release notes: product changes
We add concept document streaming from write query pipelines. Previously, we eagerly unwrapped the answers as concept rows, not letting users use `fetch` queries in write pipelines.

## Motivation

## Implementation
