### PR TITLE
Fix getting annotations when argument is not referenced in body

### DIFF
--- a/dependencies/typedb/repositories.bzl
+++ b/dependencies/typedb/repositories.bzl
@@ -36,5 +36,5 @@ def typedb_behaviour():
     git_repository(
         name = "typedb_behaviour",
         remote = "https://github.com/typedb/typedb-behaviour",
-        commit = "f560cd3fe4d791e1d26802bb415a9c2045cbb3b2",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @typedb_behaviour
+        commit = "b72a53b5912ad6b567fe2aaa44acdf6395038faf",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @typedb_behaviour
     )

--- a/ir/translation/function.rs
+++ b/ir/translation/function.rs
@@ -4,6 +4,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
+use itertools::Itertools;
 use answer::variable::Variable;
 use storage::snapshot::ReadableSnapshot;
 use typeql::{
@@ -62,13 +63,20 @@ pub fn translate_function_from(
     let body = translate_function_block(snapshot, function_index, &mut context, &mut value_parameters, block)?;
 
     // Check for unused arguments
-    for arg in &signature.args {
-        let var = context.get_variable(arg.var.name().unwrap()).ok_or_else(|| {
-            FunctionRepresentationError::FunctionArgumentUnused {
-                argument_variable: arg.var.name().unwrap().to_owned(),
-                declaration: declaration.unwrap().clone(),
+    for arg in &arguments {
+        if !body.stages.iter().any(|stage| {
+            if let TranslatedStage::Match { block, .. } = stage {
+                block.conjunction().referenced_variables().contains(&arg)
+            } else {
+                false
             }
-        })?;
+        }) {
+            let argument_variable = context.variable_registry.get_variable_name(arg.clone()).unwrap();
+            return Err(FunctionRepresentationError::FunctionArgumentUnused {
+                argument_variable: argument_variable.clone(),
+                declaration: declaration.unwrap().clone(),
+            })
+        }
     }
     // Check return declaration aligns with definition
     let returns_consistent = match (&signature.output, &body.return_operation) {


### PR DESCRIPTION
## Release notes: product changes
Fixes a crash during function annotation when  a function argument is not used in the body of the function.

## Motivation
Fix #7319 , Avoid crashes.

## Implementation
Argument annotations first check the body, then fall back to the annotations based on the signature.