### PR TITLE
Add correct version for CLI --version flag. Substitute encryption-related config crashes by user errors.

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -39,9 +39,6 @@ rust_binary(
         "@crates//:sentry",
         "@crates//:tokio",
     ],
-    compile_data = [
-        ":VERSION",
-    ],
 )
 
 # Assembly

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4168,7 +4168,7 @@ checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
 [[package]]
 name = "typeql"
 version = "0.0.0"
-source = "git+https://github.com/typedb/typeql?rev=f6b082aae7b9469d2d2d701028cf0457ab19ee24#f6b082aae7b9469d2d2d701028cf0457ab19ee24"
+source = "git+https://github.com/typedb/typeql?rev=918714f620cb1a3b117dc0c0d089e22a12d54675#918714f620cb1a3b117dc0c0d089e22a12d54675"
 dependencies = [
  "chrono",
  "itertools 0.10.5",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ features = {}
 
 	[dev-dependencies.typeql]
 		features = []
-		rev = "f6b082aae7b9469d2d2d701028cf0457ab19ee24"
+		rev = "918714f620cb1a3b117dc0c0d089e22a12d54675"
 		git = "https://github.com/typedb/typeql"
 		default-features = false
 

--- a/common/error/Cargo.toml
+++ b/common/error/Cargo.toml
@@ -16,7 +16,7 @@ features = {}
 
 	[dependencies.typeql]
 		features = []
-		rev = "f6b082aae7b9469d2d2d701028cf0457ab19ee24"
+		rev = "918714f620cb1a3b117dc0c0d089e22a12d54675"
 		git = "https://github.com/typedb/typeql"
 		default-features = false
 

--- a/common/structural_equality/Cargo.toml
+++ b/common/structural_equality/Cargo.toml
@@ -21,7 +21,7 @@ features = {}
 
 	[dependencies.typeql]
 		features = []
-		rev = "f6b082aae7b9469d2d2d701028cf0457ab19ee24"
+		rev = "918714f620cb1a3b117dc0c0d089e22a12d54675"
 		git = "https://github.com/typedb/typeql"
 		default-features = false
 

--- a/compiler/Cargo.toml
+++ b/compiler/Cargo.toml
@@ -58,7 +58,7 @@ features = {}
 
 	[dependencies.typeql]
 		features = []
-		rev = "f6b082aae7b9469d2d2d701028cf0457ab19ee24"
+		rev = "918714f620cb1a3b117dc0c0d089e22a12d54675"
 		git = "https://github.com/typedb/typeql"
 		default-features = false
 

--- a/database/Cargo.toml
+++ b/database/Cargo.toml
@@ -103,7 +103,7 @@ features = {}
 
 	[dependencies.typeql]
 		features = []
-		rev = "f6b082aae7b9469d2d2d701028cf0457ab19ee24"
+		rev = "918714f620cb1a3b117dc0c0d089e22a12d54675"
 		git = "https://github.com/typedb/typeql"
 		default-features = false
 

--- a/encoding/value/value.rs
+++ b/encoding/value/value.rs
@@ -72,14 +72,26 @@ impl PartialOrd for Value<'_> {
             (Self::String(self_string), Self::String(other_string)) => self_string.partial_cmp(other_string),
 
             // Heterogeneous
-            (Self::Integer(self_integer), Self::Double(other_double)) => i64_to_f64_lossy(*self_integer).partial_cmp(other_double),
-            (Self::Double(self_double), Self::Integer(other_integer)) => self_double.partial_cmp(&i64_to_f64_lossy(*other_integer)),
+            (Self::Integer(self_integer), Self::Double(other_double)) => {
+                i64_to_f64_lossy(*self_integer).partial_cmp(other_double)
+            }
+            (Self::Double(self_double), Self::Integer(other_integer)) => {
+                self_double.partial_cmp(&i64_to_f64_lossy(*other_integer))
+            }
 
-            (Self::Integer(self_integer), Self::Decimal(other_decimal)) => Decimal::new(*self_integer, 0).partial_cmp(other_decimal),
-            (Self::Decimal(self_decimal), Self::Integer(other_integer)) => self_decimal.partial_cmp(&Decimal::new(*other_integer, 0)),
+            (Self::Integer(self_integer), Self::Decimal(other_decimal)) => {
+                Decimal::new(*self_integer, 0).partial_cmp(other_decimal)
+            }
+            (Self::Decimal(self_decimal), Self::Integer(other_integer)) => {
+                self_decimal.partial_cmp(&Decimal::new(*other_integer, 0))
+            }
 
-            (Self::Double(self_double), Self::Decimal(other_decimal)) => self_double.partial_cmp(&other_decimal.to_f64()),
-            (Self::Decimal(self_decimal), Self::Double(other_double)) => self_decimal.to_f64().partial_cmp(other_double),
+            (Self::Double(self_double), Self::Decimal(other_decimal)) => {
+                self_double.partial_cmp(&other_decimal.to_f64())
+            }
+            (Self::Decimal(self_decimal), Self::Double(other_double)) => {
+                self_decimal.to_f64().partial_cmp(other_double)
+            }
 
             _ => None,
         }

--- a/executor/Cargo.toml
+++ b/executor/Cargo.toml
@@ -113,7 +113,7 @@ features = {}
 
 	[dependencies.typeql]
 		features = []
-		rev = "f6b082aae7b9469d2d2d701028cf0457ab19ee24"
+		rev = "918714f620cb1a3b117dc0c0d089e22a12d54675"
 		git = "https://github.com/typedb/typeql"
 		default-features = false
 

--- a/executor/read/collecting_stage_executor.rs
+++ b/executor/read/collecting_stage_executor.rs
@@ -219,7 +219,7 @@ impl SortCollector {
             }
 
             | VariableValue::ThingList(_) => unimplemented_feature!(Lists),
-            | VariableValue::ValueList(_) => unimplemented_feature!(Lists)
+            | VariableValue::ValueList(_) => unimplemented_feature!(Lists),
         }
     }
 }

--- a/function/Cargo.toml
+++ b/function/Cargo.toml
@@ -93,7 +93,7 @@ features = {}
 
 	[dependencies.typeql]
 		features = []
-		rev = "f6b082aae7b9469d2d2d701028cf0457ab19ee24"
+		rev = "918714f620cb1a3b117dc0c0d089e22a12d54675"
 		git = "https://github.com/typedb/typeql"
 		default-features = false
 

--- a/ir/Cargo.toml
+++ b/ir/Cargo.toml
@@ -88,7 +88,7 @@ features = {}
 
 	[dependencies.typeql]
 		features = []
-		rev = "f6b082aae7b9469d2d2d701028cf0457ab19ee24"
+		rev = "918714f620cb1a3b117dc0c0d089e22a12d54675"
 		git = "https://github.com/typedb/typeql"
 		default-features = false
 

--- a/main.rs
+++ b/main.rs
@@ -11,15 +11,12 @@ use std::{path::PathBuf, str::FromStr};
 
 use clap::Parser;
 use logger::initialise_logging_global;
-use resource::constants::server::{ASCII_LOGO, SENTRY_REPORTING_URI};
+use resource::constants::server::{ASCII_LOGO, DISTRIBUTION, SENTRY_REPORTING_URI, VERSION};
 use sentry::ClientInitGuard as SentryGuard;
 use server::parameters::{
     cli::CLIArgs,
     config::{Config, DiagnosticsConfig, EncryptionConfig, ServerConfig},
 };
-
-const DISTRIBUTION: &str = "TypeDB CE";
-const VERSION: &str = include_str!("VERSION");
 
 fn main() {
     setup_abort_on_panic();

--- a/query/Cargo.toml
+++ b/query/Cargo.toml
@@ -128,7 +128,7 @@ features = {}
 
 	[dependencies.typeql]
 		features = []
-		rev = "f6b082aae7b9469d2d2d701028cf0457ab19ee24"
+		rev = "918714f620cb1a3b117dc0c0d089e22a12d54675"
 		git = "https://github.com/typedb/typeql"
 		default-features = false
 

--- a/resource/BUILD
+++ b/resource/BUILD
@@ -14,6 +14,7 @@ rust_library(
     ]),
     compile_data = [
         "typedb-ascii.txt",
+        "//:VERSION",
     ],
 )
 

--- a/resource/constants.rs
+++ b/resource/constants.rs
@@ -15,6 +15,8 @@ pub mod server {
 
     use crate::constants::common::{SECONDS_IN_HOUR, SECONDS_IN_MINUTE};
 
+    pub const DISTRIBUTION: &str = "TypeDB CE";
+    pub const VERSION: &str = include_str!("../VERSION");
     pub const ASCII_LOGO: &str = include_str!("typedb-ascii.txt");
 
     pub const GRPC_CONNECTION_KEEPALIVE: Duration = Duration::from_secs(2 * SECONDS_IN_HOUR);

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -86,7 +86,7 @@ features = {}
 
 	[dependencies.typeql]
 		features = []
-		rev = "f6b082aae7b9469d2d2d701028cf0457ab19ee24"
+		rev = "918714f620cb1a3b117dc0c0d089e22a12d54675"
 		git = "https://github.com/typedb/typeql"
 		default-features = false
 

--- a/server/parameters/cli.rs
+++ b/server/parameters/cli.rs
@@ -6,11 +6,12 @@
 use std::net::SocketAddr;
 
 use clap::{ArgAction, Parser};
-use resource::constants::server::MONITORING_DEFAULT_PORT;
+use resource::constants::server::{MONITORING_DEFAULT_PORT, VERSION};
 
-/// TypeDB Core usage
+/// TypeDB CE usage
 #[derive(Parser, Debug)]
-#[command(version, about, long_about = None)]
+#[command(about, long_about = None)]
+#[clap(version = VERSION)]
 pub struct CLIArgs {
     /// Server host and port, eg., 0.0.0.0:1729
     #[arg(long = "server.address")]

--- a/server/typedb.rs
+++ b/server/typedb.rs
@@ -165,7 +165,8 @@ impl Server {
     }
 
     fn create_tonic_server(encryption_config: &EncryptionConfig) -> Result<tonic::transport::Server, ServerOpenError> {
-        let mut tonic_server = Self::configure_server_encryption(tonic::transport::Server::builder(), encryption_config)?;
+        let mut tonic_server =
+            Self::configure_server_encryption(tonic::transport::Server::builder(), encryption_config)?;
         Ok(tonic_server.http2_keepalive_interval(Some(GRPC_CONNECTION_KEEPALIVE)))
     }
 
@@ -177,30 +178,28 @@ impl Server {
             return Ok(server);
         }
 
-        let cert_path = encryption_config.cert.clone().ok_or_else(|| ServerOpenError::MissingTLSCertificate {})?;
-        let cert = fs::read_to_string(cert_path.clone()).map_err(|source| ServerOpenError::CouldNotReadTLSCertificate {
-            path: cert_path.to_string_lossy().to_string(),
+        let cert_path = encryption_config.cert.as_ref().ok_or_else(|| ServerOpenError::MissingTLSCertificate {})?;
+        let cert = fs::read_to_string(cert_path).map_err(|source| ServerOpenError::CouldNotReadTLSCertificate {
+            path: cert_path.display().to_string(),
             source: Arc::new(source),
         })?;
         let cert_key_path =
-            encryption_config.cert_key.clone().ok_or_else(|| ServerOpenError::MissingTLSCertificateKey {})?;
+            encryption_config.cert_key.as_ref().ok_or_else(|| ServerOpenError::MissingTLSCertificateKey {})?;
         let cert_key =
-            fs::read_to_string(cert_key_path.clone()).map_err(|source| ServerOpenError::CouldNotReadTLSCertificateKey {
-                path: cert_key_path.to_string_lossy().to_string(),
+            fs::read_to_string(cert_key_path).map_err(|source| ServerOpenError::CouldNotReadTLSCertificateKey {
+                path: cert_key_path.display().to_string(),
                 source: Arc::new(source),
             })?;
         let mut tls_config = ServerTlsConfig::new().identity(Identity::from_pem(cert, cert_key));
 
         if let Some(root_ca_path) = &encryption_config.root_ca {
             let root_ca = fs::read_to_string(root_ca_path).map_err(|source| ServerOpenError::CouldNotReadRootCA {
-                path: root_ca_path.to_string_lossy().to_string(),
+                path: root_ca_path.display().to_string(),
                 source: Arc::new(source),
             })?;
             tls_config = tls_config.client_ca_root(Certificate::from_pem(root_ca)).client_auth_optional(true);
         }
-        Ok(server
-            .tls_config(tls_config)
-            .map_err(|source| ServerOpenError::TLSConfigError { source: Arc::new(source) })?)
+        server.tls_config(tls_config).map_err(|source| ServerOpenError::TLSConfigError { source: Arc::new(source) })
     }
 
     fn create_storage_directory(storage_directory: &Path) -> Result<(), ServerOpenError> {

--- a/server/typedb.rs
+++ b/server/typedb.rs
@@ -122,7 +122,7 @@ impl Server {
         );
 
         Self::print_hello(self.distribution, self.version, self.config.server.is_development_mode);
-        Self::create_tonic_server(&self.config.server.encryption)
+        Self::create_tonic_server(&self.config.server.encryption)?
             .layer(&authenticator)
             .add_service(service)
             .serve_with_shutdown(self.address, async {
@@ -164,19 +164,43 @@ impl Server {
         DiagnosticsManager::new(diagnostics, config.monitoring_port, config.is_monitoring_enabled, is_development_mode)
     }
 
-    fn create_tonic_server(encryption_config: &EncryptionConfig) -> tonic::transport::Server {
-        let mut tonic_server = tonic::transport::Server::builder();
-        if encryption_config.enabled {
-            let cert = fs::read_to_string(encryption_config.cert.clone().unwrap()).unwrap();
-            let cert_key = fs::read_to_string(encryption_config.cert_key.clone().unwrap()).unwrap();
-            let mut tls_config = ServerTlsConfig::new().identity(Identity::from_pem(cert, cert_key));
-            if encryption_config.root_ca.is_some() {
-                let root_ca = fs::read_to_string(encryption_config.root_ca.clone().unwrap()).unwrap();
-                tls_config = tls_config.client_ca_root(Certificate::from_pem(root_ca)).client_auth_optional(true)
-            }
-            tonic_server = tonic_server.tls_config(tls_config).unwrap();
+    fn create_tonic_server(encryption_config: &EncryptionConfig) -> Result<tonic::transport::Server, ServerOpenError> {
+        let mut tonic_server = Self::configure_server_encryption(tonic::transport::Server::builder(), encryption_config)?;
+        Ok(tonic_server.http2_keepalive_interval(Some(GRPC_CONNECTION_KEEPALIVE)))
+    }
+
+    fn configure_server_encryption(
+        server: tonic::transport::Server,
+        encryption_config: &EncryptionConfig,
+    ) -> Result<tonic::transport::Server, ServerOpenError> {
+        if !encryption_config.enabled {
+            return Ok(server);
         }
-        tonic_server.http2_keepalive_interval(Some(GRPC_CONNECTION_KEEPALIVE))
+
+        let cert_path = encryption_config.cert.clone().ok_or_else(|| ServerOpenError::MissingTLSCertificate {})?;
+        let cert = fs::read_to_string(cert_path.clone()).map_err(|source| ServerOpenError::CouldNotReadCertificate {
+            path: cert_path.to_string_lossy().to_string(),
+            source: Arc::new(source),
+        })?;
+        let cert_key_path =
+            encryption_config.cert_key.clone().ok_or_else(|| ServerOpenError::MissingTLSCertificateKey {})?;
+        let cert_key =
+            fs::read_to_string(cert_key_path.clone()).map_err(|source| ServerOpenError::CouldNotReadCertificateKey {
+                path: cert_key_path.to_string_lossy().to_string(),
+                source: Arc::new(source),
+            })?;
+        let mut tls_config = ServerTlsConfig::new().identity(Identity::from_pem(cert, cert_key));
+
+        if let Some(root_ca_path) = &encryption_config.root_ca {
+            let root_ca = fs::read_to_string(root_ca_path).map_err(|source| ServerOpenError::CouldNotReadRootCA {
+                path: root_ca_path.to_string_lossy().to_string(),
+                source: Arc::new(source),
+            })?;
+            tls_config = tls_config.client_ca_root(Certificate::from_pem(root_ca)).client_auth_optional(true);
+        }
+        Ok(server
+            .tls_config(tls_config)
+            .map_err(|source| ServerOpenError::TLSConfigError { source: Arc::new(source) })?)
     }
 
     fn create_storage_directory(storage_directory: &Path) -> Result<(), ServerOpenError> {
@@ -257,5 +281,11 @@ typedb_error! {
         InvalidServerID(5, "Server ID read from '{path}' is invalid. Delete the corrupted file and try again.", path: String),
         DatabaseOpen(6, "Could not open database.", typedb_source: DatabaseOpenError),
         Serve(7, "Could not serve on {address}.", address: SocketAddr, source: Arc<tonic::transport::Error>),
+        MissingTLSCertificate(8, "TLS certificate path must be specified when encryption is enabled."),
+        MissingTLSCertificateKey(9, "TLS certificate key path must be specified when encryption is enabled."),
+        CouldNotReadCertificate(10, "Could not read certificate from '{path}'.", path: String, source: Arc<io::Error>),
+        CouldNotReadCertificateKey(11, "Could not read certificate key from '{path}'.", path: String, source: Arc<io::Error>),
+        CouldNotReadRootCA(12, "Could not read root CA from '{path}'.", path: String, source: Arc<io::Error>),
+        TLSConfigError(13, "Failed to configure TLS.", source: Arc<tonic::transport::Error>),
     }
 }

--- a/server/typedb.rs
+++ b/server/typedb.rs
@@ -178,14 +178,14 @@ impl Server {
         }
 
         let cert_path = encryption_config.cert.clone().ok_or_else(|| ServerOpenError::MissingTLSCertificate {})?;
-        let cert = fs::read_to_string(cert_path.clone()).map_err(|source| ServerOpenError::CouldNotReadCertificate {
+        let cert = fs::read_to_string(cert_path.clone()).map_err(|source| ServerOpenError::CouldNotReadTLSCertificate {
             path: cert_path.to_string_lossy().to_string(),
             source: Arc::new(source),
         })?;
         let cert_key_path =
             encryption_config.cert_key.clone().ok_or_else(|| ServerOpenError::MissingTLSCertificateKey {})?;
         let cert_key =
-            fs::read_to_string(cert_key_path.clone()).map_err(|source| ServerOpenError::CouldNotReadCertificateKey {
+            fs::read_to_string(cert_key_path.clone()).map_err(|source| ServerOpenError::CouldNotReadTLSCertificateKey {
                 path: cert_key_path.to_string_lossy().to_string(),
                 source: Arc::new(source),
             })?;
@@ -283,8 +283,8 @@ typedb_error! {
         Serve(7, "Could not serve on {address}.", address: SocketAddr, source: Arc<tonic::transport::Error>),
         MissingTLSCertificate(8, "TLS certificate path must be specified when encryption is enabled."),
         MissingTLSCertificateKey(9, "TLS certificate key path must be specified when encryption is enabled."),
-        CouldNotReadCertificate(10, "Could not read certificate from '{path}'.", path: String, source: Arc<io::Error>),
-        CouldNotReadCertificateKey(11, "Could not read certificate key from '{path}'.", path: String, source: Arc<io::Error>),
+        CouldNotReadTLSCertificate(10, "Could not read TLS certificate from '{path}'.", path: String, source: Arc<io::Error>),
+        CouldNotReadTLSCertificateKey(11, "Could not read TLS certificate key from '{path}'.", path: String, source: Arc<io::Error>),
         CouldNotReadRootCA(12, "Could not read root CA from '{path}'.", path: String, source: Arc<io::Error>),
         TLSConfigError(13, "Failed to configure TLS.", source: Arc<tonic::transport::Error>),
     }

--- a/system/Cargo.toml
+++ b/system/Cargo.toml
@@ -76,7 +76,7 @@ features = {}
 
 	[dependencies.typeql]
 		features = []
-		rev = "f6b082aae7b9469d2d2d701028cf0457ab19ee24"
+		rev = "918714f620cb1a3b117dc0c0d089e22a12d54675"
 		git = "https://github.com/typedb/typeql"
 		default-features = false
 

--- a/tests/behaviour/steps/Cargo.toml
+++ b/tests/behaviour/steps/Cargo.toml
@@ -81,7 +81,7 @@ features = {}
 
 	[dependencies.typeql]
 		features = []
-		rev = "f6b082aae7b9469d2d2d701028cf0457ab19ee24"
+		rev = "918714f620cb1a3b117dc0c0d089e22a12d54675"
 		git = "https://github.com/typedb/typeql"
 		default-features = false
 

--- a/tests/behaviour/steps/params.rs
+++ b/tests/behaviour/steps/params.rs
@@ -510,11 +510,8 @@ impl Value {
                 } else {
                     self.raw_value.as_str()
                 };
-                let (integer, fractional) = if let Some(split) = trimmed_value.split_once(".") {
-                    split
-                } else {
-                    (trimmed_value, "0")
-                };
+                let (integer, fractional) =
+                    if let Some(split) = trimmed_value.split_once(".") { split } else { (trimmed_value, "0") };
 
                 let integer_parsed: i64 = integer.trim().parse().unwrap();
                 let integer_parsed_abs = integer_parsed.abs();

--- a/tests/behaviour/steps/params.rs
+++ b/tests/behaviour/steps/params.rs
@@ -510,8 +510,7 @@ impl Value {
                 } else {
                     self.raw_value.as_str()
                 };
-                let (integer, fractional) =
-                    if let Some(split) = trimmed_value.split_once(".") { split } else { (trimmed_value, "0") };
+                let (integer, fractional) = trimmed_value.split_once(".").unwrap_or((trimmed_value, "0"));
 
                 let integer_parsed: i64 = integer.trim().parse().unwrap();
                 let integer_parsed_abs = integer_parsed.abs();

--- a/user/Cargo.toml
+++ b/user/Cargo.toml
@@ -46,7 +46,7 @@ features = {}
 
 	[dependencies.typeql]
 		features = []
-		rev = "f6b082aae7b9469d2d2d701028cf0457ab19ee24"
+		rev = "918714f620cb1a3b117dc0c0d089e22a12d54675"
 		git = "https://github.com/typedb/typeql"
 		default-features = false
 


### PR DESCRIPTION
## Release notes: product changes
Update the `--version` flag to return the correct version of the server when requested. 
Prevent the server from crashing when an incorrect encryption configuration is supplied, stopping it gracefully and returning a defined error instead.

## Motivation

## Implementation
Behavior of the `--version` flag:
```
bazel-bin/typedb_server_bin --version
server 3.0.3

cargo run --package typedb_server_bin --bin typedb_server_bin -- --version
server 3.0.3
```

Behavior of the insufficient encryption flags passed:
```
Ready!
Exited with error: [SRO8] TLS certificate path must be specified when encryption is enabled.

Ready!
Exited with error: [SRO10] Could not read TLS certificate from 'none'.
Cause: 
         Os { code: 2, kind: NotFound, message: "No such file or directory" }

Ready!
Exited with error: [SRO13] Failed to configure TLS.
Cause: 
         tonic::transport::Error(Transport, PrivateKeyParseError)
```
The last one is a little strange, but it's how tonic errors are converted to string, so at least it tells something about parsing. 