### PR TITLE
Add 'dec' suffix to display of decimal

### DIFF
--- a/dependencies/typedb/repositories.bzl
+++ b/dependencies/typedb/repositories.bzl
@@ -36,5 +36,5 @@ def typedb_behaviour():
     git_repository(
         name = "typedb_behaviour",
         remote = "https://github.com/typedb/typedb-behaviour",
-        commit = "9261e8d55ae6b3834b9fd77917ec725c2af1b92c",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @typedb_behaviour
+        commit = "1cef4b5af6599861fb240b722a66dc4383846554",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @typedb_behaviour
     )

--- a/encoding/value/decimal_value.rs
+++ b/encoding/value/decimal_value.rs
@@ -245,7 +245,7 @@ impl FromStr for Decimal {
 impl fmt::Display for Decimal {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         if self.fractional == 0 {
-            write!(f, "{}.0", self.integer_part())?;
+            write!(f, "{}.0dec", self.integer_part())?;
         } else {
             // count number of tailing 0's that don't have to be represented
             let mut tail_0s = 0;
@@ -256,7 +256,7 @@ impl fmt::Display for Decimal {
             }
 
             let fractional_width = FRACTIONAL_PART_DENOMINATOR_LOG10 - tail_0s;
-            write!(f, "{}.{:0width$}", self.integer_part(), fractional, width = fractional_width as usize)?;
+            write!(f, "{}.{:0width$}dec", self.integer_part(), fractional, width = fractional_width as usize)?;
         }
         Ok(())
     }


### PR DESCRIPTION
## Release notes: product changes
Add 'dec' suffix to display of decimal

## Motivation

## Implementation
Also bumps TypeDB Behaviour, which makes the dec suffix consistently used. The change in fmt::display for decimal is required for tests to pass.