### PR TITLE
Add setup_remote_docker step to docker deployment jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -283,6 +283,7 @@ jobs:
   deploy-docker-release-x86_64:
     executor: linux-x86_64-amazonlinux-2
     steps:
+      - setup_remote_docker
       - checkout
       - install-deps-yum:
           bazel-arch: amd64
@@ -292,6 +293,7 @@ jobs:
   deploy-docker-release-arm64:
     executor: linux-arm64-amazonlinux-2
     steps:
+      - setup_remote_docker
       - checkout
       - install-deps-yum:
           bazel-arch: arm64
@@ -301,6 +303,7 @@ jobs:
   deploy-docker-release-multiarch:
     executor: linux-x86_64-amazonlinux-2
     steps:
+      - setup_remote_docker
       - checkout
       - install-deps-yum:
           bazel-arch: amd64


### PR DESCRIPTION
## Release notes: product changes
Add the  'setup_remote_docker' step to docker deployment jobs

## Motivation
Fix release pipeline

## Implementation
The  'setup_remote_docker' step is required for running a docker container from a circleci job that is itself running on a docker executor.
[circleci suggested fix](https://support.circleci.com/hc/en-us/articles/115015849028-Docker-Daemon-Not-Available), [successful job](https://app.circleci.com/pipelines/github/typedb/typedb/1729/workflows/828eca0e-83d9-4dca-885a-fcd82fc53bf0)