### PR TITLE
Update grouped reduction syntax and add reduction tests

### DIFF
--- a/.factory/automation.yml
+++ b/.factory/automation.yml
@@ -120,6 +120,7 @@ build:
         bazel run @typedb_dependencies//tool/bazelinstall:remote_cache_setup.sh
         bazel test //tests/behaviour/query/language:test_match --test_output=streamed
         bazel test //tests/behaviour/query/language:test_fetch --test_output=streamed
+        bazel test //tests/behaviour/query/language:test_reduce --test_output=streamed
 #        bazel test //tests/behaviour/query/language:test_expressions --test_output=streamed
 #        bazel test //tests/behaviour/query/language:test_modifiers --test_output=streamed
 #        bazel test //tests/behaviour/query/language:test_get --test_output=streamed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3718,7 +3718,7 @@ dependencies = [
 [[package]]
 name = "typedb-protocol"
 version = "0.0.0"
-source = "git+https://github.com/typedb/typedb-protocol?rev=3ead863d3a4b15a35178ea9212bc70d0a489bbea#3ead863d3a4b15a35178ea9212bc70d0a489bbea"
+source = "git+https://github.com/typedb/typedb-protocol?tag=3.0.0#111f1a9ed8aac3360c0b5d16e68c1ecebe823137"
 dependencies = [
  "prost",
  "tonic",
@@ -3747,7 +3747,7 @@ checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
 [[package]]
 name = "typeql"
 version = "0.0.0"
-source = "git+https://github.com/typedb/typeql?rev=8acf8f2164181874d33915573f5dc09f4ab46a9e#8acf8f2164181874d33915573f5dc09f4ab46a9e"
+source = "git+https://github.com/typedb/typeql?rev=804d937b3f76383aa60df2909517ea6e90f2dabf#804d937b3f76383aa60df2909517ea6e90f2dabf"
 dependencies = [
  "chrono",
  "itertools 0.10.5",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3747,7 +3747,7 @@ checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
 [[package]]
 name = "typeql"
 version = "0.0.0"
-source = "git+https://github.com/typedb/typeql?rev=804d937b3f76383aa60df2909517ea6e90f2dabf#804d937b3f76383aa60df2909517ea6e90f2dabf"
+source = "git+https://github.com/typedb/typeql?rev=059c0332e33a892e6a04bbf83df5634d3d5df249#059c0332e33a892e6a04bbf83df5634d3d5df249"
 dependencies = [
  "chrono",
  "itertools 0.10.5",

--- a/common/error/Cargo.toml
+++ b/common/error/Cargo.toml
@@ -16,7 +16,7 @@ features = {}
 
 	[dependencies.typeql]
 		features = []
-		rev = "8acf8f2164181874d33915573f5dc09f4ab46a9e"
+		rev = "804d937b3f76383aa60df2909517ea6e90f2dabf"
 		git = "https://github.com/typedb/typeql"
 		default-features = false
 

--- a/common/error/Cargo.toml
+++ b/common/error/Cargo.toml
@@ -16,7 +16,7 @@ features = {}
 
 	[dependencies.typeql]
 		features = []
-		rev = "804d937b3f76383aa60df2909517ea6e90f2dabf"
+		rev = "059c0332e33a892e6a04bbf83df5634d3d5df249"
 		git = "https://github.com/typedb/typeql"
 		default-features = false
 

--- a/common/structural_equality/Cargo.toml
+++ b/common/structural_equality/Cargo.toml
@@ -21,7 +21,7 @@ features = {}
 
 	[dependencies.typeql]
 		features = []
-		rev = "804d937b3f76383aa60df2909517ea6e90f2dabf"
+		rev = "059c0332e33a892e6a04bbf83df5634d3d5df249"
 		git = "https://github.com/typedb/typeql"
 		default-features = false
 

--- a/common/structural_equality/Cargo.toml
+++ b/common/structural_equality/Cargo.toml
@@ -21,7 +21,7 @@ features = {}
 
 	[dependencies.typeql]
 		features = []
-		rev = "8acf8f2164181874d33915573f5dc09f4ab46a9e"
+		rev = "804d937b3f76383aa60df2909517ea6e90f2dabf"
 		git = "https://github.com/typedb/typeql"
 		default-features = false
 

--- a/compiler/Cargo.toml
+++ b/compiler/Cargo.toml
@@ -58,7 +58,7 @@ features = {}
 
 	[dependencies.typeql]
 		features = []
-		rev = "804d937b3f76383aa60df2909517ea6e90f2dabf"
+		rev = "059c0332e33a892e6a04bbf83df5634d3d5df249"
 		git = "https://github.com/typedb/typeql"
 		default-features = false
 

--- a/compiler/Cargo.toml
+++ b/compiler/Cargo.toml
@@ -36,12 +36,12 @@ features = {}
 
 [dependencies]
 
-  [dependencies.tracing]
+	[dependencies.tracing]
 		features = ["attributes", "default", "log", "std", "tracing-attributes"]
-		version = "0.1.40"
+		version = "0.1.41"
 		default-features = false
 
-  [dependencies.answer]
+	[dependencies.answer]
 		path = "../answer"
 		features = []
 		default-features = false
@@ -58,7 +58,7 @@ features = {}
 
 	[dependencies.typeql]
 		features = []
-		rev = "8acf8f2164181874d33915573f5dc09f4ab46a9e"
+		rev = "804d937b3f76383aa60df2909517ea6e90f2dabf"
 		git = "https://github.com/typedb/typeql"
 		default-features = false
 

--- a/compiler/executable/pipeline.rs
+++ b/compiler/executable/pipeline.rs
@@ -278,8 +278,8 @@ fn compile_stage(
         AnnotatedStage::Reduce(reduce, typed_reducers) => {
             debug_assert_eq!(reduce.assigned_reductions.len(), typed_reducers.len());
             let mut output_row_mapping = HashMap::new();
-            let mut input_group_positions = Vec::with_capacity(reduce.within_group.len());
-            for variable in reduce.within_group.iter() {
+            let mut input_group_positions = Vec::with_capacity(reduce.groupby.len());
+            for variable in reduce.groupby.iter() {
                 output_row_mapping.insert(*variable, VariablePosition::new(input_group_positions.len() as u32));
                 input_group_positions.push(input_variables[variable]);
             }

--- a/database/Cargo.toml
+++ b/database/Cargo.toml
@@ -103,7 +103,7 @@ features = {}
 
 	[dependencies.typeql]
 		features = []
-		rev = "804d937b3f76383aa60df2909517ea6e90f2dabf"
+		rev = "059c0332e33a892e6a04bbf83df5634d3d5df249"
 		git = "https://github.com/typedb/typeql"
 		default-features = false
 

--- a/database/Cargo.toml
+++ b/database/Cargo.toml
@@ -103,7 +103,7 @@ features = {}
 
 	[dependencies.typeql]
 		features = []
-		rev = "8acf8f2164181874d33915573f5dc09f4ab46a9e"
+		rev = "804d937b3f76383aa60df2909517ea6e90f2dabf"
 		git = "https://github.com/typedb/typeql"
 		default-features = false
 

--- a/dependencies/typedb/repositories.bzl
+++ b/dependencies/typedb/repositories.bzl
@@ -22,7 +22,7 @@ def typeql():
     git_repository(
         name = "typeql",
         remote = "https://github.com/typedb/typeql",
-        commit = "804d937b3f76383aa60df2909517ea6e90f2dabf",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @typeql
+        commit = "059c0332e33a892e6a04bbf83df5634d3d5df249",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @typeql
     )
 
 def typedb_common():
@@ -43,5 +43,5 @@ def typedb_behaviour():
     git_repository(
         name = "typedb_behaviour",
         remote = "https://github.com/typedb/typedb-behaviour",
-        commit = "5a89a6c2862ad51cc09e7ebc67103301cffc35f6",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @typedb_behaviour
+        commit = "0dcd9887f3145e28658aa1dc30eebfd65dbd93e6",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @typedb_behaviour
     )

--- a/dependencies/typedb/repositories.bzl
+++ b/dependencies/typedb/repositories.bzl
@@ -22,7 +22,7 @@ def typeql():
     git_repository(
         name = "typeql",
         remote = "https://github.com/typedb/typeql",
-        tag = "3.0.0",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @typeql
+        commit = "804d937b3f76383aa60df2909517ea6e90f2dabf",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @typeql
     )
 
 def typedb_common():
@@ -43,5 +43,5 @@ def typedb_behaviour():
     git_repository(
         name = "typedb_behaviour",
         remote = "https://github.com/typedb/typedb-behaviour",
-        commit = "d71aef0cf878c5515e48a86dfe0e5082e3cd6044",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @typedb_behaviour
+        commit = "5a89a6c2862ad51cc09e7ebc67103301cffc35f6",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @typedb_behaviour
     )

--- a/executor/Cargo.toml
+++ b/executor/Cargo.toml
@@ -113,7 +113,7 @@ features = {}
 
 	[dependencies.typeql]
 		features = []
-		rev = "804d937b3f76383aa60df2909517ea6e90f2dabf"
+		rev = "059c0332e33a892e6a04bbf83df5634d3d5df249"
 		git = "https://github.com/typedb/typeql"
 		default-features = false
 

--- a/executor/Cargo.toml
+++ b/executor/Cargo.toml
@@ -113,7 +113,7 @@ features = {}
 
 	[dependencies.typeql]
 		features = []
-		rev = "8acf8f2164181874d33915573f5dc09f4ab46a9e"
+		rev = "804d937b3f76383aa60df2909517ea6e90f2dabf"
 		git = "https://github.com/typedb/typeql"
 		default-features = false
 

--- a/function/Cargo.toml
+++ b/function/Cargo.toml
@@ -93,7 +93,7 @@ features = {}
 
 	[dependencies.typeql]
 		features = []
-		rev = "804d937b3f76383aa60df2909517ea6e90f2dabf"
+		rev = "059c0332e33a892e6a04bbf83df5634d3d5df249"
 		git = "https://github.com/typedb/typeql"
 		default-features = false
 

--- a/function/Cargo.toml
+++ b/function/Cargo.toml
@@ -93,7 +93,7 @@ features = {}
 
 	[dependencies.typeql]
 		features = []
-		rev = "8acf8f2164181874d33915573f5dc09f4ab46a9e"
+		rev = "804d937b3f76383aa60df2909517ea6e90f2dabf"
 		git = "https://github.com/typedb/typeql"
 		default-features = false
 

--- a/ir/Cargo.toml
+++ b/ir/Cargo.toml
@@ -88,7 +88,7 @@ features = {}
 
 	[dependencies.typeql]
 		features = []
-		rev = "804d937b3f76383aa60df2909517ea6e90f2dabf"
+		rev = "059c0332e33a892e6a04bbf83df5634d3d5df249"
 		git = "https://github.com/typedb/typeql"
 		default-features = false
 

--- a/ir/Cargo.toml
+++ b/ir/Cargo.toml
@@ -88,7 +88,7 @@ features = {}
 
 	[dependencies.typeql]
 		features = []
-		rev = "8acf8f2164181874d33915573f5dc09f4ab46a9e"
+		rev = "804d937b3f76383aa60df2909517ea6e90f2dabf"
 		git = "https://github.com/typedb/typeql"
 		default-features = false
 

--- a/ir/pipeline/reduce.rs
+++ b/ir/pipeline/reduce.rs
@@ -15,12 +15,12 @@ use structural_equality::StructuralEquality;
 #[derive(Debug, Clone)]
 pub struct Reduce {
     pub assigned_reductions: Vec<AssignedReduction>,
-    pub within_group: Vec<Variable>,
+    pub groupby: Vec<Variable>,
 }
 
 impl Reduce {
-    pub(crate) fn new(assigned_reductions: Vec<AssignedReduction>, within_group: Vec<Variable>) -> Self {
-        Self { assigned_reductions, within_group }
+    pub(crate) fn new(assigned_reductions: Vec<AssignedReduction>, groupby: Vec<Variable>) -> Self {
+        Self { assigned_reductions, groupby }
     }
 
     pub fn variables(&self) -> impl Iterator<Item = Variable> + '_ {
@@ -28,7 +28,7 @@ impl Reduce {
             .iter()
             .map(|assign_reduction| &assign_reduction.assigned)
             .cloned()
-            .chain(self.within_group.iter().cloned())
+            .chain(self.groupby.iter().cloned())
     }
 }
 
@@ -37,13 +37,13 @@ impl StructuralEquality for Reduce {
         // TODO: these really could be order-free
         let mut hasher = DefaultHasher::new();
         hasher.write_u64(self.assigned_reductions.hash());
-        hasher.write_u64(self.within_group.hash());
+        hasher.write_u64(self.groupby.hash());
         hasher.finish()
     }
 
     fn equals(&self, other: &Self) -> bool {
         // TODO: these really could be order-free
-        self.assigned_reductions.equals(&other.assigned_reductions) && self.within_group.equals(&other.within_group)
+        self.assigned_reductions.equals(&other.assigned_reductions) && self.groupby.equals(&other.groupby)
     }
 }
 

--- a/ir/translation/pipeline.rs
+++ b/ir/translation/pipeline.rs
@@ -85,7 +85,7 @@ impl TranslatedStage {
             Self::Offset(_) => Box::new(empty()),
             Self::Limit(_) => Box::new(empty()),
             Self::Require(require) => Box::new(require.variables.iter().cloned()),
-            Self::Reduce(reduce) => Box::new(reduce.within_group.iter().cloned()),
+            Self::Reduce(reduce) => Box::new(reduce.groupby.iter().cloned()),
         }
     }
 }

--- a/ir/translation/reduce.rs
+++ b/ir/translation/reduce.rs
@@ -32,7 +32,7 @@ pub fn translate_reduce(
         reductions.push(AssignedReduction::new(assigned_var, reducer));
     }
 
-    let group = match &typeql_reduce.within_group {
+    let group = match &typeql_reduce.groupby {
         None => Vec::new(),
         Some(group) => group
             .iter()

--- a/query/Cargo.toml
+++ b/query/Cargo.toml
@@ -123,7 +123,7 @@ features = {}
 
 	[dependencies.typeql]
 		features = []
-		rev = "8acf8f2164181874d33915573f5dc09f4ab46a9e"
+		rev = "804d937b3f76383aa60df2909517ea6e90f2dabf"
 		git = "https://github.com/typedb/typeql"
 		default-features = false
 

--- a/query/Cargo.toml
+++ b/query/Cargo.toml
@@ -123,7 +123,7 @@ features = {}
 
 	[dependencies.typeql]
 		features = []
-		rev = "804d937b3f76383aa60df2909517ea6e90f2dabf"
+		rev = "059c0332e33a892e6a04bbf83df5634d3d5df249"
 		git = "https://github.com/typedb/typeql"
 		default-features = false
 

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -86,7 +86,7 @@ features = {}
 
 	[dependencies.typeql]
 		features = []
-		rev = "8acf8f2164181874d33915573f5dc09f4ab46a9e"
+		rev = "804d937b3f76383aa60df2909517ea6e90f2dabf"
 		git = "https://github.com/typedb/typeql"
 		default-features = false
 
@@ -112,8 +112,8 @@ features = {}
 
 	[dependencies.typedb-protocol]
 		features = []
-		rev = "3ead863d3a4b15a35178ea9212bc70d0a489bbea"
 		git = "https://github.com/typedb/typedb-protocol"
+		tag = "3.0.0"
 		default-features = false
 
 	[dependencies.resource]

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -86,7 +86,7 @@ features = {}
 
 	[dependencies.typeql]
 		features = []
-		rev = "804d937b3f76383aa60df2909517ea6e90f2dabf"
+		rev = "059c0332e33a892e6a04bbf83df5634d3d5df249"
 		git = "https://github.com/typedb/typeql"
 		default-features = false
 

--- a/system/Cargo.toml
+++ b/system/Cargo.toml
@@ -76,7 +76,7 @@ features = {}
 
 	[dependencies.typeql]
 		features = []
-		rev = "8acf8f2164181874d33915573f5dc09f4ab46a9e"
+		rev = "804d937b3f76383aa60df2909517ea6e90f2dabf"
 		git = "https://github.com/typedb/typeql"
 		default-features = false
 

--- a/system/Cargo.toml
+++ b/system/Cargo.toml
@@ -76,7 +76,7 @@ features = {}
 
 	[dependencies.typeql]
 		features = []
-		rev = "804d937b3f76383aa60df2909517ea6e90f2dabf"
+		rev = "059c0332e33a892e6a04bbf83df5634d3d5df249"
 		git = "https://github.com/typedb/typeql"
 		default-features = false
 

--- a/tests/behaviour/steps/Cargo.toml
+++ b/tests/behaviour/steps/Cargo.toml
@@ -81,7 +81,7 @@ features = {}
 
 	[dependencies.typeql]
 		features = []
-		rev = "804d937b3f76383aa60df2909517ea6e90f2dabf"
+		rev = "059c0332e33a892e6a04bbf83df5634d3d5df249"
 		git = "https://github.com/typedb/typeql"
 		default-features = false
 

--- a/tests/behaviour/steps/Cargo.toml
+++ b/tests/behaviour/steps/Cargo.toml
@@ -81,7 +81,7 @@ features = {}
 
 	[dependencies.typeql]
 		features = []
-		rev = "8acf8f2164181874d33915573f5dc09f4ab46a9e"
+		rev = "804d937b3f76383aa60df2909517ea6e90f2dabf"
 		git = "https://github.com/typedb/typeql"
 		default-features = false
 

--- a/user/Cargo.toml
+++ b/user/Cargo.toml
@@ -46,7 +46,7 @@ features = {}
 
 	[dependencies.typeql]
 		features = []
-		rev = "8acf8f2164181874d33915573f5dc09f4ab46a9e"
+		rev = "804d937b3f76383aa60df2909517ea6e90f2dabf"
 		git = "https://github.com/typedb/typeql"
 		default-features = false
 

--- a/user/Cargo.toml
+++ b/user/Cargo.toml
@@ -46,7 +46,7 @@ features = {}
 
 	[dependencies.typeql]
 		features = []
-		rev = "804d937b3f76383aa60df2909517ea6e90f2dabf"
+		rev = "059c0332e33a892e6a04bbf83df5634d3d5df249"
 		git = "https://github.com/typedb/typeql"
 		default-features = false
 


### PR DESCRIPTION
## Release notes: product changes

We use the new grouped-reduction syntax. So we no longer use 'within':
```
match $x...; $y ...;
reduce $count = count($x) within $y;
```
and we now write:
```
match $x...; $y ...;
reduce $count = count($x) groupby $y;
```

## Motivation

We use a more standard notation for grouping, instead of inventing our own -- and we also add reduction tests to the default CI run configuration.
