### PR TITLE
Fix TypeDB reporting crashes when CA certificates are not found

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -888,6 +888,7 @@ dependencies = [
  "hyper-rustls",
  "logger",
  "resource",
+ "sentry",
  "serde_json",
  "sysinfo",
  "tokio",
@@ -4164,7 +4165,7 @@ checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
 [[package]]
 name = "typeql"
 version = "0.0.0"
-source = "git+https://github.com/typedb/typeql?rev=059c0332e33a892e6a04bbf83df5634d3d5df249#059c0332e33a892e6a04bbf83df5634d3d5df249"
+source = "git+https://github.com/typedb/typeql?tag=3.0.1#bb23f987091855a6ac56081206b9d3a736a1a9d5"
 dependencies = [
  "chrono",
  "itertools 0.10.5",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,8 +48,8 @@ features = {}
 
 	[dev-dependencies.typeql]
 		features = []
-		rev = "059c0332e33a892e6a04bbf83df5634d3d5df249"
 		git = "https://github.com/typedb/typeql"
+		tag = "3.0.1"
 		default-features = false
 
 	[dev-dependencies.test_utils_concept]

--- a/RELEASE_TEMPLATE.md
+++ b/RELEASE_TEMPLATE.md
@@ -4,6 +4,6 @@
 
 **Pull the Docker image:**
 
-```docker pull vaticle/typedb:{version}```
+```docker pull typedb/typedb:{version}```
 
 { release notes }

--- a/common/error/Cargo.toml
+++ b/common/error/Cargo.toml
@@ -16,7 +16,7 @@ features = {}
 
 	[dependencies.typeql]
 		features = []
-		rev = "059c0332e33a892e6a04bbf83df5634d3d5df249"
 		git = "https://github.com/typedb/typeql"
+		tag = "3.0.1"
 		default-features = false
 

--- a/common/structural_equality/Cargo.toml
+++ b/common/structural_equality/Cargo.toml
@@ -21,8 +21,8 @@ features = {}
 
 	[dependencies.typeql]
 		features = []
-		rev = "059c0332e33a892e6a04bbf83df5634d3d5df249"
 		git = "https://github.com/typedb/typeql"
+		tag = "3.0.1"
 		default-features = false
 
 	[dependencies.paste]

--- a/compiler/Cargo.toml
+++ b/compiler/Cargo.toml
@@ -58,8 +58,8 @@ features = {}
 
 	[dependencies.typeql]
 		features = []
-		rev = "059c0332e33a892e6a04bbf83df5634d3d5df249"
 		git = "https://github.com/typedb/typeql"
+		tag = "3.0.1"
 		default-features = false
 
 	[dependencies.storage]

--- a/database/Cargo.toml
+++ b/database/Cargo.toml
@@ -103,8 +103,8 @@ features = {}
 
 	[dependencies.typeql]
 		features = []
-		rev = "059c0332e33a892e6a04bbf83df5634d3d5df249"
 		git = "https://github.com/typedb/typeql"
+		tag = "3.0.1"
 		default-features = false
 
 [[test]]

--- a/dependencies/typedb/repositories.bzl
+++ b/dependencies/typedb/repositories.bzl
@@ -15,7 +15,7 @@ def typedb_dependencies():
     git_repository(
         name = "typedb_dependencies",
         remote = "https://github.com/typedb/typedb-dependencies",
-        commit = "a501e3777632d50528d7c5cff1c17afa0e98e463",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @typedb_dependencies
+        commit = "3348848e9455c1e4984a91c98436f77a8807717a",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @typedb_dependencies
     )
 
 def typeql():

--- a/diagnostics/BUILD
+++ b/diagnostics/BUILD
@@ -22,6 +22,7 @@ rust_library(
         "@crates//:hyper",
         "@crates//:hyper-rustls",
         "@crates//:serde_json",
+        "@crates//:sentry",
         "@crates//:sysinfo",
         "@crates//:tokio",
         "@crates//:tonic",

--- a/diagnostics/Cargo.toml
+++ b/diagnostics/Cargo.toml
@@ -84,3 +84,8 @@ features = {}
 		version = "1.0.135"
 		default-features = false
 
+	[dependencies.sentry]
+		features = ["backtrace", "contexts", "httpdate", "panic", "sentry-backtrace", "sentry-contexts", "sentry-panic", "ureq"]
+		version = "0.36.0"
+		default-features = false
+

--- a/diagnostics/reporter.rs
+++ b/diagnostics/reporter.rs
@@ -270,13 +270,12 @@ impl Reporter {
     }
 
     fn report_inner_error(error: DiagnosticsReporterError) {
-        let error_string = <dyn TypeDBError>::to_string(&error).as_str();
-        match error.as_ref() {
+        match error {
             DiagnosticsReporterError::HttpsClientBuilding { .. } => {
-                Self::report_inner_error_message_warning(error_string)
+                Self::report_inner_error_message_warning(<dyn TypeDBError>::to_string(&error).as_str())
             }
             DiagnosticsReporterError::HttpRequestBuilding { .. } => {
-                Self::report_inner_error_message_critical(error_string)
+                Self::report_inner_error_message_critical(<dyn TypeDBError>::to_string(&error).as_str())
             }
         }
     }
@@ -307,7 +306,7 @@ impl ReportingEndpoint {
 
 typedb_error!(
     pub DiagnosticsReporterError(component = "DiagnosticsReporter", prefix = "DIR") {
-        HttpsClientBuilding(1, "Error while building an https client.", source: Arc<std::io::Error>),
-        HttpRequestBuilding(2, "Error while building an http request.", source: Arc<http::Error>),
+        HttpsClientBuilding(1, "Error while building a diagnostics reporting https client.", source: Arc<std::io::Error>),
+        HttpRequestBuilding(2, "Error while building a diagnostics reporting http request.", source: Arc<http::Error>),
     }
 );

--- a/diagnostics/reporter.rs
+++ b/diagnostics/reporter.rs
@@ -205,21 +205,21 @@ impl Reporter {
             .body(Body::from(body))
             .map_err(|source| DiagnosticsReporterError::HttpRequestBuilding { source: Arc::new(source) })?;
 
-        Ok(match Self::new_https_client()?.request(request).await {
+        match Self::new_https_client()?.request(request).await {
             Ok(response) => {
                 if response.status().is_success() {
                     trace!("Successfully sent diagnostics data to {}", uri);
-                    true
+                    Ok(true)
                 } else {
                     trace!("Failed to send diagnostics data to {}: {}", uri, response.status());
-                    false
+                    Ok(false)
                 }
             }
             Err(e) => {
                 trace!("Failed to send diagnostics data to {}: {}", uri, e);
-                false
+                Ok(false)
             }
-        })
+        }
     }
 
     fn new_https_client() -> Result<Client<HttpsConnector<HttpConnector>>, DiagnosticsReporterError> {

--- a/executor/Cargo.toml
+++ b/executor/Cargo.toml
@@ -113,8 +113,8 @@ features = {}
 
 	[dependencies.typeql]
 		features = []
-		rev = "059c0332e33a892e6a04bbf83df5634d3d5df249"
 		git = "https://github.com/typedb/typeql"
+		tag = "3.0.1"
 		default-features = false
 
 	[dependencies.compiler]

--- a/function/Cargo.toml
+++ b/function/Cargo.toml
@@ -93,8 +93,8 @@ features = {}
 
 	[dependencies.typeql]
 		features = []
-		rev = "059c0332e33a892e6a04bbf83df5634d3d5df249"
 		git = "https://github.com/typedb/typeql"
+		tag = "3.0.1"
 		default-features = false
 
 	[dependencies.compiler]

--- a/ir/Cargo.toml
+++ b/ir/Cargo.toml
@@ -88,8 +88,8 @@ features = {}
 
 	[dependencies.typeql]
 		features = []
-		rev = "059c0332e33a892e6a04bbf83df5634d3d5df249"
 		git = "https://github.com/typedb/typeql"
+		tag = "3.0.1"
 		default-features = false
 
 	[dependencies.chrono]

--- a/query/Cargo.toml
+++ b/query/Cargo.toml
@@ -123,8 +123,8 @@ features = {}
 
 	[dependencies.typeql]
 		features = []
-		rev = "059c0332e33a892e6a04bbf83df5634d3d5df249"
 		git = "https://github.com/typedb/typeql"
+		tag = "3.0.1"
 		default-features = false
 
 	[dependencies.compiler]

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -86,8 +86,8 @@ features = {}
 
 	[dependencies.typeql]
 		features = []
-		rev = "059c0332e33a892e6a04bbf83df5634d3d5df249"
 		git = "https://github.com/typedb/typeql"
+		tag = "3.0.1"
 		default-features = false
 
 	[dependencies.compiler]

--- a/system/Cargo.toml
+++ b/system/Cargo.toml
@@ -76,8 +76,8 @@ features = {}
 
 	[dependencies.typeql]
 		features = []
-		rev = "059c0332e33a892e6a04bbf83df5634d3d5df249"
 		git = "https://github.com/typedb/typeql"
+		tag = "3.0.1"
 		default-features = false
 
 	[dependencies.compiler]

--- a/tests/behaviour/steps/Cargo.toml
+++ b/tests/behaviour/steps/Cargo.toml
@@ -81,8 +81,8 @@ features = {}
 
 	[dependencies.typeql]
 		features = []
-		rev = "059c0332e33a892e6a04bbf83df5634d3d5df249"
 		git = "https://github.com/typedb/typeql"
+		tag = "3.0.1"
 		default-features = false
 
 	[dependencies.compiler]

--- a/user/Cargo.toml
+++ b/user/Cargo.toml
@@ -46,8 +46,8 @@ features = {}
 
 	[dependencies.typeql]
 		features = []
-		rev = "059c0332e33a892e6a04bbf83df5634d3d5df249"
 		git = "https://github.com/typedb/typeql"
+		tag = "3.0.1"
 		default-features = false
 
 	[dependencies.storage]


### PR DESCRIPTION
## Release notes: product changes
We fix TypeDB reporting crashes when CA certificates are not found on the host. An additional Sentry (our crash reports endpoint) warning will be reported, but it no longer affects the server's availability. 

## Motivation

## Implementation
If reporting is not successful for either endpoints, a warning/error (based on the cause) to Sentry will be reported, and the reporting for this endpoint will stop. For simplicity, the job will be still activated every 1 hour, but it will quit after a boolean flag check.

The next real attempt to report anything will happen only after a restart.

The logic described above works for two endpoints separately. This way, if only one endpoint fails (which should not be the case now), the other one continues working as expected, reporting data every hour.