### PR TITLE
Improve query plan eviction

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,6 @@ logs/
 
 # Python cache
 __pycache__
+
+# AI tools
+.aider*

--- a/common/logger/logger.rs
+++ b/common/logger/logger.rs
@@ -6,9 +6,11 @@
 
 #![allow(unexpected_cfgs)]
 
-use tracing::{self, dispatcher::DefaultGuard, metadata::LevelFilter, Level};
+use std::io::stdout;
+
+use tracing::{self, dispatcher::DefaultGuard, Level, metadata::LevelFilter};
 pub use tracing::{debug, error, info, trace};
-use tracing_subscriber::{fmt::SubscriberBuilder, EnvFilter};
+use tracing_subscriber::{EnvFilter, fmt::SubscriberBuilder};
 
 pub mod result;
 
@@ -25,7 +27,21 @@ pub fn initialise_logging_global() {
         // .add_directive("tonic=trace".parse().unwrap());
     ;
 
-    let subscriber = SubscriberBuilder::default().with_max_level(Level::TRACE).with_env_filter(filter).finish();
+    // Create a file appender
+    // let file_appender = File::create("output.log")
+    //     .expect("Failed to create log file");
+
+    let subscriber = SubscriberBuilder::default()
+        .with_max_level(Level::TRACE)
+        .with_env_filter(filter)
+        .with_writer(stdout)
+        // .with_writer(file_appender)
+        .with_ansi(false) // Disable ANSI colors in file output
+        .with_thread_ids(true)
+        .with_file(true)
+        .with_line_number(true)
+        .finish();
+
     tracing::subscriber::set_global_default(subscriber).unwrap()
 }
 

--- a/common/logger/logger.rs
+++ b/common/logger/logger.rs
@@ -8,9 +8,9 @@
 
 use std::io::stdout;
 
-use tracing::{self, dispatcher::DefaultGuard, Level, metadata::LevelFilter};
+use tracing::{self, dispatcher::DefaultGuard, metadata::LevelFilter, Level};
 pub use tracing::{debug, error, info, trace};
-use tracing_subscriber::{EnvFilter, fmt::SubscriberBuilder};
+use tracing_subscriber::{fmt::SubscriberBuilder, EnvFilter};
 
 pub mod result;
 

--- a/concept/BUILD
+++ b/concept/BUILD
@@ -45,6 +45,7 @@ rust_library(
         "@crates//:itertools",
         "@crates//:regex",
         "@crates//:serde",
+        "@crates//:tracing",
     ],
     proc_macro_deps = [
         "@crates//:paste",

--- a/concept/Cargo.toml
+++ b/concept/Cargo.toml
@@ -29,11 +29,6 @@ features = {}
 		features = []
 		default-features = false
 
-	[dev-dependencies.tracing]
-		features = ["attributes", "default", "log", "std", "tracing-attributes"]
-		version = "0.1.41"
-		default-features = false
-
 	[dev-dependencies.criterion]
 		features = ["cargo_bench_support", "default", "plotters", "rayon"]
 		version = "0.5.1"
@@ -55,6 +50,11 @@ features = {}
 		default-features = false
 
 [dependencies]
+
+	[dependencies.tracing]
+		features = ["attributes", "default", "log", "std", "tracing-attributes"]
+		version = "0.1.41"
+		default-features = false
 
 	[dependencies.primitive]
 		path = "../common/primitive"

--- a/database/transaction.rs
+++ b/database/transaction.rs
@@ -323,10 +323,8 @@ impl<D: DurabilityClient> TransactionSchema<D> {
         thing_statistics
             .may_synchronise(&self.database.storage)
             .map_err(|typedb_source| StatisticsError { typedb_source })?;
-        let total_count = thing_statistics.total_count;
         schema.thing_statistics = Arc::new(thing_statistics);
-
-        self.database.query_cache.force_reset(total_count);
+        self.database.query_cache.force_reset(&schema.thing_statistics);
 
         *schema_commit_guard = schema;
         Ok(())

--- a/docker/BUILD
+++ b/docker/BUILD
@@ -44,13 +44,15 @@ docker_container_run_and_commit(
     image = "@ubuntu-22.04-x86_64//image",
     commands = docker_image_prepare_commands,
     target_compatible_with = constraint_linux_x86_64,
+    tags = ["manual"],
 )
 
 docker_container_run_and_commit(
     name = "typedb-ubuntu-22.04-arm64",
     image = "@ubuntu-22.04-arm64//image",
     commands = docker_image_prepare_commands,
-    target_compatible_with = constraint_linux_arm64,
+#    target_compatible_with = constraint_linux_arm64,
+    tags = ["manual"],
 )
 
 checkstyle_test(

--- a/executor/tests/execute_function.rs
+++ b/executor/tests/execute_function.rs
@@ -102,7 +102,7 @@ fn setup_common(schema: &str) -> Context {
         .unwrap();
     snapshot.commit().unwrap();
 
-    let query_manager = QueryManager::new(Some(Arc::new(QueryCache::new(0))));
+    let query_manager = QueryManager::new(Some(Arc::new(QueryCache::new())));
     // reload to obtain latest vertex generators and statistics entries
     let (type_manager, thing_manager) = load_managers(storage.clone(), None);
     Context { _tmp_dir, storage, type_manager, function_manager, query_manager, thing_manager }

--- a/executor/tests/pipelines.rs
+++ b/executor/tests/pipelines.rs
@@ -59,7 +59,7 @@ fn setup_common() -> Context {
 
     // reload to obtain latest vertex generators and statistics entries
     let (type_manager, thing_manager) = load_managers(storage.clone(), None);
-    let query_manager = QueryManager::new(Some(Arc::new(QueryCache::new(0))));
+    let query_manager = QueryManager::new(Some(Arc::new(QueryCache::new())));
     Context { _tmp_dir, storage, type_manager, function_manager, query_manager, thing_manager }
 }
 

--- a/query/benches/bench_insert_queries.rs
+++ b/query/benches/bench_insert_queries.rs
@@ -149,7 +149,7 @@ fn criterion_benchmark(c: &mut Criterion) {
     let (_tmp_dir, mut storage) = create_core_storage();
     setup_database(&mut storage);
     let (type_manager, thing_manager) = load_managers(storage.clone(), Some(storage.snapshot_watermark()));
-    let query_manager = QueryManager::new(Some(Arc::new(QueryCache::new(0))));
+    let query_manager = QueryManager::new(Some(Arc::new(QueryCache::new())));
 
     group.bench_function("insert_queries", |b| {
         b.iter(|| {

--- a/query/benches/bench_insert_queries_multithreaded.rs
+++ b/query/benches/bench_insert_queries_multithreaded.rs
@@ -11,27 +11,27 @@ use std::{
     collections::HashMap,
     sync::{Arc, OnceLock, RwLock},
     thread,
-    thread::{JoinHandle, sleep},
+    thread::{sleep, JoinHandle},
     time::{Duration, Instant},
 };
 
 use answer::variable_value::VariableValue;
 use concept::{
     thing::thing_manager::ThingManager,
-    type_::{Ordering, OwnerAPI, PlayerAPI, type_manager::TypeManager},
+    type_::{type_manager::TypeManager, Ordering, OwnerAPI, PlayerAPI},
 };
 use encoding::{
     graph::definition::definition_key_generator::DefinitionKeyGenerator,
     value::{label::Label, value_type::ValueType},
 };
-use executor::{ExecutionInterrupt, pipeline::stage::StageIterator};
+use executor::{pipeline::stage::StageIterator, ExecutionInterrupt};
 use function::function_manager::FunctionManager;
 use lending_iterator::LendingIterator;
 use query::{error::QueryError, query_cache::QueryCache, query_manager::QueryManager};
 use storage::{
     durability_client::WALClient,
-    MVCCStorage,
     snapshot::{CommittableSnapshot, WritableSnapshot},
+    MVCCStorage,
 };
 use test_utils::init_logging;
 use test_utils_concept::{load_managers, setup_concept_storage};

--- a/query/benches/bench_insert_queries_multithreaded.rs
+++ b/query/benches/bench_insert_queries_multithreaded.rs
@@ -11,27 +11,27 @@ use std::{
     collections::HashMap,
     sync::{Arc, OnceLock, RwLock},
     thread,
-    thread::{sleep, JoinHandle},
+    thread::{JoinHandle, sleep},
     time::{Duration, Instant},
 };
 
 use answer::variable_value::VariableValue;
 use concept::{
     thing::thing_manager::ThingManager,
-    type_::{type_manager::TypeManager, Ordering, OwnerAPI, PlayerAPI},
+    type_::{Ordering, OwnerAPI, PlayerAPI, type_manager::TypeManager},
 };
 use encoding::{
     graph::definition::definition_key_generator::DefinitionKeyGenerator,
     value::{label::Label, value_type::ValueType},
 };
-use executor::{pipeline::stage::StageIterator, ExecutionInterrupt};
+use executor::{ExecutionInterrupt, pipeline::stage::StageIterator};
 use function::function_manager::FunctionManager;
 use lending_iterator::LendingIterator;
 use query::{error::QueryError, query_cache::QueryCache, query_manager::QueryManager};
 use storage::{
     durability_client::WALClient,
-    snapshot::{CommittableSnapshot, WritableSnapshot},
     MVCCStorage,
+    snapshot::{CommittableSnapshot, WritableSnapshot},
 };
 use test_utils::init_logging;
 use test_utils_concept::{load_managers, setup_concept_storage};
@@ -142,7 +142,7 @@ fn multi_threaded_inserts() {
     let (_tmp_dir, mut storage) = create_core_storage();
     setup_database(&mut storage);
     let (type_manager, thing_manager) = load_managers(storage.clone(), Some(storage.snapshot_watermark()));
-    let query_manager = QueryManager::new(Some(Arc::new(QueryCache::new(0))));
+    let query_manager = QueryManager::new(Some(Arc::new(QueryCache::new())));
     const NUM_THREADS: usize = 32;
     const INTERNAL_ITERS: usize = 1000;
     let start_signal_rw_lock = Arc::new(RwLock::new(()));

--- a/query/tests/fetch.rs
+++ b/query/tests/fetch.rs
@@ -46,7 +46,7 @@ fn insert_data(
     query_string: &str,
 ) {
     let snapshot = storage.clone().open_snapshot_write();
-    let query_manager = QueryManager::new(Some(Arc::new(QueryCache::new(0))));
+    let query_manager = QueryManager::new(Some(Arc::new(QueryCache::new())));
     let query = typeql::parse_query(query_string).unwrap().into_pipeline();
     let pipeline = query_manager
         .prepare_write_pipeline(snapshot, type_manager, thing_manager, function_manager, &query, query_string)
@@ -119,7 +119,7 @@ fetch {
 
     let pipeline = query.into_pipeline();
     let snapshot = Arc::new(storage.clone().open_snapshot_read());
-    let pipeline = QueryManager::new(Some(Arc::new(QueryCache::new(0))))
+    let pipeline = QueryManager::new(Some(Arc::new(QueryCache::new())))
         .prepare_read_pipeline(
             snapshot.clone(),
             &type_manager,

--- a/query/tests/unimplemented.rs
+++ b/query/tests/unimplemented.rs
@@ -49,7 +49,7 @@ fn setup_common(schema: &str) -> Context {
         .unwrap();
     snapshot.commit().unwrap();
 
-    let query_manager = QueryManager::new(Some(Arc::new(QueryCache::new(0))));
+    let query_manager = QueryManager::new(Some(Arc::new(QueryCache::new())));
     // reload to obtain latest vertex generators and statistics entries
     let (type_manager, thing_manager) = load_managers(storage.clone(), None);
     Context { _tmp_dir, storage, type_manager, function_manager, query_manager, thing_manager }

--- a/resource/constants.rs
+++ b/resource/constants.rs
@@ -61,7 +61,7 @@ pub mod server {
 pub mod database {
     use std::time::Duration;
 
-    pub const QUERY_PLAN_CACHE_FLUSH_STATISTICS_CHANGE_PERCENT: f64 = 0.05;
+    pub const QUERY_PLAN_CACHE_FLUSH_ANY_STATISTIC_CHANGE_FRACTION: f64 = 0.25;
     pub const QUERY_PLAN_CACHE_SIZE: u64 = 100;
     pub const STATISTICS_DURABLE_WRITE_CHANGE_PERCENT: f64 = 0.05;
 


### PR DESCRIPTION
## Release notes: product changes

We improve the query plan eviction policy from a flat 1% change in total count of the data, to instead be a 25% change of _any individual_ statistic, such as a specific entity type's instances, or the count of `has` between two specific types, etc. This means the query plans will be much more accurate in rapidly changing data, in particular in the common case of building an initial dataset or benchmarking.

Before, we'd get tpcc results for the PAYMENT action that look like this:
```

Execution Results after 63 seconds
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
                  Complete        Time (µs)         minLatMs        p50             p75             p90             p95             p99             maxLatMs        Aborts                   
...
  PAYMENT         20                 61.618         7.90            12.91           1244.86         15993.48        24360.62        24360.62        24360.62        0                    
...
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
```

This shows that during a 60s execution time, a few pathological query executions would blow up the entire runtime! However, sometimes the query also executed quickly. This was fundamentally caused by the initial queries using the query plan based on old statistics, which would only get updated later in the benchmark when the total statistics updated sufficiently.

## Motivation

We move towards the goal of being able to reliably execute TPCC benchmarks without needing to force query plans to replan manually.

We now reliably get TPCC results for PAYMENT that look like this instead:

```
Execution Results after 60 seconds
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
                  Complete        Time (µs)         minLatMs        p50             p75             p90             p95             p99             maxLatMs        Aborts                
...
  PAYMENT         428                 43.54         7.00            14.05           26.01          184.51          249.36          281.22          675.73          0               
...
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
```


## Implementation

The query plan cache now retains the last full set of statistics it was flushed against, which allows calculating a much finer diff. We then take the maximum percentage that any individual statistic has changed as the signal of whether to flush the cache. For now, we increase that threshold to 25% of the minum of the old or new statistics, whichever is smaller.
