### PR TITLE
Avoid persisting empty statistics deltas

### DIFF
--- a/concept/thing/statistics.rs
+++ b/concept/thing/statistics.rs
@@ -53,6 +53,8 @@ type StatisticsEncodingVersion = u64;
 pub struct Statistics {
     encoding_version: StatisticsEncodingVersion,
     pub sequence_number: SequenceNumber,
+
+    pub last_durable_write_sequence_number: SequenceNumber,
     pub last_durable_write_total_count: u64,
 
     pub total_count: u64,
@@ -90,6 +92,7 @@ impl Statistics {
             encoding_version: Self::ENCODING_VERSION,
             sequence_number,
             last_durable_write_total_count: 0,
+            last_durable_write_sequence_number: sequence_number,
             total_count: 0,
             total_thing_count: 0,
             total_entity_count: 0,
@@ -130,27 +133,25 @@ impl Statistics {
             .map_err(|err| ReloadCommitData { typedb_source: err })?
         {
             if let RecoveryCommitStatus::Validated(record) = status {
-                match record.commit_type() {
-                    CommitType::Data => {
-                        let writes = CommittedWrites {
-                            open_sequence_number: record.open_sequence_number(),
-                            operations: record.into_operations(),
-                        };
-                        data_commits.insert(seq, writes);
-                    }
+                let commit_type = record.commit_type();
+                let writes = CommittedWrites {
+                    open_sequence_number: record.open_sequence_number(),
+                    operations: record.into_operations(),
+                };
+                match commit_type {
+                    CommitType::Data => _ = data_commits.insert(seq, writes),
                     CommitType::Schema => {
-                        self.update_writes(&data_commits, storage).map_err(|err| DataRead { source: err })?;
-                        self.durably_write(storage.durability())?;
-
+                        if self.sequence_number < seq {
+                            // If last write was at Seq[11] and this schema commit is at Seq[12],
+                            // no changes need to be applied or persisted.
+                            if self.last_durable_write_sequence_number.next() < seq {
+                                self.update_writes(&data_commits, storage).map_err(|err| DataRead { source: err })?;
+                                self.durably_write(storage.durability())?;
+                            }
+                            self.update_writes(&BTreeMap::from([(seq, writes)]), storage)
+                                .map_err(|err| DataRead { source: err })?;
+                        }
                         data_commits.clear();
-
-                        let writes = CommittedWrites {
-                            open_sequence_number: record.open_sequence_number(),
-                            operations: record.into_operations(),
-                        };
-                        let mut commits = BTreeMap::new();
-                        commits.insert(seq, writes);
-                        self.update_writes(&commits, storage).map_err(|err| DataRead { source: err })?;
                     }
                 }
             }
@@ -171,6 +172,7 @@ impl Statistics {
     pub fn durably_write(&mut self, durability: &impl DurabilityClient) -> Result<(), StatisticsError> {
         use StatisticsError::DurablyWrite;
         durability.unsequenced_write(self).map_err(|err| DurablyWrite { typedb_source: err })?;
+        self.last_durable_write_sequence_number = self.sequence_number;
         self.last_durable_write_total_count = self.total_count;
         Ok(())
     }
@@ -846,8 +848,7 @@ mod serialise {
                     V: SeqAccess<'de>,
                 {
                     let statistics_version = seq.next_element()?.ok_or_else(|| de::Error::invalid_length(0, &self))?;
-                    let open_sequence_number =
-                        seq.next_element()?.ok_or_else(|| de::Error::invalid_length(1, &self))?;
+                    let sequence_number = seq.next_element()?.ok_or_else(|| de::Error::invalid_length(1, &self))?;
                     let last_durable_write_total_count =
                         seq.next_element()?.ok_or_else(|| de::Error::invalid_length(2, &self))?;
                     let total_count = seq.next_element()?.ok_or_else(|| de::Error::invalid_length(3, &self))?;
@@ -933,7 +934,8 @@ mod serialise {
                         .collect();
                     Ok(Statistics {
                         encoding_version: statistics_version,
-                        sequence_number: open_sequence_number,
+                        sequence_number,
+                        last_durable_write_sequence_number: sequence_number,
                         last_durable_write_total_count,
                         total_count,
                         total_thing_count,
@@ -1190,6 +1192,8 @@ mod serialise {
                             .ok_or_else(|| de::Error::missing_field(Field::OpenSequenceNumber.name()))?,
                         last_durable_write_total_count: last_durable_write_total_count
                             .ok_or_else(|| de::Error::missing_field(Field::LastDurableWriteTotalCount.name()))?,
+                        last_durable_write_sequence_number: open_sequence_number
+                            .ok_or_else(|| de::Error::missing_field(Field::OpenSequenceNumber.name()))?,
                         total_count: total_count.ok_or_else(|| de::Error::missing_field(Field::TotalCount.name()))?,
                         total_thing_count: total_thing_count
                             .ok_or_else(|| de::Error::missing_field(Field::TotalThingCount.name()))?,


### PR DESCRIPTION
## Release notes: product changes

We resolve the issue in which statistics would be written to the WAL more often than necessary, which could cause WAL (not the data) to become corrupted.

## Motivation

If a schema commit was performed within 8 commits before the statistics was last updated, the sequence number stamp in the statistics would roll back, but not the counts. Any intermittent commit deltas would be reapplied repeastedly, in some cases causing underflows and crashes.

In addition, statistics would be unconditionally persisted to the WAL when said schema commit was encountered, adding needless repeated records _and_ persisting the corrupted statistics records, causing startup crashes.

## Implementation

We now keep track of when the last write was performed, as well as fix the issue with rolling back the sequence number.