### PR TITLE
Improve TypeDB error macro

### DIFF
--- a/common/error/error.rs
+++ b/common/error/error.rs
@@ -121,7 +121,7 @@ macro_rules! typedb_error {
         impl $crate::TypeDBError for $name {
             fn variant_name(&self) -> &'static str {
                 match self {
-                    $(Self::$variant { .. } => &stringify!($variant),)*
+                    $(Self::$variant { .. } => stringify!($variant),)*
                 }
             }
 
@@ -131,7 +131,7 @@ macro_rules! typedb_error {
 
             fn code(&self) -> &'static str {
                 match self {
-                    $(Self::$variant { .. } => & concat!($prefix, stringify!($number)),)*
+                    $(Self::$variant { .. } => concat!($prefix, stringify!($number)),)*
                 }
             }
 

--- a/common/error/error.rs
+++ b/common/error/error.rs
@@ -104,41 +104,24 @@ impl<T: TypeDBError> TypeDBError for Box<T> {
 // ***USAGE WARNING***: We should not set both Source and TypeDBSource, TypeDBSource has precedence!
 #[macro_export]
 macro_rules! typedb_error {
-    ( $vis: vis $name:ident(component = $component: literal, prefix = $prefix: literal) { $(
-        $variant: ident (
-            $number: literal,
-            $description: literal
-            $(, $payload_name: ident : $payload_type: ty )*
-            $(, ( source : $source: ty ) )?
-            $(, ( typedb_source : $typedb_source: ty ) )?
-        ),
+    ($vis:vis $name:ident(component = $component:literal, prefix = $prefix:literal) { $(
+        $variant:ident($number:literal, $description:literal $(, $($arg:tt)*)?),
     )*}) => {
         #[derive(Clone)]
         $vis enum $name {
-            $(
-                $variant { $(source: $source, )? $(typedb_source: $typedb_source, )? $($payload_name: $payload_type, )* },
-            )*
-
+            $($variant { $($($arg)*)? }),*
         }
 
-        impl $name {
-            const _VALIDATE_NUMBERS: () = {
-                #[deny(unreachable_patterns)] // fail to compile if any Numbers are the same
-                match 0 {
-                    $(
-                        $number => (),
-                    )*
-                    _ => (),
-               }
-           };
-        }
+        const _: () = {
+            // fail to compile if any Numbers are the same
+            trait Assert {}
+            $(impl Assert for [(); $number ] {})*
+        };
 
         impl $crate::TypeDBError for $name {
             fn variant_name(&self) -> &'static str {
                 match self {
-                    $(
-                        Self::$variant { .. } => &stringify!($variant),
-                    )*
+                    $(Self::$variant { .. } => &stringify!($variant),)*
                 }
             }
 
@@ -148,9 +131,7 @@ macro_rules! typedb_error {
 
             fn code(&self) -> &'static str {
                 match self {
-                    $(
-                        Self::$variant { .. } => & concat!($prefix, stringify!($number)),
-                    )*
+                    $(Self::$variant { .. } => & concat!($prefix, stringify!($number)),)*
                 }
             }
 
@@ -160,51 +141,81 @@ macro_rules! typedb_error {
 
             fn code_number(&self) -> usize {
                 match self {
-                    $(
-                        Self::$variant { .. } => $number,
-                    )*
+                    $(Self::$variant { .. } => $number,)*
                 }
             }
 
             fn format_description(&self) -> String {
                 match self {
-                    $(
-                        Self::$variant { $( $payload_name, )* .. } => format!($description),
-                    )*
+                    $(typedb_error!(@args $variant { $($($arg)*)? }) => format!($description),)*
                 }
             }
 
             fn source(&self) -> Option<&(dyn ::std::error::Error + Sync + 'static)> {
-                let error = match self {
-                    $(
-                        $(Self::$variant { source, .. } => {
-                            let source: &$source = source;
-                            Some(source as &(dyn ::std::error::Error + Sync))
-                        })?
-                    )*
-                    _ => None
-                };
-                error
+                match self {
+                    $(typedb_error!(@source source from $variant { $($($arg)*)? })=> {
+                        typedb_error!(@source source { $($($arg)*)? })
+                    })*
+                }
             }
 
             fn source_typedb_error(&self) -> Option<&(dyn $crate::TypeDBError + Sync + 'static)> {
-                let error = match self {
-                    $(
-                        $(Self::$variant { typedb_source, .. } => {
-                            let typedb_source: &$typedb_source = typedb_source;
-                            Some(typedb_source as &(dyn $crate::TypeDBError + Sync))
-                        })?
-                    )*
-                    _ => None
-                };
-                error
+                match self {
+                    $(typedb_error!(@typedb_source typedb_source from $variant { $($($arg)*)? })=> {
+                        typedb_error!(@typedb_source typedb_source { $($($arg)*)? })
+                    })*
+                }
             }
         }
 
         impl ::std::fmt::Debug for $name {
-           fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+        fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
                 ::std::fmt::Debug::fmt(self as &dyn $crate::TypeDBError, f)
             }
         }
+    };
+
+    (@args $variant:ident { $($arg:ident : $ty:ty),* $(,)? }) => {
+        Self::$variant { $($arg),* }
+    };
+
+    (@source $ts:ident from $variant:ident { source : $argty:ty $(, $($rest:tt)*)? }) => {
+        Self::$variant { source: $ts, .. }
+    };
+    (@source $ts:ident from $variant:ident { $arg:ident : $argty:ty $(, $($rest:tt)*)? }) => {
+        typedb_error!(@source $ts from $variant { $($($rest)*)? })
+    };
+    (@source $ts:ident from $variant:ident { $(,)? }) => {
+        Self::$variant { .. }
+    };
+
+    (@source $ts:ident { source: $_:ty $(, $($rest:tt)*)? }) => {
+        Some($ts as &(dyn ::std::error::Error + Sync + 'static))
+    };
+    (@source $ts:ident { $arg:ident : $argty:ty $(, $($rest:tt)*)? }) => {
+        typedb_error!(@source $ts { $($($rest)*)? })
+    };
+    (@source $ts:ident { $(,)? }) => {
+        None
+    };
+
+    (@typedb_source $ts:ident from $variant:ident { typedb_source : $argty:ty $(, $($rest:tt)*)? }) => {
+        Self::$variant { typedb_source: $ts, .. }
+    };
+    (@typedb_source $ts:ident from $variant:ident { $arg:ident : $argty:ty $(, $($rest:tt)*)? }) => {
+        typedb_error!(@typedb_source $ts from $variant { $($($rest)*)? })
+    };
+    (@typedb_source $ts:ident from $variant:ident { $(,)? }) => {
+        Self::$variant { .. }
+    };
+
+    (@typedb_source $ts:ident { typedb_source: $_:ty $(, $($rest:tt)*)? }) => {
+        Some($ts as &(dyn $crate::TypeDBError + Sync + 'static))
+    };
+    (@typedb_source $ts:ident { $arg:ident : $argty:ty $(, $($rest:tt)*)? }) => {
+        typedb_error!(@typedb_source $ts { $($($rest)*)? })
+    };
+    (@typedb_source $ts:ident { $(,)? }) => {
+        None
     };
 }

--- a/compiler/annotation/match_inference.rs
+++ b/compiler/annotation/match_inference.rs
@@ -122,7 +122,9 @@ pub fn infer_types(
     let type_annotations = TypeAnnotations::new(vertex_annotations, constraint_annotations);
     debug_assert!(block.block_context().referenced_variables().all(|var| {
         match variable_registry.get_variable_category(var) {
-            None => todo!("Safe to ignore. But can we know the ValueTypeCategory of an assignment at translation?"),
+            None => {
+                unreachable!("Safe to ignore. But can we know the ValueTypeCategory of an assignment at translation?")
+            }
             Some(VariableCategory::Value) | Some(VariableCategory::ValueList) => true,
             Some(_) => type_annotations.vertex_annotations_of(&Vertex::Variable(var)).is_some(),
         }

--- a/compiler/annotation/mod.rs
+++ b/compiler/annotation/mod.rs
@@ -23,34 +23,85 @@ mod type_seeder;
 typedb_error!(
     pub AnnotationError(component = "Query annotation", prefix = "QUA") {
         Unimplemented(0, "Unimplemented: {description}", description: String),
-        TypeInference(1, "Type inference error while compiling query annotations.", ( typedb_source : TypeInferenceError )),
-        PreambleTypeInference(2, "Type inference error while compiling query preamble functions.", ( typedb_source : Box<FunctionAnnotationError> )),
-        ExpressionCompilation(3, "Error inferring correct expression types.", ( source : Box<ExpressionCompileError> )),
-        FetchEntry(4, "Error during type inference for fetch operation for key '{key}'.", key: String, (typedb_source : Box<AnnotationError> )),
-        FetchBlockFunctionInferenceError(5, "Error during type inference for fetch sub-query.", (typedb_source : Box<FunctionAnnotationError> )),
-        ConceptRead(6, "Error while retrieving concept.", (source: Box<ConceptReadError> )),
+        TypeInference(1, "Type inference error while compiling query annotations.", typedb_source: TypeInferenceError),
+        PreambleTypeInference(2, "Type inference error while compiling query preamble functions.", typedb_source: Box<FunctionAnnotationError>),
+        ExpressionCompilation(3, "Error inferring correct expression types.", source: Box<ExpressionCompileError>),
+        FetchEntry(4, "Error during type inference for fetch operation for key '{key}'.", key: String, typedb_source: Box<AnnotationError>),
+        FetchBlockFunctionInferenceError(5, "Error during type inference for fetch sub-query.", typedb_source: Box<FunctionAnnotationError>),
+        ConceptRead(6, "Error while retrieving concept.", source: Box<ConceptReadError>),
         FetchAttributeNotFound(7, "Fetching '${var}.{name}' failed since the attribute type is not defined.", var: String, name: String),
-        FetchSingleAttributeNotOwned(8, "Type checking '${var}.{attribute}' failed, since attribute '{attribute}' cannot be when '${var}' has type '{owner}'.", var: String, owner: String, attribute: String),
-        FetchAttributesNotOwned(9, "Type checking '[${var}.{attribute}]' failed, since attribute '{attribute}' cannot be when '${var}' has type '{owner}'.", var: String, owner: String, attribute: String),
-        FetchSingleAttributeCannotBeOwnedByKind(10, "Type checking '${var}.{attribute}' failed, since attribute '{attribute}' cannot be when '${var}' has kind '{kind}'.", var: String, kind: String, attribute: String),
-        FetchAttributesCannotBeOwnedByKind(11, "Type checking '[${var}.{attribute}]' failed, since attribute '{attribute}' cannot be when '${var}' has kind '{kind}'.", var: String, kind: String, attribute: String),
-        AttributeFetchCardTooHigh(12, "Fetch attribute '${var}.{attribute}' must be wrapped in '[]', since this attribute can be owned more than 1 time when '${var}' has type '{owner}', according to the schema's cardinality constraints.", var: String, owner: String, attribute: String),
-        CouldNotDetermineValueTypeForReducerInput(13, "The value-type for the reducer input variable '{variable}' could not be determined.", variable: String),
-        ReducerInputVariableDidNotHaveSingleValueType(14, "The reducer input variable '{variable}' had multiple value-types.", variable: String),
-        UnsupportedValueTypeForReducer(15, "The input variable to the reducer'{reducer}({variable})' reducer had an unsupported value-type: '{value_type}'", reducer: String, variable: String, value_type: ValueTypeCategory),
-        UncomparableValueTypesForSortVariable(16, "The sort variable '{variable}' could return incomparable value-types '{category1}' & '{category2}'.", variable: String, category1: ValueTypeCategory, category2: ValueTypeCategory),
-        ReducerInputVariableIsList(17, "The input variable '{variable}' to the reducer '{reducer}' was a list.", reducer: String, variable: String),
+        FetchSingleAttributeNotOwned(
+            8,
+            "Type checking '${var}.{attribute}' failed, since attribute '{attribute}' cannot be when '${var}' has type '{owner}'.",
+            var: String,
+            owner: String,
+            attribute: String,
+        ),
+        FetchAttributesNotOwned(
+            9,
+            "Type checking '[${var}.{attribute}]' failed, since attribute '{attribute}' cannot be when '${var}' has type '{owner}'.",
+            var: String,
+            owner: String,
+            attribute: String,
+        ),
+        FetchSingleAttributeCannotBeOwnedByKind(
+            10,
+            "Type checking '${var}.{attribute}' failed, since attribute '{attribute}' cannot be when '${var}' has kind '{kind}'.",
+            var: String,
+            kind: String,
+            attribute: String,
+        ),
+        FetchAttributesCannotBeOwnedByKind(
+            11,
+            "Type checking '[${var}.{attribute}]' failed, since attribute '{attribute}' cannot be when '${var}' has kind '{kind}'.",
+            var: String,
+            kind: String,
+            attribute: String,
+        ),
+        AttributeFetchCardTooHigh(
+            12,
+            "Fetch attribute '${var}.{attribute}' must be wrapped in '[]', since this attribute can be owned more than 1 time when '${var}' has type '{owner}', according to the schema's cardinality constraints.",
+            var: String,
+            owner: String,
+            attribute: String,
+        ),
+        CouldNotDetermineValueTypeForReducerInput(
+            13, "The value-type for the reducer input variable '{variable}' could not be determined.", variable: String,
+        ),
+        ReducerInputVariableDidNotHaveSingleValueType(
+            14, "The reducer input variable '{variable}' had multiple value-types.", variable: String,
+        ),
+        UnsupportedValueTypeForReducer(
+            15,
+            "The input variable to the reducer'{reducer}({variable})' reducer had an unsupported value-type: '{value_type}'",
+            reducer: String,
+            variable: String,
+            value_type: ValueTypeCategory,
+        ),
+        UncomparableValueTypesForSortVariable(
+            16,
+            "The sort variable '{variable}' could return incomparable value-types '{category1}' & '{category2}'.",
+            variable: String,
+            category1: ValueTypeCategory,
+            category2: ValueTypeCategory,
+        ),
+        ReducerInputVariableIsList(
+            17,
+            "The input variable '{variable}' to the reducer '{reducer}' was a list.",
+            reducer: String,
+            variable: String,
+        ),
     }
 );
 
 typedb_error!(
     pub FunctionAnnotationError(component = "Function type inference", prefix = "FIN") {
-        TypeInference(0, "Type inference error while type checking function '{name}'.", name: String, ( typedb_source : Box<AnnotationError> )),
+        TypeInference(0, "Type inference error while type checking function '{name}'.", name: String, typedb_source: Box<AnnotationError>),
         CouldNotResolveArgumentType(
             1,
             "An error occurred when trying to resolve the type of the argument at index: {index}.",
             index: usize,
-            source: TypeInferenceError
+            typedb_source: TypeInferenceError
         ),
         CallerSignatureTypeMismatch(
             2,
@@ -77,25 +128,25 @@ typedb_error!(
             5,
             "An error occurred when trying to resolve the type at return index: {index}.",
             index: usize,
-            source: TypeInferenceError
+            typedb_source: TypeInferenceError
         ),
         ReturnReduce(
             6,
             "Error analysing return reduction.",
-            ( typedb_source : Box<AnnotationError> )
+            typedb_source: Box<AnnotationError>,
         ),
         SignatureReturnMismatch(
             7,
             "The types inferred for the return statement of function \"{function_name}\" did not match those declared in the signature. Mismatching index: {mismatching_index}",
             function_name: String,
-            mismatching_index: usize
+            mismatching_index: usize,
         ),
     }
 );
 
 typedb_error!(
     pub TypeInferenceError(component = "Type inference", prefix = "INF") {
-        ConceptRead(1, "Concept read error.", ( source: Box<ConceptReadError> )),
+        ConceptRead(1, "Concept read error.", source: Box<ConceptReadError>),
         LabelNotResolved(2, "Type label '{name}' not found.", name: String),
         RoleNameNotResolved(3, "Role label not found '{name}'.", name: String),
         IllegalInsertTypes(
@@ -117,6 +168,8 @@ typedb_error!(
             label: String
         ),
         ValueTypeNotFound(8, "Value type '{name}' was not found.", name: String),
+        OptionalTypesUnsupported(255, "Optional types are not yet supported."),
+        ListTypesUnsupported(256, "List types are not yet supported."),
     }
 );
 

--- a/compiler/executable/fetch/executable.rs
+++ b/compiler/executable/fetch/executable.rs
@@ -179,7 +179,7 @@ fn compile_some(
 typedb_error!(
     pub FetchCompilationError(component = "Fetch compilation", prefix = "FEC") {
         FetchVariableNotFound(1, "Internal compilation error - fetch variable {var} not found in expected inputs", var: Variable),
-        AnonymousFunctionCompilation(2, "Failed to compile inline/anonymous function.", ( typedb_source : Box<ExecutableCompilationError>)),
-        SubFetchCompilation(3, "Failed to compile sub-fetch pipeline.", ( typedb_source : Box<ExecutableCompilationError>)),
+        AnonymousFunctionCompilation(2, "Failed to compile inline/anonymous function.", typedb_source: Box<ExecutableCompilationError>),
+        SubFetchCompilation(3, "Failed to compile sub-fetch pipeline.", typedb_source: Box<ExecutableCompilationError>),
     }
 );

--- a/compiler/executable/match_/planner/plan.rs
+++ b/compiler/executable/match_/planner/plan.rs
@@ -1203,7 +1203,7 @@ impl Ord for StepExtension {
 }
 
 #[derive(Clone)]
-pub(super) struct ConjunctionPlan<'a> {
+pub(crate) struct ConjunctionPlan<'a> {
     shared_variables: Vec<Variable>,
     graph: Graph<'a>,
     type_annotations: &'a TypeAnnotations,
@@ -1224,7 +1224,7 @@ impl fmt::Debug for ConjunctionPlan<'_> {
 }
 
 impl ConjunctionPlan<'_> {
-    pub(crate) fn lower(
+    pub(super) fn lower(
         &self,
         input_variables: impl IntoIterator<Item = Variable> + Clone,
         selected_variables: impl IntoIterator<Item = Variable> + Clone,
@@ -1525,10 +1525,10 @@ impl ConjunctionPlan<'_> {
                 };
 
                 let direction = if matches!(inputs, Inputs::None([])) {
-                     let CostMetaData::Direction(unbound_direction) = metadata else {
-                         unreachable!("expected metadata for constraint")
-                     };
-                     unbound_direction
+                    let CostMetaData::Direction(unbound_direction) = metadata else {
+                        unreachable!("expected metadata for constraint")
+                    };
+                    unbound_direction
                 } else if rhs_var.is_some_and(|rhs| inputs.contains(rhs)) {
                     Direction::Reverse
                 } else {

--- a/compiler/executable/mod.rs
+++ b/compiler/executable/mod.rs
@@ -25,10 +25,10 @@ pub fn next_executable_id() -> u64 {
     EXECUTABLE_ID.fetch_add(1, Ordering::Relaxed)
 }
 
-typedb_error!(
+typedb_error! {
     pub ExecutableCompilationError(component = "Query executable", prefix = "QEE") {
-        InsertExecutableCompilation(1, "Error compiling insert clause into executable.", (source : Box<WriteCompilationError>)),
-        DeleteExecutableCompilation(2, "Error compiling delete clause into executable.", (source : Box<WriteCompilationError>)),
-        FetchCompliation(3, "Error compiling fetch clause into executable.", (typedb_source : FetchCompilationError)),
+        InsertExecutableCompilation(1, "Error compiling insert clause into executable.", source: Box<WriteCompilationError>),
+        DeleteExecutableCompilation(2, "Error compiling delete clause into executable.", source: Box<WriteCompilationError>),
+        FetchCompliation(3, "Error compiling fetch clause into executable.", typedb_source: FetchCompilationError),
     }
-);
+}

--- a/compiler/transformation/mod.rs
+++ b/compiler/transformation/mod.rs
@@ -24,6 +24,6 @@ pub(crate) trait PipelineTransformation {
 
 typedb_error!(
     pub StaticOptimiserError(component = "Static optimiser", prefix = "SOP") {
-        ConceptRead(1, "Error reading concept", ( source : Box<ConceptReadError> )),
+        ConceptRead(1, "Error reading concept", source: Box<ConceptReadError>),
     }
 );

--- a/concept/error.rs
+++ b/concept/error.rs
@@ -47,13 +47,13 @@ impl Error for ConceptError {
 
 typedb_error!(
     pub ConceptWriteError(component = "Concept write", prefix = "COW") {
-        SnapshotGet(1, "Concept write failed due to a snapshot read error.", (source: SnapshotGetError)),
-        SnapshotIterate(2, "Concept write failed due to a snapshot iteration error.", (source: Arc<SnapshotIteratorError>)),
-        ConceptRead(3, "Concept write failed due to a concept read error.", (source: Box<ConceptReadError>)),
-        SchemaValidation(4, "Concept write failed due to a schema validation error.", (typedb_source: Box<SchemaValidationError>)),
-        DataValidation(5, "Concept write failed due to a data validation error.", (typedb_source: Box<DataValidationError> )),
-        Encoding(6, "Concept write failed due to an encoding error.", (source: EncodingError)),
-        Annotation(7, "Concept write failed due to an annotation error.", (source: AnnotationError)),
+        SnapshotGet(1, "Concept write failed due to a snapshot read error.", source: SnapshotGetError),
+        SnapshotIterate(2, "Concept write failed due to a snapshot iteration error.", source: Arc<SnapshotIteratorError>),
+        ConceptRead(3, "Concept write failed due to a concept read error.", source: Box<ConceptReadError>),
+        SchemaValidation(4, "Concept write failed due to a schema validation error.", typedb_source: Box<SchemaValidationError>),
+        DataValidation(5, "Concept write failed due to a data validation error.", typedb_source: Box<DataValidationError>),
+        Encoding(6, "Concept write failed due to an encoding error.", source: EncodingError),
+        Annotation(7, "Concept write failed due to an annotation error.", source: AnnotationError),
 
         // TODO: Might refactor these to "InvalidOperationError", or just use unreachable! instead of it.
         SetHasOrderedOwnsUnordered(8, "Concept write failed, due to setting ordered owns as unordered."),

--- a/concept/thing/statistics.rs
+++ b/concept/thing/statistics.rs
@@ -458,9 +458,9 @@ struct CommittedWrites {
 
 typedb_error!(
     pub StatisticsError(component = "Statistics", prefix = "STA") {
-        DurablyWrite(1, "Error writing statistics summary WAL record.", ( typedb_source : DurabilityClientError )),
-        ReloadCommitData(2, "Failed to update statistics due to error reading commit records.", ( typedb_source: StorageRecoveryError )),
-        DataRead(3, "Error updating statistics due error reading MVCC storage layer.", ( source: MVCCReadError )),
+        DurablyWrite(1, "Error writing statistics summary WAL record.", typedb_source: DurabilityClientError),
+        ReloadCommitData(2, "Failed to update statistics due to error reading commit records.", typedb_source: StorageRecoveryError),
+        DataRead(3, "Error updating statistics due error reading MVCC storage layer.", source: MVCCReadError),
     }
 );
 

--- a/concept/thing/thing_manager/validation/mod.rs
+++ b/concept/thing/thing_manager/validation/mod.rs
@@ -19,7 +19,7 @@ pub(crate) mod validation;
 
 typedb_error!(
     pub DataValidationError(component = "Data validation", prefix = "DVL") {
-        ConceptRead(1, "Data validation failed due to concept read error.", ( source: Box<ConceptReadError>)),
+        ConceptRead(1, "Data validation failed due to concept read error.", source: Box<ConceptReadError>),
         CannotAddOwnerInstanceForNotOwnedAttributeType(
             2,
             "Type '{owner}' cannot own attribute type '{attribute}'.",
@@ -42,19 +42,19 @@ typedb_error!(
             5,
             "Constraint on entity type '{entity_type}' was violated.",
             entity_type: Label,
-            (typedb_source: Box<ConstraintError>)
+            typedb_source: Box<ConstraintError>
         ),
         RelationTypeConstraintViolated(
             6,
             "Constraint on relation type '{relation_type}' was violated.",
             relation_type: Label,
-            (typedb_source: Box<ConstraintError>)
+            typedb_source: Box<ConstraintError>
         ),
         AttributeTypeConstraintViolated(
             7,
             "Constraint on attribute type '{attribute_type}' was violated.",
             attribute_type: Label,
-            (typedb_source: Box<ConstraintError>)
+            typedb_source: Box<ConstraintError>
         ),
         KeyConstraintViolatedCard(
             8,
@@ -64,7 +64,7 @@ typedb_error!(
             attribute_type: Label,
             attribute_count: u64,
             constraint_source: Owns,
-            (typedb_source: Box<ConstraintError>)
+            typedb_source: Box<ConstraintError>
         ),
         KeyConstraintViolatedUniqueness(
             9,
@@ -74,7 +74,7 @@ typedb_error!(
             attribute_type: Label,
             value: Value<'static>,
             constraint_source: Owns,
-            (typedb_source: Box<ConstraintError>)
+            typedb_source: Box<ConstraintError>
         ),
         OwnsConstraintViolated(
             10,
@@ -83,7 +83,7 @@ typedb_error!(
             owner_type: Label,
             attribute_type: Label,
             // constraint_source: Owns
-            (typedb_source: Box<ConstraintError>)
+            typedb_source: Box<ConstraintError>
         ),
         RelatesConstraintViolated(
             11,
@@ -93,7 +93,7 @@ typedb_error!(
             role_type: Label,
             // player_iid: HexBytesFormatter<'static>,
             // constraint_source: Relates,
-            (typedb_source: Box<ConstraintError>)
+            typedb_source: Box<ConstraintError>
         ),
         PlaysConstraintViolated(
             12,
@@ -103,7 +103,7 @@ typedb_error!(
             role_type: Label,
             // relation: Option<Relation<'static>>,
             // constraint_source: Plays,
-            (typedb_source: Box<ConstraintError>)
+            typedb_source: Box<ConstraintError>
         ),
         UniqueValueTaken(
             13,

--- a/concept/type_/constraint.rs
+++ b/concept/type_/constraint.rs
@@ -576,7 +576,7 @@ pub(crate) fn type_get_constraints_closest_source<'a, T: KindAPI>(
         .next()
 }
 
-typedb_error!(
+typedb_error! {
     pub ConstraintError(component = "Constraint", prefix = "CNT") {
         CannotUnwrap(1, "Error getting mandatory constraint of type {type_}.", type_: &'static str),
         CorruptConstraintIsNotApplicableToValue(2, "Reached an invalid state: constraint {description} cannot be applied to value {value}.", description: ConstraintDescription, value: Value<'static>),
@@ -589,4 +589,4 @@ typedb_error!(
         ViolatedUnique(9, "Constraint '@unique' has been violated: there is a conflict for value '{value}'.", value: Value<'static>),
         ViolatedDistinct(10, "Constraint '@distinct' has been violated: found {count} instances", count: u64),
     }
-);
+}

--- a/concept/type_/type_manager.rs
+++ b/concept/type_/type_manager.rs
@@ -222,7 +222,7 @@ macro_rules! get_annotations_declared_methods {
             pub(crate) fn $method_name(
                 &self, snapshot: &impl ReadableSnapshot, type_: $type_
             ) -> Result<MaybeOwns<'_, HashSet<$annotation_type>>, Box<ConceptReadError>> {
-                 if let Some(cache) = &self.type_cache {
+                if let Some(cache) = &self.type_cache {
                     Ok(MaybeOwns::Borrowed(cache.$cache_method(type_)))
                 } else {
                     let annotations = TypeReader::$reader_method(snapshot, type_)?;
@@ -259,7 +259,7 @@ macro_rules! get_constraints_methods {
             pub(crate) fn $method_name(
                 &self, snapshot: &impl ReadableSnapshot, type_: $type_
             ) -> Result<MaybeOwns<'_, HashSet<$constraint_type<$type_>>>, Box<ConceptReadError>> {
-                 if let Some(cache) = &self.type_cache {
+                if let Some(cache) = &self.type_cache {
                     Ok(MaybeOwns::Borrowed(cache.$cache_method(type_)))
                 } else {
                     let constraints = TypeReader::$reader_method(snapshot, type_)?;
@@ -281,13 +281,13 @@ macro_rules! get_type_capability_constraints_methods {
                 $type_: $type_decl,
                 interface_type: <$capability as Capability>::InterfaceType,
             ) -> Result<MaybeOwns<'_, HashSet<CapabilityConstraint<$capability>>>, Box<ConceptReadError>> {
-                 if let Some(cache) = &self.type_cache {
-                     Ok(match cache.$cache_method($type_).get(&interface_type) {
-                         Some(cached) => MaybeOwns::Borrowed(cached),
-                         None => MaybeOwns::Owned(HashSet::new()),
-                     })
+                if let Some(cache) = &self.type_cache {
+                    Ok(match cache.$cache_method($type_).get(&interface_type) {
+                        Some(cached) => MaybeOwns::Borrowed(cached),
+                        None => MaybeOwns::Owned(HashSet::new()),
+                    })
                 } else {
-                     let $type_ = $reader_convert;
+                    let $type_ = $reader_convert;
                     let constraints = TypeReader::$reader_method(snapshot, $type_, interface_type)?;
                     Ok(MaybeOwns::Owned(constraints))
                 }

--- a/concept/type_/type_manager/type_cache/type_cache.rs
+++ b/concept/type_/type_manager/type_cache/type_cache.rs
@@ -489,8 +489,8 @@ impl TypeCache {
     }
 }
 
-typedb_error!(
+typedb_error! {
     pub TypeCacheCreateError(component = "TypeCache create", prefix = "TCC") {
         Empty(1, ""),
     }
-);
+}

--- a/concept/type_/type_manager/validation/mod.rs
+++ b/concept/type_/type_manager/validation/mod.rs
@@ -26,7 +26,7 @@ pub(crate) mod validation;
 
 typedb_error!(
     pub SchemaValidationError(component = "Schema validation", prefix = "SVL") {
-        ConceptRead(1, "Data validation failed due to concept read error.", (source: Box<ConceptReadError>)),
+        ConceptRead(1, "Data validation failed due to concept read error.", source: Box<ConceptReadError>),
         LabelShouldBeUnique(2, "Label '{label}' should be unique, but is already used by '{existing_kind}'.", label: Label, existing_kind: Kind),
         StructNameShouldBeUnique(3, "Struct name '{name}' must a unique, unused name.", name: String),
         StructShouldHaveAtLeastOneField(4, "Struct '{name}' should have at least one field.", name: String),
@@ -55,13 +55,13 @@ typedb_error!(
         ValueTypeIsNotCompatibleWithValuesAnnotation(27, "Value type '{value_type:?}' is not compatible with values annotation on '{attribute}'.", attribute: Label, value_type: Option<ValueType>),
         ValueTypeIsNotKeyableForUniqueConstraintOfKeyAnnotationDeclaredOnOwns(28, "Value type '{value_type:?}' is not keyable for unique constraint of key annotation declared on 'owns' for '{owner}' owning '{attribute}'.", owner: Label, attribute: Label, value_type: Option<ValueType>),
         ValueTypeIsNotKeyableForUniqueConstraintOfUniqueAnnotationDeclaredOnOwns(29, "Value type '{value_type:?}' is not keyable for unique constraint of unique annotation declared on 'owns' for '{owner}' owning '{attribute}'.", owner: Label, attribute: Label, value_type: Option<ValueType>),
-        CannotSetAnnotationToInterfaceBecauseItsConstraintIsNotNarrowedByItsCapabilityConstraint(30, "Cannot set annotation to interface '{interface}' because its constraint is not narrowed by its capability constraint.", interface: Label, (typedb_source: Box<ConstraintError>)),
-        CannotSetAnnotationToCapabilityBecauseItsConstraintDoesNotNarrowItsInterfaceConstraint(31, "Cannot set annotation on capability '{cap}' of '{interface}' on type '{label}' because its constraint does not narrow its interface constraint.", cap: CapabilityKind, interface: Label, label: Label, (typedb_source: Box<ConstraintError>)),
+        CannotSetAnnotationToInterfaceBecauseItsConstraintIsNotNarrowedByItsCapabilityConstraint(30, "Cannot set annotation to interface '{interface}' because its constraint is not narrowed by its capability constraint.", interface: Label, typedb_source: Box<ConstraintError>),
+        CannotSetAnnotationToCapabilityBecauseItsConstraintDoesNotNarrowItsInterfaceConstraint(31, "Cannot set annotation on capability '{cap}' of '{interface}' on type '{label}' because its constraint does not narrow its interface constraint.", cap: CapabilityKind, interface: Label, label: Label, typedb_source: Box<ConstraintError>),
         InvalidCardinalityArguments(32, "Invalid arguments for cardinality annotation '{card}'.", card: AnnotationCardinality),
         InvalidRegexArguments(33, "Invalid arguments for regex annotation '{regex}'.", regex: AnnotationRegex),
         InvalidRangeArgumentsForValueType(34, "Invalid arguments for range annotation '{range}' for value type '{value_type:?}'.", range: AnnotationRange, value_type: Option<ValueType>),
         InvalidValuesArgumentsForValueType(35, "Invalid arguments for values annotation '{values}' for value type '{value_type:?}'.", values: AnnotationValues, value_type: Option<ValueType>),
-        SubtypeConstraintDoesNotNarrowSupertypeConstraint(36, "Subtype constraint on '{subtype}' does not narrow supertype constraint on '{supertype}'.", subtype: Label, supertype: Label, (typedb_source: Box<ConstraintError>)),
+        SubtypeConstraintDoesNotNarrowSupertypeConstraint(36, "Subtype constraint on '{subtype}' does not narrow supertype constraint on '{supertype}'.", subtype: Label, supertype: Label, typedb_source: Box<ConstraintError>),
         CannotUnsetInheritedOwns(37, "Cannot unset inherited 'owns' constraint from '{supertype}' for '{supertype}'.", supertype: Label, subtype: Label),
         CannotUnsetInheritedPlays(38, "Cannot unset inherited 'plays' constraint from '{supertype}' for '{subtype}'.", supertype: Label, subtype: Label),
         CannotUnsetInheritedValueType(39, "Cannot unset inherited value type '{value_type}' for '{subtype}'.", value_type: ValueType, subtype: Label),
@@ -70,7 +70,7 @@ typedb_error!(
         AnnotationIsNotCompatibleWithDeclaredAnnotation(42, "Annotation '{annotation}' is not compatible with declared annotation '{declared_annotation}' for '{label}'.", annotation: AnnotationCategory, declared_annotation: AnnotationCategory, label: Label),
         RelationTypeMustRelateAtLeastOneRole(43, "Relation type '{relation}' must relate at least one role.", relation: Label),
         CannotRedeclareInheritedCapabilityWithoutSpecialisation(44, "Cannot redeclare inherited capability '{cap}' from '{supertype}' on subtype '{subtype}' without specialisation.", cap: CapabilityKind, supertype: Label, subtype: Label),
-        CannotRedeclareConstraintOnSubtypeWithoutSpecialisation(45, "Cannot redeclare constraint '{constraint}' on subtype '{subtype}' without specialisation.", constraint: ConstraintDescription,  subtype: Label),
+        CannotRedeclareConstraintOnSubtypeWithoutSpecialisation(45, "Cannot redeclare constraint '{constraint}' on subtype '{subtype}' without specialisation.", constraint: ConstraintDescription, subtype: Label),
         CapabilityConstraintAlreadyExistsForTheWholeInterfaceType(46, "Capability constraint '{constraint}' already exists for the whole interface type '{cap}' on '{label}'.", cap: CapabilityKind, label: Label, constraint: ConstraintDescription),
         ChangingAttributeSupertypeLeadsToImplicitIndependentAnnotationLossAndUnexpectedDataLoss(47, "Changing supertype of attribute '{attribute}' to '{supertype:?}' will lead to implicit loss of independent annotation and potential data loss.", attribute: Label, supertype: Option<Label>),
         CannotDeleteTypeWithExistingInstances(48, "Cannot delete type '{label}' as it has existing instances.", label: Label),
@@ -92,37 +92,37 @@ typedb_error!(
         CannotAcquireCapabilityAsExistingInstancesViolateItsConstraint(
             55,
             "Cannot add new schema as existing instances would violate the addition.",
-            (typedb_source: Box<DataValidationError>)
+            typedb_source: Box<DataValidationError>
         ),
         CannotSetAnnotationForCapabilityAsExistingInstancesViolateItsConstraint(
             56,
             "Cannot set annotation as existing instances would violate the new constraint.",
-            ( typedb_source: Box<DataValidationError>)
+            typedb_source: Box<DataValidationError>
         ),
         CannotChangeSupertypeAsUpdatedCapabilityConstraintIsViolatedByExistingInstances(
             57,
             "Cannot change supertype as the schema constraints would not be compatible with existing instances.",
-            (typedb_source: Box<DataValidationError>)
+            typedb_source: Box<DataValidationError>
         ),
         CannotChangeInterfaceTypeSupertypeAsUpdatedCapabilityConstraintIsViolatedByExistingInstances(
             58,
             "Cannot change schema as it would result in schema constraint that are compatible with existing instances.",
-            ( typedb_source: Box<DataValidationError>)
+            typedb_source: Box<DataValidationError>
         ),
         CannotUnsetInterfaceTypeSupertypeAsUpdatedCapabilityConstraintIsViolatedByExistingInstances(
             59,
             "Cannot remove schema element as the result would not be compatible with existing instances.",
-            ( typedb_source : Box<DataValidationError> )
+            typedb_source: Box<DataValidationError>
         ),
         CannotSetAnnotationAsExistingInstancesViolateItsConstraint(
             60,
             "Cannot set annotation as the result would not be compatible with existing instances.",
-            (typedb_source: Box<DataValidationError> )
+            typedb_source: Box<DataValidationError>
         ),
         CannotChangeSupertypeAsUpdatedConstraintIsViolatedByExistingInstances(
             61,
             "Cannot change superty as the resulting schema constraints would be not be compatible with existing instances.",
-            ( typedb_source: Box<DataValidationError>)
+            typedb_source: Box<DataValidationError>
         ),
     }
 );

--- a/database/database.rs
+++ b/database/database.rs
@@ -465,52 +465,52 @@ fn make_update_statistics_fn(
     }
 }
 
-typedb_error!(
+typedb_error! {
     pub DatabaseOpenError(component = "Database open", prefix = "DBO") {
-        InvalidUnicodeName(1, "Could not open database, invalid unicode name '{name:?}'.", name: OsString ),
-        CouldNotReadDataDirectory(2, "error while reading data directory at '{path:?}'.", path: PathBuf, ( source: Arc<io::Error> )),
-        DirectoryCreate(3, "Error creating directory at '{path:?}'", path: PathBuf, ( source: Arc<io::Error> )),
-        StorageOpen(4, "Error opening storage layer.", ( typedb_source: StorageOpenError )),
-        WALOpen(5, "Error opening WAL.", ( source: WALError )),
-        DurabilityClientOpen(6, "Error opening durability client.", ( typedb_source:DurabilityClientError )),
-        DurabilityClientRead(7, "Error reading from durability client.", ( typedb_source: DurabilityClientError )),
-        CheckpointLoad(8, "Error loading checkpoint for database '{name}'.", name: String, ( typedb_source: CheckpointLoadError )),
-        CheckpointCreate(9, "Error creating checkpoint for database '{name}'.", name: String, ( source: CheckpointCreateError )),
-        Encoding(10, "Data encoding error.", ( source: EncodingError )),
-        StatisticsInitialise(11, "Error initialising statistics manager.", ( typedb_source: StatisticsError )),
-        TypeCacheInitialise(12, "Error initialising type cache.", ( typedb_source : TypeCacheCreateError )),
-        FunctionCacheInitialise(13, "Error initialising function cache", ( typedb_source : FunctionError )),
+        InvalidUnicodeName(1, "Could not open database, invalid unicode name '{name:?}'.", name: OsString),
+        CouldNotReadDataDirectory(2, "error while reading data directory at '{path:?}'.", path: PathBuf, source: Arc<io::Error>),
+        DirectoryCreate(3, "Error creating directory at '{path:?}'", path: PathBuf, source: Arc<io::Error>),
+        StorageOpen(4, "Error opening storage layer.", typedb_source: StorageOpenError),
+        WALOpen(5, "Error opening WAL.", source: WALError),
+        DurabilityClientOpen(6, "Error opening durability client.", typedb_source:DurabilityClientError),
+        DurabilityClientRead(7, "Error reading from durability client.", typedb_source: DurabilityClientError),
+        CheckpointLoad(8, "Error loading checkpoint for database '{name}'.", name: String, typedb_source: CheckpointLoadError),
+        CheckpointCreate(9, "Error creating checkpoint for database '{name}'.", name: String, source: CheckpointCreateError),
+        Encoding(10, "Data encoding error.", source: EncodingError),
+        StatisticsInitialise(11, "Error initialising statistics manager.", typedb_source: StatisticsError),
+        TypeCacheInitialise(12, "Error initialising type cache.", typedb_source: TypeCacheCreateError),
+        FunctionCacheInitialise(13, "Error initialising function cache", typedb_source: FunctionError),
     }
-);
+}
 
-typedb_error!(
+typedb_error! {
     pub DatabaseCreateError(component = "Database create", prefix = "DBC") {
         InvalidName(1, "Cannot create database since '{name}' is not a valid database name.", name: String),
         InternalDatabaseCreationProhibited(2, "Creating an internal database is prohibited"),
     }
-);
+}
 
-typedb_error!(
+typedb_error! {
     pub DatabaseDeleteError(component = "Database delete", prefix = "DBD") {
         DoesNotExist(1, "Cannot delete database since it does not exist."),
         InUse(2, "Cannot delete database since it is in use."),
-        StorageDelete(3, "Error while deleting storage resources.", ( typedb_source: StorageDeleteError )),
-        DirectoryDelete(4, "Error deleting directory.", ( source: Arc<io::Error> )),
+        StorageDelete(3, "Error while deleting storage resources.", typedb_source: StorageDeleteError),
+        DirectoryDelete(4, "Error deleting directory.", source: Arc<io::Error>),
         InternalDatabaseDeletionProhibited(5, "Deleting an internal database is prohibited"),
     }
-);
+}
 
-typedb_error!(
+typedb_error! {
     pub DatabaseResetError(component = "Database reset", prefix = "DBR") {
-        DatabaseDelete(1, "Cannot delete database.", ( typedb_source: DatabaseDeleteError )),
-        DatabaseCreate(2, "Cannot create database.", ( typedb_source: DatabaseCreateError )),
-        Transaction(3, "Transaction error.", ( typedb_source: TransactionError )),
+        DatabaseDelete(1, "Cannot delete database.", typedb_source: DatabaseDeleteError),
+        DatabaseCreate(2, "Cannot create database.", typedb_source: DatabaseCreateError),
+        Transaction(3, "Transaction error.", typedb_source: TransactionError),
         InUse(4, "Database cannot be reset since it is in use."),
         StorageInUse(5, "Database cannot be reset since the storage is in use."),
         CorruptionPartialResetStorageInUse(
             6,
             "Corruption warning: database reset failed partway because the storage is still in use.",
-            ( typedb_source: StorageResetError )
+            typedb_source: StorageResetError
         ),
         CorruptionPartialResetKeyGeneratorInUse(
             7,
@@ -529,4 +529,4 @@ typedb_error!(
             "Corruption warning: Database reset failed partway because the query cache is still in use."
         ),
     }
-);
+}

--- a/database/transaction.rs
+++ b/database/transaction.rs
@@ -175,14 +175,14 @@ impl<D: DurabilityClient> TransactionWrite<D> {
     }
 }
 
-typedb_error!(
+typedb_error! {
     pub DataCommitError(component = "Data commit", prefix = "DCT") {
         SnapshotInUse(1, "Failed to commit since the transaction snapshot is still in use."),
-        ConceptWriteErrors(2, "Data commit error.", source: Vec<ConceptWriteError> ),
-        ConceptWriteErrorsFirst(3, "Data commit error.", ( typedb_source : Box<ConceptWriteError> )),
-        SnapshotError(4, "Snapshot error.", ( typedb_source: SnapshotError )),
+        ConceptWriteErrors(2, "Data commit error.", write_errors: Vec<ConceptWriteError>),
+        ConceptWriteErrorsFirst(3, "Data commit error.", typedb_source: Box<ConceptWriteError>),
+        SnapshotError(4, "Snapshot error.", typedb_source: SnapshotError),
     }
-);
+}
 
 // #[derive(Debug, Clone)]
 // pub enum DataCommitError {
@@ -357,20 +357,20 @@ impl<D: DurabilityClient> TransactionSchema<D> {
 }
 
 // TODO: Same issue with ConceptWriteErrors vs ErrorsFirst as for DataCommitError
-typedb_error!(
+typedb_error! {
     pub SchemaCommitError(component = "Schema commit", prefix = "SCT") {
-        ConceptWriteErrors(1, "Schema commit error.", source: Vec<ConceptWriteError> ),
-        ConceptWriteErrorsFirst(2, "Schema commit error.", ( typedb_source : Box<ConceptWriteError> )),
-        TypeCacheUpdateError(3, "TypeCache update error.", ( typedb_source: TypeCacheCreateError )),
-        StatisticsError(4, "Statistics error.", ( typedb_source: StatisticsError )),
-        FunctionError(5, "Function error.", ( typedb_source: FunctionError )),
-        SnapshotError(6, "Snapshot error.", ( typedb_source: SnapshotError )),
+        ConceptWriteErrors(1, "Schema commit error.", write_errors: Vec<ConceptWriteError>),
+        ConceptWriteErrorsFirst(2, "Schema commit error.", typedb_source: Box<ConceptWriteError>),
+        TypeCacheUpdateError(3, "TypeCache update error.", typedb_source: TypeCacheCreateError),
+        StatisticsError(4, "Statistics error.", typedb_source: StatisticsError),
+        FunctionError(5, "Function error.", typedb_source: FunctionError),
+        SnapshotError(6, "Snapshot error.", typedb_source: SnapshotError),
     }
-);
+}
 
-typedb_error!(
+typedb_error! {
     pub TransactionError(component = "Transaction", prefix = "TXN") {
         Timeout(1, "Transaction timeout.", source: RecvTimeoutError),
         WriteExclusivityTimeout(2, "Transaction timeout due to an exclusive write access requested by this or a concurrent transaction."),
     }
-);
+}

--- a/diagnostics/diagnostics_manager.rs
+++ b/diagnostics/diagnostics_manager.rs
@@ -43,7 +43,7 @@ impl DiagnosticsManager {
         is_monitoring_enabled: bool,
         is_development_mode: bool,
     ) -> Self {
-        let deployment_id = diagnostics.server_properties.deployment_id().clone().to_owned();
+        let deployment_id = diagnostics.server_properties.deployment_id().to_owned();
         let data_directory = diagnostics.server_metrics.data_directory().clone();
         let is_reporting_enabled = diagnostics.server_properties.is_reporting_enabled();
         let diagnostics = Arc::new(diagnostics);

--- a/diagnostics/lib.rs
+++ b/diagnostics/lib.rs
@@ -14,7 +14,6 @@ use std::{
     sync::{RwLock, RwLockReadGuard, RwLockWriteGuard},
 };
 
-use error::{typedb_error, TypeDBError};
 use serde_json::{json, Value as JSONValue};
 use xxhash_rust::xxh3::Xxh3;
 

--- a/executor/error.rs
+++ b/executor/error.rs
@@ -10,12 +10,12 @@ use error::typedb_error;
 
 use crate::InterruptType;
 
-typedb_error!(
+typedb_error! {
     pub ReadExecutionError(component = "Read execution", prefix = "REX") {
         Interrupted(1, "Execution interrupted by to a concurrent {interrupt}.", interrupt: InterruptType),
-        ConceptRead(2, "Concept read error.", ( source: Box<ConceptReadError> )),
-        CreatingIterator(3, "Error creating iterator from {instruction_name} instruction.", instruction_name: String, ( source: Box<ConceptReadError> )),
-        AdvancingIteratorTo(4, "Error moving iterator (by steps or seek) to target value.", ( source: Box<ConceptReadError> )),
-        ExpressionEvaluate(5, "Error evaluating expression", ( source: ExpressionEvaluationError )),
+        ConceptRead(2, "Concept read error.", source: Box<ConceptReadError>),
+        CreatingIterator(3, "Error creating iterator from {instruction_name} instruction.", instruction_name: String, source: Box<ConceptReadError>),
+        AdvancingIteratorTo(4, "Error moving iterator (by steps or seek) to target value.", source: Box<ConceptReadError>),
+        ExpressionEvaluate(5, "Error evaluating expression", source: ExpressionEvaluationError),
     }
-);
+}

--- a/executor/pipeline/fetch.rs
+++ b/executor/pipeline/fetch.rs
@@ -618,7 +618,7 @@ fn variable_value_to_document(variable_value: VariableValue<'_>) -> Result<Docum
     }
 }
 
-typedb_error!(
+typedb_error! {
     pub FetchExecutionError(component = "Fetch execution", prefix = "FEX") {
         Unimplemented(0, "Unimplemented: {description}.", description: &'static str),
 
@@ -633,10 +633,10 @@ typedb_error!(
         FetchSingleFunctionNotScalar(7, "Fetching results of a function call '{func_name}()' expected a scalar return, got a tuple instead.", func_name: String),
         FetchSingleFunctionNotSingle(8, "Fetching results of a function call '{func_name}()' expected a single return, got a stream instead. It must be wrapped in `[]` to collect into a list.", func_name: String),
 
-        SubFetch(10, "Error executing sub fetch.", ( typedb_source : Box<PipelineExecutionError>)),
+        SubFetch(10, "Error executing sub fetch.", typedb_source: Box<PipelineExecutionError>),
 
-        ConceptRead(30, "Unexpected failed to read concept.", ( source: Box<ConceptReadError>)),
-        ReadExecution(31, "Unexpected failed to execute read.", ( typedb_source: Box<ReadExecutionError> )),
-        Pipeline(32, "Pipeline error.", ( typedb_source: Box<PipelineError> )),
+        ConceptRead(30, "Unexpected failed to read concept.", source: Box<ConceptReadError>),
+        ReadExecution(31, "Unexpected failed to execute read.", typedb_source: Box<ReadExecutionError>),
+        Pipeline(32, "Pipeline error.", typedb_source: Box<PipelineError>),
     }
-);
+}

--- a/executor/pipeline/mod.rs
+++ b/executor/pipeline/mod.rs
@@ -60,16 +60,16 @@ impl StageIterator for WrittenRowsIterator {
     }
 }
 
-typedb_error!(
+typedb_error! {
     pub PipelineExecutionError(component = "Pipeline execution", prefix = "PEX") {
         // TODO: migrate to `typedb_error` once they are typedb errors
         Interrupted(1, "Execution interrupted by to a concurrent {interrupt}.", interrupt: InterruptType),
         FetchUsedAsRows(2, "Cannot use a Fetch query to return ConceptRows"),
         RowsUsedAsFetch(3, "Cannot use query returning ConceptRows as a Fetch query."),
-        ConceptRead(4, "Error reading concept.", ( source: Box<ConceptReadError> )),
-        InitialisingMatchIterator(5, "Error initialising Match clause iterator.", ( source: Box<ConceptReadError> )),
-        WriteError(6, "Error executing write operation.", ( typedb_source: Box<WriteError> )),
-        ReadPatternExecution(7, "Error executing a read pattern.", ( typedb_source : ReadExecutionError )),
-        FetchError(8, "Error executing fetch operation.", ( typedb_source: FetchExecutionError )),
+        ConceptRead(4, "Error reading concept.", source: Box<ConceptReadError>),
+        InitialisingMatchIterator(5, "Error initialising Match clause iterator.", source: Box<ConceptReadError>),
+        WriteError(6, "Error executing write operation.", typedb_source: Box<WriteError>),
+        ReadPatternExecution(7, "Error executing a read pattern.", typedb_source: ReadExecutionError),
+        FetchError(8, "Error executing fetch operation.", typedb_source: FetchExecutionError),
     }
-);
+}

--- a/executor/pipeline/pipeline.rs
+++ b/executor/pipeline/pipeline.rs
@@ -246,8 +246,8 @@ impl<Snapshot: WritableSnapshot + 'static> Pipeline<Snapshot, WritePipelineStage
     }
 }
 
-typedb_error!(
+typedb_error! {
     pub PipelineError(component = "Pipeline", prefix = "PIP") {
-        InvalidReadPipelineStage(1, "{stage} clause cannot exist in a read pipeline.", stage : String),
+        InvalidReadPipelineStage(1, "{stage} clause cannot exist in a read pipeline.", stage: String),
     }
-);
+}

--- a/executor/write/mod.rs
+++ b/executor/write/mod.rs
@@ -9,8 +9,8 @@ use error::typedb_error;
 
 pub(crate) mod write_instruction;
 
-typedb_error!(
+typedb_error! {
     pub WriteError(component = "Write execution", prefix = "WEX") {
-        ConceptWrite(1, "Write execution failed due to a concept write error.", (typedb_source : Box<ConceptWriteError>)),
+        ConceptWrite(1, "Write execution failed due to a concept write error.", typedb_source: Box<ConceptWriteError>),
     }
-);
+}

--- a/function/lib.rs
+++ b/function/lib.rs
@@ -13,16 +13,16 @@ pub mod function;
 pub mod function_cache;
 pub mod function_manager;
 
-typedb_error!(
+typedb_error! {
     pub FunctionError(component = "Function", prefix = "FUN") {
         FunctionNotFound(1, "Function was not found"),
-        AllFunctionsTypeCheckFailure(2, "Type checking all functions currently defined failed.", ( typedb_source: Box<FunctionAnnotationError> )),
-        CommittedFunctionsTypeCheck(3, "Type checking stored functions failed.", ( typedb_source: Box<FunctionAnnotationError> )),
-        FunctionTranslation(4, "Failed to translate TypeQL function into internal representation", ( typedb_source: FunctionRepresentationError )),
+        AllFunctionsTypeCheckFailure(2, "Type checking all functions currently defined failed.", typedb_source: Box<FunctionAnnotationError>),
+        CommittedFunctionsTypeCheck(3, "Type checking stored functions failed.", typedb_source: Box<FunctionAnnotationError>),
+        FunctionTranslation(4, "Failed to translate TypeQL function into internal representation", typedb_source: FunctionRepresentationError),
         FunctionAlreadyExists(5, "A function with name '{name}' already exists", name: String),
-        CreateFunctionEncoding(6, "Encoding error while trying to create function.", ( source: EncodingError )),
-        FunctionRetrieval(7, "Error retrieving function.", (  source: FunctionReadError )),
-        CommittedFunctionParseError(8, "Error while parsing committed.", ( typedb_source: typeql::Error )),
+        CreateFunctionEncoding(6, "Encoding error while trying to create function.", source: EncodingError),
+        FunctionRetrieval(7, "Error retrieving function.", source: FunctionReadError),
+        CommittedFunctionParseError(8, "Error while parsing committed.", typedb_source: typeql::Error),
         StratificationViolation(9, "Detected a recursive cycle through a negation or reduction: [{cycle_names}]", cycle_names: String),
     }
-);
+}

--- a/ir/lib.rs
+++ b/ir/lib.rs
@@ -29,12 +29,12 @@ pub mod pipeline;
 pub mod translation;
 
 // TODO: include declaration source for each error message
-typedb_error!(
+typedb_error! {
     pub RepresentationError(component = "Representation", prefix = "REP") {
         DisjointVariableReuse(
             0,
             "Variable '{name}' is re-used across different branches of the query. Variables that do not represent the same concept must be named uniquely, to prevent clashes within answers.",
-            name: String
+            name: String,
         ),
         VariableCategoryMismatch(
             1,
@@ -42,7 +42,7 @@ typedb_error!(
             variable_name: String,
             category_1: VariableCategory,
             // category_1_source: Constraint<Variable>,
-            category_2: VariableCategory
+            category_2: VariableCategory,
             // category_2_source: Constraint<Variable>,
         ),
         FunctionCallReturnCountMismatch(
@@ -50,137 +50,148 @@ typedb_error!(
             "Invalid call to function '{name}', which returns '{function_return_count}' outputs but only '{assigned_var_count}' were assigned.",
             name: String,
             assigned_var_count: usize,
-            function_return_count: usize
+            function_return_count: usize,
         ),
         FunctionCallArgumentCountMismatch(
             3,
             "Invalid call to function '{name}', which requires '{expected}' arguments but only '{actual}' were provided.",
             name: String,
             expected: usize,
-            actual: usize
+            actual: usize,
         ),
         UnresolvedFunction(4, "Could not resolve function with name '{function_name}'.", function_name: String),
-        FunctionRepresentation(5, "Error translating function into intermediate representation.", ( typedb_source : FunctionRepresentationError )),
+        FunctionRepresentation(5, "Error translating function into intermediate representation.", typedb_source: FunctionRepresentationError),
         ExpectedStreamFunctionReturnsSingle(
             6,
             "Invalid invocation of function '{function_name}' in an iterable assignment ('in'), since it returns a non-iterable single answer. Use the single-answer assignment '=' instead.",
-            function_name: String
+            function_name: String,
         ),
         ExpectedSingleFunctionReturnsStream(
             7,
             "Invalid invocation of function '{function_name}' in a single-answer assignment (=), since it returns an iterable stream of answers. Use the iterable assignment 'in' instead.",
-            function_name: String
+            function_name: String,
         ),
         OptionalVariableForRequiredArgument(
             8,
             "Optionally present variable '{input_var}' cannot be used as the non-optional argument '{arg_name}' in function '{name}'.",
             name: String,
             arg_name: String,
-            input_var: String
+            input_var: String,
         ),
         InAssignmentMustBeListOrStream(
             9,
             "Iterable assignments ('in') must have an iterable stream or list on the right hand side.\nSource:\n{declaration}",
-            declaration: InIterable
+            declaration: InIterable,
         ),
         FunctionReadError(
             10,
             "Error reading function.",
-            ( source: FunctionReadError )
+            source: FunctionReadError ,
         ),
         ParseError(
             11,
             "Error parsing query.",
-            ( typedb_source: typeql::Error )
+            typedb_source: typeql::Error ,
         ),
         LiteralParseError(
             12,
             "Error parsing literal '{literal}'.",
             literal: String,
-            ( source: LiteralParseError )
+            source: LiteralParseError ,
         ),
         ExpressionDefinitionError(
             13,
             "Expression error.",
-            ( source: ExpressionDefinitionError )
+            source: ExpressionDefinitionError ,
         ),
         ExpressionAssignmentMustOneVariable(
             14,
             "Expressions must be assigned to a single variable, received {assigned_count} instead.",
-            assigned_count: usize
+            assigned_count: usize,
         ),
         ExpressionBuiltinArgumentCountMismatch(
             15,
             "Built-in expression function '{builtin}' expects '{expected}' arguments but received '{actual}' arguments.",
             builtin: token::Function,
             expected: usize,
-            actual: usize
+            actual: usize,
         ),
         UnimplementedStructAssignment(
             16,
             "Destructuring structs via assignment is not yet implemented.\nSource:\n{declaration}",
-            declaration: StructDeconstruct
+            declaration: StructDeconstruct,
         ),
         ScopedRoleNameInRelation(
             17,
             "Relation's declared role types should not contain scopes (':').\nSource:\n{declaration}",
-            declaration: typeql::statement::thing::RolePlayer
+            declaration: typeql::statement::thing::RolePlayer,
         ),
         OperatorStageVariableUnavailable(
             18,
             "The variable '{variable_name}' was not available in the stage.\nSource:\n{declaration}",
             variable_name: String,
-            declaration: typeql::query::pipeline::stage::Stage
+            declaration: typeql::query::pipeline::stage::Stage,
         ),
         ReduceVariableNotAvailable(
             19,
             "The variable '{variable_name}' was not available in for use in the reduce.\nSource:\n{declaration}",
             variable_name: String,
-            declaration: Reducer
+            declaration: Reducer,
         ),
         LabelWithKind(
             20,
             "Specifying a kind on a label is not allowed.\nSource:\n{declaration}",
-            declaration: typeql::statement::Type
+            declaration: typeql::statement::Type,
         ),
         LabelWithLabel(
             30,
             "Specifying a label constraint on a label is not allowed.\nSource:\n{declaration}",
-            declaration: typeql::Label
+            declaration: typeql::Label,
         ),
         ScopedLabelWithLabel(
             31,
             "Specifying a scoped label constraint on a label is not allowed.\nSource:\n{declaration}",
-            declaration: typeql::ScopedLabel
+            declaration: typeql::ScopedLabel,
         ),
         UnrecognisedClause(
             22,
             "Clause type not recognised.\nSource:\n{declaration}",
-            declaration: typeql::query::stage::Stage
+            declaration: typeql::query::stage::Stage,
         ),
         FetchRepresentation(
             23,
             "Error building representation of fetch clause.",
-            ( typedb_source : Box<FetchRepresentationError> )
+            typedb_source: Box<FetchRepresentationError> ,
         ),
         NonTerminalFetch(
             24,
             "Fetch clauses must be the final clause in a query pipeline.\nSource:\n{declaration}",
-            declaration: typeql::query::stage::Stage
+            declaration: typeql::query::stage::Stage,
         ),
         UnboundVariable(
             25,
             "Invalid query containing unbound concept variable {variable}",
-            variable: String
+            variable: String,
         ),
         ScopedValueTypeName(26, "Value type names cannot have scopes. Provided illegal name: '{scope}:{name}'.", scope: String, name: String),
         ReservedKeywordAsIdentifier(
             27,
             "A reserved keyword \"{identifier}\" was used as identifier",
-            identifier: typeql::Identifier
+            identifier: typeql::Identifier,
+        ),
+
+        UnimplementedOptionalType(
+            255,
+            "Optional types are not yet implemented.\nSource:\n{declaration}",
+            declaration: typeql::type_::Optional,
+        ),
+        UnimplementedListType(
+            256,
+            "List types are not yet implemented.\nSource:\n{declaration}",
+            declaration: typeql::type_::List,
         ),
     }
-);
+}
 
 #[derive(Debug, Clone)]
 pub enum LiteralParseError {

--- a/ir/pattern/negation.rs
+++ b/ir/pattern/negation.rs
@@ -49,7 +49,7 @@ impl Negation {
 
 impl Scope for Negation {
     fn scope_id(&self) -> ScopeId {
-        todo!()
+        self.conjunction.scope_id()
     }
 }
 

--- a/ir/pattern/optional.rs
+++ b/ir/pattern/optional.rs
@@ -49,7 +49,7 @@ impl Optional {
 
 impl Scope for Optional {
     fn scope_id(&self) -> ScopeId {
-        todo!()
+        self.conjunction.scope_id()
     }
 }
 

--- a/ir/pipeline/mod.rs
+++ b/ir/pipeline/mod.rs
@@ -80,13 +80,13 @@ typedb_error! {
             4,
             "Function pattern contains an error.\nSource:\n{declaration}",
             declaration: FunctionBlock,
-            ( typedb_source : Box<RepresentationError>)
+            typedb_source: Box<RepresentationError>,
         ),
         ReturnReduction(
             5,
             "Error building representation of the return reduction.\nSource:\n{declaration}",
             declaration: ReturnReduction,
-            ( typedb_source : Box<RepresentationError>)
+            typedb_source: Box<RepresentationError>,
         ),
         IllegalFetch(
             6,

--- a/ir/translation/constraints.rs
+++ b/ir/translation/constraints.rs
@@ -190,8 +190,12 @@ fn register_typeql_type_any(
 ) -> Result<Vertex<Variable>, Box<RepresentationError>> {
     match type_ {
         typeql::TypeRefAny::Type(type_) => register_typeql_type(constraints, type_),
-        typeql::TypeRefAny::Optional(_) => todo!(),
-        typeql::TypeRefAny::List(_) => todo!(),
+        typeql::TypeRefAny::Optional(optional) => {
+            Err(Box::new(RepresentationError::UnimplementedOptionalType { declaration: optional.clone() }))
+        }
+        typeql::TypeRefAny::List(list) => {
+            Err(Box::new(RepresentationError::UnimplementedListType { declaration: list.clone() }))
+        }
     }
 }
 

--- a/ir/translation/fetch.rs
+++ b/ir/translation/fetch.rs
@@ -530,7 +530,7 @@ fn register_key(parameters: &mut ParameterRegistry, key: &StringLiteral) -> Para
     parameters.register_fetch_key(String::from_typeql_literal(key).unwrap())
 }
 
-typedb_error!(
+typedb_error! {
     pub FetchRepresentationError(component = "Fetch representation", prefix = "FER") {
         Unimplemented(
             0,
@@ -566,18 +566,18 @@ typedb_error!(
         ExpressionRepresentation(
             6,
             "Error building representation of expression.",
-            ( typedb_source : Box<RepresentationError> )
+            typedb_source: Box<RepresentationError>
         ),
         ExpressionAsMatchRepresentation(
             7,
             "Failed to convert fetch-expression ('key': <expression>) into full match-return ('key': (match $anon = <expression>; return first $anon;)) failed.",
-            ( typedb_source : Box<RepresentationError> )
+            typedb_source: Box<RepresentationError>
         ),
         FunctionRetrieval(
             8,
             "Error while retrieving function '{name}'.",
             name: String,
-            ( source : FunctionReadError )
+            source: FunctionReadError
         ),
         FunctionNotFound(
             9,
@@ -634,7 +634,7 @@ typedb_error!(
         SubFetchRepresentation(
             19,
             "Error building representation of fetch sub-query.",
-            (typedb_source : Box<RepresentationError>)
+            typedb_source: Box<RepresentationError>
         ),
         SubQueryIsNotFetch(
             20,
@@ -648,4 +648,4 @@ typedb_error!(
             declaration: TypeQLFetchObject
         ),
     }
-);
+}

--- a/query/definable_resolution.rs
+++ b/query/definable_resolution.rs
@@ -462,7 +462,7 @@ pub(crate) fn try_resolve_plays_role_label(
 }
 
 // TODO: ideally these all have TypeQL declarations, so we can pinpoint line number in these errors!
-typedb_error!(
+typedb_error! {
     pub(crate) SymbolResolutionError(component = "Symbol resolution", prefix = "SYR") {
         TypeNotFound(1, "The type '{label}' was not found.", label: Label),
         StructNotFound(2, "The struct value type '{name}' was not found.", name: String),
@@ -475,12 +475,12 @@ typedb_error!(
         AttributeTypeNotFound(9, "The attribute type '{label}' was not found.", label: Label),
         RoleTypeNotFound(10, "The role type '{label}' was not found.", label: Label),
         RelatesNotFound(11, "The relation type '{label}' does not relate role '{role_name}'", label: Label, role_name: String),
-        OwnsNotFound(12, "The type '{owner_label}' does not own attribute type '{attribute_label}'.", owner_label: Label, attribute_label: Label ),
+        OwnsNotFound(12, "The type '{owner_label}' does not own attribute type '{attribute_label}'.", owner_label: Label, attribute_label: Label),
         PlaysNotFound(13, "The type '{player_label}' does not play the role '{role_label}'.", player_label: Label, role_label: Label),
         ScopedValueTypeName(14, "Value type names cannot have scopes. Provided illegal name: '{scope}:{name}'.", scope: String, name: String),
-        ExpectedNonOptionalTypeSymbol(15, "Expected a type label or a type[] label, but not an optional type? label.\nSource:\n{declaration}", declaration: TypeRefAny ),
+        ExpectedNonOptionalTypeSymbol(15, "Expected a type label or a type[] label, but not an optional type? label.\nSource:\n{declaration}", declaration: TypeRefAny),
         ExpectedLabelButGotBuiltinValueType(16, "Expected type label got built-in value type name:\nSource:\n{declaration}", declaration: NamedType),
-        UnexpectedConceptRead(17, "Unexpected concept read error.", ( source: Box<ConceptReadError> ) ),
+        UnexpectedConceptRead(17, "Unexpected concept read error.", source: Box<ConceptReadError>),
         IllegalKeywordAsIdentifier(18, "The reserved keyword \"{identifier}\" cannot be used as an identifier.", identifier: typeql::Identifier),
     }
-);
+}

--- a/query/define.rs
+++ b/query/define.rs
@@ -979,17 +979,17 @@ fn err_unsupported_capability(label: &Label, kind: Kind, capability: &TypeQLCapa
     DefineError::TypeCannotHaveCapability { type_: label.to_owned(), kind, capability: capability.clone() }
 }
 
-typedb_error!(
+typedb_error! {
     pub DefineError(component = "Define execution", prefix = "DEX") {
         Unimplemented(1, "Unimplemented define functionality: {description}", description: String),
-        UnexpectedConceptRead(2, "Concept read error. ", ( source: Box<ConceptReadError> )),
-        SymbolResolution(3, "Failed to find symbol.", ( typedb_source: Box<SymbolResolutionError> )),
-        LiteralParseError(4, "Failed to parse literal.", ( source: LiteralParseError )),
+        UnexpectedConceptRead(2, "Concept read error. ", source: Box<ConceptReadError>),
+        SymbolResolution(3, "Failed to find symbol.", typedb_source: Box<SymbolResolutionError>),
+        LiteralParseError(4, "Failed to parse literal.", source: LiteralParseError),
         TypeCreateError(
             5,
             "Failed to create type.\nSource:\n{type_declaration}",
             type_declaration: Type,
-            ( typedb_source: Box<ConceptWriteError> )
+            typedb_source: Box<ConceptWriteError>
         ),
         RoleTypeDirectCreate(
             6,
@@ -1000,14 +1000,14 @@ typedb_error!(
             7,
             "Failed to create struct.\nSource:\n{struct_declaration}",
             struct_declaration: Struct,
-            ( typedb_source: Box<ConceptWriteError> )
+            typedb_source: Box<ConceptWriteError>
         ),
         StructFieldCreateError(
             8,
             "Failed to create struct field '{struct_field}' in struct type '{struct_name}'.",
             struct_field: Field,
             struct_name: String,
-            ( typedb_source: Box<ConceptWriteError> )
+            typedb_source: Box<ConceptWriteError>
         ),
         StructFieldAlreadyDefinedButDifferent(
             9,
@@ -1020,7 +1020,7 @@ typedb_error!(
             10,
             "Setting supertype failed.\nSource: {sub}",
             sub: typeql::schema::definable::type_::capability::Sub,
-            ( typedb_source: Box<ConceptWriteError> )
+            typedb_source: Box<ConceptWriteError>
         ),
         TypeCannotHaveCapability(
             11,
@@ -1032,7 +1032,7 @@ typedb_error!(
         ValueTypeSymbolResolution(
             12,
             "Error resolving value type in define query.",
-            ( typedb_source: Box<SymbolResolutionError> )
+            typedb_source: Box<SymbolResolutionError>
         ),
         TypeSubAlreadyDefinedButDifferent(
             13,
@@ -1103,46 +1103,46 @@ typedb_error!(
             "Defining '{type_}' to have value type '{value_type}' failed.",
             type_: Label,
             value_type: ValueType,
-            ( typedb_source: Box<ConceptWriteError> )
+            typedb_source: Box<ConceptWriteError>
         ),
         CreateRelates(
             21,
             "Defining new '{key}' failed.\nSource:\n{relates}",
             relates: TypeQLRelates,
             key: Keyword,
-            ( typedb_source: Box<ConceptWriteError> )
+            typedb_source: Box<ConceptWriteError>
         ),
         CreatePlays(
             22,
             "Defining new '{key}' failed.\nSource:\n{plays}",
             plays: TypeQLPlays,
             key: Keyword,
-            ( typedb_source: Box<ConceptWriteError> )
+            typedb_source: Box<ConceptWriteError>
         ),
         CreateOwns(
             23,
             "Defining new '{key}' failed.\nSource:\n{owns}",
             owns: TypeQLOwns,
             key: Keyword,
-            ( typedb_source: Box<ConceptWriteError> )
+            typedb_source: Box<ConceptWriteError>
         ),
         IllegalAnnotation(
             24,
             "Illegal annotation",
-            ( source: AnnotationError )
+            source: AnnotationError
         ),
         SetAnnotation(
             25,
             "Defining annotation failed for type '{type_}'.\nSource:\n{annotation_declaration}",
             type_: Label,
             annotation_declaration: typeql::annotation::Annotation,
-            ( typedb_source: Box<ConceptWriteError> )
+            typedb_source: Box<ConceptWriteError>
         ),
         SetSpecialise(
             26,
             "Defining specialise failed for type '{type_}'.",
             type_: Label,
-            ( typedb_source: Box<ConceptWriteError> )
+            typedb_source: Box<ConceptWriteError>
         ),
         CapabilityKindMismatch(
             27,
@@ -1156,8 +1156,8 @@ typedb_error!(
         FunctionDefinition(
             28,
             "An error occurred by defining the function",
-            ( typedb_source: FunctionError )
+            typedb_source: FunctionError
         ),
         IllegalKeywordAsIdentifier(29, "The reserved keyword \"{identifier}\" cannot be used as an identifier.", identifier: typeql::Identifier),
     }
-);
+}

--- a/query/error.rs
+++ b/query/error.rs
@@ -16,23 +16,23 @@ use ir::RepresentationError;
 
 use crate::{define::DefineError, redefine::RedefineError, undefine::UndefineError};
 
-typedb_error!(
+typedb_error! {
     pub QueryError(component = "Query execution", prefix = "QEX") {
         // TODO: decide if we want to include whole query
-        ParseError(1, "Failed to parse TypeQL query.", query: String, ( typedb_source: typeql::Error )),
-        Define(2, "Failed to execute define query.", ( typedb_source: DefineError )),
-        Redefine(3, "Failed to execute redefine query.", ( typedb_source: RedefineError )),
-        Undefine(4, "Failed to execute undefine query.", ( typedb_source: UndefineError )),
-        FunctionDefinition(5, "Error defining function. ", ( typedb_source: FunctionError )),
-        Representation(7, "Error in provided query. ", ( typedb_source: Box<RepresentationError> )),
-        Annotation(8, "Error analysing query. ", ( typedb_source: AnnotationError )),
-        Transformation(9, "Error applying query transformation. ", ( typedb_source: StaticOptimiserError )),
-        ExecutableCompilation(10, "Error compiling query. ", ( typedb_source: ExecutableCompilationError )),
-        WriteCompilation(11, "Error while compiling write query.", ( source: WriteCompilationError )),
-        ExpressionCompilation(12, "Error while compiling expression.", ( source: ExpressionCompileError )),
-        Pipeline(13, "Pipeline error.", ( typedb_source: Box<PipelineError> )),
-        WritePipelineExecution(14, "Error while execution write pipeline.", ( typedb_source: Box<PipelineExecutionError> )),
-        ReadPipelineExecution(15, "Error while executing read pipeline.", ( typedb_source: Box<PipelineExecutionError> )),
+        ParseError(1, "Failed to parse TypeQL query.", query: String, typedb_source: typeql::Error),
+        Define(2, "Failed to execute define query.", typedb_source: DefineError),
+        Redefine(3, "Failed to execute redefine query.", typedb_source: RedefineError),
+        Undefine(4, "Failed to execute undefine query.", typedb_source: UndefineError),
+        FunctionDefinition(5, "Error defining function. ", typedb_source: FunctionError),
+        Representation(7, "Error in provided query. ", typedb_source: Box<RepresentationError>),
+        Annotation(8, "Error analysing query. ", typedb_source: AnnotationError),
+        Transformation(9, "Error applying query transformation. ", typedb_source: StaticOptimiserError),
+        ExecutableCompilation(10, "Error compiling query. ", typedb_source: ExecutableCompilationError),
+        WriteCompilation(11, "Error while compiling write query.", source: WriteCompilationError),
+        ExpressionCompilation(12, "Error while compiling expression.", source: ExpressionCompileError),
+        Pipeline(13, "Pipeline error.", typedb_source: Box<PipelineError>),
+        WritePipelineExecution(14, "Error while execution write pipeline.", typedb_source: Box<PipelineExecutionError>),
+        ReadPipelineExecution(15, "Error while executing read pipeline.", typedb_source: Box<PipelineExecutionError>),
         QueryExecutionClosedEarly(16, "Query execution was closed before it finished, possibly due to transaction close, rollback, commit, or a server-side error (these should be visible in the server logs)."),
     }
-);
+}

--- a/query/redefine.rs
+++ b/query/redefine.rs
@@ -1002,13 +1002,13 @@ fn error_if_anything_redefined_else_set_true(anything_redefined: &mut bool) -> R
     }
 }
 
-typedb_error!(
+typedb_error! {
     pub RedefineError(component = "Redefine execution", prefix = "REX") {
         Unimplemented(1, "Unimplemented redefine functionality: {description}", description: String),
-        UnexpectedConceptRead(2, "Concept read error during redefine query execution.", ( source: Box<ConceptReadError> )),
+        UnexpectedConceptRead(2, "Concept read error during redefine query execution.", source: Box<ConceptReadError>),
         NothingRedefined(3, "Nothing was redefined."),
-        DefinitionResolution(4, "Could not find symbol in redefine query.", ( typedb_source: Box<SymbolResolutionError> )),
-        LiteralParseError(5, "Error parsing literal in redefine query.", ( source : LiteralParseError )),
+        DefinitionResolution(4, "Could not find symbol in redefine query.", typedb_source: Box<SymbolResolutionError>),
+        LiteralParseError(5, "Error parsing literal in redefine query.", source: LiteralParseError),
         CanOnlyRedefineOneThingPerQuery(6, "Redefine queries can currently only mutate exactly one schema element per query."),
         StructFieldDoesNotExist(7, "Struct field used in redefine query does not exist.\nSource:\n{declaration}", declaration: Field),
         StructFieldRemainsSame(8, "Struct field in redefine was not changed. Redefine queries are required to update the schema.\nSource:\n{declaration}", declaration: Field),
@@ -1017,20 +1017,20 @@ typedb_error!(
             "Error removing field from struct type '{struct_name}'.\nSource:\n{declaration}",
             struct_name: String,
             declaration: Field,
-            ( typedb_source: Box<ConceptWriteError> )
+            typedb_source: Box<ConceptWriteError>
         ),
         StructFieldCreateError(
             10,
             "Error creating new field in struct type '{struct_name}'.\nSource:\n{declaration}",
             struct_name: String,
             declaration: Field,
-            ( typedb_source: Box<ConceptWriteError> )
+            typedb_source: Box<ConceptWriteError>
         ),
         SetSupertype(
             11,
             "Error setting supertype during redefine.\nSource:\n{declaration}",
             declaration: typeql::schema::definable::type_::capability::Sub,
-            ( typedb_source: Box<ConceptWriteError> )
+            typedb_source: Box<ConceptWriteError>
         ),
         TypeCannotHaveCapability(
             12,
@@ -1042,7 +1042,7 @@ typedb_error!(
         ValueTypeSymbolResolution(
             13,
             "Error resolving value type in redefine query.",
-            ( typedb_source: Box<SymbolResolutionError> )
+            typedb_source: Box<SymbolResolutionError>
         ),
         TypeSubNotDefined(
             14,
@@ -1151,7 +1151,7 @@ typedb_error!(
             "Redefining '{type_}' to have value type '{value_type}' failed.",
             type_: Label,
             value_type: ValueType,
-            ( typedb_source: Box<ConceptWriteError> )
+            typedb_source: Box<ConceptWriteError>
         ),
         SetRelatesOrdering(
             28,
@@ -1159,7 +1159,7 @@ typedb_error!(
             type_: Label,
             key: Keyword,
             declaration: TypeQLRelates,
-            ( typedb_source: Box<ConceptWriteError> )
+            typedb_source: Box<ConceptWriteError>
         ),
         SetOwnsOrdering(
             29,
@@ -1167,7 +1167,7 @@ typedb_error!(
             type_: Label,
             key: Keyword,
             declaration: TypeQLOwns,
-            ( typedb_source: Box<ConceptWriteError> )
+            typedb_source: Box<ConceptWriteError>
         ),
         IllegalTypeAnnotation(
             30,
@@ -1175,14 +1175,14 @@ typedb_error!(
             type_: Label,
             annotation: Annotation,
             declaration: Type,
-            ( source: AnnotationError )
+            source: AnnotationError
         ),
         IllegalCapabilityAnnotation(
             31,
             "Redefining to have annotation '{annotation}' failed.\nSource:\n{declaration}",
             annotation: Annotation,
             declaration: Capability,
-            ( source: AnnotationError )
+            source: AnnotationError
         ),
         SetTypeAnnotation(
             32,
@@ -1190,14 +1190,14 @@ typedb_error!(
             type_: Label,
             annotation: Annotation,
             declaration: Type,
-            ( typedb_source: Box<ConceptWriteError> )
+            typedb_source: Box<ConceptWriteError>
         ),
         SetCapabilityAnnotation(
             33,
             "Redefining '{annotation}' failed.\nSource:\n{declaration}",
             annotation: Annotation,
             declaration: Capability,
-            ( typedb_source: Box<ConceptWriteError> )
+            typedb_source: Box<ConceptWriteError>
         ),
         SetRelatesSpecialise(
             34,
@@ -1206,7 +1206,7 @@ typedb_error!(
             relates_key: Keyword,
             as_key: Keyword,
             declaration: TypeQLRelates,
-            ( typedb_source: Box<ConceptWriteError> )
+            typedb_source: Box<ConceptWriteError>
         ),
         CapabilityKindMismatch(
             35,
@@ -1221,11 +1221,11 @@ typedb_error!(
             36,
             "Redefining the function \"{name}\" failed",
             name: String,
-            ( typedb_source: Box<FunctionError> )
+            typedb_source: Box<FunctionError>
         ),
         IllegalKeywordAsIdentifier(37, "The reserved keyword \"{identifier}\" cannot be used as an identifier.", identifier: typeql::Identifier),
     }
-);
+}
 
 fn err_unsupported_capability(label: &Label, kind: Kind, capability: &Capability) -> RedefineError {
     RedefineError::TypeCannotHaveCapability { type_: label.to_owned(), kind, declaration: capability.clone() }

--- a/query/undefine.rs
+++ b/query/undefine.rs
@@ -930,62 +930,62 @@ fn err_unsupported_capability(label: &Label, kind: Kind, capability: &Capability
     UndefineError::TypeCannotHaveCapability { type_: label.to_owned(), kind, capability: capability.clone() }
 }
 
-typedb_error!(
+typedb_error! {
     pub UndefineError(component = "Undefine execution", prefix = "UEX") {
         Unimplemented(1, "Unimplemented undefine functionality: {description}", description: String),
-        UnexpectedConceptRead(2, "Concept read error during undefine query execution.", ( source: Box<ConceptReadError> )),
-        DefinitionResolution(3, "Could not find symbol in undefine query.", ( typedb_source: Box<SymbolResolutionError> )),
-        LiteralParseError(4, "Error parsing literal in undefine query.", ( source : LiteralParseError )),
+        UnexpectedConceptRead(2, "Concept read error during undefine query execution.", source: Box<ConceptReadError>),
+        DefinitionResolution(3, "Could not find symbol in undefine query.", typedb_source: Box<SymbolResolutionError>),
+        LiteralParseError(4, "Error parsing literal in undefine query.", source: LiteralParseError),
         StructDoesNotExist(5, "Struct used in undefine query does not exist.\nSource:\n{declaration}", declaration: Struct),
         StructDeleteError(
             6,
             "Error removing struct type '{struct_name}'.\nSource:\n{declaration}",
             struct_name: String,
             declaration: Struct,
-            ( typedb_source: Box<ConceptWriteError> )
+            typedb_source: Box<ConceptWriteError>
         ),
         TypeDeleteError(
             7,
             "Error removing type '{label}'.\nSource:\n{declaration}",
             label: Label,
             declaration: TypeQLLabel,
-            ( typedb_source: Box<ConceptWriteError> )
+            typedb_source: Box<ConceptWriteError>
         ),
         ValueTypeSymbolResolution(
             8,
             "Error resolving value type in undefine query.",
-            ( typedb_source: Box<SymbolResolutionError> )
+            typedb_source: Box<SymbolResolutionError>
         ),
         UnsetSupertypeError(
             9,
             "Undefining supertype failed.\nSource: {sub}",
             sub: TypeQLSub,
-            ( typedb_source: Box<ConceptWriteError> )
+            typedb_source: Box<ConceptWriteError>
         ),
         UnsetOwnsError(
             10,
             "Undefining owns failed.\nSource: {owns}",
             owns: TypeQLOwns,
-            ( typedb_source: Box<ConceptWriteError> )
+            typedb_source: Box<ConceptWriteError>
         ),
         DeleteRoleTypeError(
             11,
             "Undefining relates (role type) failed.\nSource: {relates}",
             relates: TypeQLRelates,
-            ( typedb_source: Box<ConceptWriteError> )
+            typedb_source: Box<ConceptWriteError>
         ),
         UnsetPlaysError(
             12,
             "Undefining plays failed.\nSource: {plays}",
             plays: TypeQLPlays,
-            ( typedb_source: Box<ConceptWriteError> )
+            typedb_source: Box<ConceptWriteError>
         ),
         UnsetValueTypeError(
             13,
             "Undefining '{label}' to have value type '{value_type}' failed.",
             label: Label,
             value_type: ValueType,
-            ( typedb_source: Box<ConceptWriteError> )
+            typedb_source: Box<ConceptWriteError>
         ),
         UnsetTypeAnnotationError(
             14,
@@ -993,21 +993,21 @@ typedb_error!(
             label: Label,
             annotation_category: AnnotationCategory,
             declaration: AnnotationType,
-            ( typedb_source: Box<ConceptWriteError> )
+            typedb_source: Box<ConceptWriteError>
         ),
         UnsetCapabilityAnnotationError(
             15,
             "Undefining '{annotation_category}' failed.\nSource:\n{declaration}",
             annotation_category: AnnotationCategory,
             declaration: AnnotationCapability,
-            ( typedb_source: Box<ConceptWriteError> )
+            typedb_source: Box<ConceptWriteError>
         ),
         UnsetRelatesSpecialiseError(
             16,
             "For relation type '{type_}', undefining `relates as' failed.\nSource:\n{declaration}",
             type_: Label,
             declaration: Specialise,
-            ( typedb_source: Box<ConceptWriteError> )
+            typedb_source: Box<ConceptWriteError>
         ),
         TypeCannotHaveCapability(
             17,
@@ -1155,7 +1155,7 @@ typedb_error!(
         IllegalAnnotation(
             33,
             "Illegal annotation",
-            ( source: AnnotationError )
+            source: AnnotationError
         ),
         CapabilityKindMismatch(
             34,
@@ -1170,8 +1170,8 @@ typedb_error!(
             35,
             "Undefining the function \"{name}\" failed",
             name: String,
-            ( typedb_source: Box<FunctionError> )
+            typedb_source: Box<FunctionError>
         ),
         IllegalKeywordAsIdentifier(37, "The reserved keyword \"{identifier}\" cannot be used as an identifier.", identifier: typeql::Identifier),
     }
-);
+}

--- a/resource/constants.rs
+++ b/resource/constants.rs
@@ -30,7 +30,10 @@ pub mod server {
 
     pub const SERVER_ID_FILE_NAME: &str = "_server_id";
     pub const SERVER_ID_LENGTH: u64 = 16;
-    pub const SERVER_ID_ALPHABET: &str = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
+    pub const SERVER_ID_ALPHABET: [char; 36] = [
+        'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M', 'N', 'O', 'P', 'Q', 'R', 'S', 'T', 'U', 'V',
+        'W', 'X', 'Y', 'Z', '0', '1', '2', '3', '4', '5', '6', '7', '8', '9',
+    ];
 
     pub const AUTHENTICATOR_USERNAME_FIELD: &str = "username";
     pub const AUTHENTICATOR_PASSWORD_FIELD: &str = "password";

--- a/server/service/transaction_service.rs
+++ b/server/service/transaction_service.rs
@@ -91,7 +91,7 @@ pub enum Transaction {
 }
 
 macro_rules! with_readable_transaction {
-    ($match_:expr, |$transaction: ident| $block: block ) => {{
+    ($match_:expr, |$transaction:ident| $block:block) => {{
         match $match_ {
             Transaction::Read($transaction) => $block
             Transaction::Write($transaction) => $block
@@ -1634,18 +1634,18 @@ impl<T, E> ResultControlFlowExt<T, E> for ControlFlow<Result<T, E>> {
     }
 }
 
-typedb_error!(
+typedb_error! {
     pub(crate) TransactionServiceError(component = "Transaction service", prefix = "TSV") {
         DatabaseNotFound(1, "Database '{name}' not found.", name: String),
         CannotCommitReadTransaction(2, "Read transactions cannot be committed."),
         CannotRollbackReadTransaction(3, "Read transactions cannot be rolled back, since they never contain writes."),
-        TransactionFailed(4, "Transaction failed.", ( typedb_source: TransactionError )),
-        DataCommitFailed(5, "Data transaction commit failed.", ( typedb_source: DataCommitError )),
-        SchemaCommitFailed(6, "Schema transaction commit failed.", ( typedb_source : SchemaCommitError )),
-        QueryParseFailed(7, "Query parsing failed.", ( typedb_source: typeql::Error )),
+        TransactionFailed(4, "Transaction failed.", typedb_source: TransactionError),
+        DataCommitFailed(5, "Data transaction commit failed.", typedb_source: DataCommitError),
+        SchemaCommitFailed(6, "Schema transaction commit failed.", typedb_source: SchemaCommitError),
+        QueryParseFailed(7, "Query parsing failed.", typedb_source: typeql::Error),
         SchemaQueryRequiresSchemaTransaction(8, "Schema modification queries require schema transactions."),
         WriteQueryRequiresSchemaOrWriteTransaction(9, "Data modification queries require either write or schema transactions."),
-        TxnAbortSchemaQueryFailed(10, "Aborting transaction due to failed schema query.", ( typedb_source : QueryError )),
+        TxnAbortSchemaQueryFailed(10, "Aborting transaction due to failed schema query.", typedb_source: QueryError),
         NoOpenTransaction(11, "Operation failed - no open transaction."),
         QueryInterrupted(12, "Execution interrupted by to a concurrent {interrupt}.", interrupt: InterruptType),
         QueryStreamNotFound(
@@ -1658,4 +1658,4 @@ typedb_error!(
         ),
         ServiceClosingFailedQueueCleanup(14, "The operation failed since the service is closing."),
     }
-);
+}

--- a/server/service/typedb_service.rs
+++ b/server/service/typedb_service.rs
@@ -345,11 +345,11 @@ fn extract_username_field(metadata: &MetadataMap) -> String {
         .to_string()
 }
 
-typedb_error!(
+typedb_error! {
     ServiceError(component = "Server", prefix = "SRV") {
         Unimplemented(1, "Not implemented: {description}", description: String),
         OperationNotPermitted(2, "The user is not permitted to execute the operation"),
         DatabaseDoesNotExist(3, "Database '{name}' does not exist.", name: String),
         UserDoesNotExist(4, "User does not exist"),
     }
-);
+}

--- a/server/typedb.rs
+++ b/server/typedb.rs
@@ -10,7 +10,7 @@ use concurrency::IntervalRunner;
 use database::{database_manager::DatabaseManager, DatabaseOpenError};
 use diagnostics::{diagnostics_manager::DiagnosticsManager, Diagnostics};
 use error::typedb_error;
-use rand::Rng;
+use rand::seq::SliceRandom;
 use resource::constants::server::{
     DATABASE_METRICS_UPDATE_INTERVAL, GRPC_CONNECTION_KEEPALIVE, SERVER_ID_ALPHABET, SERVER_ID_FILE_NAME,
     SERVER_ID_LENGTH,
@@ -211,12 +211,7 @@ impl Server {
 
     fn generate_server_id() -> String {
         let mut rng = rand::thread_rng();
-        (0..SERVER_ID_LENGTH)
-            .map(|_| {
-                let idx = rng.gen_range(0..SERVER_ID_ALPHABET.len());
-                SERVER_ID_ALPHABET.chars().nth(idx).unwrap()
-            })
-            .collect()
+        (0..SERVER_ID_LENGTH).map(|_| SERVER_ID_ALPHABET.choose(&mut rng).unwrap()).collect()
     }
 
     fn print_hello(distribution: &'static str, version: &'static str, is_development_mode_enabled: bool) {

--- a/server/typedb.rs
+++ b/server/typedb.rs
@@ -4,7 +4,12 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-use std::{fs, io, net::SocketAddr, path::PathBuf, sync::Arc};
+use std::{
+    fs, io,
+    net::SocketAddr,
+    path::{Path, PathBuf},
+    sync::Arc,
+};
 
 use concurrency::IntervalRunner;
 use database::{database_manager::DatabaseManager, DatabaseOpenError};
@@ -58,7 +63,7 @@ impl Server {
         let server_id = Self::initialise_server_id(storage_directory)?;
         let deployment_id = deployment_id.unwrap_or(server_id.clone());
         let server_address = resolve_address(server_config.address.clone()).await;
-        let mut diagnostics_manager = Arc::new(Self::initialise_diagnostics(
+        let diagnostics_manager = Arc::new(Self::initialise_diagnostics(
             deployment_id.clone(),
             server_id.clone(),
             distribution,
@@ -127,7 +132,7 @@ impl Server {
             .await
     }
 
-    fn initialise_storage_directory(storage_directory: &PathBuf) -> Result<(), ServerOpenError> {
+    fn initialise_storage_directory(storage_directory: &Path) -> Result<(), ServerOpenError> {
         if !storage_directory.exists() {
             Self::create_storage_directory(storage_directory)
         } else if !storage_directory.is_dir() {
@@ -173,7 +178,7 @@ impl Server {
         tonic_server.http2_keepalive_interval(Some(GRPC_CONNECTION_KEEPALIVE))
     }
 
-    fn create_storage_directory(storage_directory: &PathBuf) -> Result<(), ServerOpenError> {
+    fn create_storage_directory(storage_directory: &Path) -> Result<(), ServerOpenError> {
         fs::create_dir_all(storage_directory).map_err(|source| ServerOpenError::CouldNotCreateDataDirectory {
             path: storage_directory.to_str().unwrap_or("").to_owned(),
             source: Arc::new(source),
@@ -181,7 +186,7 @@ impl Server {
         Ok(())
     }
 
-    fn initialise_server_id(storage_directory: &PathBuf) -> Result<String, ServerOpenError> {
+    fn initialise_server_id(storage_directory: &Path) -> Result<String, ServerOpenError> {
         let server_id_file = storage_directory.join(SERVER_ID_FILE_NAME);
         if server_id_file.exists() {
             let server_id = fs::read_to_string(&server_id_file)
@@ -215,11 +220,12 @@ impl Server {
     }
 
     fn print_hello(distribution: &'static str, version: &'static str, is_development_mode_enabled: bool) {
-        print!("{}", format!("Running {distribution} {version}"));
         if is_development_mode_enabled {
-            print!(" in development mode");
+            println!("Running {distribution} {version} in development mode.");
+        } else {
+            println!("Running {distribution} {version}.");
         }
-        println!(".\nReady!");
+        println!("Ready!");
     }
 }
 
@@ -238,7 +244,7 @@ async fn resolve_address(address: String) -> SocketAddr {
         .await
         .unwrap()
         .next()
-        .expect(format!("Unable to map address '{}' to any IP addresses", address).as_str())
+        .unwrap_or_else(|| panic!("Unable to map address '{}' to any IP addresses", address))
 }
 
 typedb_error!(

--- a/server/typedb.rs
+++ b/server/typedb.rs
@@ -247,13 +247,13 @@ async fn resolve_address(address: String) -> SocketAddr {
         .unwrap_or_else(|| panic!("Unable to map address '{}' to any IP addresses", address))
 }
 
-typedb_error!(
+typedb_error! {
     pub ServerOpenError(component = "Server open", prefix = "SRO") {
         NotADirectory(1, "Invalid path '{path}': not a directory.", path: String),
-        CouldNotReadServerIDFile(2, "Could not read data from server ID file '{path}'.", path: String, ( source: Arc<io::Error> )),
-        CouldNotCreateServerIDFile(3, "Could not write data to server ID file '{path}'.", path: String, ( source: Arc<io::Error> )),
-        CouldNotCreateDataDirectory(4, "Could not create data directory in '{path}'.", path: String, ( source: Arc<io::Error> )),
+        CouldNotReadServerIDFile(2, "Could not read data from server ID file '{path}'.", path: String, source: Arc<io::Error>),
+        CouldNotCreateServerIDFile(3, "Could not write data to server ID file '{path}'.", path: String, source: Arc<io::Error>),
+        CouldNotCreateDataDirectory(4, "Could not create data directory in '{path}'.", path: String, source: Arc<io::Error>),
         InvalidServerID(5, "Server ID read from '{path}' is invalid. Delete the corrupted file and try again.", path: String),
-        DatabaseOpen(6, "Could not open database.", ( typedb_source: DatabaseOpenError )),
+        DatabaseOpen(6, "Could not open database.", typedb_source: DatabaseOpenError),
     }
-);
+}

--- a/storage/durability_client.rs
+++ b/storage/durability_client.rs
@@ -237,13 +237,13 @@ impl DurabilityClient for WALClient {
     }
 }
 
-typedb_error!(
+typedb_error! {
     pub DurabilityClientError(component = "Durability client", prefix = "DUC") {
-        SerializeError(1, "Durability client failed to serialise/deserialise durability record", ( source: Arc<bincode::Error> )),
-        ServiceError(2, "Error from durability service.", ( source: DurabilityServiceError )),
-        CompressionError(3, "Error while compressing durability record.", ( source: Arc<io::Error> )),
+        SerializeError(1, "Durability client failed to serialise/deserialise durability record", source: Arc<bincode::Error>),
+        ServiceError(2, "Error from durability service.", source: DurabilityServiceError),
+        CompressionError(3, "Error while compressing durability record.", source: Arc<io::Error>),
     }
-);
+}
 
 impl From<bincode::Error> for DurabilityClientError {
     fn from(source: bincode::Error) -> Self {

--- a/storage/recovery/checkpoint.rs
+++ b/storage/recovery/checkpoint.rs
@@ -251,17 +251,17 @@ impl Error for CheckpointCreateError {
     }
 }
 
-typedb_error!(
+typedb_error! {
     pub CheckpointLoadError(component = "Checkpoint load.", prefix = "CLO") {
-        CheckpointRead(1, "Error to reading checkpoint directory '{dir:?}'.", dir: PathBuf, ( source: Arc<io::Error> )),
-        MetadataRead(2, "Error reading checkpoint metadata file in directory '{dir:?}.", dir: PathBuf, ( source: Arc<io::Error> )),
+        CheckpointRead(1, "Error to reading checkpoint directory '{dir:?}'.", dir: PathBuf, source: Arc<io::Error>),
+        MetadataRead(2, "Error reading checkpoint metadata file in directory '{dir:?}.", dir: PathBuf, source: Arc<io::Error>),
         CheckpointNotFound(3, "No checkpoints found in directory '{dir:?}.", dir: PathBuf),
-        CommitRecoveryFailed(4, "Failed to recover commits that are in the WAL but not in the storage layer.", ( typedb_source : StorageRecoveryError )),
-        CheckpointRestore(5, "Error restoring checkpoint in directory '{dir:?}'.)", dir: PathBuf, ( source: Arc<io::Error> )),
-        KeyspaceOpen(7, "Error while opening storage keyspaces.", ( source: KeyspaceOpenError )),
+        CommitRecoveryFailed(4, "Failed to recover commits that are in the WAL but not in the storage layer.", typedb_source: StorageRecoveryError),
+        CheckpointRestore(5, "Error restoring checkpoint in directory '{dir:?}'.)", dir: PathBuf, source: Arc<io::Error>),
+        KeyspaceOpen(7, "Error while opening storage keyspaces.", source: KeyspaceOpenError),
 
-        AdditionalDataNotFound(8, "Checkpoint additional data with identifier '{name}' not found.", name: String ),
-        AdditionalDataIO(9, "Error accessing checkpoint additional data with identifier '{name}'.", name: String, ( source: Arc<io::Error> )),
-        AdditionalDataDeserialise(10, "Error deserialising checkpoint additional data with identifier '{name}'.", name: String, ( source: Arc<bincode::Error> )),
+        AdditionalDataNotFound(8, "Checkpoint additional data with identifier '{name}' not found.", name: String),
+        AdditionalDataIO(9, "Error accessing checkpoint additional data with identifier '{name}'.", name: String, source: Arc<io::Error>),
+        AdditionalDataDeserialise(10, "Error deserialising checkpoint additional data with identifier '{name}'.", name: String, source: Arc<bincode::Error>),
     }
-);
+}

--- a/storage/recovery/commit_recovery.rs
+++ b/storage/recovery/commit_recovery.rs
@@ -131,16 +131,16 @@ pub enum RecoveryCommitStatus {
     Rejected,
 }
 
-typedb_error!(
+typedb_error! {
     pub StorageRecoveryError(component = "Storage recovery", prefix = "REC") {
-        DurabilityRecordDeserialize(1, "Failed to deserialise WAL record.", ( source: Arc<bincode::Error> )),
-        DurabilityClientRead(2, "Durability client read error.", (typedb_source : DurabilityClientError )),
-        DurabilityClientWrite(3, "Durability client write error.", (typedb_source : DurabilityClientError )),
+        DurabilityRecordDeserialize(1, "Failed to deserialise WAL record.", source: Arc<bincode::Error>),
+        DurabilityClientRead(2, "Durability client read error.", typedb_source: DurabilityClientError),
+        DurabilityClientWrite(3, "Durability client write error.", typedb_source: DurabilityClientError),
         DurabilityRecordsMissing(
             4,
             "Missing initial WAL records - expected first record number '{expected_sequence_number}', but found '{first_record_sequence_number}'.",
             expected_sequence_number: SequenceNumber, first_record_sequence_number: SequenceNumber
         ),
-        KeyspaceWrite(5, "Error writing recovered commits to keyspace.", ( source: KeyspaceError )),
+        KeyspaceWrite(5, "Error writing recovered commits to keyspace.", source: KeyspaceError),
     }
-);
+}

--- a/storage/snapshot/snapshot.rs
+++ b/storage/snapshot/snapshot.rs
@@ -554,11 +554,11 @@ impl<D: DurabilityClient> CommittableSnapshot<D> for SchemaSnapshot<D> {
     }
 }
 
-typedb_error!(
+typedb_error! {
     pub SnapshotError(component = "Snapshot error", prefix = "SST") {
-        Commit(1, "Snapshot commit failed due to storage commit error.", (typedb_source : StorageCommitError )),
+        Commit(1, "Snapshot commit failed due to storage commit error.", typedb_source: StorageCommitError),
     }
-);
+}
 
 #[derive(Debug, Clone)]
 pub enum SnapshotGetError {

--- a/storage/storage.rs
+++ b/storage/storage.rs
@@ -459,51 +459,51 @@ impl<Durability> MVCCStorage<Durability> {
     }
 }
 
-typedb_error!(
+typedb_error! {
     pub StorageOpenError(component = "Storage open", prefix = "STO") {
         StorageDirectoryExists(1, "Failed to open database '{name}' in directory '{path:?}'", name: String, path: PathBuf),
-        StorageDirectoryCreate(2, "Failed to create database '{name}'.", name: String, ( source: Arc<io::Error> )),
-        StorageDirectoryRecreate(3, "Failed to recreate database '{name}'.", name: String, ( source: Arc<io::Error> )),
+        StorageDirectoryCreate(2, "Failed to create database '{name}'.", name: String, source: Arc<io::Error>),
+        StorageDirectoryRecreate(3, "Failed to recreate database '{name}'.", name: String, source: Arc<io::Error>),
 
-        DurabilityClientOpen(4, "Failed to open durability client for database '{name}'.", name: String, (source: Arc<io::Error>)),
-        DurabilityClientRead(5, "Failed to read from durability client for database '{name}'.", name: String, (typedb_source: DurabilityClientError)),
-        DurabilityClientWrite(6, "Failed to write to durability client for database '{name}'.", name: String, (typedb_source: DurabilityClientError)),
+        DurabilityClientOpen(4, "Failed to open durability client for database '{name}'.", name: String, source: Arc<io::Error>),
+        DurabilityClientRead(5, "Failed to read from durability client for database '{name}'.", name: String, typedb_source: DurabilityClientError),
+        DurabilityClientWrite(6, "Failed to write to durability client for database '{name}'.", name: String, typedb_source: DurabilityClientError),
 
-        KeyspaceOpen(7, "Failed to open keyspace '{name}'.", name: String, (source: KeyspaceOpenError)),
-        Keyspace(8, "Failed to operate with keyspaces.", (source: KeyspaceError)),
+        KeyspaceOpen(7, "Failed to open keyspace '{name}'.", name: String, source: KeyspaceOpenError),
+        Keyspace(8, "Failed to operate with keyspaces.", source: KeyspaceError),
 
-        CheckpointCreate(9, "Failed to create checkpoint for database '{name}'.", name: String, (source: CheckpointCreateError)),
+        CheckpointCreate(9, "Failed to create checkpoint for database '{name}'.", name: String, source: CheckpointCreateError),
 
-        RecoverFromCheckpoint(10, "Failed to recover from checkpoint for database '{name}'.", name: String, (typedb_source: CheckpointLoadError)),
-        RecoverFromDurability(11, "Failed to recover from durability logs for database '{name}'.", name: String, (typedb_source: StorageRecoveryError)),
+        RecoverFromCheckpoint(10, "Failed to recover from checkpoint for database '{name}'.", name: String, typedb_source: CheckpointLoadError),
+        RecoverFromDurability(11, "Failed to recover from durability logs for database '{name}'.", name: String, typedb_source: StorageRecoveryError),
     }
-);
+}
 
-typedb_error!(
+typedb_error! {
     pub StorageCommitError(component = "Storage commit", prefix = "STC") {
-        Internal(1, "Commit in database '{name}' failed with internal error.", name: Arc<String>, (source: Arc<dyn Error + Send + Sync + 'static>)),
+        Internal(1, "Commit in database '{name}' failed with internal error.", name: Arc<String>, source: Arc<dyn Error + Send + Sync + 'static>),
         Isolation(2, "Commit in database '{name}' failed with isolation conflict: {conflict}", name: Arc<String>, conflict: IsolationConflict),
-        IO(3, "Commit in database '{name}' failed with I/O error'.", name: Arc<String>, ( source: Arc<io::Error> )),
-        MVCCRead(4, "Commit in database '{name}' failed due to failed read from MVCC storage layer.", name: Arc<String>, ( source: MVCCReadError )),
-        Keyspace(5, "Commit in database '{name}' failed due to a storage keyspace error.", name: Arc<String>, ( source: Arc<KeyspaceError> )),
-        Durability(6, "Commit in database '{name}' failed due to error in durability client.", name: Arc<String>, ( typedb_source: DurabilityClientError )),
+        IO(3, "Commit in database '{name}' failed with I/O error'.", name: Arc<String>, source: Arc<io::Error>),
+        MVCCRead(4, "Commit in database '{name}' failed due to failed read from MVCC storage layer.", name: Arc<String>, source: MVCCReadError),
+        Keyspace(5, "Commit in database '{name}' failed due to a storage keyspace error.", name: Arc<String>, source: Arc<KeyspaceError>),
+        Durability(6, "Commit in database '{name}' failed due to error in durability client.", name: Arc<String>, typedb_source: DurabilityClientError),
     }
-);
+}
 
-typedb_error!(
+typedb_error! {
     pub StorageDeleteError(component = "Storage delete", prefix = "STD") {
-        DurabilityDelete(1, "Deleting storage of database '{name}' failed partway while deleting durability records.", name: Arc<String>,  (typedb_source : DurabilityClientError )),
-        KeyspaceDelete(2, "Deleting storage of database '{name}' failed partway while deleting keyspaces: {errors:?}", name: Arc<String>, errors: Vec<KeyspaceDeleteError> ),
-        DirectoryDelete(3, "Deleting storage of database '{name}' failed partway while deleting directory.", name: Arc<String>, ( source: Arc<io::Error> )),
+        DurabilityDelete(1, "Deleting storage of database '{name}' failed partway while deleting durability records.", name: Arc<String>, typedb_source: DurabilityClientError),
+        KeyspaceDelete(2, "Deleting storage of database '{name}' failed partway while deleting keyspaces: {errors:?}", name: Arc<String>, errors: Vec<KeyspaceDeleteError>),
+        DirectoryDelete(3, "Deleting storage of database '{name}' failed partway while deleting directory.", name: Arc<String>, source: Arc<io::Error>),
     }
-);
+}
 
-typedb_error!(
+typedb_error! {
     pub StorageResetError(component = "Storage reset", prefix = "STR") {
-        KeyspaceError(1, "Resetting storage of database '{name}' failed partway while resetting keyspace.", name: Arc<String>, ( source: KeyspaceError )),
-        Durability(2, "Resetting storage of database '{name}' failed partway while resetting durability records.", name: Arc<String>, ( typedb_source : DurabilityClientError )),
+        KeyspaceError(1, "Resetting storage of database '{name}' failed partway while resetting keyspace.", name: Arc<String>, source: KeyspaceError),
+        Durability(2, "Resetting storage of database '{name}' failed partway while resetting durability records.", name: Arc<String>, typedb_source: DurabilityClientError),
     }
-);
+}
 
 /// MVCC keys are made of three parts: the [KEY][SEQ][OP]
 pub struct MVCCKey<'bytes> {

--- a/system/repositories.rs
+++ b/system/repositories.rs
@@ -178,10 +178,10 @@ pub mod user_repository {
         is_valid_identifier(value)
     }
 
-    typedb_error!(
+    typedb_error! {
         pub SystemDBError(component = "System database", prefix = "SDB") {
             EmptyUpdate(1, "There is nothing to update"),
             IllegalQueryInput(2, "The specified input contains one or more illegal character(s)"),
         }
-    );
+    }
 }

--- a/tests/behaviour/steps/connection/transaction.rs
+++ b/tests/behaviour/steps/connection/transaction.rs
@@ -123,7 +123,7 @@ pub async fn transaction_commits(context: &mut Context, may_error: params::MayEr
         ActiveTransaction::Write(tx) => {
             if let Some(error) = may_error.check(tx.commit()) {
                 match error {
-                    DataCommitError::ConceptWriteErrors { source: errors, .. } => {
+                    DataCommitError::ConceptWriteErrors { write_errors: errors, .. } => {
                         for error in errors {
                             may_error.check_concept_write_without_read_errors::<()>(&Err(Box::new(error)));
                         }
@@ -140,7 +140,7 @@ pub async fn transaction_commits(context: &mut Context, may_error: params::MayEr
         ActiveTransaction::Schema(tx) => {
             if let Some(error) = may_error.check(tx.commit()) {
                 match error {
-                    SchemaCommitError::ConceptWriteErrors { source: errors, .. } => {
+                    SchemaCommitError::ConceptWriteErrors { write_errors: errors, .. } => {
                         for error in errors {
                             may_error.check_concept_write_without_read_errors::<()>(&Err(Box::new(error)));
                         }

--- a/user/errors.rs
+++ b/user/errors.rs
@@ -6,35 +6,35 @@
 
 use error::typedb_error;
 
-typedb_error!(
+typedb_error! {
     pub UserGetError(component = "User create", prefix = "USC") {
         IllegalUsername(1, "Invalid credential supplied"),
         Unexpected(4, "An unexpected error has occurred in the process of getting a user"),
     }
-);
+}
 
-typedb_error!(
+typedb_error! {
     pub UserCreateError(component = "User create", prefix = "USC") {
         IllegalUsername(1, "Invalid credential supplied"),
         UserAlreadyExist(2, "Invalid credential supplied"),
         IncompleteUserDetail(3, "Incomplete user detail"),
         Unexpected(4, "An unexpected error has occurred in the process of creating a new user"),
     }
-);
+}
 
-typedb_error!(
+typedb_error! {
     pub UserUpdateError(component = "User update", prefix = "USU") {
         UserDetailNotProvided(1, "User detail not provided"),
         IllegalUsername(2, "Invalid credential supplied"),
         Unexpected(3, "An unexpected error has occurred in the process of updating a user"),
     }
-);
+}
 
-typedb_error!(
+typedb_error! {
     pub UserDeleteError(component = "User delete", prefix = "USD") {
         DefaultUserCannotBeDeleted(1, "Default user cannot be deleted"),
         IllegalUsername(2, "Invalid credential supplied"),
         UserDoesNotExist(3, "User does not exist"),
         Unexpected(4, "An unexpected error has occurred in the process of deleting a user"),
     }
-);
+}


### PR DESCRIPTION
## Release notes: product changes

We refactor the `typedb_error!` macro to avoid the use of meaningful parentheses and position-dependence.

## Motivation

Previously, when defining a new typedb error variant with a source, that source had to come at the end of the field list, and be wrapped in parentheses to help distinguish it from the rest of the fields. We refactor the macro by creating internal rules that perform incremental token tree munching to lift those restrictions.

## Implementation
