### PR TITLE
Enable functions in write pipelines

### DIFF
--- a/compiler/annotation/match_inference.rs
+++ b/compiler/annotation/match_inference.rs
@@ -166,6 +166,13 @@ pub(crate) fn prune_types(graph: &mut TypeInferenceGraph<'_>) {
     }
 
     // Then do it for the nested negations & optionals
+    // TODO: This is too permissive. We should have seeded these with the pruned types from the parent.
+    prune_types_for_nested_negations_and_optionals(graph);
+}
+
+fn prune_types_for_nested_negations_and_optionals(graph: &mut TypeInferenceGraph<'_>) {
+    graph.nested_disjunctions.iter_mut().flat_map(|disjunction| disjunction.disjunction.iter_mut())
+        .for_each(|nested| prune_types_for_nested_negations_and_optionals(nested));
     graph.nested_negations.iter_mut().for_each(|nested| prune_types(nested));
     graph.nested_optionals.iter_mut().for_each(|nested| prune_types(nested));
 }

--- a/compiler/annotation/match_inference.rs
+++ b/compiler/annotation/match_inference.rs
@@ -171,7 +171,10 @@ pub(crate) fn prune_types(graph: &mut TypeInferenceGraph<'_>) {
 }
 
 fn prune_types_for_nested_negations_and_optionals(graph: &mut TypeInferenceGraph<'_>) {
-    graph.nested_disjunctions.iter_mut().flat_map(|disjunction| disjunction.disjunction.iter_mut())
+    graph
+        .nested_disjunctions
+        .iter_mut()
+        .flat_map(|disjunction| disjunction.disjunction.iter_mut())
         .for_each(|nested| prune_types_for_nested_negations_and_optionals(nested));
     chain(graph.nested_negations.iter_mut(), graph.nested_optionals.iter_mut()).for_each(|nested| {
         for (vertex, parent_annotations) in &graph.vertices.annotations {

--- a/compiler/annotation/type_seeder.rs
+++ b/compiler/annotation/type_seeder.rs
@@ -123,18 +123,17 @@ impl<'this, Snapshot: ReadableSnapshot> TypeGraphSeedingContext<'this, Snapshot>
         self.seed_edges(graph).map_err(|source| TypeInferenceError::ConceptRead { typedb_source: source })?;
 
         // Now we recurse into the nested negations & optionals
-        self.seed_types_in_nested_negations_and_optionals(graph, context);
-        Ok(())
+        self.seed_types_in_nested_negations_and_optionals(graph, context)
     }
 
     fn seed_types_in_nested_negations_and_optionals(
         &self,
         graph: &mut TypeInferenceGraph<'_>,
         context: &BlockContext,
-    ) -> Result<(), TypeInferenceError>{
+    ) -> Result<(), TypeInferenceError> {
         let TypeInferenceGraph { vertices, nested_disjunctions, nested_negations, nested_optionals, .. } = graph;
         for nested_graph in nested_disjunctions.iter_mut().flat_map(|disjunction| disjunction.disjunction.iter_mut()) {
-            self.seed_types_in_nested_negations_and_optionals(nested_graph, context).unwrap()
+            self.seed_types_in_nested_negations_and_optionals(nested_graph, context)?;
         }
         for nested_graph in nested_negations {
             self.seed_types(nested_graph, context, vertices)?;

--- a/dependencies/typedb/repositories.bzl
+++ b/dependencies/typedb/repositories.bzl
@@ -36,5 +36,5 @@ def typedb_behaviour():
     git_repository(
         name = "typedb_behaviour",
         remote = "https://github.com/typedb/typedb-behaviour",
-        commit = "8098e03c3c7be016e709b51744ebfd5c2c06cda1",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @typedb_behaviour
+        commit = "692c099bdb9ac418707be276c120a144219df816",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @typedb_behaviour
     )

--- a/dependencies/typedb/repositories.bzl
+++ b/dependencies/typedb/repositories.bzl
@@ -35,6 +35,6 @@ def typedb_protocol():
 def typedb_behaviour():
     git_repository(
         name = "typedb_behaviour",
-        remote = "https://github.com/typedb/typedb-behaviour",
-        commit = "97d4bdc7683287e8c1de6a291228a2f864786b61",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @typedb_behaviour
+        remote = "https://github.com/krishnangovindraj/typedb-behaviour",
+        commit = "ca3f3e661cbe25c7d60b79b6993c2597e1f5a800",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @typedb_behaviour
     )

--- a/dependencies/typedb/repositories.bzl
+++ b/dependencies/typedb/repositories.bzl
@@ -35,6 +35,6 @@ def typedb_protocol():
 def typedb_behaviour():
     git_repository(
         name = "typedb_behaviour",
-        remote = "https://github.com/krishnangovindraj/typedb-behaviour",
-        commit = "ca3f3e661cbe25c7d60b79b6993c2597e1f5a800",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @typedb_behaviour
+        remote = "https://github.com/typedb/typedb-behaviour",
+        commit = "8098e03c3c7be016e709b51744ebfd5c2c06cda1",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @typedb_behaviour
     )

--- a/executor/pipeline/pipeline.rs
+++ b/executor/pipeline/pipeline.rs
@@ -192,6 +192,7 @@ impl<Snapshot: WritableSnapshot + 'static> Pipeline<Snapshot, WritePipelineStage
         snapshot: Snapshot,
         variable_names: &HashMap<Variable, String>,
         thing_manager: Arc<ThingManager>,
+        executable_functions: Arc<ExecutableFunctionRegistry>,
         executable_stages: Vec<ExecutableStage>,
         executable_fetch: Option<Arc<ExecutableFetch>>,
         parameters: Arc<ParameterRegistry>,
@@ -199,8 +200,6 @@ impl<Snapshot: WritableSnapshot + 'static> Pipeline<Snapshot, WritePipelineStage
         let output_variable_positions = executable_stages.last().unwrap().output_row_mapping();
         let context = ExecutionContext::new(Arc::new(snapshot), thing_manager, parameters);
         let mut last_stage = WritePipelineStage::Initial(Box::new(InitialStage::new_empty(context)));
-        // TODO: Receive as an argument from schema
-        let executable_functions = Arc::new(ExecutableFunctionRegistry::empty());
         for executable_stage in executable_stages {
             match executable_stage {
                 ExecutableStage::Match(match_executable) => {
@@ -253,7 +252,7 @@ impl<Snapshot: WritableSnapshot + 'static> Pipeline<Snapshot, WritePipelineStage
         }
         Pipeline::build_with_fetch(
             variable_names,
-            executable_functions,
+            executable_functions.clone(),
             last_stage,
             output_variable_positions,
             executable_fetch,

--- a/executor/tests/execute_function.rs
+++ b/executor/tests/execute_function.rs
@@ -5,12 +5,11 @@
  */
 
 use std::{collections::HashMap, sync::Arc};
-use answer::variable_value::VariableValue;
 
+use answer::variable_value::VariableValue;
 use compiler::VariablePosition;
 use concept::{thing::thing_manager::ThingManager, type_::type_manager::TypeManager};
-use encoding::graph::definition::definition_key_generator::DefinitionKeyGenerator;
-use encoding::value::value::Value;
+use encoding::{graph::definition::definition_key_generator::DefinitionKeyGenerator, value::value::Value};
 use executor::{
     pipeline::{stage::ExecutionContext, PipelineExecutionError},
     row::MaybeOwnedRow,
@@ -511,13 +510,15 @@ fn fibonacci() {
 
 #[test]
 fn write_pipelines() {
-    let context = setup_common(r#"
+    let context = setup_common(
+        r#"
         define
             relation edge relates begin, relates end;
             entity node, plays edge:begin, plays edge:end, owns id @key;
             attribute id, value integer;
             attribute number @independent, value integer;
-    "#);
+    "#,
+    );
     let insert_query = r#"insert
         $n0  isa number  0;
         $n1  isa number  1;

--- a/function/function_manager.rs
+++ b/function/function_manager.rs
@@ -26,6 +26,7 @@ use encoding::{
 use ir::{
     pattern::{conjunction::Conjunction, constraint::Constraint, nested_pattern::NestedPattern},
     pipeline::{
+        function::ReturnOperation,
         function_signature::{
             FunctionID, FunctionIDAPI, FunctionSignature, FunctionSignatureIndex, HashMapFunctionSignatureIndex,
         },
@@ -44,7 +45,6 @@ use storage::{
     snapshot::{ReadableSnapshot, WritableSnapshot},
 };
 use typeql::common::Spanned;
-use ir::pipeline::function::ReturnOperation;
 
 use crate::{function::SchemaFunction, function_cache::FunctionCache, FunctionError};
 
@@ -343,11 +343,8 @@ fn validate_no_cycles_impl<ID: FunctionIDAPI + Ord + Eq>(
         ReturnOperation::Stream(_, _) | ReturnOperation::Single(_, _, _) => false,
         ReturnOperation::ReduceCheck(_) | ReturnOperation::ReduceReducer(_, _) => true,
     };
-    let unnegated_stratum = if has_aggregate_stage || has_aggregate_return {
-        current_stratum.add(1, 1)
-    } else {
-        current_stratum.add(0, 1)
-    };
+    let unnegated_stratum =
+        if has_aggregate_stage || has_aggregate_return { current_stratum.add(1, 1) } else { current_stratum.add(0, 1) };
     for called_id in unnegated_function_calls(function) {
         validate_no_cycles_impl(called_id, functions, active, complete, unnegated_stratum)?;
     }

--- a/function/function_manager.rs
+++ b/function/function_manager.rs
@@ -44,6 +44,7 @@ use storage::{
     snapshot::{ReadableSnapshot, WritableSnapshot},
 };
 use typeql::common::Spanned;
+use ir::pipeline::function::ReturnOperation;
 
 use crate::{function::SchemaFunction, function_cache::FunctionCache, FunctionError};
 
@@ -328,7 +329,7 @@ fn validate_no_cycles_impl<ID: FunctionIDAPI + Ord + Eq>(
         validate_no_cycles_impl(called_id, functions, active, complete, current_stratum.add(1, 1))?;
     }
 
-    let this_stage_has_operator = function.function_body.stages.iter().any(|stage| {
+    let has_aggregate_stage = function.function_body.stages.iter().any(|stage| {
         matches!(
             stage,
             TranslatedStage::Sort(_)
@@ -338,7 +339,15 @@ fn validate_no_cycles_impl<ID: FunctionIDAPI + Ord + Eq>(
                 | TranslatedStage::Reduce(_)
         )
     });
-    let unnegated_stratum = if this_stage_has_operator { current_stratum.add(1, 1) } else { current_stratum.add(0, 1) };
+    let has_aggregate_return = match function.function_body.return_operation {
+        ReturnOperation::Stream(_, _) | ReturnOperation::Single(_, _, _) => false,
+        ReturnOperation::ReduceCheck(_) | ReturnOperation::ReduceReducer(_, _) => true,
+    };
+    let unnegated_stratum = if has_aggregate_stage || has_aggregate_return {
+        current_stratum.add(1, 1)
+    } else {
+        current_stratum.add(0, 1)
+    };
     for called_id in unnegated_function_calls(function) {
         validate_no_cycles_impl(called_id, functions, active, complete, unnegated_stratum)?;
     }

--- a/query/query_manager.rs
+++ b/query/query_manager.rs
@@ -8,7 +8,10 @@ use std::{collections::HashSet, sync::Arc};
 
 use compiler::{
     annotation::pipeline::{annotate_preamble_and_pipeline, AnnotatedPipeline},
-    executable::pipeline::{compile_pipeline_and_functions, ExecutablePipeline},
+    executable::{
+        function::ExecutableFunctionRegistry,
+        pipeline::{compile_pipeline_and_functions, ExecutablePipeline},
+    },
     transformation::transform::apply_transformations,
 };
 use concept::{thing::thing_manager::ThingManager, type_::type_manager::TypeManager};
@@ -25,7 +28,6 @@ use resource::perf_counters::{QUERY_CACHE_HITS, QUERY_CACHE_MISSES};
 use storage::snapshot::{ReadableSnapshot, WritableSnapshot};
 use tracing::{event, Level};
 use typeql::query::SchemaQuery;
-use compiler::executable::function::ExecutableFunctionRegistry;
 
 use crate::{define, error::QueryError, query_cache::QueryCache, redefine, undefine};
 

--- a/query/query_manager.rs
+++ b/query/query_manager.rs
@@ -25,6 +25,7 @@ use resource::perf_counters::{QUERY_CACHE_HITS, QUERY_CACHE_MISSES};
 use storage::snapshot::{ReadableSnapshot, WritableSnapshot};
 use tracing::{event, Level};
 use typeql::query::SchemaQuery;
+use compiler::executable::function::ExecutableFunctionRegistry;
 
 use crate::{define, error::QueryError, query_cache::QueryCache, redefine, undefine};
 
@@ -309,6 +310,7 @@ impl QueryManager {
             snapshot,
             variable_registry.variable_names(),
             thing_manager,
+            Arc::new(executable_functions),
             executable_stages,
             executable_fetch,
             Arc::new(value_parameters),


### PR DESCRIPTION
## Release notes: product changes
Enable functions in write pipelines

## Motivation
Enable functions in write pipelines.
fixes #7363 
Requires typedb/typedb-behaviour#337

## Implementation
* Passes the function registry to the write pipeline.
* Fixes a bug in type_seeder where we didn't recurse into negations within disjunctions.