### PR TITLE
Fix retries for suspended recursive functions

### DIFF
--- a/compiler/executable/match_/planner/plan.rs
+++ b/compiler/executable/match_/planner/plan.rs
@@ -56,8 +56,8 @@ use crate::{
                     },
                     variable::{InputPlanner, ThingPlanner, TypePlanner, ValuePlanner, VariableVertex},
                     ComparisonPlanner, Cost, CostMetaData, Costed, Direction, DisjunctionPlanner, ExpressionPlanner,
-                    FunctionCallPlanner, Input, IsPlanner, LinksDeduplicationPlanner, NegationPlanner,
-                    UnsatisfiablePlanner, PlannerVertex,
+                    FunctionCallPlanner, Input, IsPlanner, LinksDeduplicationPlanner, NegationPlanner, PlannerVertex,
+                    UnsatisfiablePlanner,
                 },
                 DisjunctionBuilder, ExpressionBuilder, FunctionCallBuilder, IntersectionBuilder,
                 MatchExecutableBuilder, NegationBuilder, StepBuilder, StepInstructionsBuilder,
@@ -1580,9 +1580,7 @@ impl ConjunctionPlan<'_> {
                 match_builder.push_check(&vars, check)
             }
             PlannerVertex::Constraint(constraint) => self.lower_constraint_check(match_builder, constraint),
-            PlannerVertex::Unsatisfiable(_) => {
-                match_builder.push_check(&Vec::new(), CheckInstruction::Unsatisfiable)
-            }
+            PlannerVertex::Unsatisfiable(_) => match_builder.push_check(&Vec::new(), CheckInstruction::Unsatisfiable),
             PlannerVertex::Expression(_) => {
                 unreachable!("Would require multiple assignments to the same variable and be flagged")
             }
@@ -2048,8 +2046,7 @@ impl<'a> Graph<'a> {
     fn push_optimised_to_unsatisfiable(&mut self, optimised_unsatisfiable: UnsatisfiablePlanner<'a>) {
         let pattern_index = self.next_pattern_index();
         self.pattern_to_variable.entry(pattern_index).or_default();
-        self.elements
-            .insert(VertexId::Pattern(pattern_index), PlannerVertex::Unsatisfiable(optimised_unsatisfiable));
+        self.elements.insert(VertexId::Pattern(pattern_index), PlannerVertex::Unsatisfiable(optimised_unsatisfiable));
     }
 
     fn push_expression(&mut self, output: VariableVertexId, expression: ExpressionPlanner<'a>) {

--- a/executor/match_executor.rs
+++ b/executor/match_executor.rs
@@ -84,10 +84,8 @@ impl MatchExecutor {
             //  when the function returns None, AND it's possibly the head of a cycle.
             while return_batch.is_none() && !self.suspensions.is_empty() {
                 self.last_seen_table_size = self.tabled_functions.total_table_size();
-                for function_state in self.tabled_functions.iterate_states() {
-                    let mut guard = function_state.executor_state.try_lock().unwrap();
-                    guard.prepare_to_retry_suspended();
-                }
+                debug_assert!(self.tabled_functions.iterate_states().all(|state| state.executor_state.try_lock().unwrap().pattern_executor.has_empty_control_stack()));
+                self.tabled_functions.may_prepare_to_retry_suspended();
                 // And on the entry
                 self.suspensions.prepare_restoring_from_suspending();
                 self.entry.prepare_to_restore_from_suspension(0);

--- a/executor/match_executor.rs
+++ b/executor/match_executor.rs
@@ -73,12 +73,7 @@ impl MatchExecutor {
             self.entry.prepare(FixedBatch::from(input.into_owned()));
         }
         self.entry
-            .compute_next_batch_restore_and_retry_as_needed(
-                context,
-                interrupt,
-                &mut self.tabled_functions,
-                &mut self.suspensions,
-            )
+            .compute_next_batch_with_retries(context, interrupt, &mut self.tabled_functions, &mut self.suspensions)
             .map_err(|err| Box::new(err))
     }
 }

--- a/executor/pipeline/fetch.rs
+++ b/executor/pipeline/fetch.rs
@@ -245,7 +245,12 @@ fn execute_single_function(
 
     let batch = exactly_one_or_return_err!(
         pattern_executor
-            .compute_next_batch(&execution_context, &mut interrupt, &mut tabled_functions, &mut suspend_points)
+            .compute_next_batch_restore_and_retry_as_needed(
+                &execution_context,
+                &mut interrupt,
+                &mut tabled_functions,
+                &mut suspend_points
+            )
             .map_err(|err| FetchExecutionError::ReadExecution { typedb_source: Box::new(err) })?,
         FetchExecutionError::FetchSingleFunctionNotSingle { func_name: "func".to_string() } // TODO: Can we get function name here?
     );
@@ -335,7 +340,12 @@ fn execute_list_function(
     let mut nodes = Vec::new();
     // TODO: We could create an iterator over rows in a single call here instead
     while let Some(batch) = pattern_executor
-        .compute_next_batch(&execution_context, &mut interrupt, &mut tabled_functions, &mut suspend_points)
+        .compute_next_batch_restore_and_retry_as_needed(
+            &execution_context,
+            &mut interrupt,
+            &mut tabled_functions,
+            &mut suspend_points,
+        )
         .map_err(|err| FetchExecutionError::ReadExecution { typedb_source: Box::new(err) })?
     {
         for row in batch {

--- a/executor/pipeline/fetch.rs
+++ b/executor/pipeline/fetch.rs
@@ -245,7 +245,7 @@ fn execute_single_function(
 
     let batch = exactly_one_or_return_err!(
         pattern_executor
-            .compute_next_batch_restore_and_retry_as_needed(
+            .compute_next_batch_with_retries(
                 &execution_context,
                 &mut interrupt,
                 &mut tabled_functions,
@@ -340,12 +340,7 @@ fn execute_list_function(
     let mut nodes = Vec::new();
     // TODO: We could create an iterator over rows in a single call here instead
     while let Some(batch) = pattern_executor
-        .compute_next_batch_restore_and_retry_as_needed(
-            &execution_context,
-            &mut interrupt,
-            &mut tabled_functions,
-            &mut suspend_points,
-        )
+        .compute_next_batch_with_retries(&execution_context, &mut interrupt, &mut tabled_functions, &mut suspend_points)
         .map_err(|err| FetchExecutionError::ReadExecution { typedb_source: Box::new(err) })?
     {
         for row in batch {

--- a/executor/read/control_instruction.rs
+++ b/executor/read/control_instruction.rs
@@ -52,6 +52,7 @@ pub(super) struct ExecuteInlinedFunction {
 pub(super) struct ExecuteNegation {
     pub(super) index: ExecutorIndex,
     pub(super) input: MaybeOwnedRow<'static>,
+    pub(super) last_seen_table_size: Option<usize>,
 }
 
 #[derive(Debug)]
@@ -69,6 +70,7 @@ pub(super) struct TabledCall {
 #[derive(Debug)]
 pub(super) struct CollectingStage {
     pub(super) index: ExecutorIndex,
+    pub(super) last_seen_table_size: Option<usize>,
 }
 
 #[derive(Debug)]

--- a/executor/read/control_instruction.rs
+++ b/executor/read/control_instruction.rs
@@ -52,7 +52,6 @@ pub(super) struct ExecuteInlinedFunction {
 pub(super) struct ExecuteNegation {
     pub(super) index: ExecutorIndex,
     pub(super) input: MaybeOwnedRow<'static>,
-    pub(super) last_seen_table_size: Option<usize>,
 }
 
 #[derive(Debug)]
@@ -70,7 +69,6 @@ pub(super) struct TabledCall {
 #[derive(Debug)]
 pub(super) struct CollectingStage {
     pub(super) index: ExecutorIndex,
-    pub(super) last_seen_table_size: Option<usize>,
 }
 
 #[derive(Debug)]

--- a/executor/read/pattern_executor.rs
+++ b/executor/read/pattern_executor.rs
@@ -156,12 +156,7 @@ impl PatternExecutor {
                     match result {
                         None => {
                             if !negation_suspensions.is_empty() {
-                                for function_state in tabled_functions.iterate_states() {
-                                    let mut guard = function_state.executor_state.try_lock().unwrap();
-                                    if guard.pattern_executor.has_empty_control_stack() {
-                                        guard.prepare_to_retry_suspended();
-                                    }
-                                }
+                                tabled_functions.may_prepare_to_retry_suspended();
                                 negation_suspensions.prepare_restoring_from_suspending();
                                 inner.prepare_to_restore_from_suspension(0);
                             } else {

--- a/executor/read/pattern_executor.rs
+++ b/executor/read/pattern_executor.rs
@@ -402,12 +402,13 @@ impl PatternExecutor {
                     tabled_functions,
                     function_suspensions,
                 )?;
-                let suspension_count_after = function_suspensions.record_nested_pattern_exit();
+                let _suspension_count_after = function_suspensions.record_nested_pattern_exit();
                 if let Some(batch) = batch_opt {
                     let deduplicated_batch = executor.add_batch_to_table(&function_state, batch);
                     Some(deduplicated_batch)
                 } else {
-                    if suspension_count_after.0 > 0 {
+                    // Don't use suspend_count_before == suspend_count_after, since we can get away with just one.
+                    if !function_suspensions.is_empty() {
                         // TODO: Consider retrying here. For now, just record a suspension point for ourselves.
                         query_suspensions.push_tabled_call(index, executor);
                     }

--- a/executor/read/pattern_executor.rs
+++ b/executor/read/pattern_executor.rs
@@ -81,7 +81,6 @@ impl PatternExecutor {
                 }
             }
         }
-        // debug_assert!(state_after == state_before); // TODO: Enable once we figure out retries at the calls. // As long as compute_next_batch is only called for the entry.
         Ok(result)
     }
 

--- a/executor/read/pattern_executor.rs
+++ b/executor/read/pattern_executor.rs
@@ -155,6 +155,7 @@ impl PatternExecutor {
                     negation_suspensions.record_nested_pattern_exit();
                     match result {
                         None => {
+                            compile_error!("We have to track table size here for termination");
                             if !negation_suspensions.is_empty() {
                                 tabled_functions.may_prepare_to_retry_suspended();
                                 negation_suspensions.prepare_restoring_from_suspending();
@@ -242,6 +243,7 @@ impl PatternExecutor {
                     match result {
                         None => {
                             if !inner_suspensions.is_empty() {
+                                compile_error!("We have to track table size here for termination");
                                 tabled_functions.may_prepare_to_retry_suspended();
                                 inner_suspensions.prepare_restoring_from_suspending();
                                 inner.prepare_to_restore_from_suspension(0);

--- a/executor/read/pattern_executor.rs
+++ b/executor/read/pattern_executor.rs
@@ -58,7 +58,7 @@ impl PatternExecutor {
         self.control_stack.is_empty()
     }
 
-    pub(crate) fn compute_next_batch_restore_and_retry_as_needed(
+    pub(crate) fn compute_next_batch_with_retries(
         &mut self,
         context: &ExecutionContext<impl ReadableSnapshot + 'static>,
         interrupt: &mut ExecutionInterrupt,
@@ -157,7 +157,7 @@ impl PatternExecutor {
                     else {
                         unreachable!();
                     };
-                    let result = inner.compute_next_batch_restore_and_retry_as_needed(
+                    let result = inner.compute_next_batch_with_retries(
                         context,
                         interrupt,
                         tabled_functions,
@@ -240,7 +240,7 @@ impl PatternExecutor {
                 ControlInstruction::CollectingStage(CollectingStage { index }) => {
                     let (inner, collector) = executors[index.0].unwrap_collecting_stage().to_parts_mut();
                     let mut inner_suspensions = QueryPatternSuspensions::new();
-                    while let Some(batch) = inner.compute_next_batch_restore_and_retry_as_needed(
+                    while let Some(batch) = inner.compute_next_batch_with_retries(
                         context,
                         interrupt,
                         tabled_functions,

--- a/executor/read/stream_modifier.rs
+++ b/executor/read/stream_modifier.rs
@@ -73,15 +73,11 @@ impl StreamModifierExecutor {
             StreamModifierExecutor::Offset { offset, .. } => {
                 StreamModifierResultMapper::Offset(OffsetMapper::new(*offset))
             }
-            StreamModifierExecutor::Limit { limit, .. } => {
-                StreamModifierResultMapper::Limit(LimitMapper::new(*limit))
-            }
+            StreamModifierExecutor::Limit { limit, .. } => StreamModifierResultMapper::Limit(LimitMapper::new(*limit)),
             StreamModifierExecutor::Distinct { output_width, .. } => {
                 StreamModifierResultMapper::Distinct(DistinctMapper::new(*output_width))
             }
-            StreamModifierExecutor::Last { .. } => {
-                StreamModifierResultMapper::Last(LastMapper::new())
-            }
+            StreamModifierExecutor::Last { .. } => StreamModifierResultMapper::Last(LastMapper::new()),
         }
     }
 

--- a/executor/read/stream_modifier.rs
+++ b/executor/read/stream_modifier.rs
@@ -55,7 +55,7 @@ impl StreamModifierExecutor {
         Self::Last { inner }
     }
 
-    pub(crate) fn get_inner(&mut self) -> &mut PatternExecutor {
+    pub(crate) fn inner(&mut self) -> &mut PatternExecutor {
         match self {
             Self::Select { inner, .. } => inner,
             Self::Offset { inner, .. } => inner,
@@ -65,8 +65,28 @@ impl StreamModifierExecutor {
         }
     }
 
+    pub(crate) fn create_mapper(&self) -> StreamModifierResultMapper {
+        match self {
+            StreamModifierExecutor::Select { removed_positions, .. } => {
+                StreamModifierResultMapper::Select(SelectMapper::new(removed_positions.clone()))
+            }
+            StreamModifierExecutor::Offset { offset, .. } => {
+                StreamModifierResultMapper::Offset(OffsetMapper::new(*offset))
+            }
+            StreamModifierExecutor::Limit { limit, .. } => {
+                StreamModifierResultMapper::Limit(LimitMapper::new(*limit))
+            }
+            StreamModifierExecutor::Distinct { output_width, .. } => {
+                StreamModifierResultMapper::Distinct(DistinctMapper::new(*output_width))
+            }
+            StreamModifierExecutor::Last { .. } => {
+                StreamModifierResultMapper::Last(LastMapper::new())
+            }
+        }
+    }
+
     pub(crate) fn reset(&mut self) {
-        self.get_inner().reset()
+        self.inner().reset()
     }
 }
 

--- a/executor/read/tabled_functions.rs
+++ b/executor/read/tabled_functions.rs
@@ -100,7 +100,7 @@ impl TabledFunctionPatternExecutorState {
         debug_assert!(self.pattern_executor.has_empty_control_stack());
         self.pattern_executor.reset();
         if !self.suspensions.is_empty() {
-            self.suspensions.prepare_restoring_from_suspending();
+            self.suspensions.prepare_for_restore_if_needed(None);
             self.pattern_executor.prepare_to_restore_from_suspension(0);
         }
     }

--- a/executor/tests/execute_function.rs
+++ b/executor/tests/execute_function.rs
@@ -451,6 +451,10 @@ fn linear_reachability_in_tree() {
         let query = query_template.replace(placeholder_start_node, "e2");
         let (rows, _) = run_read_query(&context, query.as_str()).unwrap();
         assert_eq!(8, rows.len()); // all except e1. e2 should be reachable from itself
+
+        let query = query_template.replace(placeholder_start_node, "e4");
+        let (rows, _) = run_read_query(&context, query.as_str()).unwrap();
+        assert_eq!(8, rows.len()); // all except e1
     }
 }
 
@@ -509,6 +513,108 @@ fn fibonacci() {
 }
 
 #[test]
+fn test_retries_at_negation() {
+    let custom_schema = r#"define
+        attribute name value string;
+        entity node, owns name @card(0..), plays edge:start, plays edge:end;
+        relation edge, relates start, relates end;
+    "#;
+    let context = setup_common(custom_schema);
+    let (rows, _positions) = run_write_query(&context, REACHABILITY_DATA).unwrap();
+    assert_eq!(1, rows.len());
+
+    let placeholder_start_node = "<<NODE_NAME>>";
+    let query_template = r#"
+            with
+            fun reachable($start: node) -> { node }:
+            match
+                $return-me has name $name;
+                { let $middle in reachable($start); edge (start: $middle, end: $indirect); $indirect has name $name; } or
+                { edge (start: $start, end: $direct); $direct has name $name; }; # Do we have is yet?
+            return { $return-me };
+
+            match
+                let $reachable = "dummy";
+                not {
+                    $start isa node, has name "<<NODE_NAME>>";
+                    $goal isa node, has name "<<GOAL_NAME>>";
+                    let $to in reachable($start); $goal is $to;
+                };
+        "#;
+
+    {
+        // tree
+        let query = query_template.replace(placeholder_start_node, "t2").replace("<<GOAL_NAME>>", "t4");
+        let (rows, _) = run_read_query(&context, query.as_str()).unwrap();
+        assert_eq!(rows.len(), 0); // reachable, hence not fails
+    }
+
+    {
+        // tree
+        let query = query_template.replace(placeholder_start_node, "t2").replace("<<GOAL_NAME>>", "t6");
+        let (rows, _) = run_read_query(&context, query.as_str()).unwrap();
+        assert_eq!(rows.len(), 1); // not reachable
+    }
+
+    {
+        // ant
+        let query = query_template.replace(placeholder_start_node, "e1").replace("<<GOAL_NAME>>", "e4");
+        let (rows, _) = run_read_query(&context, query.as_str()).unwrap();
+        assert_eq!(rows.len(), 0); // reachable, hence not fails
+    }
+    {
+        // ant
+        let query = query_template.replace(placeholder_start_node, "e4").replace("<<GOAL_NAME>>", "e1");
+        let (rows, _) = run_read_query(&context, query.as_str()).unwrap();
+        assert_eq!(rows.len(), 1); // not reachable
+    }
+}
+
+#[test]
+fn test_retries_at_collection() {
+    let custom_schema = r#"define
+        attribute name value string;
+        entity node, owns name @card(0..), plays edge:start, plays edge:end;
+        relation edge, relates start, relates end;
+    "#;
+    let context = setup_common(custom_schema);
+    let (rows, _positions) = run_write_query(&context, REACHABILITY_DATA).unwrap();
+    assert_eq!(1, rows.len());
+
+    let placeholder_start_node = "<<NODE_NAME>>";
+    let query_template = r#"
+            with
+            fun reachable($start: node) -> { node }:
+            match
+                $return-me has name $name;
+                { let $middle in reachable($start); edge (start: $middle, end: $indirect); $indirect has name $name; } or
+                { edge (start: $start, end: $direct); $direct has name $name; }; # Do we have is yet?
+            return { $return-me };
+
+            match
+                $start isa node, has name "<<NODE_NAME>>";
+                let $to in reachable($start);
+                reduce $reachable_count = count($to);
+        "#;
+
+    {
+        // tree
+        let query = query_template.replace(placeholder_start_node, "t1");
+        let (rows, positions) = run_read_query(&context, query.as_str()).unwrap();
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].get(*positions.get("reachable_count").unwrap()), &VariableValue::Value(Value::Integer(6)));
+    }
+
+    {
+        // tree
+        let query = query_template.replace(placeholder_start_node, "t2");
+        let (rows, positions) = run_read_query(&context, query.as_str()).unwrap();
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].get(*positions.get("reachable_count").unwrap()), &VariableValue::Value(Value::Integer(2)));
+    }
+}
+
+#[test]
 fn reduce_depends_on_cyclic_function() {
     let custom_schema = r#"define
         attribute name value string;
@@ -559,7 +665,6 @@ fn reduce_depends_on_cyclic_function() {
         let (rows, positions) = run_read_query(&context, query.as_str()).unwrap();
         assert_eq!(rows.len(), 1);
         assert_eq!(rows[0].get(*positions.get("sum").unwrap()), &VariableValue::Value(Value::Integer(90)));
-
     }
 }
 


### PR DESCRIPTION
## Release notes: product changes
Fixes a bug where recursive functions were not retried properly if called by a negation, or collecting stage such as 'sort' or 'reduce'.
Also fixes a panic which wrongly assumed suspend points could not exist at certain modifiers.

## Motivation
Correctness, avoids crashes, simplicity.

## Implementation
* Allow restoring suspend points at any modifier - needed as we restore at a negation/collection/root rather than at cycle entry.
* Move all restore logic to  a single place (`PatternExecution::compute_next_batch_with_retries`). Negations, collections & the root query now call it => Negations & collections retry inline rather than making the PatternExecutor re-evaluate them