### PR TITLE
Cartesian input fix

### DIFF
--- a/concept/thing/thing_manager.rs
+++ b/concept/thing/thing_manager.rs
@@ -1278,15 +1278,12 @@ impl ThingManager {
         snapshot: &impl ReadableSnapshot,
         relation_type: RelationType,
     ) -> Result<IndexedRelationsIterator, Box<ConceptReadError>> {
-        if !self.type_manager.relation_index_available(snapshot, relation_type)? {
-            Err(ConceptReadError::RelationIndexNotAvailable {
-                relation_label: relation_type.get_label(snapshot, self.type_manager())?.to_owned(),
-            })?;
-        }
         let prefix = ThingEdgeIndexedRelation::prefix_relation_type(relation_type.vertex().type_id_());
-        Ok(IndexedRelationsIterator::new(
-            snapshot.iterate_range(&KeyRange::new_within(prefix, ThingEdgeIndexedRelation::FIXED_WIDTH_ENCODING)),
-        ))
+        self.iterate_indexed_relations(
+            snapshot,
+            &KeyRange::new_within(prefix, ThingEdgeIndexedRelation::FIXED_WIDTH_ENCODING),
+            relation_type,
+        )
     }
 
     pub(crate) fn has_indexed_relation_player(

--- a/executor/read/immediate_executor.rs
+++ b/executor/read/immediate_executor.rs
@@ -555,6 +555,8 @@ impl CartesianIterator {
                                     .map_err(|err| ReadExecutionError::ConceptRead { source: err })?;
                                 debug_assert_eq!(next_value_cmp, Some(std::cmp::Ordering::Equal));
                                 iter
+                            } else if value == source_intersection_value {
+                                iter
                             } else {
                                 self.reopen_iterator(context, &iterator_executors[index])?
                             }


### PR DESCRIPTION
## Release notes: product changes

We fix the issue where a join on an indexed relation would skip all additional data within the join variable.

## Motivation

## Implementation

The `IndexedRelationExecutor` checks whether the input row contains a value for the relation instance (regardless of mode). That value is then used as a filter for the produced iterator. During a cartesian product, instead of the input row, the previous instersection row (i.e., output row) was passed into the executor during (re)opening. That meant that the only accepted relation index tuples would have to come from the same relation the first encountered one did.