### PR TITLE
Allow duration literals without date component

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4184,7 +4184,7 @@ checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
 [[package]]
 name = "typeql"
 version = "0.0.0"
-source = "git+https://github.com/typedb/typeql?rev=2a90021b1c51a6cadc21ac41d0e0a942eb2a6ff0#2a90021b1c51a6cadc21ac41d0e0a942eb2a6ff0"
+source = "git+https://github.com/typedb/typeql?rev=c3651b6d3b82f6dc8a0db499592cb22e60e79b49#c3651b6d3b82f6dc8a0db499592cb22e60e79b49"
 dependencies = [
  "chrono",
  "itertools 0.10.5",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4184,7 +4184,7 @@ checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
 [[package]]
 name = "typeql"
 version = "0.0.0"
-source = "git+https://github.com/typedb/typeql?rev=a84767c1849029c9d6cd74a00ec1d29f3ab76b80#a84767c1849029c9d6cd74a00ec1d29f3ab76b80"
+source = "git+https://github.com/typedb/typeql?rev=2a90021b1c51a6cadc21ac41d0e0a942eb2a6ff0#2a90021b1c51a6cadc21ac41d0e0a942eb2a6ff0"
 dependencies = [
  "chrono",
  "itertools 0.10.5",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ features = {}
 
 	[dev-dependencies.typeql]
 		features = []
-		rev = "2a90021b1c51a6cadc21ac41d0e0a942eb2a6ff0"
+		rev = "c3651b6d3b82f6dc8a0db499592cb22e60e79b49"
 		git = "https://github.com/typedb/typeql"
 		default-features = false
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ features = {}
 
 	[dev-dependencies.typeql]
 		features = []
-		rev = "a84767c1849029c9d6cd74a00ec1d29f3ab76b80"
+		rev = "2a90021b1c51a6cadc21ac41d0e0a942eb2a6ff0"
 		git = "https://github.com/typedb/typeql"
 		default-features = false
 
@@ -168,10 +168,6 @@ features = {}
 [[test]]
 	path = "tests/behaviour/concept/type/attribute_type.rs"
 	name = "test_attributetype"
-
-[[test]]
-	path = "tests/behaviour/concept/migration/function.rs"
-	name = "test_function"
 
 [[test]]
 	path = "tests/behaviour/concept/migration/data_validation.rs"

--- a/common/error/Cargo.toml
+++ b/common/error/Cargo.toml
@@ -21,7 +21,7 @@ features = {}
 
 	[dependencies.typeql]
 		features = []
-		rev = "2a90021b1c51a6cadc21ac41d0e0a942eb2a6ff0"
+		rev = "c3651b6d3b82f6dc8a0db499592cb22e60e79b49"
 		git = "https://github.com/typedb/typeql"
 		default-features = false
 

--- a/common/error/Cargo.toml
+++ b/common/error/Cargo.toml
@@ -21,7 +21,7 @@ features = {}
 
 	[dependencies.typeql]
 		features = []
-		rev = "a84767c1849029c9d6cd74a00ec1d29f3ab76b80"
+		rev = "2a90021b1c51a6cadc21ac41d0e0a942eb2a6ff0"
 		git = "https://github.com/typedb/typeql"
 		default-features = false
 

--- a/common/structural_equality/Cargo.toml
+++ b/common/structural_equality/Cargo.toml
@@ -21,7 +21,7 @@ features = {}
 
 	[dependencies.typeql]
 		features = []
-		rev = "2a90021b1c51a6cadc21ac41d0e0a942eb2a6ff0"
+		rev = "c3651b6d3b82f6dc8a0db499592cb22e60e79b49"
 		git = "https://github.com/typedb/typeql"
 		default-features = false
 

--- a/common/structural_equality/Cargo.toml
+++ b/common/structural_equality/Cargo.toml
@@ -21,7 +21,7 @@ features = {}
 
 	[dependencies.typeql]
 		features = []
-		rev = "a84767c1849029c9d6cd74a00ec1d29f3ab76b80"
+		rev = "2a90021b1c51a6cadc21ac41d0e0a942eb2a6ff0"
 		git = "https://github.com/typedb/typeql"
 		default-features = false
 

--- a/compiler/Cargo.toml
+++ b/compiler/Cargo.toml
@@ -58,7 +58,7 @@ features = {}
 
 	[dependencies.typeql]
 		features = []
-		rev = "a84767c1849029c9d6cd74a00ec1d29f3ab76b80"
+		rev = "2a90021b1c51a6cadc21ac41d0e0a942eb2a6ff0"
 		git = "https://github.com/typedb/typeql"
 		default-features = false
 

--- a/compiler/Cargo.toml
+++ b/compiler/Cargo.toml
@@ -58,7 +58,7 @@ features = {}
 
 	[dependencies.typeql]
 		features = []
-		rev = "2a90021b1c51a6cadc21ac41d0e0a942eb2a6ff0"
+		rev = "c3651b6d3b82f6dc8a0db499592cb22e60e79b49"
 		git = "https://github.com/typedb/typeql"
 		default-features = false
 

--- a/concept/Cargo.toml
+++ b/concept/Cargo.toml
@@ -128,7 +128,7 @@ features = {}
 
 	[dependencies.typeql]
 		features = []
-		rev = "a84767c1849029c9d6cd74a00ec1d29f3ab76b80"
+		rev = "2a90021b1c51a6cadc21ac41d0e0a942eb2a6ff0"
 		git = "https://github.com/typedb/typeql"
 		default-features = false
 

--- a/concept/Cargo.toml
+++ b/concept/Cargo.toml
@@ -128,7 +128,7 @@ features = {}
 
 	[dependencies.typeql]
 		features = []
-		rev = "2a90021b1c51a6cadc21ac41d0e0a942eb2a6ff0"
+		rev = "c3651b6d3b82f6dc8a0db499592cb22e60e79b49"
 		git = "https://github.com/typedb/typeql"
 		default-features = false
 

--- a/database/Cargo.toml
+++ b/database/Cargo.toml
@@ -103,7 +103,7 @@ features = {}
 
 	[dependencies.typeql]
 		features = []
-		rev = "2a90021b1c51a6cadc21ac41d0e0a942eb2a6ff0"
+		rev = "c3651b6d3b82f6dc8a0db499592cb22e60e79b49"
 		git = "https://github.com/typedb/typeql"
 		default-features = false
 

--- a/database/Cargo.toml
+++ b/database/Cargo.toml
@@ -103,7 +103,7 @@ features = {}
 
 	[dependencies.typeql]
 		features = []
-		rev = "a84767c1849029c9d6cd74a00ec1d29f3ab76b80"
+		rev = "2a90021b1c51a6cadc21ac41d0e0a942eb2a6ff0"
 		git = "https://github.com/typedb/typeql"
 		default-features = false
 

--- a/dependencies/typedb/repositories.bzl
+++ b/dependencies/typedb/repositories.bzl
@@ -21,8 +21,8 @@ def typedb_dependencies():
 def typeql():
     git_repository(
         name = "typeql",
-        remote = "https://github.com/typedb/typeql",
-        commit = "a84767c1849029c9d6cd74a00ec1d29f3ab76b80",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @typeql
+        remote = "https://github.com/dmitrii-ubskii/typeql",
+        commit = "2a90021b1c51a6cadc21ac41d0e0a942eb2a6ff0",
     )
 
 def typedb_protocol():

--- a/dependencies/typedb/repositories.bzl
+++ b/dependencies/typedb/repositories.bzl
@@ -21,8 +21,8 @@ def typedb_dependencies():
 def typeql():
     git_repository(
         name = "typeql",
-        remote = "https://github.com/dmitrii-ubskii/typeql",
-        commit = "2a90021b1c51a6cadc21ac41d0e0a942eb2a6ff0",
+        remote = "https://github.com/typedb/typeql",
+        commit = "c3651b6d3b82f6dc8a0db499592cb22e60e79b49",
     )
 
 def typedb_protocol():

--- a/diagnostics/Cargo.toml
+++ b/diagnostics/Cargo.toml
@@ -61,7 +61,7 @@ features = {}
 
 	[dependencies.typeql]
 		features = []
-		rev = "2a90021b1c51a6cadc21ac41d0e0a942eb2a6ff0"
+		rev = "c3651b6d3b82f6dc8a0db499592cb22e60e79b49"
 		git = "https://github.com/typedb/typeql"
 		default-features = false
 

--- a/diagnostics/Cargo.toml
+++ b/diagnostics/Cargo.toml
@@ -61,7 +61,7 @@ features = {}
 
 	[dependencies.typeql]
 		features = []
-		rev = "a84767c1849029c9d6cd74a00ec1d29f3ab76b80"
+		rev = "2a90021b1c51a6cadc21ac41d0e0a942eb2a6ff0"
 		git = "https://github.com/typedb/typeql"
 		default-features = false
 

--- a/encoding/Cargo.toml
+++ b/encoding/Cargo.toml
@@ -113,7 +113,7 @@ features = {}
 
 	[dependencies.typeql]
 		features = []
-		rev = "a84767c1849029c9d6cd74a00ec1d29f3ab76b80"
+		rev = "2a90021b1c51a6cadc21ac41d0e0a942eb2a6ff0"
 		git = "https://github.com/typedb/typeql"
 		default-features = false
 

--- a/encoding/Cargo.toml
+++ b/encoding/Cargo.toml
@@ -113,7 +113,7 @@ features = {}
 
 	[dependencies.typeql]
 		features = []
-		rev = "2a90021b1c51a6cadc21ac41d0e0a942eb2a6ff0"
+		rev = "c3651b6d3b82f6dc8a0db499592cb22e60e79b49"
 		git = "https://github.com/typedb/typeql"
 		default-features = false
 

--- a/executor/Cargo.toml
+++ b/executor/Cargo.toml
@@ -118,7 +118,7 @@ features = {}
 
 	[dependencies.typeql]
 		features = []
-		rev = "a84767c1849029c9d6cd74a00ec1d29f3ab76b80"
+		rev = "2a90021b1c51a6cadc21ac41d0e0a942eb2a6ff0"
 		git = "https://github.com/typedb/typeql"
 		default-features = false
 

--- a/executor/Cargo.toml
+++ b/executor/Cargo.toml
@@ -118,7 +118,7 @@ features = {}
 
 	[dependencies.typeql]
 		features = []
-		rev = "2a90021b1c51a6cadc21ac41d0e0a942eb2a6ff0"
+		rev = "c3651b6d3b82f6dc8a0db499592cb22e60e79b49"
 		git = "https://github.com/typedb/typeql"
 		default-features = false
 

--- a/function/Cargo.toml
+++ b/function/Cargo.toml
@@ -93,7 +93,7 @@ features = {}
 
 	[dependencies.typeql]
 		features = []
-		rev = "a84767c1849029c9d6cd74a00ec1d29f3ab76b80"
+		rev = "2a90021b1c51a6cadc21ac41d0e0a942eb2a6ff0"
 		git = "https://github.com/typedb/typeql"
 		default-features = false
 

--- a/function/Cargo.toml
+++ b/function/Cargo.toml
@@ -93,7 +93,7 @@ features = {}
 
 	[dependencies.typeql]
 		features = []
-		rev = "2a90021b1c51a6cadc21ac41d0e0a942eb2a6ff0"
+		rev = "c3651b6d3b82f6dc8a0db499592cb22e60e79b49"
 		git = "https://github.com/typedb/typeql"
 		default-features = false
 

--- a/ir/Cargo.toml
+++ b/ir/Cargo.toml
@@ -88,7 +88,7 @@ features = {}
 
 	[dependencies.typeql]
 		features = []
-		rev = "2a90021b1c51a6cadc21ac41d0e0a942eb2a6ff0"
+		rev = "c3651b6d3b82f6dc8a0db499592cb22e60e79b49"
 		git = "https://github.com/typedb/typeql"
 		default-features = false
 

--- a/ir/Cargo.toml
+++ b/ir/Cargo.toml
@@ -88,7 +88,7 @@ features = {}
 
 	[dependencies.typeql]
 		features = []
-		rev = "a84767c1849029c9d6cd74a00ec1d29f3ab76b80"
+		rev = "2a90021b1c51a6cadc21ac41d0e0a942eb2a6ff0"
 		git = "https://github.com/typedb/typeql"
 		default-features = false
 

--- a/query/Cargo.toml
+++ b/query/Cargo.toml
@@ -128,7 +128,7 @@ features = {}
 
 	[dependencies.typeql]
 		features = []
-		rev = "a84767c1849029c9d6cd74a00ec1d29f3ab76b80"
+		rev = "2a90021b1c51a6cadc21ac41d0e0a942eb2a6ff0"
 		git = "https://github.com/typedb/typeql"
 		default-features = false
 

--- a/query/Cargo.toml
+++ b/query/Cargo.toml
@@ -128,7 +128,7 @@ features = {}
 
 	[dependencies.typeql]
 		features = []
-		rev = "2a90021b1c51a6cadc21ac41d0e0a942eb2a6ff0"
+		rev = "c3651b6d3b82f6dc8a0db499592cb22e60e79b49"
 		git = "https://github.com/typedb/typeql"
 		default-features = false
 

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -86,7 +86,7 @@ features = {}
 
 	[dependencies.typeql]
 		features = []
-		rev = "2a90021b1c51a6cadc21ac41d0e0a942eb2a6ff0"
+		rev = "c3651b6d3b82f6dc8a0db499592cb22e60e79b49"
 		git = "https://github.com/typedb/typeql"
 		default-features = false
 

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -86,7 +86,7 @@ features = {}
 
 	[dependencies.typeql]
 		features = []
-		rev = "a84767c1849029c9d6cd74a00ec1d29f3ab76b80"
+		rev = "2a90021b1c51a6cadc21ac41d0e0a942eb2a6ff0"
 		git = "https://github.com/typedb/typeql"
 		default-features = false
 

--- a/storage/Cargo.toml
+++ b/storage/Cargo.toml
@@ -133,7 +133,7 @@ features = {}
 
 	[dependencies.typeql]
 		features = []
-		rev = "a84767c1849029c9d6cd74a00ec1d29f3ab76b80"
+		rev = "2a90021b1c51a6cadc21ac41d0e0a942eb2a6ff0"
 		git = "https://github.com/typedb/typeql"
 		default-features = false
 

--- a/storage/Cargo.toml
+++ b/storage/Cargo.toml
@@ -133,7 +133,7 @@ features = {}
 
 	[dependencies.typeql]
 		features = []
-		rev = "2a90021b1c51a6cadc21ac41d0e0a942eb2a6ff0"
+		rev = "c3651b6d3b82f6dc8a0db499592cb22e60e79b49"
 		git = "https://github.com/typedb/typeql"
 		default-features = false
 

--- a/system/Cargo.toml
+++ b/system/Cargo.toml
@@ -76,7 +76,7 @@ features = {}
 
 	[dependencies.typeql]
 		features = []
-		rev = "a84767c1849029c9d6cd74a00ec1d29f3ab76b80"
+		rev = "2a90021b1c51a6cadc21ac41d0e0a942eb2a6ff0"
 		git = "https://github.com/typedb/typeql"
 		default-features = false
 

--- a/system/Cargo.toml
+++ b/system/Cargo.toml
@@ -76,7 +76,7 @@ features = {}
 
 	[dependencies.typeql]
 		features = []
-		rev = "2a90021b1c51a6cadc21ac41d0e0a942eb2a6ff0"
+		rev = "c3651b6d3b82f6dc8a0db499592cb22e60e79b49"
 		git = "https://github.com/typedb/typeql"
 		default-features = false
 

--- a/tests/behaviour/steps/Cargo.toml
+++ b/tests/behaviour/steps/Cargo.toml
@@ -81,7 +81,7 @@ features = {}
 
 	[dependencies.typeql]
 		features = []
-		rev = "a84767c1849029c9d6cd74a00ec1d29f3ab76b80"
+		rev = "2a90021b1c51a6cadc21ac41d0e0a942eb2a6ff0"
 		git = "https://github.com/typedb/typeql"
 		default-features = false
 

--- a/tests/behaviour/steps/Cargo.toml
+++ b/tests/behaviour/steps/Cargo.toml
@@ -81,7 +81,7 @@ features = {}
 
 	[dependencies.typeql]
 		features = []
-		rev = "2a90021b1c51a6cadc21ac41d0e0a942eb2a6ff0"
+		rev = "c3651b6d3b82f6dc8a0db499592cb22e60e79b49"
 		git = "https://github.com/typedb/typeql"
 		default-features = false
 

--- a/user/Cargo.toml
+++ b/user/Cargo.toml
@@ -46,7 +46,7 @@ features = {}
 
 	[dependencies.typeql]
 		features = []
-		rev = "2a90021b1c51a6cadc21ac41d0e0a942eb2a6ff0"
+		rev = "c3651b6d3b82f6dc8a0db499592cb22e60e79b49"
 		git = "https://github.com/typedb/typeql"
 		default-features = false
 

--- a/user/Cargo.toml
+++ b/user/Cargo.toml
@@ -46,7 +46,7 @@ features = {}
 
 	[dependencies.typeql]
 		features = []
-		rev = "a84767c1849029c9d6cd74a00ec1d29f3ab76b80"
+		rev = "2a90021b1c51a6cadc21ac41d0e0a942eb2a6ff0"
 		git = "https://github.com/typedb/typeql"
 		default-features = false
 


### PR DESCRIPTION
## Release notes: product changes

We add support for duration literals without the date component in TypeQL (https://github.com/typedb/typeql/pull/394).

## Motivation

## Implementation
