### PR TITLE
Activate diagnostics reporting for the Docker image

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -271,29 +271,11 @@ alias(
 )
 
 # docker
-docker_image_prepare_commands = [
-    "apt-get update",
-    "apt-get install -y ca-certificates",
-    "rm -rf /var/lib/apt/lists/*",
-]
-
-docker_container_run_and_commit(
-    name = "typedb-ubuntu-22.04-x86_64",
-    image = "@ubuntu-22.04-x86_64//image",
-    commands = docker_image_prepare_commands,
-)
-
-docker_container_run_and_commit(
-    name = "typedb-ubuntu-22.04-arm64",
-    image = "@ubuntu-22.04-arm64//image",
-    commands = docker_image_prepare_commands,
-)
-
 docker_container_image(
     name = "assemble-docker-x86_64",
     operating_system = "linux",
     architecture = "amd64",
-    base = ":typedb-ubuntu-22.04-x86_64",
+    base = "//docker:typedb-ubuntu-22.04-x86_64",
     cmd = ["/opt/typedb-server-linux-x86_64/typedb", "server"],
     directory = "opt",
     env = {
@@ -312,7 +294,7 @@ docker_container_image(
     name = "assemble-docker-arm64",
     operating_system = "linux",
     architecture = "arm64",
-    base = ":typedb-ubuntu-22.04-arm64",
+    base = "//docker:typedb-ubuntu-22.04-arm64",
     cmd = ["/opt/typedb-server-linux-arm64/typedb", "server"],
     directory = "opt",
     env = {

--- a/BUILD
+++ b/BUILD
@@ -15,7 +15,6 @@ load("@typedb_bazel_distribution//platform:constraints.bzl", "constraint_linux_a
 
 load("@io_bazel_rules_docker//container:image.bzl", docker_container_image = "container_image")
 load("@io_bazel_rules_docker//container:container.bzl", docker_container_push = "container_push")
-load("@io_bazel_rules_docker//docker/util:run.bzl", docker_container_run_and_commit = "container_run_and_commit")
 
 load("@rules_pkg//:mappings.bzl", "pkg_files", "pkg_attributes")
 load("@rules_pkg//:pkg.bzl", "pkg_tar")

--- a/BUILD
+++ b/BUILD
@@ -15,6 +15,7 @@ load("@typedb_bazel_distribution//platform:constraints.bzl", "constraint_linux_a
 
 load("@io_bazel_rules_docker//container:image.bzl", docker_container_image = "container_image")
 load("@io_bazel_rules_docker//container:container.bzl", docker_container_push = "container_push")
+load("@io_bazel_rules_docker//docker/util:run.bzl", docker_container_run_and_commit = "container_run_and_commit")
 
 load("@rules_pkg//:mappings.bzl", "pkg_files", "pkg_attributes")
 load("@rules_pkg//:pkg.bzl", "pkg_tar")
@@ -270,11 +271,29 @@ alias(
 )
 
 # docker
+docker_image_prepare_commands = [
+    "apt-get update",
+    "apt-get install -y ca-certificates",
+    "rm -rf /var/lib/apt/lists/*",
+]
+
+docker_container_run_and_commit(
+    name = "typedb-ubuntu-22.04-x86_64",
+    image = "@ubuntu-22.04-x86_64//image",
+    commands = docker_image_prepare_commands,
+)
+
+docker_container_run_and_commit(
+    name = "typedb-ubuntu-22.04-arm64",
+    image = "@ubuntu-22.04-arm64//image",
+    commands = docker_image_prepare_commands,
+)
+
 docker_container_image(
     name = "assemble-docker-x86_64",
     operating_system = "linux",
     architecture = "amd64",
-    base = "@ubuntu-22.04-x86_64//image",
+    base = ":typedb-ubuntu-22.04-x86_64",
     cmd = ["/opt/typedb-server-linux-x86_64/typedb", "server"],
     directory = "opt",
     env = {
@@ -293,7 +312,7 @@ docker_container_image(
     name = "assemble-docker-arm64",
     operating_system = "linux",
     architecture = "arm64",
-    base = "@ubuntu-22.04-arm64//image",
+    base = ":typedb-ubuntu-22.04-arm64",
     cmd = ["/opt/typedb-server-linux-arm64/typedb", "server"],
     directory = "opt",
     env = {

--- a/diagnostics/reporter.rs
+++ b/diagnostics/reporter.rs
@@ -87,7 +87,7 @@ impl Reporter {
                 }
             },
             REPORT_INTERVAL,
-            Duration::from_secs(10), // TODO: Temp
+            self.calculate_initial_delay(),
             true,
         );
         *self._reporting_job.lock().expect("Expected reporting job exclusive lock acquisition") = Some(reporting_job);
@@ -141,7 +141,6 @@ impl Reporter {
 
         // The request is sent once, so it's fine to take a snapshot lossy with a small delay
         if is_reported {
-            println!("Reported successfully to service!");
             trace!("Service reporting is successful. Taking a snapshot...");
             diagnostics.take_service_snapshot();
         }
@@ -173,7 +172,7 @@ impl Reporter {
         if !is_reported {
             trace!("PostHog reporting is not successful. Restoring the snapshot...");
             diagnostics.restore_posthog_snapshot();
-        } else {println!("reported successfully to posthog!");}
+        }
         is_reported
     }
 
@@ -226,10 +225,7 @@ impl Reporter {
     fn new_https_client() -> Result<Client<HttpsConnector<HttpConnector>>, DiagnosticsReporterError> {
         let https = HttpsConnectorBuilder::new()
             .with_native_roots()
-            .map_err(|source| {
-                println!("TEST: Cannot build an https client: {source:?}");
-                DiagnosticsReporterError::HttpsClientBuilding { source: Arc::new(source) }
-            })?
+            .map_err(|source| DiagnosticsReporterError::HttpsClientBuilding { source: Arc::new(source) })?
             .https_only()
             .enable_http1()
             .build();
@@ -280,12 +276,10 @@ impl Reporter {
     }
 
     fn report_inner_error_message_critical(message: &str) {
-        println!("Cannot send reporting: critical");
         sentry::capture_message(message, sentry::Level::Error);
     }
 
     fn report_inner_error_message_warning(message: &str) {
-        println!("Cannot send reporting: warning");
         sentry::capture_message(message, sentry::Level::Warning);
     }
 }

--- a/docker/BUILD
+++ b/docker/BUILD
@@ -3,6 +3,7 @@
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 package(default_visibility = ["//visibility:public"])
+load("@io_bazel_rules_docker//docker/util:run.bzl", docker_container_run_and_commit = "container_run_and_commit")
 load("@typedb_bazel_distribution//platform:constraints.bzl", "constraint_linux_arm64", "constraint_linux_x86_64")
 load("@typedb_dependencies//tool/checkstyle:rules.bzl", "checkstyle_test")
 
@@ -24,13 +25,30 @@ genrule(
   cmd = "VERSION=$$(cat $(location //:VERSION)); echo \"$$VERSION-arm64\" > $@"
 )
 
-
 genrule(
   name = "version-x86_64",
   srcs = ["//:VERSION"],
   outs = ["version-x86_64.txt"],
   tools = [],
   cmd = "VERSION=$$(cat $(location //:VERSION)); echo \"$$VERSION-x86_64\" > $@"
+)
+
+docker_image_prepare_commands = [
+    "apt-get update",
+    "apt-get install -y ca-certificates",
+    "rm -rf /var/lib/apt/lists/*",
+]
+
+docker_container_run_and_commit(
+    name = "typedb-ubuntu-22.04-x86_64",
+    image = "@ubuntu-22.04-x86_64//image",
+    commands = docker_image_prepare_commands,
+)
+
+docker_container_run_and_commit(
+    name = "typedb-ubuntu-22.04-arm64",
+    image = "@ubuntu-22.04-arm64//image",
+    commands = docker_image_prepare_commands,
 )
 
 checkstyle_test(

--- a/docker/BUILD
+++ b/docker/BUILD
@@ -43,12 +43,14 @@ docker_container_run_and_commit(
     name = "typedb-ubuntu-22.04-x86_64",
     image = "@ubuntu-22.04-x86_64//image",
     commands = docker_image_prepare_commands,
+    target_compatible_with = constraint_linux_x86_64,
 )
 
 docker_container_run_and_commit(
     name = "typedb-ubuntu-22.04-arm64",
     image = "@ubuntu-22.04-arm64//image",
     commands = docker_image_prepare_commands,
+    target_compatible_with = constraint_linux_arm64,
 )
 
 checkstyle_test(


### PR DESCRIPTION
## Release notes: product changes
The TypeDB Docker image receives enough minimal dependencies to report diagnostics and error data for maintenance.

## Motivation
Enable diagnostics reporting from the Docker image. Previously, it could not build HTTPS clients for reporting.

## Implementation
The issue was in a lack of CA certificates on the base Ubuntu image we use for TypeDB CE. It is not relevant to TypeDB (Cluster) as it uses another image with much more preinstalled dependencies (thus weighs much more).

We decided to add another image layer with certificates preinstalled on it.
To achieve it, we use the `container_run_and_commit` rule to create another layer for Docker, which is equivalent to the `RUN` command from Dockerfile. This rule requires a docker binary on the system, but it is already required to at least authenticate on our CD agents, so it's not a limitation.
*NOTE: if docker is installed after bazel, bazel may have issues finding the binary to run this rule, and a `bazel clear --expunge` is needed.*

**Alternatively,** we could use the image used in TypeDB (Cluster), [prepared in dependencies](https://github.com/typedb/typedb-dependencies/tree/development/images/docker/ubuntu). However, it depends on OpenJDK for TypeDB Console support and has a bigger size we don't need for the CE version. 

Whenever we decide to bundle TypeDB CE with TypeDB Console or TypeDB Console is rewritten in Rust, so the Cluster's image does not require OpenJDK anymore, we can consider using the same lighter image in both versions of TypeDB.

We expect the current image to have a limited usage only for TypeDB CE, so we don't move it to the dependencies repo, preparing these image layers directly in TypeDB CE's build files. 