### PR TITLE
Implement put stage

### DIFF
--- a/.factory/automation.yml
+++ b/.factory/automation.yml
@@ -132,6 +132,7 @@ build:
         bazel test //tests/behaviour/query/language:test_insert --test_output=streamed
         bazel test //tests/behaviour/query/language:test_delete --test_output=streamed
         bazel test //tests/behaviour/query/language:test_update --test_output=streamed
+        bazel test //tests/behaviour/query/language:test_put --test_output=streamed
         bazel test //tests/behaviour/query/language:test_pipelines --test_output=streamed
 
     test-behaviour-query-definable:

--- a/BUILD
+++ b/BUILD
@@ -504,7 +504,7 @@ checkstyle_test(
     exclude = glob([
         "*.md",
         ".circleci/windows/*",
-        "docs/*",
+        "docs/**",
         "tools/**",
         "Cargo.*",
     ]) + [

--- a/compiler/annotation/mod.rs
+++ b/compiler/annotation/mod.rs
@@ -199,7 +199,7 @@ typedb_error!(
         ),
         AnnotationsUnavailableForVariableInWrite(
             10,
-            "Typing information for the variable '{variable}' is not available. Check if the variable is available from a previous stage or is inserted in this stage.",
+            "Typing information for the variable '{variable}' is not available. Ensure the variable is available from a previous stage or is inserted in this stage.",
             variable: Variable,
             source_span: Option<Span>,
         ),

--- a/compiler/annotation/pipeline.rs
+++ b/compiler/annotation/pipeline.rs
@@ -79,6 +79,12 @@ pub enum AnnotatedStage {
         annotations: TypeAnnotations,
         source_span: Option<Span>,
     },
+    Put {
+        block: Block,
+        match_annotations: TypeAnnotations,
+        insert_annotations: TypeAnnotations,
+        source_span: Option<Span>,
+    },
     Delete {
         block: Block,
         deleted_variables: Vec<Variable>,
@@ -104,6 +110,7 @@ impl AnnotatedStage {
             AnnotatedStage::Match { block, .. } => Box::new(block.variables()),
             AnnotatedStage::Insert { block, .. } => Box::new(block.variables()),
             AnnotatedStage::Update { block, .. } => Box::new(block.variables()),
+            AnnotatedStage::Put { block, .. } => Box::new(block.variables()),
             AnnotatedStage::Delete { block, .. } => Box::new(block.variables()),
             AnnotatedStage::Select(select) => Box::new(select.variables.iter().cloned()),
             AnnotatedStage::Sort(sort) => Box::new(sort.variables.iter().map(|sort_variable| sort_variable.variable())),
@@ -338,6 +345,43 @@ fn annotate_stage(
             Ok(AnnotatedStage::Update { block, annotations, source_span })
         }
 
+        TranslatedStage::Put { block, source_span } => {
+            let match_annotations = infer_types(
+                snapshot,
+                &block,
+                variable_registry,
+                type_manager,
+                running_variable_annotations,
+                annotated_function_signatures,
+                false,
+            ).map_err(|typedb_source| AnnotationError::TypeInference { typedb_source })?;
+            let insert_annotations = annotate_write_stage(
+                running_variable_annotations,
+                variable_registry,
+                snapshot,
+                type_manager,
+                annotated_function_signatures,
+                &block,
+            )?;
+            check_type_combinations_for_write(
+                snapshot,
+                type_manager,
+                &block,
+                running_variable_annotations,
+                running_constraint_annotations,
+                &insert_annotations,
+            )
+                .map_err(|typedb_source| AnnotationError::TypeInference { typedb_source })?;
+
+            // Update running annotations based on match annotations as they will be less strict.
+            match_annotations.vertex_annotations().iter().for_each(|(vertex, types)| {
+                if let Some(var) = vertex.as_variable() {
+                    running_variable_annotations.insert(var, types.clone());
+                }
+            });
+
+            Ok(AnnotatedStage::Put { block, match_annotations, insert_annotations, source_span })
+        }
         TranslatedStage::Delete { block, deleted_variables, source_span } => {
             let delete_annotations = annotate_write_stage(
                 running_variable_annotations,

--- a/compiler/annotation/pipeline.rs
+++ b/compiler/annotation/pipeline.rs
@@ -354,7 +354,8 @@ fn annotate_stage(
                 running_variable_annotations,
                 annotated_function_signatures,
                 false,
-            ).map_err(|typedb_source| AnnotationError::TypeInference { typedb_source })?;
+            )
+            .map_err(|typedb_source| AnnotationError::TypeInference { typedb_source })?;
             let insert_annotations = annotate_write_stage(
                 running_variable_annotations,
                 variable_registry,
@@ -371,7 +372,7 @@ fn annotate_stage(
                 running_constraint_annotations,
                 &insert_annotations,
             )
-                .map_err(|typedb_source| AnnotationError::TypeInference { typedb_source })?;
+            .map_err(|typedb_source| AnnotationError::TypeInference { typedb_source })?;
 
             // Update running annotations based on match annotations as they will be less strict.
             match_annotations.vertex_annotations().iter().for_each(|(vertex, types)| {

--- a/compiler/executable/delete/executable.rs
+++ b/compiler/executable/delete/executable.rs
@@ -20,7 +20,7 @@ use crate::{
     executable::{
         delete::instructions::{ConnectionInstruction, Has, Links, ThingInstruction},
         insert::{
-            executable::{collect_role_type_bindings, get_thing_input_position},
+            executable::{collect_named_role_type_bindings, get_thing_position},
             ThingPosition, TypeSource,
         },
         next_executable_id, WriteCompilationError,
@@ -45,19 +45,19 @@ pub fn compile(
     deleted_concepts: &[Variable],
     source_span: Option<Span>,
 ) -> Result<DeleteExecutable, Box<WriteCompilationError>> {
-    let named_role_types = collect_role_type_bindings(constraints, type_annotations, variable_registry)?;
+    let named_role_types = collect_named_role_type_bindings(constraints, type_annotations, variable_registry)?;
     let mut connection_deletes = Vec::new();
     for constraint in constraints {
         match constraint {
             Constraint::Has(has) => {
                 connection_deletes.push(ConnectionInstruction::Has(Has {
-                    owner: get_thing_input_position(
+                    owner: get_thing_position(
                         input_variables,
                         has.owner().as_variable().unwrap(),
                         variable_registry,
                         has.source_span(),
                     )?,
-                    attribute: get_thing_input_position(
+                    attribute: get_thing_position(
                         input_variables,
                         has.attribute().as_variable().unwrap(),
                         variable_registry,
@@ -66,13 +66,13 @@ pub fn compile(
                 }));
             }
             Constraint::Links(links) => {
-                let relation = get_thing_input_position(
+                let relation = get_thing_position(
                     input_variables,
                     links.relation().as_variable().unwrap(),
                     variable_registry,
                     links.source_span(),
                 )?;
-                let player = get_thing_input_position(
+                let player = get_thing_position(
                     input_variables,
                     links.player().as_variable().unwrap(),
                     variable_registry,

--- a/compiler/executable/insert/executable.rs
+++ b/compiler/executable/insert/executable.rs
@@ -57,9 +57,11 @@ pub fn compile(
     input_variables: &HashMap<Variable, VariablePosition>,
     type_annotations: &TypeAnnotations,
     variable_registry: &VariableRegistry,
+    desired_output_variable_positions: Option<HashMap<Variable, VariablePosition>>,
     source_span: Option<Span>,
 ) -> Result<InsertExecutable, Box<WriteCompilationError>> {
     let mut variable_positions = input_variables.clone();
+    compile_error!("Figure out how to accept desire output positions");
     let concept_inserts = add_inserted_concepts(
         constraints,
         type_annotations,

--- a/compiler/executable/insert/executable.rs
+++ b/compiler/executable/insert/executable.rs
@@ -13,6 +13,7 @@ use ir::{
         constraint,
         constraint::{Comparator, Constraint},
         expression::Expression,
+        variable_category::VariableCategory,
         ParameterID, Vertex,
     },
     pipeline::VariableRegistry,
@@ -65,6 +66,7 @@ pub fn compile(
         .map(|positions| { input_variables.iter().all(|(k, v)| positions.get(k).unwrap() == v) })
         .unwrap_or(true));
     let mut variable_positions = desired_output_variable_positions.unwrap_or_else(|| input_variables.clone());
+
     let concept_inserts = add_inserted_concepts(
         constraints,
         type_annotations,
@@ -74,15 +76,27 @@ pub fn compile(
         source_span,
     )?;
 
+    #[cfg(debug_assertions)]
+    let mut variable_positions_tmp = variable_positions
+        .iter()
+        .filter(|(var, _)| {
+            !(variable_registry.get_variable_name(**var).is_none()
+                && variable_registry.get_variable_category(**var).unwrap() == VariableCategory::RoleType)
+        })
+        .map(|(k, v)| (k.clone(), v.clone()))
+        .collect::<HashMap<_, _>>();
+    #[cfg(not(debug_assertions))]
+    compile_error!("Remove the above");
+
     let mut connection_inserts = Vec::with_capacity(constraints.len());
     add_has(constraints, &variable_positions, variable_registry, &mut connection_inserts)?;
-    add_links(constraints, type_annotations, &variable_positions, variable_registry, &mut connection_inserts)?;
+    add_links(constraints, type_annotations, &variable_positions_tmp, variable_registry, &mut connection_inserts)?;
 
     Ok(InsertExecutable {
         executable_id: next_executable_id(),
         concept_instructions: concept_inserts,
         connection_instructions: connection_inserts,
-        output_row_schema: prepare_output_row_schema(&variable_positions),
+        output_row_schema: prepare_output_row_schema(input_variables, &variable_positions),
     })
 }
 
@@ -237,19 +251,19 @@ pub(crate) fn add_inserted_concepts(
 
 fn add_has(
     constraints: &[Constraint<Variable>],
-    input_variables: &HashMap<Variable, VariablePosition>,
+    variable_positions: &HashMap<Variable, VariablePosition>,
     variable_registry: &VariableRegistry,
     instructions: &mut Vec<ConnectionInstruction>,
 ) -> Result<(), Box<WriteCompilationError>> {
     filter_variants!(Constraint::Has: constraints).try_for_each(|has| {
-        let owner = get_thing_input_position(
-            input_variables,
+        let owner = get_thing_position(
+            variable_positions,
             has.owner().as_variable().unwrap(),
             variable_registry,
             has.source_span(),
         )?;
-        let attribute = get_thing_input_position(
-            input_variables,
+        let attribute = get_thing_position(
+            variable_positions,
             has.attribute().as_variable().unwrap(),
             variable_registry,
             has.source_span(),
@@ -262,31 +276,32 @@ fn add_has(
 fn add_links(
     constraints: &[Constraint<Variable>],
     type_annotations: &TypeAnnotations,
-    input_variables: &HashMap<Variable, VariablePosition>,
+    variable_positions: &HashMap<Variable, VariablePosition>,
     variable_registry: &VariableRegistry,
     instructions: &mut Vec<ConnectionInstruction>,
 ) -> Result<(), Box<WriteCompilationError>> {
-    let named_role_types = collect_role_type_bindings(constraints, type_annotations, variable_registry)?;
+    let named_role_types = collect_named_role_type_bindings(constraints, type_annotations, variable_registry)?;
     for links in filter_variants!(Constraint::Links: constraints) {
-        let relation = get_thing_input_position(
-            input_variables,
+        let relation = get_thing_position(
+            variable_positions,
             links.relation().as_variable().unwrap(),
             variable_registry,
             links.source_span(),
         )?;
-        let player = get_thing_input_position(
-            input_variables,
+        let player = get_thing_position(
+            variable_positions,
             links.player().as_variable().unwrap(),
             variable_registry,
             links.source_span(),
         )?;
-        let role = resolve_links_role(type_annotations, input_variables, variable_registry, &named_role_types, links)?;
+        let role =
+            resolve_links_role(type_annotations, variable_positions, variable_registry, &named_role_types, links)?;
         instructions.push(ConnectionInstruction::Links(Links { relation, player, role }));
     }
     Ok(())
 }
 
-pub(crate) fn get_thing_input_position(
+pub(crate) fn get_thing_position(
     input_variables: &HashMap<Variable, VariablePosition>,
     variable: Variable,
     variable_registry: &VariableRegistry,
@@ -387,13 +402,18 @@ pub(crate) fn get_kinds_from_types(types: &BTreeSet<Type>) -> HashSet<Kind> {
 }
 
 pub(crate) fn prepare_output_row_schema(
-    variable_positions: &HashMap<Variable, VariablePosition>,
+    input_positions: &HashMap<Variable, VariablePosition>,
+    output_positions: &HashMap<Variable, VariablePosition>,
 ) -> Vec<Option<(Variable, VariableSource)>> {
-    let output_width = variable_positions.values().map(|i| i.position + 1).max().unwrap_or(0);
+    let output_width = output_positions.values().map(|i| i.position + 1).max().unwrap_or(0);
     let mut output_row_schema = vec![None; output_width as usize];
-    variable_positions.iter().map(|(v, i)| (i, v)).for_each(|(&i, &v)| {
-        output_row_schema[i.position as usize] = Some((v, VariableSource::InputVariable(i)));
+    output_positions.iter().for_each(|(var, pos)| {
+        let source =
+            input_positions.get(var).map(|pos| VariableSource::Input(*pos)).unwrap_or(VariableSource::Inserted);
+        output_row_schema[pos.position as usize] = Some((*var, source));
     });
+    // This assumption is made in prepare_output_rows, though it's likely to be violated only for put which doesn't make that assumption.
+    debug_assert!(input_positions.iter().all(|(k, v)| output_positions.get(k) == Some(v)));
     output_row_schema
 }
 
@@ -456,7 +476,7 @@ fn collect_type_bindings(
         .collect()
 }
 
-pub(crate) fn collect_role_type_bindings(
+pub(crate) fn collect_named_role_type_bindings(
     constraints: &[Constraint<Variable>],
     type_annotations: &TypeAnnotations,
     variable_registry: &VariableRegistry,

--- a/compiler/executable/insert/executable.rs
+++ b/compiler/executable/insert/executable.rs
@@ -60,9 +60,10 @@ pub fn compile(
     desired_output_variable_positions: Option<HashMap<Variable, VariablePosition>>,
     source_span: Option<Span>,
 ) -> Result<InsertExecutable, Box<WriteCompilationError>> {
-    debug_assert!(desired_output_variable_positions.clone().map(|positions| {
-            input_variables.iter().all(|(k,v)| positions.get(k).unwrap() == v)
-        }).unwrap_or(true));
+    debug_assert!(desired_output_variable_positions
+        .clone()
+        .map(|positions| { input_variables.iter().all(|(k, v)| positions.get(k).unwrap() == v) })
+        .unwrap_or(true));
     let mut variable_positions = desired_output_variable_positions.unwrap_or_else(|| input_variables.clone());
     let concept_inserts = add_inserted_concepts(
         constraints,
@@ -93,8 +94,7 @@ pub(crate) fn add_inserted_concepts(
     output_variables: &mut HashMap<Variable, VariablePosition>,
     stage_source_span: Option<Span>,
 ) -> Result<Vec<ConceptInstruction>, Box<WriteCompilationError>> {
-    let mut next_insert_position =
-        output_variables.values().map(|pos| pos.position + 1).max().unwrap_or(0) as usize;
+    let mut next_insert_position = output_variables.values().map(|pos| pos.position + 1).max().unwrap_or(0) as usize;
     let type_bindings = collect_type_bindings(constraints, type_annotations)?;
     let value_bindings = collect_value_bindings(constraints)?;
     let mut concept_instructions = HashMap::<Variable, ConceptInstruction>::new();
@@ -225,8 +225,7 @@ pub(crate) fn add_inserted_concepts(
                     next_insert_position += 1;
                 };
                 let write_to = ThingPosition(*output_variables.get(&thing).unwrap());
-                let instruction =
-                    ConceptInstruction::PutAttribute(PutAttribute { type_, value, write_to });
+                let instruction = ConceptInstruction::PutAttribute(PutAttribute { type_, value, write_to });
                 concept_instructions.insert(thing, instruction);
             }
         };

--- a/compiler/executable/insert/executable.rs
+++ b/compiler/executable/insert/executable.rs
@@ -61,8 +61,7 @@ pub fn compile(
     desired_output_variable_positions: Option<HashMap<Variable, VariablePosition>>,
     source_span: Option<Span>,
 ) -> Result<InsertExecutable, Box<WriteCompilationError>> {
-    debug_assert!(desired_output_variable_positions
-        .clone()
+    debug_assert!(desired_output_variable_positions.as_ref()
         .map(|positions| { input_variables.iter().all(|(k, v)| positions.get(k).unwrap() == v) })
         .unwrap_or(true));
     let mut variable_positions = desired_output_variable_positions.unwrap_or_else(|| input_variables.clone());
@@ -412,8 +411,6 @@ pub(crate) fn prepare_output_row_schema(
             input_positions.get(var).map(|pos| VariableSource::Input(*pos)).unwrap_or(VariableSource::Inserted);
         output_row_schema[pos.position as usize] = Some((*var, source));
     });
-    // This assumption is made in prepare_output_rows, though it's likely to be violated only for put which doesn't make that assumption.
-    debug_assert!(input_positions.iter().all(|(k, v)| output_positions.get(k) == Some(v)));
     output_row_schema
 }
 

--- a/compiler/executable/insert/executable.rs
+++ b/compiler/executable/insert/executable.rs
@@ -61,7 +61,8 @@ pub fn compile(
     desired_output_variable_positions: Option<HashMap<Variable, VariablePosition>>,
     source_span: Option<Span>,
 ) -> Result<InsertExecutable, Box<WriteCompilationError>> {
-    debug_assert!(desired_output_variable_positions.as_ref()
+    debug_assert!(desired_output_variable_positions
+        .as_ref()
         .map(|positions| { input_variables.iter().all(|(k, v)| positions.get(k).unwrap() == v) })
         .unwrap_or(true));
     let mut variable_positions = desired_output_variable_positions.unwrap_or_else(|| input_variables.clone());

--- a/compiler/executable/insert/mod.rs
+++ b/compiler/executable/insert/mod.rs
@@ -15,7 +15,7 @@ use crate::VariablePosition;
 pub mod executable;
 pub mod instructions;
 
-#[derive(Clone, Debug, Hash, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Hash, Eq, PartialEq)]
 pub enum VariableSource {
     Input(VariablePosition),
     Inserted,

--- a/compiler/executable/insert/mod.rs
+++ b/compiler/executable/insert/mod.rs
@@ -8,7 +8,6 @@ use std::error::Error;
 
 use ir::pattern::ParameterID;
 use itertools::Itertools;
-use typeql::match_;
 
 use crate::VariablePosition;
 

--- a/compiler/executable/insert/mod.rs
+++ b/compiler/executable/insert/mod.rs
@@ -8,15 +8,17 @@ use std::error::Error;
 
 use ir::pattern::ParameterID;
 use itertools::Itertools;
+use typeql::match_;
 
 use crate::VariablePosition;
 
 pub mod executable;
 pub mod instructions;
 
-#[derive(Clone, Copy, Debug, Hash, Eq, PartialEq)]
+#[derive(Clone, Debug, Hash, Eq, PartialEq)]
 pub enum VariableSource {
-    InputVariable(VariablePosition), // TODO: This needs to be renamed
+    Input(VariablePosition),
+    Inserted,
 }
 
 #[derive(Clone, Debug, Hash, Eq, PartialEq)]

--- a/compiler/executable/mod.rs
+++ b/compiler/executable/mod.rs
@@ -38,8 +38,8 @@ typedb_error! {
         DeleteExecutableCompilation(3, "Error compiling delete stage into executable.", typedb_source: Box<WriteCompilationError>),
         FetchCompilation(4, "Error compiling fetch stage into executable.", typedb_source: FetchCompilationError),
         MatchCompilation(5, "Error compiling match stage into executable.", typedb_source: MatchCompilationError),
-        PutMatchCompilation(6, "Error compiling the match version of put stage into executable.", typedb_source: MatchCompilationError),
-        PutInsertCompilation(7, "Error compiling the write version of put stage into executable.", typedb_source: Box<WriteCompilationError>),
+        PutMatchCompilation(6, "Error compiling put stage into a match executable.", typedb_source: MatchCompilationError),
+        PutInsertCompilation(7, "Error compiling put stage into an insert executable.", typedb_source: Box<WriteCompilationError>),
     }
 }
 

--- a/compiler/executable/mod.rs
+++ b/compiler/executable/mod.rs
@@ -21,6 +21,7 @@ pub mod insert;
 pub mod match_;
 pub mod modifiers;
 pub mod pipeline;
+pub mod put;
 pub mod reduce;
 pub mod update;
 
@@ -37,6 +38,8 @@ typedb_error! {
         DeleteExecutableCompilation(3, "Error compiling delete stage into executable.", typedb_source: Box<WriteCompilationError>),
         FetchCompilation(4, "Error compiling fetch stage into executable.", typedb_source: FetchCompilationError),
         MatchCompilation(5, "Error compiling match stage into executable.", typedb_source: MatchCompilationError),
+        PutMatchCompilation(6, "Error compiling the match version of put stage into executable.", typedb_source: MatchCompilationError),
+        PutInsertCompilation(7, "Error compiling the write version of put stage into executable.", typedb_source: Box<WriteCompilationError>),
     }
 }
 

--- a/compiler/executable/pipeline.rs
+++ b/compiler/executable/pipeline.rs
@@ -70,14 +70,14 @@ impl ExecutableStage {
                 .output_row_schema
                 .iter()
                 .enumerate()
-                .filter_map(|(i, opt)| opt.clone().map(|(v, _)| (i, v)))
+                .filter_map(|(i, opt)| opt.map(|(v, _)| (i, v)))
                 .map(|(i, v)| (v, VariablePosition::new(i as u32)))
                 .collect(),
             ExecutableStage::Update(executable) => executable
                 .output_row_schema
                 .iter()
                 .enumerate()
-                .filter_map(|(i, opt)| opt.clone().map(|(v, _)| (i, v)))
+                .filter_map(|(i, opt)| opt.map(|(v, _)| (i, v)))
                 .map(|(i, v)| (v, VariablePosition::new(i as u32)))
                 .collect(),
             ExecutableStage::Delete(executable) => executable

--- a/compiler/executable/pipeline.rs
+++ b/compiler/executable/pipeline.rs
@@ -70,14 +70,14 @@ impl ExecutableStage {
                 .output_row_schema
                 .iter()
                 .enumerate()
-                .filter_map(|(i, opt)| opt.map(|(v, _)| (i, v)))
+                .filter_map(|(i, opt)| opt.clone().map(|(v, _)| (i, v)))
                 .map(|(i, v)| (v, VariablePosition::new(i as u32)))
                 .collect(),
             ExecutableStage::Update(executable) => executable
                 .output_row_schema
                 .iter()
                 .enumerate()
-                .filter_map(|(i, opt)| opt.map(|(v, _)| (i, v)))
+                .filter_map(|(i, opt)| opt.clone().map(|(v, _)| (i, v)))
                 .map(|(i, v)| (v, VariablePosition::new(i as u32)))
                 .collect(),
             ExecutableStage::Delete(executable) => executable

--- a/compiler/executable/pipeline.rs
+++ b/compiler/executable/pipeline.rs
@@ -30,13 +30,13 @@ use crate::{
         modifiers::{
             DistinctExecutable, LimitExecutable, OffsetExecutable, RequireExecutable, SelectExecutable, SortExecutable,
         },
+        put::PutExecutable,
         reduce::{ReduceExecutable, ReduceRowsExecutable},
         update::executable::UpdateExecutable,
         ExecutableCompilationError,
     },
     VariablePosition,
 };
-use crate::executable::put::PutExecutable;
 
 #[derive(Debug, Clone)]
 pub struct ExecutablePipeline {

--- a/compiler/executable/put/mod.rs
+++ b/compiler/executable/put/mod.rs
@@ -1,0 +1,30 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use answer::variable::Variable;
+use crate::executable::insert::executable::InsertExecutable;
+use crate::executable::match_::planner::match_executable::MatchExecutable;
+use crate::VariablePosition;
+
+#[derive(Debug)]
+pub struct PutExecutable {
+    pub executable_id: u64,
+    pub match_: MatchExecutable,
+    pub insert: InsertExecutable,
+    pub output_row_mapping: HashMap<Variable, VariablePosition>,
+}
+
+impl PutExecutable {
+    pub(crate) fn new(
+        match_executable: MatchExecutable,
+        insert_executable: InsertExecutable,
+        input_variables: &HashMap<Variable, VariablePosition>)
+    -> PutExecutable {
+        todo!()
+    }
+}

--- a/compiler/executable/put/mod.rs
+++ b/compiler/executable/put/mod.rs
@@ -30,7 +30,7 @@ impl PutExecutable {
                     .output_row_schema
                     .iter()
                     .enumerate()
-                    .filter_map(|(i, opt)| opt.map(|(v, _)| (i, v)))
+                    .filter_map(|(i, opt)| opt.clone().map(|(v, _)| (i, v)))
                     .map(|(i, v)| (v, VariablePosition::new(i as u32)))
                     .collect::<HashMap<_, _>>()
         );

--- a/compiler/executable/put/mod.rs
+++ b/compiler/executable/put/mod.rs
@@ -34,4 +34,8 @@ impl PutExecutable {
     pub(crate) fn output_row_mapping(&self) -> &HashMap<Variable, VariablePosition> {
         self.match_.variable_positions()
     }
+
+    pub fn output_width(&self) -> usize {
+        self.insert.output_width()
+    }
 }

--- a/compiler/executable/put/mod.rs
+++ b/compiler/executable/put/mod.rs
@@ -30,7 +30,7 @@ impl PutExecutable {
                     .output_row_schema
                     .iter()
                     .enumerate()
-                    .filter_map(|(i, opt)| opt.clone().map(|(v, _)| (i, v)))
+                    .filter_map(|(i, opt)| opt.map(|(v, _)| (i, v)))
                     .map(|(i, v)| (v, VariablePosition::new(i as u32)))
                     .collect::<HashMap<_, _>>()
         );

--- a/compiler/executable/put/mod.rs
+++ b/compiler/executable/put/mod.rs
@@ -9,6 +9,7 @@ use std::sync::Arc;
 use answer::variable::Variable;
 use crate::executable::insert::executable::InsertExecutable;
 use crate::executable::match_::planner::match_executable::MatchExecutable;
+use crate::executable::next_executable_id;
 use crate::VariablePosition;
 
 #[derive(Debug)]
@@ -16,15 +17,21 @@ pub struct PutExecutable {
     pub executable_id: u64,
     pub match_: MatchExecutable,
     pub insert: InsertExecutable,
-    pub output_row_mapping: HashMap<Variable, VariablePosition>,
 }
 
 impl PutExecutable {
-    pub(crate) fn new(
-        match_executable: MatchExecutable,
-        insert_executable: InsertExecutable,
-        input_variables: &HashMap<Variable, VariablePosition>)
-    -> PutExecutable {
-        todo!()
+    pub(crate) fn new(match_: MatchExecutable, insert: InsertExecutable) -> PutExecutable {
+        debug_assert!(match_.variable_positions() == &insert
+                .output_row_schema
+                .iter()
+                .enumerate()
+                .filter_map(|(i, opt)| opt.map(|(v, _)| (i, v)))
+                .map(|(i, v)| (v, VariablePosition::new(i as u32)))
+                .collect::<HashMap<_,_>>());
+        Self { executable_id: next_executable_id(), match_, insert }
+    }
+
+    pub(crate) fn output_row_mapping(&self) -> &HashMap<Variable, VariablePosition> {
+        self.match_.variable_positions()
     }
 }

--- a/compiler/executable/put/mod.rs
+++ b/compiler/executable/put/mod.rs
@@ -4,13 +4,16 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-use std::collections::HashMap;
-use std::sync::Arc;
+use std::{collections::HashMap, sync::Arc};
+
 use answer::variable::Variable;
-use crate::executable::insert::executable::InsertExecutable;
-use crate::executable::match_::planner::match_executable::MatchExecutable;
-use crate::executable::next_executable_id;
-use crate::VariablePosition;
+
+use crate::{
+    executable::{
+        insert::executable::InsertExecutable, match_::planner::match_executable::MatchExecutable, next_executable_id,
+    },
+    VariablePosition,
+};
 
 #[derive(Debug)]
 pub struct PutExecutable {
@@ -21,13 +24,16 @@ pub struct PutExecutable {
 
 impl PutExecutable {
     pub(crate) fn new(match_: MatchExecutable, insert: InsertExecutable) -> PutExecutable {
-        debug_assert!(match_.variable_positions() == &insert
-                .output_row_schema
-                .iter()
-                .enumerate()
-                .filter_map(|(i, opt)| opt.map(|(v, _)| (i, v)))
-                .map(|(i, v)| (v, VariablePosition::new(i as u32)))
-                .collect::<HashMap<_,_>>());
+        debug_assert!(
+            match_.variable_positions()
+                == &insert
+                    .output_row_schema
+                    .iter()
+                    .enumerate()
+                    .filter_map(|(i, opt)| opt.map(|(v, _)| (i, v)))
+                    .map(|(i, v)| (v, VariablePosition::new(i as u32)))
+                    .collect::<HashMap<_, _>>()
+        );
         Self { executable_id: next_executable_id(), match_, insert }
     }
 

--- a/dependencies/typedb/repositories.bzl
+++ b/dependencies/typedb/repositories.bzl
@@ -36,5 +36,5 @@ def typedb_behaviour():
     git_repository(
         name = "typedb_behaviour",
         remote = "https://github.com/krishnangovindraj/typedb-behaviour",
-        commit = "43d5de503f8e2f34c628fde5a37f203784d89183",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @typedb_behaviour
+        commit = "36fea1228bde6baef094abb6674d212d7837016a",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @typedb_behaviour
     )

--- a/dependencies/typedb/repositories.bzl
+++ b/dependencies/typedb/repositories.bzl
@@ -36,5 +36,5 @@ def typedb_behaviour():
     git_repository(
         name = "typedb_behaviour",
         remote = "https://github.com/krishnangovindraj/typedb-behaviour",
-        commit = "740b90ac987865614da90887653d6ec753fefbda",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @typedb_behaviour
+        commit = "6b8d1205b4b53434e1a557fdc9b1d6fdaa570b1e",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @typedb_behaviour
     )

--- a/dependencies/typedb/repositories.bzl
+++ b/dependencies/typedb/repositories.bzl
@@ -36,5 +36,5 @@ def typedb_behaviour():
     git_repository(
         name = "typedb_behaviour",
         remote = "https://github.com/krishnangovindraj/typedb-behaviour",
-        commit = "7b078c761aa693e07fa34ad1d2a7845f80f8f05b",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @typedb_behaviour
+        commit = "740b90ac987865614da90887653d6ec753fefbda",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @typedb_behaviour
     )

--- a/dependencies/typedb/repositories.bzl
+++ b/dependencies/typedb/repositories.bzl
@@ -36,5 +36,5 @@ def typedb_behaviour():
     git_repository(
         name = "typedb_behaviour",
         remote = "https://github.com/krishnangovindraj/typedb-behaviour",
-        commit = "901841125088a5e3817f81b4406297c2a2b0021f",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @typedb_behaviour
+        commit = "43d5de503f8e2f34c628fde5a37f203784d89183",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @typedb_behaviour
     )

--- a/dependencies/typedb/repositories.bzl
+++ b/dependencies/typedb/repositories.bzl
@@ -36,5 +36,5 @@ def typedb_behaviour():
     git_repository(
         name = "typedb_behaviour",
         remote = "https://github.com/krishnangovindraj/typedb-behaviour",
-        commit = "6b8d1205b4b53434e1a557fdc9b1d6fdaa570b1e",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @typedb_behaviour
+        commit = "901841125088a5e3817f81b4406297c2a2b0021f",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @typedb_behaviour
     )

--- a/dependencies/typedb/repositories.bzl
+++ b/dependencies/typedb/repositories.bzl
@@ -35,6 +35,6 @@ def typedb_protocol():
 def typedb_behaviour():
     git_repository(
         name = "typedb_behaviour",
-        remote = "https://github.com/typedb/typedb-behaviour",
-        commit = "d040d5c4ae8434b1802d54295035506f21821f52",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @typedb_behaviour
+        remote = "https://github.com/krishnangovindraj/typedb-behaviour",
+        commit = "7b078c761aa693e07fa34ad1d2a7845f80f8f05b",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @typedb_behaviour
     )

--- a/dependencies/typedb/repositories.bzl
+++ b/dependencies/typedb/repositories.bzl
@@ -35,6 +35,6 @@ def typedb_protocol():
 def typedb_behaviour():
     git_repository(
         name = "typedb_behaviour",
-        remote = "https://github.com/krishnangovindraj/typedb-behaviour",
-        commit = "36fea1228bde6baef094abb6674d212d7837016a",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @typedb_behaviour
+        remote = "https://github.com/typedb/typedb-behaviour",
+        commit = "877df36a50287f462e2c3ee919bc6d048b912b6d",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @typedb_behaviour
     )

--- a/executor/batch.rs
+++ b/executor/batch.rs
@@ -196,10 +196,12 @@ impl Batch {
         self.row_internal_mut(index)
     }
 
+    // We keep the implementation of append & append_mapped separate
+    // hoping copy_from_row does a memcpy that's better for large rows
     pub(crate) fn append(&mut self, row: MaybeOwnedRow<'_>) {
-        debug_assert!(self.width as usize >= row.len());
-        let row_len = row.len();
-        self.append_mapped(row, (0..row_len as u32).map(|i| (VariablePosition::new(i), VariablePosition::new(i))))
+        let mut destination_row = self.row_internal_mut(self.entries);
+        destination_row.copy_from_row(row);
+        self.entries += 1;
     }
 
     pub(crate) fn append_mapped(

--- a/executor/batch.rs
+++ b/executor/batch.rs
@@ -11,6 +11,7 @@ use std::{
 };
 
 use answer::variable_value::VariableValue;
+use compiler::VariablePosition;
 use itertools::Itertools;
 use lending_iterator::LendingIterator;
 
@@ -181,7 +182,7 @@ impl Batch {
     }
 
     pub(crate) fn get_multiplicities(&self) -> &[u64] {
-        self.multiplicities.as_ref()
+        &self.multiplicities[0..self.entries]
     }
 
     pub(crate) fn get_row(&self, index: usize) -> MaybeOwnedRow<'_> {
@@ -200,6 +201,16 @@ impl Batch {
     pub(crate) fn append(&mut self, row: MaybeOwnedRow<'_>) {
         let mut destination_row = self.row_internal_mut(self.entries);
         destination_row.copy_from_row(row);
+        self.entries += 1;
+    }
+
+    pub(crate) fn append_mapped(
+        &mut self,
+        row: MaybeOwnedRow<'_>,
+        mapping: impl Iterator<Item = (VariablePosition, VariablePosition)>,
+    ) {
+        let mut destination_row = self.row_internal_mut(self.entries);
+        destination_row.copy_mapped(row, mapping);
         self.entries += 1;
     }
 

--- a/executor/batch.rs
+++ b/executor/batch.rs
@@ -166,6 +166,7 @@ pub struct Batch {
 }
 
 impl Batch {
+    pub(crate) const DEFAULT_LENGTH: usize = 10;
     pub(crate) fn new(width: u32, length: usize) -> Self {
         let size = width as usize * length;
         Batch { width, data: vec![VariableValue::Empty; size], entries: 0, multiplicities: vec![1; length] }

--- a/executor/pipeline/insert.rs
+++ b/executor/pipeline/insert.rs
@@ -115,7 +115,7 @@ pub(crate) fn prepare_output_rows(
     Ok(output_batch)
 }
 
-fn execute_insert(
+pub(crate) fn execute_insert(
     executable: &InsertExecutable,
     snapshot: &mut impl WritableSnapshot,
     thing_manager: &ThingManager,

--- a/executor/pipeline/insert.rs
+++ b/executor/pipeline/insert.rs
@@ -6,11 +6,13 @@
 
 use std::sync::Arc;
 
-use answer::variable::Variable;
-use compiler::executable::insert::{
-    executable::InsertExecutable,
-    instructions::{ConceptInstruction, ConnectionInstruction},
-    VariableSource,
+use compiler::{
+    executable::insert::{
+        executable::InsertExecutable,
+        instructions::{ConceptInstruction, ConnectionInstruction},
+        VariableSource,
+    },
+    VariablePosition,
 };
 use concept::thing::thing_manager::ThingManager;
 use ir::pipeline::ParameterRegistry;
@@ -64,16 +66,20 @@ where
         let profile = context.profile.profile_stage(|| String::from("Insert"), executable.executable_id);
 
         // prepare_output_rows copies unmapped
-        debug_assert!(executable.output_row_schema.iter().enumerate().all(|(i, source_opt)| {
-            match source_opt {
-                Some((_, VariableSource::Input(position))) => position.as_usize() == i,
-                None | Some((_, VariableSource::Inserted)) => true,
-            }
-        }));
-        let mut batch = match prepare_output_rows(executable.output_width() as u32, previous_iterator) {
-            Ok(output_rows) => output_rows,
-            Err(err) => return Err((err, context)),
-        };
+        let input_output_mapping = executable
+            .output_row_schema
+            .iter()
+            .enumerate()
+            .filter_map(|(i, entry)| match entry {
+                Some((_, VariableSource::Input(src))) => Some((*src, VariablePosition::new(i as u32))),
+                Some((_, VariableSource::Inserted)) | None => None,
+            })
+            .collect();
+        let mut batch =
+            match prepare_output_rows(executable.output_width() as u32, previous_iterator, &input_output_mapping) {
+                Ok(output_rows) => output_rows,
+                Err(err) => return Err((err, context)),
+            };
 
         // once the previous iterator is complete, this must be the exclusive owner of Arc's, so we can get mut:
         let snapshot_mut = Arc::get_mut(&mut context.snapshot).unwrap();
@@ -105,23 +111,33 @@ where
 pub(crate) fn prepare_output_rows(
     output_width: u32,
     input_iterator: impl StageIterator,
+    mapping: &Vec<(VariablePosition, VariablePosition)>,
 ) -> Result<Batch, Box<PipelineExecutionError>> {
     // TODO: if the previous stage is not already in Collected format, this will end up temporarily allocating 2x
     //       the current memory. However, in the other case we don't know how many rows in the output batch to allocate ahead of time
     //       and require resizing. For now we take the simpler strategy that doesn't require resizing.
     let input_batch = input_iterator.collect_owned()?;
-    let total_output_rows: u64 = input_batch.get_multiplicities().iter().sum();
-    let mut output_batch = Batch::new(output_width, total_output_rows as usize);
-    let mut input_batch_iterator = input_batch.into_iterator_mut();
-    while let Some(mut row) = input_batch_iterator.next() {
-        // copy out row multiplicity M, set it to 1, then append the row M times
-        let multiplicity = row.get_multiplicity();
-        row.set_multiplicity(1);
-        for _ in 0..multiplicity {
-            output_batch.append(MaybeOwnedRow::new_from_row(&row));
-        }
+    let total_output_rows = input_batch.get_multiplicities().iter().sum::<u64>() as usize;
+    let mut output_batch = Batch::new(output_width, total_output_rows);
+    let mut input_batch_iterator = input_batch.into_iterator();
+    while let Some(row) = input_batch_iterator.next() {
+        append_row_for_insert_mapped(&mut output_batch, row.as_reference(), mapping);
     }
+    debug_assert_eq!(output_batch.len(), total_output_rows);
     Ok(output_batch)
+}
+
+pub(crate) fn append_row_for_insert_mapped(
+    output_batch: &mut Batch,
+    unmapped_row: MaybeOwnedRow<'_>,
+    mapping: &Vec<(VariablePosition, VariablePosition)>,
+) {
+    // copy out row multiplicity M, set it to 1, then append the row M times
+    let one = 1;
+    let with_multiplicity_one = MaybeOwnedRow::new_borrowed(unmapped_row.row(), &one);
+    for _ in 0..unmapped_row.multiplicity() {
+        output_batch.append_mapped(with_multiplicity_one.as_reference(), mapping.iter().copied())
+    }
 }
 
 pub(crate) fn execute_insert(

--- a/executor/pipeline/insert.rs
+++ b/executor/pipeline/insert.rs
@@ -5,9 +5,13 @@
  */
 
 use std::sync::Arc;
-use answer::variable::Variable;
 
-use compiler::executable::insert::{executable::InsertExecutable, instructions::{ConceptInstruction, ConnectionInstruction}, VariableSource};
+use answer::variable::Variable;
+use compiler::executable::insert::{
+    executable::InsertExecutable,
+    instructions::{ConceptInstruction, ConnectionInstruction},
+    VariableSource,
+};
 use concept::thing::thing_manager::ThingManager;
 use ir::pipeline::ParameterRegistry;
 use lending_iterator::LendingIterator;

--- a/executor/pipeline/match_.rs
+++ b/executor/pipeline/match_.rs
@@ -138,7 +138,7 @@ type AsOwnedRows<I> = IntoIter<
         lending_iterator::higher_order::AdHocHkt<Result<MaybeOwnedRow<'static>, ReadExecutionError>>,
     >,
 >;
-fn as_owned_rows<I>(iter: I) -> AsOwnedRows<I>
+pub(crate) fn as_owned_rows<I>(iter: I) -> AsOwnedRows<I>
 where
     I: for<'a> LendingIterator<Item<'a> = Result<MaybeOwnedRow<'a>, &'a ReadExecutionError>>,
 {
@@ -158,7 +158,7 @@ type UniqueRows<I> = UniqueBy<
     fn(&Result<MaybeOwnedRow<'static>, ReadExecutionError>) -> Result<MaybeOwnedRow<'static>, ()>,
 >;
 
-fn unique_rows<I>(iter: I) -> UniqueRows<I>
+pub(crate) fn unique_rows<I>(iter: I) -> UniqueRows<I>
 where
     I: Iterator<Item = Result<MaybeOwnedRow<'static>, ReadExecutionError>>,
 {

--- a/executor/pipeline/mod.rs
+++ b/executor/pipeline/mod.rs
@@ -24,6 +24,7 @@ pub mod insert;
 pub mod match_;
 pub mod modifiers;
 pub mod pipeline;
+pub mod put;
 pub mod reduce;
 pub mod stage;
 pub mod update;

--- a/executor/pipeline/pipeline.rs
+++ b/executor/pipeline/pipeline.rs
@@ -8,7 +8,10 @@ use std::{collections::HashMap, sync::Arc};
 
 use answer::variable::Variable;
 use compiler::{
-    executable::{fetch::executable::ExecutableFetch, function::ExecutableFunctionRegistry, pipeline::ExecutableStage},
+    executable::{
+        fetch::executable::ExecutableFetch, function::ExecutableFunctionRegistry, pipeline::ExecutableStage,
+        put::PutExecutable,
+    },
     VariablePosition,
 };
 use concept::thing::thing_manager::ThingManager;
@@ -16,7 +19,6 @@ use error::typedb_error;
 use ir::pipeline::ParameterRegistry;
 use storage::snapshot::{ReadableSnapshot, WritableSnapshot};
 use typeql::common::Span;
-use compiler::executable::put::PutExecutable;
 
 use crate::{
     document::ConceptDocument,
@@ -30,6 +32,7 @@ use crate::{
             DistinctStageExecutor, LimitStageExecutor, OffsetStageExecutor, RequireStageExecutor, SelectStageExecutor,
             SortStageExecutor,
         },
+        put::PutStageExecutor,
         reduce::ReduceStageExecutor,
         stage::{ExecutionContext, ReadPipelineStage, StageAPI, WritePipelineStage},
         update::UpdateStageExecutor,
@@ -38,7 +41,6 @@ use crate::{
     row::MaybeOwnedRow,
     ExecutionInterrupt,
 };
-use crate::pipeline::put::PutStageExecutor;
 
 pub enum Pipeline<Snapshot: ReadableSnapshot, Nonterminals: StageAPI<Snapshot>> {
     Unfetched(Nonterminals, HashMap<String, VariablePosition>),

--- a/executor/pipeline/pipeline.rs
+++ b/executor/pipeline/pipeline.rs
@@ -222,7 +222,7 @@ impl<Snapshot: WritableSnapshot + 'static> Pipeline<Snapshot, WritePipelineStage
                     last_stage = WritePipelineStage::Update(Box::new(update_stage));
                 }
                 ExecutableStage::Put(put_executable) => {
-                    let put_stage = PutStageExecutor::new(put_executable, last_stage);
+                    let put_stage = PutStageExecutor::new(put_executable, last_stage, executable_functions.clone());
                     last_stage = WritePipelineStage::Put(Box::new(put_stage));
                 }
                 ExecutableStage::Delete(delete_executable) => {

--- a/executor/pipeline/pipeline.rs
+++ b/executor/pipeline/pipeline.rs
@@ -144,6 +144,9 @@ impl<Snapshot: ReadableSnapshot + 'static> Pipeline<Snapshot, ReadPipelineStage<
                 ExecutableStage::Update(_) => {
                     return Err(Box::new(PipelineError::InvalidReadPipelineStage { stage: "Update".to_string() }))
                 }
+                ExecutableStage::Put(_) => {
+                    return Err(Box::new(PipelineError::InvalidReadPipelineStage { stage: "Put".to_string() }))
+                }
                 ExecutableStage::Delete(_) => {
                     return Err(Box::new(PipelineError::InvalidReadPipelineStage { stage: "Delete".to_string() }))
                 }
@@ -215,6 +218,11 @@ impl<Snapshot: WritableSnapshot + 'static> Pipeline<Snapshot, WritePipelineStage
                 ExecutableStage::Update(update_executable) => {
                     let update_stage = UpdateStageExecutor::new(update_executable, last_stage);
                     last_stage = WritePipelineStage::Update(Box::new(update_stage));
+                }
+                ExecutableStage::Put(_) => {
+                    todo!()
+                    // let update_stage = PutStageExecutor::new(put_executable, last_stage);
+                    // last_stage = WritePipelineStage::Put(Box::new(update_stage));
                 }
                 ExecutableStage::Delete(delete_executable) => {
                     let delete_stage = DeleteStageExecutor::new(delete_executable, last_stage);

--- a/executor/pipeline/pipeline.rs
+++ b/executor/pipeline/pipeline.rs
@@ -220,7 +220,7 @@ impl<Snapshot: WritableSnapshot + 'static> Pipeline<Snapshot, WritePipelineStage
                     last_stage = WritePipelineStage::Update(Box::new(update_stage));
                 }
                 ExecutableStage::Put(_) => {
-                    todo!()
+                    compile_error!("todo");
                     // let update_stage = PutStageExecutor::new(put_executable, last_stage);
                     // last_stage = WritePipelineStage::Put(Box::new(update_stage));
                 }

--- a/executor/pipeline/put.rs
+++ b/executor/pipeline/put.rs
@@ -61,7 +61,7 @@ where
     > {
         let Self { previous: previous_stage, executable, function_registry } = self;
 
-        let mut output_batch = Batch::new(executable.output_width() as u32, 10); // We don't know how many ahead of time
+        let mut output_batch = Batch::new(executable.output_width() as u32, Batch::DEFAULT_LENGTH);
         let mut must_insert = Vec::new();
 
         let (mut previous_iterator, mut context) = previous_stage.into_iterator(interrupt.clone())?;

--- a/executor/pipeline/put.rs
+++ b/executor/pipeline/put.rs
@@ -1,0 +1,40 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+use std::sync::Arc;
+use compiler::executable::put::PutExecutable;
+use storage::snapshot::WritableSnapshot;
+use crate::ExecutionInterrupt;
+use crate::pipeline::{PipelineExecutionError, WrittenRowsIterator};
+use crate::pipeline::stage::{ExecutionContext, StageAPI};
+
+pub struct PutStageExecutor<PreviousStage> {
+    executable: Arc<PutExecutable>,
+    previous: PreviousStage,
+}
+
+
+impl<PreviousStage> PutStageExecutor<PreviousStage> {
+    pub fn new(executable: Arc<PutExecutable>, previous: PreviousStage) -> Self {
+        Self { executable, previous }
+    }
+
+    pub(crate) fn output_width(&self) -> usize {
+        self.executable.output_width()
+    }
+}
+
+impl<Snapshot, PreviousStage> StageAPI<Snapshot> for PutStageExecutor<PreviousStage>
+    where
+        Snapshot: WritableSnapshot + 'static,
+        PreviousStage: StageAPI<Snapshot>,
+{
+    type OutputIterator = WrittenRowsIterator;
+
+    fn into_iterator(self, interrupt: ExecutionInterrupt) -> Result<(Self::OutputIterator, ExecutionContext<Snapshot>), (Box<PipelineExecutionError>, ExecutionContext<Snapshot>)> {
+        todo!()
+    }
+}

--- a/executor/pipeline/put.rs
+++ b/executor/pipeline/put.rs
@@ -11,6 +11,7 @@ use compiler::{
     VariablePosition,
 };
 use lending_iterator::LendingIterator;
+use resource::constants::traversal::BATCH_DEFAULT_LENGTH;
 use storage::snapshot::{ReadableSnapshot, WritableSnapshot};
 
 use crate::{
@@ -77,7 +78,7 @@ fn into_iterator_impl<Snapshot: WritableSnapshot + 'static>(
     function_registry: Arc<ExecutableFunctionRegistry>,
     mut previous_iterator: impl StageIterator,
 ) -> Result<WrittenRowsIterator, Box<PipelineExecutionError>> {
-    let mut output_batch = Batch::new(executable.output_width() as u32, Batch::DEFAULT_LENGTH);
+    let mut output_batch = Batch::new(executable.output_width() as u32, BATCH_DEFAULT_LENGTH);
     let mut must_insert = Vec::new();
     let input_output_mapping = executable
         .insert

--- a/executor/pipeline/put.rs
+++ b/executor/pipeline/put.rs
@@ -4,28 +4,26 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-use std::{collections::HashMap, sync::Arc};
+use std::sync::Arc;
 
-use answer::variable_value::VariableValue;
 use compiler::{
     executable::{function::ExecutableFunctionRegistry, insert::VariableSource, put::PutExecutable},
     VariablePosition,
 };
-use concept::thing::thing_manager::ThingManager;
 use lending_iterator::LendingIterator;
 use storage::snapshot::{ReadableSnapshot, WritableSnapshot};
 
 use crate::{
     batch::Batch,
+    error::ReadExecutionError,
     match_executor::MatchExecutor,
     pipeline::{
-        stage::{ExecutionContext, StageAPI},
+        stage::{ExecutionContext, StageAPI, StageIterator},
         PipelineExecutionError, WrittenRowsIterator,
     },
     row::MaybeOwnedRow,
     ExecutionInterrupt,
 };
-use crate::error::ReadExecutionError;
 
 pub struct PutStageExecutor<PreviousStage> {
     executable: Arc<PutExecutable>,
@@ -62,76 +60,72 @@ where
         (Box<PipelineExecutionError>, ExecutionContext<Snapshot>),
     > {
         let Self { previous: previous_stage, executable, function_registry } = self;
-
-        let mut output_batch = Batch::new(executable.output_width() as u32, Batch::DEFAULT_LENGTH);
-        let mut must_insert = Vec::new();
-
-        let (mut previous_iterator, mut context) = previous_stage.into_iterator(interrupt.clone())?;
-        let stage_profile = context.profile.profile_stage(|| String::from("Put"), executable.executable_id);
-        let empty_output_row = vec![VariableValue::Empty; executable.output_width()];
-        let input_output_mapping = executable
-            .insert
-            .output_row_schema
-            .iter()
-            .enumerate()
-            .filter_map(|(i, entry_opt)| match entry_opt {
-                Some((_, VariableSource::Input(pos))) => Some((*pos, VariablePosition::new(i as u32))),
-                _ => None,
-            })
-            .collect::<HashMap<_, _>>();
-        while let Some(input_result) = previous_iterator.next() {
-            let input_row = match input_result {
-                Ok(row) => row,
-                Err(err) => return Err((err, context)),
-            };
-            let size_before = output_batch.len();
-            if let Err(err) = may_append_matched_rows(&context, &interrupt, &executable, function_registry.clone(), &mut output_batch, &mut must_insert, input_row.clone()) {
-                return Err((err, context))
-            }
-
-            if size_before == output_batch.len() {
-                prepare_rows_for_insertion(&empty_output_row, &input_output_mapping, &mut output_batch, &mut must_insert, input_row);
-            }
+        let (previous_iterator, mut context) = previous_stage.into_iterator(interrupt.clone())?;
+        let result =
+            into_iterator_impl(&mut context, &mut interrupt, &executable, function_registry, previous_iterator);
+        match result {
+            Ok(written_rows_iterator) => Ok((written_rows_iterator, context)),
+            Err(err) => Err((err, context)),
         }
-        drop(previous_iterator);
-        debug_assert_eq!(output_batch.len(), must_insert.len());
-        // once the previous iterator is complete, this must be the exclusive owner of Arc's, so we can get mut:
-        let snapshot_mut = Arc::get_mut(&mut context.snapshot).unwrap();
-        for index in 0..output_batch.len() {
-            // TODO: parallelise -- though this requires our snapshots support parallel writes!
-            let mut row = output_batch.get_row_mut(index);
-            if must_insert[index] {
-                if let Err(typedb_source) = crate::pipeline::insert::execute_insert(
-                    &executable.insert,
-                    snapshot_mut,
-                    &context.thing_manager,
-                    &context.parameters,
-                    &mut row,
-                    &stage_profile,
-                ) {
-                    return Err((Box::new(PipelineExecutionError::WriteError { typedb_source }), context));
-                }
-            }
-            if index % 100 == 0 {
-                if let Some(interrupt) = interrupt.check() {
-                    return Err((Box::new(PipelineExecutionError::Interrupted { interrupt }), context));
-                }
-            }
-        }
-
-        Ok((WrittenRowsIterator::new(output_batch), context))
     }
 }
 
-fn may_append_matched_rows<Snapshot: ReadableSnapshot + 'static>(
+fn into_iterator_impl<Snapshot: WritableSnapshot + 'static>(
+    context: &mut ExecutionContext<Snapshot>,
+    interrupt: &mut ExecutionInterrupt,
+    executable: &PutExecutable,
+    function_registry: Arc<ExecutableFunctionRegistry>,
+    mut previous_iterator: impl StageIterator,
+) -> Result<WrittenRowsIterator, Box<PipelineExecutionError>> {
+    let mut output_batch = Batch::new(executable.output_width() as u32, Batch::DEFAULT_LENGTH);
+    let mut must_insert = Vec::new();
+    let input_output_mapping = executable
+        .insert
+        .output_row_schema
+        .iter()
+        .enumerate()
+        .filter_map(|(i, entry_opt)| match entry_opt {
+            Some((_, VariableSource::Input(pos))) => Some((*pos, VariablePosition::new(i as u32))),
+            _ => None,
+        })
+        .collect::<Vec<_>>();
+    while let Some(input_row_result) = previous_iterator.next() {
+        let input_row = input_row_result?;
+        let size_before = output_batch.len();
+        let mut match_iterator =
+            match_iterator_for_row(&context, &interrupt, &executable, function_registry.clone(), input_row.clone())?;
+        match_iterator
+            .try_for_each(|row_result| {
+                output_batch.append(row_result?);
+                must_insert.push(false);
+                Ok(())
+            })
+            .map_err(|typedb_source| Box::new(PipelineExecutionError::ReadPatternExecution { typedb_source }))?;
+
+        if size_before == output_batch.len() {
+            must_insert.extend((0..input_row.multiplicity()).map(|_| true));
+            crate::pipeline::insert::append_row_for_insert_mapped(
+                &mut output_batch,
+                input_row.as_reference(),
+                &input_output_mapping,
+            );
+        }
+    }
+    drop(previous_iterator);
+    debug_assert_eq!(output_batch.len(), must_insert.len());
+    // once the previous iterator is complete, this must be the exclusive owner of Arc's, so we can get mut:
+    perform_inserts(context, interrupt, executable, &mut output_batch, &must_insert)?;
+
+    Ok(WrittenRowsIterator::new(output_batch))
+}
+
+fn match_iterator_for_row<Snapshot: ReadableSnapshot + 'static>(
     context: &ExecutionContext<Snapshot>,
     interrupt: &ExecutionInterrupt,
     put_executable: &PutExecutable,
     function_registry: Arc<ExecutableFunctionRegistry>,
-    output_batch: &mut Batch,
-    must_insert: &mut Vec<bool>,
     input_row: MaybeOwnedRow<'_>,
-) -> Result<(), Box<PipelineExecutionError>> {
+) -> Result<impl Iterator<Item = Result<MaybeOwnedRow<'static>, ReadExecutionError>>, Box<PipelineExecutionError>> {
     let executor = MatchExecutor::new(
         &put_executable.match_,
         &context.snapshot,
@@ -140,34 +134,41 @@ fn may_append_matched_rows<Snapshot: ReadableSnapshot + 'static>(
         function_registry,
         &context.profile,
     )
-        .map_err(|err| Box::new(PipelineExecutionError::InitialisingMatchIterator { typedb_source: err }))?;
-    let mut match_iterator = crate::pipeline::match_::unique_rows(crate::pipeline::match_::as_owned_rows(
+    .map_err(|err| Box::new(PipelineExecutionError::InitialisingMatchIterator { typedb_source: err }))?;
+    Ok(crate::pipeline::match_::unique_rows(crate::pipeline::match_::as_owned_rows(
         executor.into_iterator(context.clone(), interrupt.clone()),
-    )).peekable();
-    while let Some(row_result) = match_iterator.next() {
-        match row_result {
-            Ok(row) => {
-                output_batch.append(row);
-                must_insert.push(false);
-            }
-            Err(typedb_source) => {
-                return Err(Box::new(PipelineExecutionError::ReadPatternExecution { typedb_source }))
+    ))
+    .peekable())
+}
+
+fn perform_inserts<Snapshot: WritableSnapshot>(
+    context: &mut ExecutionContext<Snapshot>,
+    interrupt: &mut ExecutionInterrupt,
+    executable: &PutExecutable,
+    output_batch: &mut Batch,
+    must_insert: &Vec<bool>,
+) -> Result<(), Box<PipelineExecutionError>> {
+    let snapshot_mut = Arc::get_mut(&mut context.snapshot).unwrap();
+    let stage_profile = context.profile.profile_stage(|| String::from("PutInsert"), executable.executable_id);
+    for index in 0..output_batch.len() {
+        // TODO: parallelise -- though this requires our snapshots support parallel writes!
+        let mut row = output_batch.get_row_mut(index);
+        if must_insert[index] {
+            crate::pipeline::insert::execute_insert(
+                &executable.insert,
+                snapshot_mut,
+                &context.thing_manager,
+                &context.parameters,
+                &mut row,
+                &stage_profile,
+            )
+            .map_err(|typedb_source| Box::new(PipelineExecutionError::WriteError { typedb_source }))?;
+        }
+        if index % 100 == 0 {
+            if let Some(interrupt) = interrupt.check() {
+                return Err(Box::new(PipelineExecutionError::Interrupted { interrupt }));
             }
         }
     }
     Ok(())
-}
-
-fn prepare_rows_for_insertion(empty_output_row: &[VariableValue<'static>], input_output_mapping: &HashMap<VariablePosition, VariablePosition>, output_batch: &mut Batch, must_insert: &mut Vec<bool>, input_row: MaybeOwnedRow<'_>) {
-    // copy out row multiplicity M, set it to 1, then append the row M times
-    let multiplicity = input_row.multiplicity();
-    for _ in 0..multiplicity {
-        output_batch.append(MaybeOwnedRow::new_borrowed(&empty_output_row, &1)); // Insert an empty row
-        output_batch.get_row_mut(output_batch.len() - 1).copy_mapped(
-            // Copy over input_row
-            input_row.as_reference(),
-            input_output_mapping.iter().map(|(s, d)| (s.clone(), d.clone())),
-        );
-        must_insert.push(true);
-    }
 }

--- a/executor/pipeline/put.rs
+++ b/executor/pipeline/put.rs
@@ -4,21 +4,26 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-use std::collections::HashMap;
-use std::sync::Arc;
+use std::{collections::HashMap, sync::Arc};
+
 use answer::variable_value::VariableValue;
-use compiler::executable::function::ExecutableFunctionRegistry;
-use compiler::executable::insert::VariableSource;
-use compiler::executable::put::PutExecutable;
-use compiler::VariablePosition;
+use compiler::{
+    executable::{function::ExecutableFunctionRegistry, insert::VariableSource, put::PutExecutable},
+    VariablePosition,
+};
 use lending_iterator::LendingIterator;
 use storage::snapshot::WritableSnapshot;
-use crate::batch::Batch;
-use crate::ExecutionInterrupt;
-use crate::match_executor::MatchExecutor;
-use crate::pipeline::{PipelineExecutionError, WrittenRowsIterator};
-use crate::pipeline::stage::{ExecutionContext, StageAPI};
-use crate::row::MaybeOwnedRow;
+
+use crate::{
+    batch::Batch,
+    match_executor::MatchExecutor,
+    pipeline::{
+        stage::{ExecutionContext, StageAPI},
+        PipelineExecutionError, WrittenRowsIterator,
+    },
+    row::MaybeOwnedRow,
+    ExecutionInterrupt,
+};
 
 pub struct PutStageExecutor<PreviousStage> {
     executable: Arc<PutExecutable>,
@@ -27,7 +32,11 @@ pub struct PutStageExecutor<PreviousStage> {
 }
 
 impl<PreviousStage> PutStageExecutor<PreviousStage> {
-    pub fn new(executable: Arc<PutExecutable>, previous: PreviousStage, function_registry: Arc<ExecutableFunctionRegistry>) -> Self {
+    pub fn new(
+        executable: Arc<PutExecutable>,
+        previous: PreviousStage,
+        function_registry: Arc<ExecutableFunctionRegistry>,
+    ) -> Self {
         Self { executable, previous, function_registry }
     }
 
@@ -37,13 +46,19 @@ impl<PreviousStage> PutStageExecutor<PreviousStage> {
 }
 
 impl<Snapshot, PreviousStage> StageAPI<Snapshot> for PutStageExecutor<PreviousStage>
-    where
-        Snapshot: WritableSnapshot + 'static,
-        PreviousStage: StageAPI<Snapshot>,
+where
+    Snapshot: WritableSnapshot + 'static,
+    PreviousStage: StageAPI<Snapshot>,
 {
     type OutputIterator = WrittenRowsIterator;
 
-    fn into_iterator(self, mut interrupt: ExecutionInterrupt) -> Result<(Self::OutputIterator, ExecutionContext<Snapshot>), (Box<PipelineExecutionError>, ExecutionContext<Snapshot>)> {
+    fn into_iterator(
+        self,
+        mut interrupt: ExecutionInterrupt,
+    ) -> Result<
+        (Self::OutputIterator, ExecutionContext<Snapshot>),
+        (Box<PipelineExecutionError>, ExecutionContext<Snapshot>),
+    > {
         let Self { previous: previous_stage, executable, function_registry } = self;
         let (mut previous_iterator, mut context) = previous_stage.into_iterator(interrupt.clone())?;
 
@@ -52,13 +67,16 @@ impl<Snapshot, PreviousStage> StageAPI<Snapshot> for PutStageExecutor<PreviousSt
         let mut output_batch = Batch::new(executable.output_width() as u32, 10); // We don't know how many ahead of time
         let mut must_insert = Vec::new();
         let empty_output_row = vec![VariableValue::Empty; executable.output_width()];
-        let input_output_mapping = executable.insert.output_row_schema.iter().enumerate()
-            .filter_map(|(i, entry_opt)| {
-                match entry_opt {
-                    Some((_, VariableSource::InputVariable(pos))) => Some((*pos, VariablePosition::new(i as u32))),
-                    _ => None
-                }
-            }).collect::<HashMap<_,_>>();
+        let input_output_mapping = executable
+            .insert
+            .output_row_schema
+            .iter()
+            .enumerate()
+            .filter_map(|(i, entry_opt)| match entry_opt {
+                Some((_, VariableSource::InputVariable(pos))) => Some((*pos, VariablePosition::new(i as u32))),
+                _ => None,
+            })
+            .collect::<HashMap<_, _>>();
         while let Some(input_result) = previous_iterator.next() {
             let input_row = match input_result {
                 Ok(row) => row,
@@ -73,13 +91,12 @@ impl<Snapshot, PreviousStage> StageAPI<Snapshot> for PutStageExecutor<PreviousSt
                 function_registry.clone(),
                 &context.profile,
             )
-                .map_err(|err| Box::new(PipelineExecutionError::InitialisingMatchIterator { typedb_source: err }));
+            .map_err(|err| Box::new(PipelineExecutionError::InitialisingMatchIterator { typedb_source: err }));
             let mut match_iterator = match executor {
-                Ok(executor) => {
-                    crate::pipeline::match_::unique_rows(crate::pipeline::match_::as_owned_rows(
-                        executor.into_iterator(context.clone(), interrupt.clone()),
-                    )).peekable()
-                }
+                Ok(executor) => crate::pipeline::match_::unique_rows(crate::pipeline::match_::as_owned_rows(
+                    executor.into_iterator(context.clone(), interrupt.clone()),
+                ))
+                .peekable(),
                 Err(err) => return Err((err, context)),
             };
             // TODO: if the previous stage is not already in Collected format, this will end up temporarily allocating 2x
@@ -92,10 +109,9 @@ impl<Snapshot, PreviousStage> StageAPI<Snapshot> for PutStageExecutor<PreviousSt
                         output_batch.append(row);
                         must_insert.push(false);
                     }
-                    Err(typedb_source) => return Err((
-                        Box::new(PipelineExecutionError::ReadPatternExecution { typedb_source }),
-                        context)
-                    ),
+                    Err(typedb_source) => {
+                        return Err((Box::new(PipelineExecutionError::ReadPatternExecution { typedb_source }), context))
+                    }
                 }
             }
             if size_before == output_batch.len() {
@@ -103,7 +119,10 @@ impl<Snapshot, PreviousStage> StageAPI<Snapshot> for PutStageExecutor<PreviousSt
                 let multiplicity = input_row.multiplicity();
                 for _ in 0..multiplicity {
                     output_batch.append(MaybeOwnedRow::new_borrowed(&empty_output_row, &1));
-                    output_batch.get_row_mut(output_batch.len()).copy_mapped(input_row.as_reference(), input_output_mapping.iter().map(|(s,d)| (s.clone(), d.clone())));
+                    output_batch.get_row_mut(output_batch.len()).copy_mapped(
+                        input_row.as_reference(),
+                        input_output_mapping.iter().map(|(s, d)| (s.clone(), d.clone())),
+                    );
                     must_insert.push(true);
                 }
             }

--- a/executor/pipeline/put.rs
+++ b/executor/pipeline/put.rs
@@ -4,22 +4,31 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
+use std::collections::HashMap;
 use std::sync::Arc;
+use answer::variable_value::VariableValue;
+use compiler::executable::function::ExecutableFunctionRegistry;
+use compiler::executable::insert::VariableSource;
 use compiler::executable::put::PutExecutable;
+use compiler::VariablePosition;
+use lending_iterator::LendingIterator;
 use storage::snapshot::WritableSnapshot;
+use crate::batch::Batch;
 use crate::ExecutionInterrupt;
+use crate::match_executor::MatchExecutor;
 use crate::pipeline::{PipelineExecutionError, WrittenRowsIterator};
 use crate::pipeline::stage::{ExecutionContext, StageAPI};
+use crate::row::MaybeOwnedRow;
 
 pub struct PutStageExecutor<PreviousStage> {
     executable: Arc<PutExecutable>,
     previous: PreviousStage,
+    function_registry: Arc<ExecutableFunctionRegistry>,
 }
 
-
 impl<PreviousStage> PutStageExecutor<PreviousStage> {
-    pub fn new(executable: Arc<PutExecutable>, previous: PreviousStage) -> Self {
-        Self { executable, previous }
+    pub fn new(executable: Arc<PutExecutable>, previous: PreviousStage, function_registry: Arc<ExecutableFunctionRegistry>) -> Self {
+        Self { executable, previous, function_registry }
     }
 
     pub(crate) fn output_width(&self) -> usize {
@@ -34,7 +43,96 @@ impl<Snapshot, PreviousStage> StageAPI<Snapshot> for PutStageExecutor<PreviousSt
 {
     type OutputIterator = WrittenRowsIterator;
 
-    fn into_iterator(self, interrupt: ExecutionInterrupt) -> Result<(Self::OutputIterator, ExecutionContext<Snapshot>), (Box<PipelineExecutionError>, ExecutionContext<Snapshot>)> {
-        todo!()
+    fn into_iterator(self, mut interrupt: ExecutionInterrupt) -> Result<(Self::OutputIterator, ExecutionContext<Snapshot>), (Box<PipelineExecutionError>, ExecutionContext<Snapshot>)> {
+        let Self { previous: previous_stage, executable, function_registry } = self;
+        let (mut previous_iterator, mut context) = previous_stage.into_iterator(interrupt.clone())?;
+
+        let ExecutionContext { snapshot, thing_manager, profile, .. } = &context;
+        let stage_profile = context.profile.profile_stage(|| String::from("Put"), executable.executable_id);
+        let mut output_batch = Batch::new(executable.output_width() as u32, 10); // We don't know how many ahead of time
+        let mut must_insert = Vec::new();
+        let empty_output_row = vec![VariableValue::Empty; executable.output_width()];
+        let input_output_mapping = executable.insert.output_row_schema.iter().enumerate()
+            .filter_map(|(i, entry_opt)| {
+                match entry_opt {
+                    Some((_, VariableSource::InputVariable(pos))) => Some((*pos, VariablePosition::new(i as u32))),
+                    _ => None
+                }
+            }).collect::<HashMap<_,_>>();
+        while let Some(input_result) = previous_iterator.next() {
+            let input_row = match input_result {
+                Ok(row) => row,
+                Err(err) => return Err((err, context)),
+            };
+
+            let executor = MatchExecutor::new(
+                &executable.match_,
+                snapshot,
+                thing_manager,
+                input_row.clone(),
+                function_registry.clone(),
+                &context.profile,
+            )
+                .map_err(|err| Box::new(PipelineExecutionError::InitialisingMatchIterator { typedb_source: err }));
+            let mut match_iterator = match executor {
+                Ok(executor) => {
+                    crate::pipeline::match_::unique_rows(crate::pipeline::match_::as_owned_rows(
+                        executor.into_iterator(context.clone(), interrupt.clone()),
+                    )).peekable()
+                }
+                Err(err) => return Err((err, context)),
+            };
+            // TODO: if the previous stage is not already in Collected format, this will end up temporarily allocating 2x
+            //       the current memory. However, in the other case we don't know how many rows in the output batch to allocate ahead of time
+            //       and require resizing. For now we take the simpler strategy that doesn't require resizing.
+            let size_before = output_batch.len();
+            while let Some(row_result) = match_iterator.next() {
+                match row_result {
+                    Ok(row) => {
+                        output_batch.append(row);
+                        must_insert.push(false);
+                    }
+                    Err(typedb_source) => return Err((
+                        Box::new(PipelineExecutionError::ReadPatternExecution { typedb_source }),
+                        context)
+                    ),
+                }
+            }
+            if size_before == output_batch.len() {
+                // copy out row multiplicity M, set it to 1, then append the row M times
+                let multiplicity = input_row.multiplicity();
+                for _ in 0..multiplicity {
+                    output_batch.append(MaybeOwnedRow::new_borrowed(&empty_output_row, &1));
+                    output_batch.get_row_mut(output_batch.len()).copy_mapped(input_row.as_reference(), input_output_mapping.iter().map(|(s,d)| (s.clone(), d.clone())));
+                    must_insert.push(true);
+                }
+            }
+        }
+        debug_assert_eq!(output_batch.len(), must_insert.len());
+        // once the previous iterator is complete, this must be the exclusive owner of Arc's, so we can get mut:
+        let snapshot_mut = Arc::get_mut(&mut context.snapshot).unwrap();
+        for index in 0..output_batch.len() {
+            // TODO: parallelise -- though this requires our snapshots support parallel writes!
+            let mut row = output_batch.get_row_mut(index);
+            if must_insert[index] {
+                if let Err(typedb_source) = crate::pipeline::insert::execute_insert(
+                    &executable.insert,
+                    snapshot_mut,
+                    &context.thing_manager,
+                    &context.parameters,
+                    &mut row,
+                    &stage_profile,
+                ) {
+                    return Err((Box::new(PipelineExecutionError::WriteError { typedb_source }), context));
+                }
+            }
+            if index % 100 == 0 {
+                if let Some(interrupt) = interrupt.check() {
+                    return Err((Box::new(PipelineExecutionError::Interrupted { interrupt }), context));
+                }
+            }
+        }
+
+        Ok((WrittenRowsIterator::new(output_batch), context))
     }
 }

--- a/executor/pipeline/put.rs
+++ b/executor/pipeline/put.rs
@@ -118,8 +118,8 @@ where
                 // copy out row multiplicity M, set it to 1, then append the row M times
                 let multiplicity = input_row.multiplicity();
                 for _ in 0..multiplicity {
-                    output_batch.append(MaybeOwnedRow::new_borrowed(&empty_output_row, &1));
-                    output_batch.get_row_mut(output_batch.len()).copy_mapped(
+                    output_batch.append(MaybeOwnedRow::new_borrowed(&empty_output_row, &1)); // Insert an empty row
+                    output_batch.get_row_mut(output_batch.len()-1).copy_mapped( // Copy over input_row
                         input_row.as_reference(),
                         input_output_mapping.iter().map(|(s, d)| (s.clone(), d.clone())),
                     );

--- a/executor/pipeline/stage.rs
+++ b/executor/pipeline/stage.rs
@@ -109,7 +109,7 @@ pub trait StageIterator:
             None => return Ok(Batch::new(0, 1)),
             Some(row) => {
                 let row = row?;
-                let mut batch = Batch::new(row.len() as u32, 10);
+                let mut batch = Batch::new(row.len() as u32, Batch::DEFAULT_LENGTH);
                 batch.append(row);
                 batch
             }

--- a/executor/pipeline/stage.rs
+++ b/executor/pipeline/stage.rs
@@ -9,9 +9,9 @@ use std::sync::Arc;
 use concept::{thing::thing_manager::ThingManager, type_::type_manager::TypeManager};
 use ir::pipeline::ParameterRegistry;
 use lending_iterator::LendingIterator;
+use resource::constants::traversal::BATCH_DEFAULT_LENGTH;
 use storage::snapshot::{ReadableSnapshot, WritableSnapshot};
 use tracing::Level;
-use resource::constants::traversal::BATCH_DEFAULT_LENGTH;
 
 use crate::{
     batch::Batch,

--- a/executor/pipeline/stage.rs
+++ b/executor/pipeline/stage.rs
@@ -32,6 +32,7 @@ use crate::{
     row::MaybeOwnedRow,
     ExecutionInterrupt,
 };
+use crate::pipeline::put::PutStageExecutor;
 
 #[derive(Debug)]
 pub struct ExecutionContext<Snapshot> {
@@ -235,6 +236,7 @@ pub enum WritePipelineStage<Snapshot: WritableSnapshot + 'static> {
     Match(Box<MatchStageExecutor<WritePipelineStage<Snapshot>>>),
     Insert(Box<InsertStageExecutor<WritePipelineStage<Snapshot>>>),
     Update(Box<UpdateStageExecutor<WritePipelineStage<Snapshot>>>),
+    Put(Box<PutStageExecutor<WritePipelineStage<Snapshot>>>),
     Delete(Box<DeleteStageExecutor<WritePipelineStage<Snapshot>>>),
     Sort(Box<SortStageExecutor<WritePipelineStage<Snapshot>>>),
     Limit(Box<LimitStageExecutor<WritePipelineStage<Snapshot>>>),
@@ -269,6 +271,10 @@ impl<Snapshot: WritableSnapshot + 'static> StageAPI<Snapshot> for WritePipelineS
                 Ok((WriteStageIterator::Write(iterator), context))
             }
             WritePipelineStage::Update(stage) => {
+                let (iterator, context) = stage.into_iterator(interrupt)?;
+                Ok((WriteStageIterator::Write(iterator), context))
+            }
+            WritePipelineStage::Put(stage) => {
                 let (iterator, context) = stage.into_iterator(interrupt)?;
                 Ok((WriteStageIterator::Write(iterator), context))
             }

--- a/executor/pipeline/stage.rs
+++ b/executor/pipeline/stage.rs
@@ -24,6 +24,7 @@ use crate::{
             OffsetStageIterator, RequireStageExecutor, RequireStageIterator, SelectStageExecutor, SelectStageIterator,
             SortStageExecutor, SortStageIterator,
         },
+        put::PutStageExecutor,
         reduce::ReduceStageExecutor,
         update::UpdateStageExecutor,
         PipelineExecutionError, WrittenRowsIterator,
@@ -32,7 +33,6 @@ use crate::{
     row::MaybeOwnedRow,
     ExecutionInterrupt,
 };
-use crate::pipeline::put::PutStageExecutor;
 
 #[derive(Debug)]
 pub struct ExecutionContext<Snapshot> {

--- a/executor/pipeline/stage.rs
+++ b/executor/pipeline/stage.rs
@@ -11,6 +11,7 @@ use ir::pipeline::ParameterRegistry;
 use lending_iterator::LendingIterator;
 use storage::snapshot::{ReadableSnapshot, WritableSnapshot};
 use tracing::Level;
+use resource::constants::traversal::BATCH_DEFAULT_LENGTH;
 
 use crate::{
     batch::Batch,
@@ -109,7 +110,7 @@ pub trait StageIterator:
             None => return Ok(Batch::new(0, 1)),
             Some(row) => {
                 let row = row?;
-                let mut batch = Batch::new(row.len() as u32, Batch::DEFAULT_LENGTH);
+                let mut batch = Batch::new(row.len() as u32, BATCH_DEFAULT_LENGTH);
                 batch.append(row);
                 batch
             }

--- a/executor/pipeline/update.rs
+++ b/executor/pipeline/update.rs
@@ -12,18 +12,16 @@ use compiler::executable::{
 };
 use concept::thing::thing_manager::ThingManager;
 use ir::pipeline::ParameterRegistry;
-use lending_iterator::LendingIterator;
 use storage::snapshot::WritableSnapshot;
 
 use crate::{
-    batch::Batch,
     pipeline::{
         insert::prepare_output_rows,
         stage::{ExecutionContext, StageAPI},
-        PipelineExecutionError, StageIterator, WrittenRowsIterator,
+        PipelineExecutionError, WrittenRowsIterator,
     },
     profile::StageProfile,
-    row::{MaybeOwnedRow, Row},
+    row::Row,
     write::{write_instruction::AsWriteInstruction, WriteError},
     ExecutionInterrupt,
 };

--- a/executor/pipeline/update.rs
+++ b/executor/pipeline/update.rs
@@ -7,10 +7,9 @@
 use std::sync::Arc;
 
 use compiler::executable::{
-    insert::instructions::ConceptInstruction,
+    insert::{instructions::ConceptInstruction, VariableSource},
     update::{executable::UpdateExecutable, instructions::ConnectionInstruction},
 };
-use compiler::executable::insert::VariableSource;
 use concept::thing::thing_manager::ThingManager;
 use ir::pipeline::ParameterRegistry;
 use storage::snapshot::WritableSnapshot;

--- a/executor/read/step_executor.rs
+++ b/executor/read/step_executor.rs
@@ -337,7 +337,7 @@ pub(super) fn create_executors_for_function_pipeline_stages(
             );
             Ok(vec![StepExecutors::CollectingStage(step)])
         }
-        ExecutableStage::Insert(_) | ExecutableStage::Update(_) | ExecutableStage::Delete(_) => {
+        ExecutableStage::Insert(_) | ExecutableStage::Update(_) | ExecutableStage::Put(_) | ExecutableStage::Delete(_) => {
             unreachable!(
                 "Not allowed in function pipelines. TODO: Accept flag for whether this is a write pipeline & port the write stages here."
             )

--- a/executor/read/step_executor.rs
+++ b/executor/read/step_executor.rs
@@ -337,7 +337,10 @@ pub(super) fn create_executors_for_function_pipeline_stages(
             );
             Ok(vec![StepExecutors::CollectingStage(step)])
         }
-        ExecutableStage::Insert(_) | ExecutableStage::Update(_) | ExecutableStage::Put(_) | ExecutableStage::Delete(_) => {
+        ExecutableStage::Insert(_)
+        | ExecutableStage::Update(_)
+        | ExecutableStage::Put(_)
+        | ExecutableStage::Delete(_) => {
             unreachable!(
                 "Not allowed in function pipelines. TODO: Accept flag for whether this is a write pipeline & port the write stages here."
             )

--- a/executor/row.rs
+++ b/executor/row.rs
@@ -62,7 +62,7 @@ impl<'a> Row<'a> {
         mapping: impl Iterator<Item = (VariablePosition, VariablePosition)>,
     ) {
         for (src, dst) in mapping {
-            if row.len() > src.as_usize() {
+            if src.as_usize() < row.len() {
                 self.set(dst, row.get(src).clone().into_owned());
             }
         }

--- a/executor/tests/writes.rs
+++ b/executor/tests/writes.rs
@@ -179,6 +179,7 @@ fn execute_insert<Snapshot: WritableSnapshot + 'static>(
         &entry_annotations,
         &translation_context.variable_registry,
         None,
+        None,
     )
     .unwrap();
 

--- a/ir/lib.rs
+++ b/ir/lib.rs
@@ -225,6 +225,12 @@ typedb_error! {
             "Illegal statement provided for an update stage. Only 'update $0 has $1' and 'update $0 links $1' are allowed.",
             source_span: Option<Span>,
         ),
+        IllegalStatementForPut(
+            43,
+            "Illegal statement '{constraint_type}' provided for a put stage. Only 'has', 'links' and 'isa' constraints are allowed.",
+            constraint_type: String,
+            source_span: Option<Span>,
+        ),
         RegexExpectedStringLiteral(50,
             "Expected a string literal as regex.",
             source_span: Option<Span>

--- a/ir/pattern/constraint.rs
+++ b/ir/pattern/constraint.rs
@@ -531,8 +531,8 @@ impl<ID: IrID> Constraint<ID> {
             Constraint::Links(_) => typeql::token::Keyword::Links.as_str(),
             Constraint::IndexedRelation(_) => "indexed-relation",
             Constraint::Has(_) => typeql::token::Keyword::Has.as_str(),
-            Constraint::ExpressionBinding(_) => typeql::token::Comparator::Eq.as_str(),
-            Constraint::FunctionCallBinding(_) => "=/in",
+            Constraint::ExpressionBinding(_) => "expression",
+            Constraint::FunctionCallBinding(_) => "function-call",
             Constraint::Comparison(comp) => comp.comparator.name(),
             Constraint::Owns(_) => typeql::token::Keyword::Owns.as_str(),
             Constraint::Relates(_) => typeql::token::Keyword::Relates.as_str(),
@@ -540,7 +540,7 @@ impl<ID: IrID> Constraint<ID> {
             Constraint::Value(_) => typeql::token::Keyword::Value.as_str(),
 
             Constraint::RoleName(_) => "role-name",
-            Constraint::LinksDeduplication(_) => "role-player-deduplication",
+            Constraint::LinksDeduplication(_) => "links-deduplication",
             Constraint::Unsatisfiable(_) => "optimised-away",
         }
     }
@@ -665,6 +665,30 @@ impl<ID: IrID> Constraint<ID> {
             Self::Value(inner) => Constraint::Value(inner.map(mapping)),
             Self::LinksDeduplication(inner) => Constraint::LinksDeduplication(inner.map(mapping)),
             Self::Unsatisfiable(inner) => Constraint::Unsatisfiable(inner.map(mapping)),
+        }
+    }
+
+    pub(crate) fn source_span(&self) -> Option<Span> {
+        match self {
+            Constraint::Is(inner) => inner.source_span(),
+            Constraint::Kind(inner) => None,
+            Constraint::Label(inner) => inner.source_span(),
+            Constraint::RoleName(inner) => inner.source_span(),
+            Constraint::Sub(inner) => inner.source_span(),
+            Constraint::Isa(inner) => inner.source_span(),
+            Constraint::Iid(inner) => inner.source_span(),
+            Constraint::Links(inner) => inner.source_span(),
+            Constraint::IndexedRelation(inner) => inner.source_span(),
+            Constraint::Has(inner) => inner.source_span(),
+            Constraint::ExpressionBinding(inner) => inner.source_span(),
+            Constraint::FunctionCallBinding(inner) => inner.source_span(),
+            Constraint::Comparison(inner) => inner.source_span(),
+            Constraint::Owns(inner) => inner.source_span(),
+            Constraint::Relates(inner) => inner.source_span(),
+            Constraint::Plays(inner) => inner.source_span(),
+            Constraint::Value(inner) => inner.source_span(),
+            Constraint::LinksDeduplication(inner) => None,
+            Constraint::Unsatisfiable(inner) => None,
         }
     }
 

--- a/ir/translation/function.rs
+++ b/ir/translation/function.rs
@@ -128,7 +128,10 @@ pub(crate) fn translate_function_block(
             })?;
 
     let has_illegal_stages = stages.iter().any(|stage| match stage {
-        TranslatedStage::Insert { .. } | TranslatedStage::Update { .. } | TranslatedStage::Put { .. } | TranslatedStage::Delete { .. } => true,
+        TranslatedStage::Insert { .. }
+        | TranslatedStage::Update { .. }
+        | TranslatedStage::Put { .. }
+        | TranslatedStage::Delete { .. } => true,
         TranslatedStage::Match { .. }
         | TranslatedStage::Distinct(_)
         | TranslatedStage::Require(_)

--- a/ir/translation/function.rs
+++ b/ir/translation/function.rs
@@ -128,7 +128,7 @@ pub(crate) fn translate_function_block(
             })?;
 
     let has_illegal_stages = stages.iter().any(|stage| match stage {
-        TranslatedStage::Insert { .. } | TranslatedStage::Update { .. } | TranslatedStage::Delete { .. } => true,
+        TranslatedStage::Insert { .. } | TranslatedStage::Update { .. } | TranslatedStage::Put { .. } | TranslatedStage::Delete { .. } => true,
         TranslatedStage::Match { .. }
         | TranslatedStage::Distinct(_)
         | TranslatedStage::Require(_)

--- a/ir/translation/pipeline.rs
+++ b/ir/translation/pipeline.rs
@@ -37,12 +37,11 @@ use crate::{
             translate_distinct, translate_limit, translate_offset, translate_require, translate_select, translate_sort,
         },
         reduce::translate_reduce,
-        writes::{translate_delete, translate_insert, translate_update},
+        writes::{translate_delete, translate_insert, translate_put, translate_update},
         TranslationContext,
     },
     RepresentationError,
 };
-use crate::translation::writes::translate_put;
 
 #[derive(Debug, Clone)]
 pub struct TranslatedPipeline {

--- a/ir/translation/pipeline.rs
+++ b/ir/translation/pipeline.rs
@@ -75,6 +75,7 @@ pub enum TranslatedStage {
     Match { block: Block, source_span: Option<Span> },
     Insert { block: Block, source_span: Option<Span> },
     Update { block: Block, source_span: Option<Span> },
+    Put { block: Block, source_span: Option<Span> },
     Delete { block: Block, deleted_variables: Vec<Variable>, source_span: Option<Span> },
 
     // ...
@@ -85,7 +86,6 @@ pub enum TranslatedStage {
     Require(Require),
     Reduce(Reduce),
     Distinct(Distinct),
-    Put { block: Block, source_span: Option<Span> },
 }
 
 impl TranslatedStage {

--- a/ir/translation/pipeline.rs
+++ b/ir/translation/pipeline.rs
@@ -42,6 +42,7 @@ use crate::{
     },
     RepresentationError,
 };
+use crate::translation::writes::translate_put;
 
 #[derive(Debug, Clone)]
 pub struct TranslatedPipeline {
@@ -85,6 +86,7 @@ pub enum TranslatedStage {
     Require(Require),
     Reduce(Reduce),
     Distinct(Distinct),
+    Put { block: Block, source_span: Option<Span> },
 }
 
 impl TranslatedStage {
@@ -93,6 +95,7 @@ impl TranslatedStage {
             Self::Match { block, .. }
             | Self::Insert { block, .. }
             | Self::Update { block, .. }
+            | Self::Put { block, .. }
             | Self::Delete { block, .. } => Box::new(block.variables()),
             Self::Select(select) => Box::new(select.variables.iter().cloned()),
             Self::Sort(sort) => Box::new(sort.variables.iter().map(|sort_var| sort_var.variable())),
@@ -112,6 +115,7 @@ impl StructuralEquality for TranslatedStage {
                 Self::Match { block, .. } => block.hash(),
                 Self::Insert { block, .. } => block.hash(),
                 Self::Update { block, .. } => block.hash(),
+                Self::Put { block, .. } => block.hash(),
                 Self::Delete { block, deleted_variables, .. } => {
                     let mut hasher = DefaultHasher::new();
                     block.hash_into(&mut hasher);
@@ -132,6 +136,7 @@ impl StructuralEquality for TranslatedStage {
         match (self, other) {
             (Self::Match { block, .. }, Self::Match { block: other_block, .. }) => block.equals(other_block),
             (Self::Insert { block, .. }, Self::Insert { block: other_block, .. }) => block.equals(other_block),
+            (Self::Put { block, .. }, Self::Put { block: other_block, .. }) => block.equals(other_block),
             (Self::Update { block, .. }, Self::Update { block: other_block, .. }) => block.equals(other_block),
             (Self::Delete { block, .. }, Self::Delete { block: other_block, .. }) => block.equals(other_block),
             (Self::Select(select), Self::Select(other_select)) => select.equals(other_select),
@@ -145,6 +150,7 @@ impl StructuralEquality for TranslatedStage {
             (Self::Match { .. }, _)
             | (Self::Insert { .. }, _)
             | (Self::Update { .. }, _)
+            | (Self::Put { .. }, _)
             | (Self::Delete { .. }, _)
             | (Self::Select { .. }, _)
             | (Self::Sort { .. }, _)
@@ -233,6 +239,8 @@ fn translate_stage(
             .map(|block| Either::First(TranslatedStage::Insert { block, source_span: insert.span() })),
         TypeQLStage::Update(update) => translate_update(translation_context, value_parameters, update)
             .map(|block| Either::First(TranslatedStage::Update { block, source_span: update.span() })),
+        TypeQLStage::Put(put) => translate_put(translation_context, value_parameters, put)
+            .map(|block| Either::First(TranslatedStage::Put { block, source_span: put.span() })),
         TypeQLStage::Delete(delete) => {
             translate_delete(translation_context, value_parameters, delete).map(|(block, deleted_variables)| {
                 Either::First(TranslatedStage::Delete { block, deleted_variables, source_span: delete.span() })
@@ -261,6 +269,5 @@ fn translate_stage(
             TypeQLOperator::Distinct(distinct) => translate_distinct(translation_context, distinct)
                 .map(|distinct| Either::First(TranslatedStage::Distinct(distinct))),
         },
-        _ => Err(Box::new(RepresentationError::UnrecognisedClause { source_span: typeql_stage.span() })),
     }
 }

--- a/ir/translation/writes.rs
+++ b/ir/translation/writes.rs
@@ -7,11 +7,10 @@
 use answer::variable::Variable;
 use typeql::{
     common::{Span, Spanned},
-    query::stage::delete::DeletableKind,
+    query::stage::{delete::DeletableKind, Put},
     statement::thing::{Constraint, HasValue, Head, RolePlayer},
     Expression, Identifier, Statement,
 };
-use typeql::query::stage::Put;
 
 use crate::{
     pipeline::{block::Block, function_signature::HashMapFunctionSignatureIndex, ParameterRegistry},
@@ -64,11 +63,10 @@ pub fn translate_update(
     builder.finish()
 }
 
-
 pub fn translate_put(
     context: &mut TranslationContext,
     value_parameters: &mut ParameterRegistry,
-    put: &Put
+    put: &Put,
 ) -> Result<Block, Box<RepresentationError>> {
     let mut builder = Block::builder(context.new_block_builder_context(value_parameters));
     let function_index = HashMapFunctionSignatureIndex::empty();

--- a/ir/translation/writes.rs
+++ b/ir/translation/writes.rs
@@ -11,6 +11,7 @@ use typeql::{
     statement::thing::{Constraint, HasValue, Head, RolePlayer},
     Expression, Identifier, Statement,
 };
+use typeql::query::stage::Put;
 
 use crate::{
     pipeline::{block::Block, function_signature::HashMapFunctionSignatureIndex, ParameterRegistry},
@@ -58,6 +59,20 @@ pub fn translate_update(
     let mut builder = Block::builder(context.new_block_builder_context(value_parameters));
     let function_index = HashMapFunctionSignatureIndex::empty();
     for statement in &update.statements {
+        add_statement(&function_index, &mut builder.conjunction_mut(), statement)?;
+    }
+    builder.finish()
+}
+
+
+pub fn translate_put(
+    context: &mut TranslationContext,
+    value_parameters: &mut ParameterRegistry,
+    put: &Put
+) -> Result<Block, Box<RepresentationError>> {
+    let mut builder = Block::builder(context.new_block_builder_context(value_parameters));
+    let function_index = HashMapFunctionSignatureIndex::empty();
+    for statement in &put.statements {
         add_statement(&function_index, &mut builder.conjunction_mut(), statement)?;
     }
     builder.finish()

--- a/resource/constants.rs
+++ b/resource/constants.rs
@@ -86,6 +86,8 @@ pub mod concept {
 
 pub mod traversal {
     pub const CONSTANT_CONCEPT_LIMIT: usize = 1000;
+    pub const FIXED_BATCH_ROWS_MAX: u32 = 64;
+    pub const BATCH_DEFAULT_LENGTH: usize = 10;
 }
 
 pub mod snapshot {

--- a/tests/behaviour/query/language/BUILD
+++ b/tests/behaviour/query/language/BUILD
@@ -72,7 +72,6 @@ rust_test(
     crate_features = ["bazel"],
 )
 
-
 rust_test(
     name = "test_update",
     srcs = ["update.rs"],
@@ -81,6 +80,17 @@ rust_test(
         "@crates//:tokio",
     ],
     data = ["@typedb_behaviour//query/language:update.feature"],
+    crate_features = ["bazel"],
+)
+
+rust_test(
+    name = "test_put",
+    srcs = ["put.rs"],
+    deps = [
+        "//tests/behaviour/steps:steps",
+        "@crates//:tokio",
+    ],
+    data = ["@typedb_behaviour//query/language:put.feature"],
     crate_features = ["bazel"],
 )
 

--- a/tests/behaviour/query/language/put.rs
+++ b/tests/behaviour/query/language/put.rs
@@ -1,0 +1,23 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+#![allow(unexpected_cfgs, reason = "features defined in Bazel targets aren't currently communicated to Cargo")]
+
+use steps::Context;
+
+#[tokio::test]
+async fn test() {
+    // Bazel specific path: when running the test in bazel, the external data from
+    // @typedb_behaviour is stored in a directory that is a sibling to
+    // the working directory.
+    #[cfg(feature = "bazel")]
+    let path = "../typedb_behaviour/query/language/put.feature";
+
+    #[cfg(not(feature = "bazel"))]
+    let path = "bazel-typedb/external/typedb_behaviour/query/language/put.feature";
+
+    assert!(Context::test(path, true).await);
+}


### PR DESCRIPTION
## Release notes: product changes
Implements the `put` stage. 
A `put <pattern>;`will perform an insert if no answers matched `<pattern>`; else, it returns all answers matched by the pattern.
**Note:** The put matches the entire pattern or inserts the entire pattern. Partial matching and partial inserts are not performed.

**Examples**
```
insert $p isa person, has name "Alice"; # Create some initial data.
```

```
put $p1 isa person, has name "Alice"; # Does nothing
```
```
put $p2 isa person, has name "Bob"; # Creates a person with name Bob
```

```
put $p3 isa person, has name "Alice", has age 10; # Creates a new person with name "Alice" & age 10.
```
The above statement (for $p3) creates a new person because the pattern fails to match, as the existing person with name "Alice" does not have age 10.
To achieve the desired result of not re-creating the person if only the age attribute is missing, `put` stages can be pipelined.
```
put $p4 isa person, has name "Bob"; # Will match the person with name "bob", if it exists.
put $p4 isa person, has age 11; # Adds an attribute to the same person, since we use $p4 again.
```


## Motivation
Feature 'Put'
requires: typedb/typedb-behaviour#346

## Implementation
* Introduces a `PutExecutable` containing a `MatchExecutable` and `InsertExecutable`
* Updates `InsertExecutable` to be able to optionally accept the desired output row format - this allows the match & put to share the same output row format.
* Implements `PutStageExecutor`, whose `into_iterator` method holds the `if not match { insert; } else { match; }` logic.
  - The rows from the previous stage are streamed in, and collected in a batch. A `must_insert` vector is maintained alongside, indicating whether a collected row must perform an insert.
  - For each row, we run the MatchExecutor. If any rows are returned, these are appended to the collector batch and marked as not needing insert.
  - If no rows are returned, we append a new empty row with spaces for the inserted concept.
  - Once all rows are collected, all inserts are performed and then the collected rows are streamed out.