### PR TITLE
Avoid writing tombstones for temporary concepts

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -170,10 +170,6 @@ features = {}
 	name = "test_attributetype"
 
 [[test]]
-	path = "tests/behaviour/concept/migration/function.rs"
-	name = "test_function"
-
-[[test]]
 	path = "tests/behaviour/concept/migration/data_validation.rs"
 	name = "test_data_validation"
 

--- a/concept/iterator.rs
+++ b/concept/iterator.rs
@@ -129,6 +129,7 @@ macro_rules! edge_iterator {
         impl Iterator for $name {
             type Item = Result<$mapped_type, Box<$crate::error::ConceptReadError>>;
             fn next(&mut self) -> Option<Self::Item> {
+                use ::lending_iterator::LendingIterator;
                 use $crate::error::ConceptReadError::SnapshotIterate;
                 self.snapshot_iterator.as_mut()?.next().map(|result| {
                     result

--- a/concept/thing/attribute.rs
+++ b/concept/thing/attribute.rs
@@ -9,7 +9,6 @@ use std::{
     collections::HashSet,
     fmt,
     hash::{Hash, Hasher},
-    io::Read,
     iter,
     sync::{Arc, OnceLock},
 };
@@ -17,10 +16,7 @@ use std::{
 use bytes::Bytes;
 use encoding::{
     graph::{
-        thing::{
-            edge::{ThingEdgeHas, ThingEdgeHasReverse},
-            vertex_attribute::AttributeVertex,
-        },
+        thing::{edge::ThingEdgeHasReverse, vertex_attribute::AttributeVertex},
         type_::vertex::{PrefixedTypeVertexEncoding, TypeVertexEncoding},
         Typed,
     },
@@ -30,16 +26,13 @@ use encoding::{
 };
 use iterator::State;
 use itertools::Itertools;
-use lending_iterator::{higher_order::Hkt, LendingIterator};
+use lending_iterator::higher_order::Hkt;
 use resource::constants::snapshot::{BUFFER_KEY_INLINE, BUFFER_VALUE_INLINE};
 use storage::{
-    key_range::{KeyRange, RangeEnd, RangeStart},
-    key_value::{StorageKey, StorageKeyArray},
+    key_value::StorageKey,
     snapshot::{
-        buffer::BufferRangeIterator,
-        iterator::SnapshotRangeIterator,
-        write::{Write, WriteCategory},
-        ReadableSnapshot, WritableSnapshot,
+        buffer::BufferRangeIterator, iterator::SnapshotRangeIterator, write::WriteCategory, ReadableSnapshot,
+        WritableSnapshot,
     },
 };
 
@@ -47,7 +40,7 @@ use crate::{
     edge_iterator,
     error::{ConceptReadError, ConceptWriteError},
     thing::{object::Object, thing_manager::ThingManager, HKInstance, ThingAPI},
-    type_::{attribute_type::AttributeType, ObjectTypeAPI, TypeAPI},
+    type_::{attribute_type::AttributeType, ObjectTypeAPI},
     ConceptAPI, ConceptStatus,
 };
 

--- a/concept/thing/entity.rs
+++ b/concept/thing/entity.rs
@@ -105,7 +105,11 @@ impl ThingAPI for Entity {
             thing_manager.unset_links(snapshot, relation, self, role)?;
         }
 
-        thing_manager.delete_entity(snapshot, self);
+        if self.get_status(snapshot, thing_manager) == ConceptStatus::Inserted {
+            thing_manager.uninsert_entity(snapshot, self);
+        } else {
+            thing_manager.delete_entity(snapshot, self);
+        }
         Ok(())
     }
 

--- a/concept/thing/entity.rs
+++ b/concept/thing/entity.rs
@@ -105,11 +105,7 @@ impl ThingAPI for Entity {
             thing_manager.unset_links(snapshot, relation, self, role)?;
         }
 
-        if self.get_status(snapshot, thing_manager) == ConceptStatus::Inserted {
-            thing_manager.uninsert_entity(snapshot, self);
-        } else {
-            thing_manager.delete_entity(snapshot, self);
-        }
+        thing_manager.delete_entity(snapshot, self);
         Ok(())
     }
 

--- a/concept/thing/relation.rs
+++ b/concept/thing/relation.rs
@@ -389,11 +389,7 @@ impl ThingAPI for Relation {
             ));
         }
 
-        if self.get_status(snapshot, thing_manager) == ConceptStatus::Inserted {
-            thing_manager.uninsert_relation(snapshot, self);
-        } else {
-            thing_manager.delete_relation(snapshot, self);
-        }
+        thing_manager.delete_relation(snapshot, self);
         Ok(())
     }
 

--- a/tests/behaviour/steps/connection/mod.rs
+++ b/tests/behaviour/steps/connection/mod.rs
@@ -13,7 +13,7 @@ use std::{
 use macro_rules_attribute::apply;
 use server::{parameters::config::Config, typedb};
 use test_utils::{create_tmp_dir, TempDir};
-use tokio::{runtime::Runtime, sync::OnceCell};
+use tokio::sync::OnceCell;
 
 use crate::{generic_step, Context};
 


### PR DESCRIPTION
## Release notes: product changes

When deleting an entity or an attribute that was inserted in the same transaction (i.e. never committed), we remove the key from the write buffer rather than create a tombstone. This logic was already present for relations.

## Motivation

Inserting and deleting an entity within a transaction would write a tombstone without a corresponding insert. Statistics would read that tombstone as a delta of -1 and, at best, undercount the population of its type, and at worst underflow the count and crash.

## Implementation

We've pushed this logic to thing manager, and removed `uninsert_{entity,relation}` and made `unput_attribute` private to reduce room for mistakes.