### PR TITLE
Introduce multi-staged server termination

### DIFF
--- a/server/service/transaction_service.rs
+++ b/server/service/transaction_service.rs
@@ -276,8 +276,7 @@ impl TransactionService {
 
     pub(crate) async fn listen(&mut self) {
         loop {
-            let result = if self.running_write_query.is_some() {
-                let (req_id, write_query_worker) = self.running_write_query.as_mut().unwrap();
+            let result = if let Some((req_id, write_query_worker)) = &mut self.running_write_query {
                 tokio::select! { biased;
                     _ = self.shutdown_receiver.changed() => {
                         event!(Level::TRACE, "Shutdown signal received, closing transaction service.");

--- a/server/typedb.rs
+++ b/server/typedb.rs
@@ -262,7 +262,7 @@ impl Server {
     }
 
     async fn shutdown_handler(shutdown_signal_sender: tokio::sync::watch::Sender<()>) {
-        Self::block_and_listen_ctrl_c().await;
+        Self::listen_ctrl_c().await;
         println!("\nReceived CTRL-C. Initiating shutdown...");
         shutdown_signal_sender.send(()).expect("Expected a successful shutdown signal");
 
@@ -270,12 +270,12 @@ impl Server {
     }
 
     async fn forced_shutdown_handler() {
-        Self::block_and_listen_ctrl_c().await;
+        Self::listen_ctrl_c().await;
         println!("\nReceived CTRL-C. Forcing shutdown...");
         std::process::exit(1);
     }
 
-    async fn block_and_listen_ctrl_c() {
+    async fn listen_ctrl_c() {
         tokio::signal::ctrl_c().await.expect("Failed to listen for CTRL-C signal");
     }
 }


### PR DESCRIPTION
## Release notes: product changes
Make server termination through `CTRL-C` interrupt opened transactions to proceed with the resource deallocation.
Introduce two stages of termination:
* When `CTRL-C` is pressed, a graceful termination will be initiated, ensuring that all resources are freed securely and all open transactions finish preparing current batches of streamed answers (this might take some time to calculate answers for the whole batch, but will not wait until all the answers are sent).
* When `CTRL-C` is pressed while a graceful termination is active, the server's process will be forcefully immediately terminated. This prevents the server from hanging because of long-running queries or other issues. 

## Motivation
Current graceful termination does not initiate the closure of existing transactions, and there is no way to use `CTRL-C` for forced process termination. With this PR, the server's binary matches the standard of applications running through a terminal.

## Implementation
Create a channel for a shutdown signal. This channel can be used for multiple components of the system initialized in a `Server` instance. The sender of the signal is the `Server` itself, while current listeners are `TransactionService`s.  

The following sections are a breakdown of the current server's behavior for different situations regarding process termination and transaction deletion.

### Database deletion while a transaction is open
`Cannot delete database since it is in use.` -> can be forcefully shut down, then this command will reconnect the console and successfully delete the db. Is fine

### Transaction closure
Correctly closes the transaction awaiting current answer batches, etc.

### CTRL+C without opened transaction 
```
Running TypeDB CE 3.0.5 in development mode.
Ready!
^C
Received CTRL-C. Initiating graceful shutdown...
Exited.
```
Closes through a graceful shutdown just like transaction closure, finishes immediately. It waits for 2 seconds if it's run in a published mode and already sent a diagnostics reporting batch once (it will send another batch on shutdown).

### CTRL+C with opened transaction
Same as the previous option, with little branches: 

#### No queries are running
The server is terminated instantly. TypeDB Console does not react on it. What's happening with the Console based on multiple commands:

```
> transaction a schema
a::schema> match $p isa person;
           
[CXN06] The transaction is closed and no further operation is allowed.
```

```
> transaction a schema
a::schema> close
Transaction closed without committing changes
```

```
> transaction a schema
a::schema> commit
[CXN06] The transaction is closed and no further operation is allowed.
```

#### There is an active query streaming answers
There are multiple possible options. What errors I've seen:

When the answers are not yet streamed:
```
a::schema> match $p isa person; not {$v isa person; $v is $p;};
           
Finished validation and compilation...
TSV12 
[TSV12] Execution interrupted by to a concurrent transaction close.
```

When answer streaming is interrupted:
```
…..
   --------
    $p | iid 0x1e00000000000000002866 isa person
    $v | iid 0x1e00000000000000012866 isa person
   --------
[CXN06] The transaction is closed and no further operation is allowed.
```

#### Somewhere in between
**!!!!!!!**
Probably, the driver waited for the initial response but got Close. It's clearly a driver's mistake, we can also cover it on the driver's side:
```
a::schema> match $p isa person; insert $v isa person;
           
[INT4] Unexpected response type for remote procedure call: Close. This is either a version compatibility issue or a bug.
```

### Double CTRL+C anywhere
Terminates immediately without the "Exited" keyword. It is reproducible if we send diagnostics data on shutdown (this way, you have a moment to actually press the button the second time. In my other cases, everything works just too fast without many operations going in parallel):
```
Running TypeDB CE 3.0.5.
Ready!
Reported? true and true
^C
Received CTRL-C. Initiating graceful shutdown...
^C
Received CTRL-C. Forcing shutdown...
λ ~/work/typedb/
```
