### PR TITLE
Handle zero-length rows in batch

### DIFF
--- a/executor/batch.rs
+++ b/executor/batch.rs
@@ -110,13 +110,11 @@ impl IntoIterator for FixedBatch {
     type Item = MaybeOwnedRow<'static>;
 
     fn into_iter(self) -> Self::IntoIter {
-        let rows = self
-            .data
-            .into_iter()
-            .chunks(self.width as usize)
-            .into_iter()
-            .map(|chunk| chunk.collect_vec())
-            .collect_vec();
+        let rows = if self.width == 0 {
+            vec![vec![]; self.entries as usize]
+        } else {
+            self.data.into_iter().chunks(self.width as usize).into_iter().map(|chunk| chunk.collect_vec()).collect_vec()
+        };
         rows.into_iter()
             .zip(self.multiplicities)
             .take(self.entries as usize)


### PR DESCRIPTION
## Release notes: product changes

Fix the bug where iteration over zero-length rows in a fixed batch caused a panic.

## Motivation

`.chunks()` rightfully panics when given a zero size, as it can't make progress in that case. We handle that situation ourselves.

## Implementation
