### PR TITLE
Fix rollback and remove dependency on typedb-common

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -141,12 +141,9 @@ docker_base_images()
 # Load @typedb/typedb dependencies #
 #####################################
 
-# We don't load Maven artifacts for @typedb_common as they are only needed
-# if you depend on @typedb_common//test/server
-load("//dependencies/typedb:repositories.bzl", "typedb_common", "typeql", "typedb_protocol", "typedb_behaviour")
+load("//dependencies/typedb:repositories.bzl", "typeql", "typedb_protocol", "typedb_behaviour")
 typedb_behaviour()
 load("@typedb_dependencies//tool/common:deps.bzl", "typedb_dependencies_ci_pip", typedb_dependencies_tool_maven_artifacts = "maven_artifacts")
-typedb_common()
 
 typeql()
 

--- a/dependencies/typedb/repositories.bzl
+++ b/dependencies/typedb/repositories.bzl
@@ -25,13 +25,6 @@ def typeql():
         commit = "059c0332e33a892e6a04bbf83df5634d3d5df249",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @typeql
     )
 
-def typedb_common():
-    git_repository(
-        name = "typedb_common",
-        remote = "https://github.com/typedb/typedb-common",
-        tag = "2.25.3",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @typedb_common
-    )
-
 def typedb_protocol():
     git_repository(
         name = "typedb_protocol",
@@ -43,5 +36,5 @@ def typedb_behaviour():
     git_repository(
         name = "typedb_behaviour",
         remote = "https://github.com/typedb/typedb-behaviour",
-        commit = "0dcd9887f3145e28658aa1dc30eebfd65dbd93e6",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @typedb_behaviour
+        commit = "7e37704295e54056941ede9783f854d2e03331a8",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @typedb_behaviour
     )

--- a/server/service/response_builders.rs
+++ b/server/service/response_builders.rs
@@ -269,6 +269,13 @@ pub(crate) mod transaction {
     ) -> typedb_protocol::transaction::Server {
         transaction_server_res_part(req_id, transaction_res_part_res_part_stream_signal_error(error))
     }
+
+    pub(crate) fn transaction_server_res_rollback_res(
+        req_id: Uuid,
+        message: typedb_protocol::transaction::rollback::Res,
+    ) -> typedb_protocol::transaction::Server {
+        transaction_server_res(req_id, typedb_protocol::transaction::res::Res::RollbackRes(message))
+    }
 }
 
 pub(crate) mod user_manager {

--- a/tests/behaviour/steps/connection/transaction.rs
+++ b/tests/behaviour/steps/connection/transaction.rs
@@ -169,8 +169,14 @@ pub async fn transaction_rollbacks(context: &mut Context, may_error: params::May
                 BehaviourConnectionTestExecutionError::CannotRollbackReadTransaction,
             ));
         }
-        ActiveTransaction::Write(mut tx) => tx.rollback(),
-        ActiveTransaction::Schema(mut tx) => tx.rollback(),
+        ActiveTransaction::Write(mut tx) => {
+            tx.rollback();
+            context.set_transaction(ActiveTransaction::Write(tx))
+        }
+        ActiveTransaction::Schema(mut tx) => {
+            tx.rollback();
+            context.set_transaction(ActiveTransaction::Schema(tx))
+        }
     }
 }
 


### PR DESCRIPTION
## Release notes: product changes
We fix the `rollback` feature, which used to hang the transaction operated from an external driver, not allowing the operations to proceed correctly.

Additionally, we remove an outdated Bazel dependency on `typedb-common`, which is no longer needed for TypeDB 3.0.

## Motivation

## Implementation
There were two issues:
* We didn't return the transaction into the member of the service, so it got lost for the future operations;
* We could not receive any more operations for the transaction stream as the driver did not receive any response on this operation, while the `ControlFlow` was hanging on `Continue`.