### PR TITLE
Allow multiple expression assignments in different branches

### DIFF
--- a/compiler/annotation/expression/block_compiler.rs
+++ b/compiler/annotation/expression/block_compiler.rs
@@ -86,7 +86,7 @@ pub fn compile_expressions<'block, Snapshot: ReadableSnapshot>(
     }
     for (var, _) in &expression_index {
         if !context.visited_expressions.contains(var) {
-            let _value_type = try_value_type_from_expression_assignments(&mut context, *var, &expression_index)?;
+            let _value_type = try_value_type_from_assignments(&mut context, *var, &expression_index)?;
             debug_assert!(_value_type.is_some());
         }
     }
@@ -170,10 +170,9 @@ fn resolve_type_for_variable<'a, Snapshot: ReadableSnapshot>(
 ) -> Result<ExpressionValueType, Box<ExpressionCompileError>> {
     if let Some(value) = context.variable_value_types.get(&variable) {
         Ok(value.clone())
-    } else if let Some(value) = try_value_type_from_expression_assignments(context, variable, expression_assignments)? {
+    } else if let Some(value) = try_value_type_from_assignments(context, variable, expression_assignments)? {
         Ok(value)
     } else if let Some(value) = try_value_type_from_type_annotations(context, variable)? {
-        context.variable_value_types.insert(variable, value.clone());
         Ok(value)
     } else {
         Err(Box::new(ExpressionCompileError::CouldNotDetermineValueTypeForVariable {
@@ -183,7 +182,7 @@ fn resolve_type_for_variable<'a, Snapshot: ReadableSnapshot>(
     }
 }
 
-fn try_value_type_from_expression_assignments<'a, Snapshot: ReadableSnapshot>(
+fn try_value_type_from_assignments<'a, Snapshot: ReadableSnapshot>(
     context: &mut BlockExpressionsCompilationContext<'a, Snapshot>,
     variable: Variable,
     expression_assignments: &HashMap<Variable, Vec<&'a ExpressionBinding<Variable>>>,

--- a/compiler/annotation/expression/block_compiler.rs
+++ b/compiler/annotation/expression/block_compiler.rs
@@ -19,6 +19,8 @@ use ir::{
     pipeline::{block::Block, ParameterRegistry, VariableRegistry},
 };
 use itertools::Itertools;
+use typeql::common::Span;
+use ir::pattern::disjunction::Disjunction;
 use storage::snapshot::ReadableSnapshot;
 
 use crate::annotation::{
@@ -40,9 +42,19 @@ struct BlockExpressionsCompilationContext<'block, Snapshot: ReadableSnapshot> {
     type_manager: &'block TypeManager,
     type_annotations: &'block TypeAnnotations,
 
-    compiled_expressions: HashMap<Variable, ExecutableExpression<Variable>>,
     variable_value_types: HashMap<Variable, ExpressionValueType>,
+    compiled_expressions: HashMap<ExpressionBinding<Variable>, ExecutableExpression<Variable>>,
     visited_expressions: HashSet<Variable>,
+}
+
+impl<'block, Snapshot: ReadableSnapshot> BlockExpressionsCompilationContext<'block, Snapshot> {
+    pub(crate) fn variable_name(&self, variable: &Variable) -> String {
+        self.variable_registry
+            .variable_names()
+            .get(variable)
+            .cloned()
+            .unwrap_or_else(|| VariableRegistry::UNNAMED_VARIABLE_DISPLAY_NAME.to_string())
+    }
 }
 
 pub fn compile_expressions<'block, Snapshot: ReadableSnapshot>(
@@ -53,7 +65,7 @@ pub fn compile_expressions<'block, Snapshot: ReadableSnapshot>(
     parameters: &'block ParameterRegistry,
     type_annotations: &'block TypeAnnotations,
     input_value_type_annotations: &mut BTreeMap<Variable, ExpressionValueType>,
-) -> Result<HashMap<Variable, ExecutableExpression<Variable>>, Box<ExpressionCompileError>> {
+) -> Result<HashMap<ExpressionBinding<Variable>, ExecutableExpression<Variable>>, Box<ExpressionCompileError>> {
     let mut context = BlockExpressionsCompilationContext {
         block,
         variable_registry,
@@ -65,82 +77,111 @@ pub fn compile_expressions<'block, Snapshot: ReadableSnapshot>(
         visited_expressions: HashSet::new(),
         compiled_expressions: HashMap::new(),
     };
-    let mut expression_index = HashMap::new();
-    index_expressions(&context, block.conjunction(), &mut expression_index)?;
-    let assigned_variables = expression_index.keys().cloned().collect_vec();
-
-    for variable in assigned_variables {
-        compile_expressions_recursive(&mut context, variable, &expression_index)?
+    let mut expression_index = index_expressions_conjunction(&context, block.conjunction())?;
+    if expression_index.keys().any(|var| input_value_type_annotations.contains_key(var)) {
+        todo!("Assigning to already bound variable");
+    }
+    for (var, _) in &expression_index {
+        if !context.visited_expressions.contains(var) {
+            compile_expressions_recursive(&mut context, *var, &expression_index)?;
+        }
     }
 
     let BlockExpressionsCompilationContext { compiled_expressions, .. } = context;
-    for (&var, compiled) in &compiled_expressions {
-        let category = match &compiled.return_type {
-            ExpressionValueType::Single(_) => VariableCategory::Value,
-            ExpressionValueType::List(_) => VariableCategory::ValueList,
-        };
-        let source = Constraint::ExpressionBinding((*expression_index.get(&var).unwrap()).clone());
+    for (binding, compiled) in &compiled_expressions {
+        let assigned = binding.left().as_variable().unwrap();
+        let source = Constraint::ExpressionBinding(binding.clone());
         variable_registry
-            .set_assigned_value_variable_category(var, category, source)
+            .set_assigned_value_variable_category(assigned, compiled.return_category(), source)
             .map_err(|typedb_source| Box::new(ExpressionCompileError::Representation { typedb_source }))?;
     }
     Ok(compiled_expressions)
 }
 
-fn index_expressions<'block, Snapshot: ReadableSnapshot>(
+fn index_expressions_conjunction<'block, Snapshot: ReadableSnapshot>(
     context: &BlockExpressionsCompilationContext<'_, Snapshot>,
     conjunction: &'block Conjunction,
-    index: &mut HashMap<Variable, &'block ExpressionBinding<Variable>>,
+) -> Result<HashMap<Variable, Vec<&'block ExpressionBinding<Variable>>>, Box<ExpressionCompileError>> {
+    let mut expression_index = HashMap::new();
+    index_expressions_conjunction_into(context, conjunction, &mut expression_index)?;
+    Ok(expression_index)
+}
+
+fn index_expressions_conjunction_into<'block, Snapshot: ReadableSnapshot>(
+    context: &BlockExpressionsCompilationContext<'_, Snapshot>,
+    conjunction: &'block Conjunction,
+    index: &mut HashMap<Variable, Vec<&'block ExpressionBinding<Variable>>>,
 ) -> Result<(), Box<ExpressionCompileError>> {
-    for constraint in conjunction.constraints() {
-        if let Some(expression_binding) = constraint.as_expression_binding() {
-            let &Vertex::Variable(left) = expression_binding.left() else { unreachable!() };
-            if index.contains_key(&left) {
-                Err(Box::new(ExpressionCompileError::MultipleAssignmentsForVariable {
-                    variable: context
-                        .variable_registry
-                        .variable_names()
-                        .get(&left)
-                        .cloned()
-                        .unwrap_or_else(|| VariableRegistry::UNNAMED_VARIABLE_DISPLAY_NAME.to_string()),
-                    source_span: expression_binding.source_span(),
-                }))?;
-            }
-            index.insert(left, expression_binding);
+    for expression_binding in conjunction.constraints().iter().filter_map(|c| c.as_expression_binding()) {
+        let left = expression_binding.left().as_variable().unwrap();
+        if index.insert(left, vec![expression_binding]).is_some() {
+            return Err(Box::new(ExpressionCompileError::MultipleAssignmentsForVariable {
+                variable: context.variable_name(&left),
+                source_span: expression_binding.source_span(),
+            }))?;
         }
     }
+
     for nested in conjunction.nested_patterns() {
         match nested {
             NestedPattern::Disjunction(disjunction) => {
-                for nested_conjunction in disjunction.conjunctions() {
-                    index_expressions(context, nested_conjunction, index)?;
-                }
+                index_expressions_disjunction_into(context, disjunction, index)?;
             }
             NestedPattern::Negation(negation) => {
-                index_expressions(context, negation.conjunction(), index)?;
+                index_expressions_conjunction_into(context, negation.conjunction(), index)?;
             }
             NestedPattern::Optional(optional) => {
-                index_expressions(context, optional.conjunction(), index)?;
+                index_expressions_conjunction_into(context, optional.conjunction(), index)?;
             }
         }
     }
     Ok(())
 }
 
+fn index_expressions_disjunction_into<'block, Snapshot: ReadableSnapshot>(
+    context: &BlockExpressionsCompilationContext<'_, Snapshot>,
+    disjunction: &'block Disjunction,
+    index: &mut HashMap<Variable, Vec<&'block ExpressionBinding<Variable>>>,
+) -> Result<(), Box<ExpressionCompileError>> {
+    let mut combined_indices = HashMap::<Variable, Vec<&'block ExpressionBinding<Variable>>>::new();
+    let mut branch_indices = disjunction.conjunctions().iter().map(|branch| {
+        index_expressions_conjunction(context, branch)
+    }).collect::<Result<Vec<_>, _>>()?;
+    branch_indices.into_iter().flat_map(|branch_index| branch_index.into_iter())
+        .for_each(|(var, expressions)| {
+            combined_indices.entry(var).or_default().extend(expressions)
+        });
+    combined_indices.into_iter().try_for_each(|(var, expressions)| {
+        match index.insert(var, expressions) {
+            Some(_) => Err(ExpressionCompileError::MultipleAssignmentsForVariable {
+                variable: context.variable_name(&var),
+                source_span: None
+            }),
+            None => Ok(())
+        }
+    })?;
+    Ok(())
+}
+
 fn compile_expressions_recursive<'a, Snapshot: ReadableSnapshot>(
     context: &mut BlockExpressionsCompilationContext<'a, Snapshot>,
-    assigned_variable: Variable,
-    expression_assignments: &HashMap<Variable, &'a ExpressionBinding<Variable>>,
+    assigned: Variable,
+    expression_assignments: &HashMap<Variable, Vec<&'a ExpressionBinding<Variable>>>,
 ) -> Result<(), Box<ExpressionCompileError>> {
-    context.visited_expressions.insert(assigned_variable);
-    let expression = expression_assignments.get(&assigned_variable).unwrap().expression();
-    for variable in expression.variables() {
-        resolve_type_for_variable(context, variable, expression_assignments)?;
+    if !context.visited_expressions.insert(assigned) {
+        return Err(Box::new(ExpressionCompileError::CircularDependency {
+            variable: context.variable_name(&assigned),
+            source_span: None,
+        }));
     }
-    let compiled =
-        ExpressionCompilationContext::compile(expression, &context.variable_value_types, context.parameters)?;
-    context.variable_value_types.insert(assigned_variable, compiled.return_type.clone());
-    context.compiled_expressions.insert(assigned_variable, compiled);
+    for assignment in expression_assignments.get(&assigned).unwrap() {
+        assignment.expression().variables().try_for_each(|var| {
+            resolve_type_for_variable(context, var, expression_assignments, assignment.source_span())
+                .map(|_| ())
+        })?;
+        let compiled = ExpressionCompilationContext::compile(assignment.expression(), &context.variable_value_types, context.parameters)?;
+        context.compiled_expressions.insert((*assignment).clone(), compiled);
+    }
     Ok(())
 }
 
@@ -148,91 +189,88 @@ fn compile_expressions_recursive<'a, Snapshot: ReadableSnapshot>(
 fn resolve_type_for_variable<'a, Snapshot: ReadableSnapshot>(
     context: &mut BlockExpressionsCompilationContext<'a, Snapshot>,
     variable: Variable,
-    expression_assignments: &HashMap<Variable, &'a ExpressionBinding<Variable>>,
-) -> Result<(), Box<ExpressionCompileError>> {
+    expression_assignments: &HashMap<Variable, Vec<&'a ExpressionBinding<Variable>>>,
+    source_span: Option<Span>,
+) -> Result<ExpressionValueType, Box<ExpressionCompileError>> {
+    if let Some(value) = context.variable_value_types.get(&variable) {
+        Ok(value.clone())
+    } else if let Some(value) = try_value_type_from_expression_assignments(context, variable, expression_assignments)? {
+        Ok(value)
+    } else if let Some(value) = try_value_type_from_type_annotations(context, variable)? {
+        context.variable_value_types.insert(variable, value.clone());
+        Ok(value)
+    } else {
+        Err(Box::new(ExpressionCompileError::CouldNotDetermineValueTypeForVariable {
+            variable: context.variable_name(&variable),
+            source_span, // TODO: this can be improved?
+        }))
+    }
+}
+
+fn try_value_type_from_expression_assignments<'a, Snapshot: ReadableSnapshot>(
+    context: &mut BlockExpressionsCompilationContext<'a, Snapshot>,
+    variable: Variable,
+    expression_assignments: &HashMap<Variable, Vec<&'a ExpressionBinding<Variable>>>
+) -> Result<Option<ExpressionValueType>, Box<ExpressionCompileError>> {
     if expression_assignments.contains_key(&variable) {
-        if !context.compiled_expressions.contains_key(&variable) {
-            if context.visited_expressions.contains(&variable) {
-                Err(Box::new(ExpressionCompileError::CircularDependency {
-                    variable: context
-                        .variable_registry
-                        .variable_names()
-                        .get(&variable)
-                        .cloned()
-                        .unwrap_or_else(|| VariableRegistry::UNNAMED_VARIABLE_DISPLAY_NAME.to_string()),
-                    source_span: expression_assignments.get(&variable).unwrap().source_span(),
-                }))
-            } else {
-                compile_expressions_recursive(context, variable, expression_assignments)?;
-                context
-                    .variable_value_types
-                    .insert(variable, context.compiled_expressions.get(&variable).unwrap().return_type.clone());
-                Ok(())
-            }
+        compile_expressions_recursive(context, variable, expression_assignments)?;
+        let mut return_types = expression_assignments.get(&variable).unwrap().iter()
+            .map(|binding| context.compiled_expressions.get(&binding).unwrap().return_type.clone())
+            .collect::<Vec<_>>();
+        if return_types.len() == 1 {
+            let value_type = return_types.pop().unwrap();
+            context.variable_value_types.insert(variable, value_type.clone());
+            Ok(Some(value_type))
         } else {
-            Ok(())
+            debug_assert!(return_types.len() > 1);
+            Err(Box::new(ExpressionCompileError::VariableMultipleValueTypes {
+                variable: context.variable_name(&variable),
+                value_types: return_types.iter().join(", "),
+                source_span: None,
+            }))
         }
-    } else if context.variable_value_types.contains_key(&variable) {
-        Ok(())
-    } else if let Some(types) = context.type_annotations.vertex_annotations_of(&Vertex::Variable(variable)) {
-        // resolve_value_types will error if the type_annotations aren't all attribute(list) types
-        let value_types = resolve_value_types(types, context.snapshot, context.type_manager).map_err(|_source| {
+    } else {
+        Ok(None)
+    }
+}
+
+fn try_value_type_from_type_annotations<'a, Snapshot: ReadableSnapshot>(
+    context: &mut BlockExpressionsCompilationContext<'a, Snapshot>,
+    variable: Variable,
+) -> Result<Option<ExpressionValueType>, Box<ExpressionCompileError>> {
+    let Some(annotations) = context.type_annotations.vertex_annotations_of(&Vertex::Variable(variable)) else {
+        return Ok(None);
+    };
+    let variable_category = context.variable_registry.get_variable_category(variable).unwrap();
+    let is_list = match variable_category {
+        VariableCategory::Value | VariableCategory::Attribute | VariableCategory::Thing => false,
+        VariableCategory::ValueList | VariableCategory::AttributeList | VariableCategory::ThingList => true,
+        _ => {
+            return Err(Box::new(ExpressionCompileError::VariableMustBeValueOrAttribute {
+                variable: context.variable_name(&variable),
+                category: variable_category,
+                source_span: None, // TODO: this can be improved?
+            }));
+        }
+    };
+    let value_types = resolve_value_types(annotations, context.snapshot, context.type_manager)
+        .map_err(|_source| {
             Box::new(ExpressionCompileError::CouldNotDetermineValueTypeForVariable {
-                variable: context
-                    .variable_registry
-                    .variable_names()
-                    .get(&variable)
-                    .cloned()
-                    .unwrap_or_else(|| VariableRegistry::UNNAMED_VARIABLE_DISPLAY_NAME.to_string()),
+                variable: context.variable_name(&variable),
                 source_span: None, // TODO: this can be improved?
             })
         })?;
-        if value_types.len() != 1 {
-            Err(Box::new(ExpressionCompileError::VariableMultipleValueTypes {
-                variable: context
-                    .variable_registry
-                    .variable_names()
-                    .get(&variable)
-                    .cloned()
-                    .unwrap_or_else(|| VariableRegistry::UNNAMED_VARIABLE_DISPLAY_NAME.to_string()),
-                value_types: value_types.iter().join(", "),
-                source_span: None, // TODO: this can be improved?
-            }))
-        } else {
-            let value_type = value_types.iter().find(|_| true).unwrap();
-            let variable_category = context.variable_registry.get_variable_category(variable).unwrap();
-            match variable_category {
-                VariableCategory::Value | VariableCategory::Attribute | VariableCategory::Thing => {
-                    debug_assert!(types.iter().all(|t| matches!(t, answer::Type::Attribute(_))));
-                    context.variable_value_types.insert(variable, ExpressionValueType::Single(value_type.clone()));
-                    Ok(())
-                }
-                VariableCategory::ValueList | VariableCategory::AttributeList | VariableCategory::ThingList => {
-                    debug_assert!(types.iter().all(|t| matches!(t, answer::Type::Attribute(_))));
-                    context.variable_value_types.insert(variable, ExpressionValueType::List(value_type.clone()));
-                    Ok(())
-                }
-                _ => Err(Box::new(ExpressionCompileError::VariableMustBeValueOrAttribute {
-                    variable: context
-                        .variable_registry
-                        .variable_names()
-                        .get(&variable)
-                        .cloned()
-                        .unwrap_or_else(|| VariableRegistry::UNNAMED_VARIABLE_DISPLAY_NAME.to_string()),
-                    category: variable_category,
-                    source_span: None, // TODO: this can be improved?
-                }))?, // TODO: I think this is practically unreachable?
-            }
-        }
-    } else {
-        Err(Box::new(ExpressionCompileError::CouldNotDetermineValueTypeForVariable {
-            variable: context
-                .variable_registry
-                .variable_names()
-                .get(&variable)
-                .cloned()
-                .unwrap_or_else(|| VariableRegistry::UNNAMED_VARIABLE_DISPLAY_NAME.to_string()),
+    let unique_value_type = value_types.iter().exactly_one().map_err(|_| {
+        Box::new(ExpressionCompileError::VariableMultipleValueTypes {
+            variable: context.variable_name(&variable),
+            value_types: value_types.iter().join(", "),
             source_span: None, // TODO: this can be improved?
-        }))
-    }
+        })
+    })?.clone();
+    let expression_value_type = match is_list {
+        true => ExpressionValueType::List(unique_value_type),
+        false => ExpressionValueType::Single(unique_value_type),
+    };
+    context.variable_value_types.insert(variable, expression_value_type.clone());
+    Ok(Some(expression_value_type))
 }

--- a/compiler/annotation/expression/block_compiler.rs
+++ b/compiler/annotation/expression/block_compiler.rs
@@ -78,8 +78,10 @@ pub fn compile_expressions<'block, Snapshot: ReadableSnapshot>(
         compiled_expressions: HashMap::new(),
     };
     let mut expression_index = index_expressions_conjunction(&context, block.conjunction())?;
-    if expression_index.keys().any(|var| input_value_type_annotations.contains_key(var)) {
-        todo!("Assigning to already bound variable");
+    if let Some(var) = expression_index.keys().find(|var| input_value_type_annotations.contains_key(var)) {
+        return Err(Box::new(ExpressionCompileError::ReassigningValueVariable {
+            variable: context.variable_name(var),
+        }));
     }
     for (var, _) in &expression_index {
         if !context.visited_expressions.contains(var) {

--- a/compiler/annotation/expression/compiled_expression.rs
+++ b/compiler/annotation/expression/compiled_expression.rs
@@ -7,8 +7,7 @@
 use std::{collections::HashMap, fmt};
 
 use encoding::value::value_type::ValueType;
-use ir::pattern::{IrID, ParameterID};
-use ir::pattern::variable_category::VariableCategory;
+use ir::pattern::{variable_category::VariableCategory, IrID, ParameterID};
 
 use crate::annotation::expression::instructions::op_codes::ExpressionOpCode;
 
@@ -56,7 +55,7 @@ impl<ID: IrID> ExecutableExpression<ID> {
     }
 }
 
-#[derive(Debug, Clone, Eq, PartialEq)]
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Ord, PartialOrd)]
 pub enum ExpressionValueType {
     // TODO: we haven't implemented ConceptList, only ValueList right now.
     // TODO: this should hold an actual ValueType, not a Category!

--- a/compiler/annotation/expression/compiled_expression.rs
+++ b/compiler/annotation/expression/compiled_expression.rs
@@ -8,6 +8,7 @@ use std::{collections::HashMap, fmt};
 
 use encoding::value::value_type::ValueType;
 use ir::pattern::{IrID, ParameterID};
+use ir::pattern::variable_category::VariableCategory;
 
 use crate::annotation::expression::instructions::op_codes::ExpressionOpCode;
 
@@ -34,6 +35,12 @@ impl<ID> ExecutableExpression<ID> {
 
     pub fn return_type(&self) -> &ExpressionValueType {
         &self.return_type
+    }
+    pub(crate) fn return_category(&self) -> VariableCategory {
+        match &self.return_type {
+            ExpressionValueType::Single(_) => VariableCategory::Value,
+            ExpressionValueType::List(_) => VariableCategory::ValueList,
+        }
     }
 }
 

--- a/compiler/annotation/expression/mod.rs
+++ b/compiler/annotation/expression/mod.rs
@@ -47,7 +47,7 @@ typedb_error! {
         ),
         MultipleAssignmentsForVariable(
             7,
-            "Variable '{variable}' cannot be assigned to multiple times.",
+            "Variable '{variable}' cannot be assigned to multiple times in the same branch.",
             variable: String,
             source_span: Option<Span>,
         ),
@@ -104,6 +104,13 @@ typedb_error! {
             "The variable '{variable}' cannot be assigned to, as it was already assigned in a the previous stage.",
             variable: String,
         ),
-        Representation(19, "Error building expression reprentation.", typedb_source: Box<RepresentationError>),
+        ValueVariableConflictingAssignmentTypes(
+            19,
+            "All assignments of the variable '{variable}' must have the same value type. Found: {value_types}.",
+            variable: String,
+            value_types: String,
+            source_span: Option<Span>,
+        ),
+        Representation(20, "Error building expression reprentation.", typedb_source: Box<RepresentationError>),
     }
 }

--- a/compiler/annotation/expression/mod.rs
+++ b/compiler/annotation/expression/mod.rs
@@ -99,6 +99,11 @@ typedb_error! {
             "Cannot infer inner value types of an empty list constructor.",
             source_span: Option<Span>,
         ),
-        Representation(18, "Error building expression reprentation.", typedb_source: Box<RepresentationError>),
+        ReassigningValueVariable(
+            18,
+            "The variable '{variable}' cannot be assigned to, as it was already assigned in a the previous stage.",
+            variable: String,
+        ),
+        Representation(19, "Error building expression reprentation.", typedb_source: Box<RepresentationError>),
     }
 }

--- a/compiler/annotation/expression/mod.rs
+++ b/compiler/annotation/expression/mod.rs
@@ -99,7 +99,7 @@ typedb_error! {
             "Cannot infer inner value types of an empty list constructor.",
             source_span: Option<Span>,
         ),
-        ReassigningValueVariable(
+        ReassigningValueVariableFromPreviousStage(
             18,
             "The variable '{variable}' cannot be assigned to, as it was already assigned in a the previous stage.",
             variable: String,

--- a/compiler/annotation/expression/mod.rs
+++ b/compiler/annotation/expression/mod.rs
@@ -101,7 +101,7 @@ typedb_error! {
         ),
         ReassigningValueVariableFromPreviousStage(
             18,
-            "The variable '{variable}' cannot be assigned to, as it was already assigned in a the previous stage.",
+            "The variable '{variable}' cannot be assigned to, as it was already assigned in a previous stage.",
             variable: String,
         ),
         ValueVariableConflictingAssignmentTypes(

--- a/compiler/annotation/pipeline.rs
+++ b/compiler/annotation/pipeline.rs
@@ -15,7 +15,11 @@ use answer::{variable::Variable, Type};
 use concept::type_::type_manager::TypeManager;
 use encoding::value::value_type::{ValueType, ValueTypeCategory};
 use ir::{
-    pattern::{conjunction::Conjunction, constraint::Constraint, nested_pattern::NestedPattern},
+    pattern::{
+        conjunction::Conjunction,
+        constraint::{Constraint, ExpressionBinding},
+        nested_pattern::NestedPattern,
+    },
     pipeline::{
         block::Block,
         fetch::FetchObject,
@@ -28,7 +32,6 @@ use ir::{
 };
 use storage::snapshot::ReadableSnapshot;
 use typeql::common::Span;
-use ir::pattern::constraint::ExpressionBinding;
 
 use crate::{
     annotation::{
@@ -277,10 +280,9 @@ fn annotate_stage(
             )
             .map_err(|typedb_source| AnnotationError::ExpressionCompilation { typedb_source })?;
             compiled_expressions.iter().for_each(|(binding, compiled)| {
-                let existing = running_value_variable_assigned_types.insert(
-                    binding.left().as_variable().unwrap(), compiled.return_type().clone()
-                );
-                debug_assert!(existing.is_none() || existing == Some(compiled.return_type().clone()))
+                let _existing = running_value_variable_assigned_types
+                    .insert(binding.left().as_variable().unwrap(), compiled.return_type().clone());
+                debug_assert!(_existing.is_none() || _existing == Some(compiled.return_type().clone()))
             });
             Ok(AnnotatedStage::Match {
                 block,

--- a/compiler/executable/match_/planner/mod.rs
+++ b/compiler/executable/match_/planner/mod.rs
@@ -9,9 +9,11 @@ use std::collections::{hash_map, HashMap, HashSet};
 use answer::variable::Variable;
 use concept::thing::statistics::Statistics;
 use error::typedb_error;
-use ir::pipeline::{block::Block, function_signature::FunctionID, VariableRegistry};
+use ir::{
+    pattern::constraint::ExpressionBinding,
+    pipeline::{block::Block, function_signature::FunctionID, VariableRegistry},
+};
 use itertools::Itertools;
-use ir::pattern::constraint::ExpressionBinding;
 
 use crate::{
     annotation::{expression::compiled_expression::ExecutableExpression, type_annotations::TypeAnnotations},

--- a/compiler/executable/match_/planner/mod.rs
+++ b/compiler/executable/match_/planner/mod.rs
@@ -11,6 +11,7 @@ use concept::thing::statistics::Statistics;
 use error::typedb_error;
 use ir::pipeline::{block::Block, function_signature::FunctionID, VariableRegistry};
 use itertools::Itertools;
+use ir::pattern::constraint::ExpressionBinding;
 
 use crate::{
     annotation::{expression::compiled_expression::ExecutableExpression, type_annotations::TypeAnnotations},
@@ -47,7 +48,7 @@ pub fn compile(
     selected_variables: &[Variable],
     type_annotations: &TypeAnnotations,
     variable_registry: &VariableRegistry,
-    expressions: &HashMap<Variable, ExecutableExpression<Variable>>,
+    expressions: &HashMap<ExpressionBinding<Variable>, ExecutableExpression<Variable>>,
     statistics: &Statistics,
     call_cost_provider: &impl FunctionCallCostProvider,
 ) -> Result<MatchExecutable, MatchCompilationError> {

--- a/compiler/executable/match_/planner/plan.rs
+++ b/compiler/executable/match_/planner/plan.rs
@@ -405,7 +405,7 @@ impl<'a> ConjunctionPlanBuilder<'a> {
                 Constraint::Links(links) => self.register_links(links),
                 Constraint::IndexedRelation(indexed_relation) => self.register_indexed_relation(indexed_relation),
 
-                Constraint::ExpressionBinding(expression) => self.register_expression_binding(expression, expressions),
+                Constraint::ExpressionBinding(binding) => self.register_expression_binding(binding, expressions),
                 Constraint::FunctionCallBinding(call) => self.register_function_call_binding(call, call_cost_provider),
 
                 Constraint::Is(is) => self.register_is(is),
@@ -506,12 +506,12 @@ impl<'a> ConjunctionPlanBuilder<'a> {
 
     fn register_expression_binding(
         &mut self,
-        expression: &ExpressionBinding<Variable>,
+        binding: &ExpressionBinding<Variable>,
         expressions: &'a HashMap<ExpressionBinding<Variable>, ExecutableExpression<Variable>>,
     ) {
-        let variable = expression.left().as_variable().unwrap();
+        let variable = binding.left().as_variable().unwrap();
         let output = self.graph.variable_index[&variable];
-        let expression = &expressions[expression];
+        let expression = &expressions[binding];
         let inputs = expression.variables().iter().map(|&var| self.graph.variable_index[&var]).unique().collect_vec();
         self.graph.push_expression(output, ExpressionPlanner::from_expression(expression, inputs, output));
     }

--- a/compiler/executable/match_/planner/plan.rs
+++ b/compiler/executable/match_/planner/plan.rs
@@ -85,7 +85,7 @@ pub(crate) fn plan_conjunction<'a>(
     variable_positions: &HashMap<Variable, VariablePosition>,
     type_annotations: &'a TypeAnnotations,
     variable_registry: &VariableRegistry,
-    expressions: &'a HashMap<Variable, ExecutableExpression<Variable>>,
+    expressions: &'a HashMap<ExpressionBinding<Variable>, ExecutableExpression<Variable>>,
     statistics: &'a Statistics,
     call_cost_provider: &'a impl FunctionCallCostProvider,
 ) -> Result<ConjunctionPlan<'a>, QueryPlanningError> {
@@ -108,7 +108,7 @@ fn make_builder<'a>(
     variable_positions: &HashMap<Variable, VariablePosition>,
     type_annotations: &'a TypeAnnotations,
     variable_registry: &VariableRegistry,
-    expressions: &'a HashMap<Variable, ExecutableExpression<Variable>>,
+    expressions: &'a HashMap<ExpressionBinding<Variable>, ExecutableExpression<Variable>>,
     statistics: &'a Statistics,
     call_cost_provider: &impl FunctionCallCostProvider,
 ) -> Result<ConjunctionPlanBuilder<'a>, QueryPlanningError> {
@@ -384,7 +384,7 @@ impl<'a> ConjunctionPlanBuilder<'a> {
     fn register_constraints(
         &mut self,
         conjunction: &'a Conjunction,
-        expressions: &'a HashMap<Variable, ExecutableExpression<Variable>>,
+        expressions: &'a HashMap<ExpressionBinding<Variable>, ExecutableExpression<Variable>>,
         call_cost_provider: &impl FunctionCallCostProvider,
     ) {
         for constraint in conjunction.constraints() {
@@ -507,11 +507,11 @@ impl<'a> ConjunctionPlanBuilder<'a> {
     fn register_expression_binding(
         &mut self,
         expression: &ExpressionBinding<Variable>,
-        expressions: &'a HashMap<Variable, ExecutableExpression<Variable>>,
+        expressions: &'a HashMap<ExpressionBinding<Variable>, ExecutableExpression<Variable>>,
     ) {
         let variable = expression.left().as_variable().unwrap();
         let output = self.graph.variable_index[&variable];
-        let expression = &expressions[&variable];
+        let expression = &expressions[expression];
         let inputs = expression.variables().iter().map(|&var| self.graph.variable_index[&var]).unique().collect_vec();
         self.graph.push_expression(output, ExpressionPlanner::from_expression(expression, inputs, output));
     }

--- a/dependencies/typedb/repositories.bzl
+++ b/dependencies/typedb/repositories.bzl
@@ -36,5 +36,5 @@ def typedb_behaviour():
     git_repository(
         name = "typedb_behaviour",
         remote = "https://github.com/krishnangovindraj/typedb-behaviour",
-        commit = "425b7005336e57c11d079b96d92d04af5c3ed1d4",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @typedb_behaviour
+        commit = "82368a6ed424bc272f9472c27bac336237141784",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @typedb_behaviour
     )

--- a/dependencies/typedb/repositories.bzl
+++ b/dependencies/typedb/repositories.bzl
@@ -35,6 +35,6 @@ def typedb_protocol():
 def typedb_behaviour():
     git_repository(
         name = "typedb_behaviour",
-        remote = "https://github.com/typedb/typedb-behaviour",
-        commit = "ae5dcc5b8ff854c5d72fd91b5a3970b79833aeba",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @typedb_behaviour
+        remote = "https://github.com/krishnangovindraj/typedb-behaviour",
+        commit = "545fa67687d5646e774f87fbb4a2d63638cf18dd",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @typedb_behaviour
     )

--- a/dependencies/typedb/repositories.bzl
+++ b/dependencies/typedb/repositories.bzl
@@ -35,6 +35,6 @@ def typedb_protocol():
 def typedb_behaviour():
     git_repository(
         name = "typedb_behaviour",
-        remote = "https://github.com/krishnangovindraj/typedb-behaviour",
-        commit = "d7444877584144969c631c8de2ecbf96eaaf3129",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @typedb_behaviour
+        remote = "https://github.com/typedb/typedb-behaviour",
+        commit = "d040d5c4ae8434b1802d54295035506f21821f52",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @typedb_behaviour
     )

--- a/dependencies/typedb/repositories.bzl
+++ b/dependencies/typedb/repositories.bzl
@@ -36,5 +36,5 @@ def typedb_behaviour():
     git_repository(
         name = "typedb_behaviour",
         remote = "https://github.com/krishnangovindraj/typedb-behaviour",
-        commit = "82368a6ed424bc272f9472c27bac336237141784",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @typedb_behaviour
+        commit = "50fb93b961cc93ae533da89f894edb115c4a996c",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @typedb_behaviour
     )

--- a/dependencies/typedb/repositories.bzl
+++ b/dependencies/typedb/repositories.bzl
@@ -36,5 +36,5 @@ def typedb_behaviour():
     git_repository(
         name = "typedb_behaviour",
         remote = "https://github.com/krishnangovindraj/typedb-behaviour",
-        commit = "50fb93b961cc93ae533da89f894edb115c4a996c",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @typedb_behaviour
+        commit = "d7444877584144969c631c8de2ecbf96eaaf3129",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @typedb_behaviour
     )

--- a/dependencies/typedb/repositories.bzl
+++ b/dependencies/typedb/repositories.bzl
@@ -36,5 +36,5 @@ def typedb_behaviour():
     git_repository(
         name = "typedb_behaviour",
         remote = "https://github.com/krishnangovindraj/typedb-behaviour",
-        commit = "545fa67687d5646e774f87fbb4a2d63638cf18dd",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @typedb_behaviour
+        commit = "425b7005336e57c11d079b96d92d04af5c3ed1d4",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @typedb_behaviour
     )


### PR DESCRIPTION
## Release notes: product changes
Allows multiple expression assignments for the same variable in different branches - essential for meaningful recursive functions.
* Assignments in different branches of the same disjunction are allowed
* Assignments in different constraints/nested-patterns of the same conjunction are not allowed.
* Assignments across branches must have the same value type.

Example isage:
```
  with
  fun factorial($i: integer) -> { integer }:
  match
      { $i <= 1; let $factorial = 1; } or
      { $i > 1; let $factorial = $i * factorial($i - 1); }; 
  return { $factorial };

  match
      let $f_5 in factorial(5);
```
## Motivation
Allow multiple expression assignments in different branches - essential for meaningful recursive functions.
requires: typedb/typedb-behaviour#343

## Implementation
* Rework the multiple assignments checks to allow multiple assignments in different branches of the same conjunction.
* Refactor compiled_expressions datastructures to index by constraint instead of assigned variable, since these are no longer 1:1.