### PR TITLE
Fix concurrent schema and write transactions locking issues

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4221,7 +4221,7 @@ checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
 [[package]]
 name = "typeql"
 version = "0.0.0"
-source = "git+https://github.com/typedb/typeql?rev=5ccc1da728b381286b66cf059df010586eb60b48#5ccc1da728b381286b66cf059df010586eb60b48"
+source = "git+https://github.com/typedb/typeql?rev=d1ef6785b27681bc2296c00e61db793d41f7f018#d1ef6785b27681bc2296c00e61db793d41f7f018"
 dependencies = [
  "chrono",
  "itertools 0.10.5",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ features = {}
 
 	[dev-dependencies.typeql]
 		features = []
-		rev = "5ccc1da728b381286b66cf059df010586eb60b48"
+		rev = "d1ef6785b27681bc2296c00e61db793d41f7f018"
 		git = "https://github.com/typedb/typeql"
 		default-features = false
 
@@ -180,6 +180,10 @@ features = {}
 [[test]]
 	path = "tests/behaviour/query/language/fetch.rs"
 	name = "test_fetch"
+
+[[test]]
+	path = "tests/behaviour/query/language/put.rs"
+	name = "test_put"
 
 [[test]]
 	path = "tests/behaviour/query/language/expressions.rs"

--- a/common/error/Cargo.toml
+++ b/common/error/Cargo.toml
@@ -21,7 +21,7 @@ features = {}
 
 	[dependencies.typeql]
 		features = []
-		rev = "5ccc1da728b381286b66cf059df010586eb60b48"
+		rev = "d1ef6785b27681bc2296c00e61db793d41f7f018"
 		git = "https://github.com/typedb/typeql"
 		default-features = false
 

--- a/common/structural_equality/Cargo.toml
+++ b/common/structural_equality/Cargo.toml
@@ -21,7 +21,7 @@ features = {}
 
 	[dependencies.typeql]
 		features = []
-		rev = "5ccc1da728b381286b66cf059df010586eb60b48"
+		rev = "d1ef6785b27681bc2296c00e61db793d41f7f018"
 		git = "https://github.com/typedb/typeql"
 		default-features = false
 

--- a/compiler/Cargo.toml
+++ b/compiler/Cargo.toml
@@ -58,7 +58,7 @@ features = {}
 
 	[dependencies.typeql]
 		features = []
-		rev = "5ccc1da728b381286b66cf059df010586eb60b48"
+		rev = "d1ef6785b27681bc2296c00e61db793d41f7f018"
 		git = "https://github.com/typedb/typeql"
 		default-features = false
 

--- a/concept/Cargo.toml
+++ b/concept/Cargo.toml
@@ -128,7 +128,7 @@ features = {}
 
 	[dependencies.typeql]
 		features = []
-		rev = "5ccc1da728b381286b66cf059df010586eb60b48"
+		rev = "d1ef6785b27681bc2296c00e61db793d41f7f018"
 		git = "https://github.com/typedb/typeql"
 		default-features = false
 

--- a/concept/type_/relation_type.rs
+++ b/concept/type_/relation_type.rs
@@ -301,12 +301,10 @@ impl RelationType {
     ) -> Result<HashSet<Relates>, Box<ConceptReadError>> {
         self.get_relates_declared(snapshot, type_manager)?
             .iter()
-            .filter_map(|relates| {
-                match relates.is_implicit(snapshot, type_manager) {
-                    Ok(false) => Some(Ok(*relates)),
-                    Ok(true) => None,
-                    Err(err) => return Some(Err(err)),
-                }
+            .filter_map(|relates| match relates.is_implicit(snapshot, type_manager) {
+                Ok(false) => Some(Ok(*relates)),
+                Ok(true) => None,
+                Err(err) => return Some(Err(err)),
             })
             .try_collect()
     }
@@ -326,12 +324,10 @@ impl RelationType {
     ) -> Result<HashSet<Relates>, Box<ConceptReadError>> {
         self.get_relates(snapshot, type_manager)?
             .iter()
-            .filter_map(|relates| {
-                match relates.is_implicit(snapshot, type_manager) {
-                    Ok(false) => Some(Ok(*relates)),
-                    Ok(true) => None,
-                    Err(err) => return Some(Err(err)),
-                }
+            .filter_map(|relates| match relates.is_implicit(snapshot, type_manager) {
+                Ok(false) => Some(Ok(*relates)),
+                Ok(true) => None,
+                Err(err) => return Some(Err(err)),
             })
             .try_collect()
     }

--- a/database/Cargo.toml
+++ b/database/Cargo.toml
@@ -103,11 +103,15 @@ features = {}
 
 	[dependencies.typeql]
 		features = []
-		rev = "5ccc1da728b381286b66cf059df010586eb60b48"
+		rev = "d1ef6785b27681bc2296c00e61db793d41f7f018"
 		git = "https://github.com/typedb/typeql"
 		default-features = false
 
 [[test]]
 	path = "tests/database.rs"
 	name = "test_database"
+
+[[test]]
+	path = "tests/transaction.rs"
+	name = "test_transaction"
 

--- a/database/database.rs
+++ b/database/database.rs
@@ -183,19 +183,47 @@ impl<D> Database<D> {
         guard: &mut MutexGuard<'_, (bool, usize, VecDeque<TransactionReservationRequest>)>,
     ) {
         let (has_schema_transaction, running_write_transactions, notify_queue) = &mut **guard;
-        if notify_queue.is_empty() {
-            return;
-        }
-        let head = notify_queue.pop_front().unwrap();
-        if let TransactionReservationRequest::Schema(notifier) = head {
-            // fulfill exactly 1 schema request
-            *has_schema_transaction = true;
-            let _skipped_sync_error = notifier.send(()).ok();
-        } else {
-            // fulfill as many write requests as possible
-            while let Some(TransactionReservationRequest::Write(notifier)) = notify_queue.pop_front() {
-                *running_write_transactions += 1;
-                let _skipped_sync_error = notifier.send(()).ok();
+
+        loop {
+            let (next_schema, next_write) = match notify_queue.front() {
+                Some(TransactionReservationRequest::Schema(_)) => (true, false),
+                Some(TransactionReservationRequest::Write(_)) => (false, true),
+                None => (false, false),
+            };
+
+            if next_schema {
+                if *running_write_transactions > 0 {
+                    // wait for the write queries to finish, leave the request in the queue
+                    break;
+                }
+                let TransactionReservationRequest::Schema(notifier) =
+                    notify_queue.pop_front().expect("Expected the next schema request")
+                else {
+                    panic!("Expected the next schema request: the queue cannot be changed")
+                };
+                match notifier.send(()).ok() {
+                    Some(_) => {
+                        // fulfill exactly 1 awaiting schema request
+                        *has_schema_transaction = true;
+                        break;
+                    }
+                    None => {}
+                }
+            } else if next_write {
+                let TransactionReservationRequest::Write(notifier) =
+                    notify_queue.pop_front().expect("Expected the next write request")
+                else {
+                    panic!("Expected the next write request: the queue cannot be changed")
+                };
+                match notifier.send(()).ok() {
+                    Some(_) => {
+                        // fulfill as many write requests as possible
+                        *running_write_transactions += 1;
+                    }
+                    None => {}
+                }
+            } else {
+                break;
             }
         }
     }

--- a/database/tests/BUILD
+++ b/database/tests/BUILD
@@ -9,7 +9,7 @@ package(default_visibility = ["//visibility:public",])
 rust_test(
     name = "test_database",
     srcs = glob([
-        "*.rs",
+        "database.rs",
     ]),
     deps = [
         "//common/logger",
@@ -20,6 +20,25 @@ rust_test(
 
         "@crates//:rocksdb",
         "@crates//:tracing",
+    ]
+)
+
+rust_test(
+    name = "test_transaction",
+    srcs = glob([
+        "transaction.rs",
+    ]),
+    deps = [
+        "//common/logger",
+        "//common/options",
+        "//database",
+        "//encoding",
+        "//storage",
+        "//util/test:test_utils",
+
+        "@crates//:rocksdb",
+        "@crates//:tracing",
+        "@crates//:tokio",
     ]
 )
 

--- a/database/tests/transaction.rs
+++ b/database/tests/transaction.rs
@@ -1,0 +1,845 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+use std::{
+    sync::Arc,
+    time::{Duration, Instant},
+};
+
+use database::{
+    database_manager::DatabaseManager,
+    transaction::{TransactionError, TransactionRead, TransactionSchema, TransactionWrite},
+    Database,
+};
+use options::TransactionOptions;
+use storage::durability_client::WALClient;
+use test_utils::{create_tmp_dir, init_logging, TempDir};
+use tokio::{
+    runtime::Runtime,
+    sync::{broadcast, mpsc, Notify},
+    time::sleep,
+};
+
+const DB_NAME: &'static str = "test";
+
+macro_rules! assert_ok {
+    ($res:ident) => {
+        assert!($res.is_ok(), "{:?}", $res.as_ref().unwrap_err());
+    };
+}
+
+macro_rules! assert_transaction_timeout {
+    ($error:ident) => {
+        let error_str = format!("{:?}", $error);
+        assert!(error_str.contains("Transaction timeout"));
+    };
+}
+
+fn create_database(databases_path: &TempDir) -> Arc<Database<WALClient>> {
+    let database_manager = DatabaseManager::new(databases_path).expect("Expected database manager");
+    database_manager.create_database(DB_NAME).expect("Expected database creation");
+    database_manager.database(DB_NAME).expect("Expected database retrieval")
+}
+
+fn open_schema(database: Arc<Database<WALClient>>) -> TransactionSchema<WALClient> {
+    let open_result = TransactionSchema::open(database, TransactionOptions::default());
+    assert_ok!(open_result);
+    open_result.unwrap()
+}
+
+fn open_write(database: Arc<Database<WALClient>>) -> TransactionWrite<WALClient> {
+    let open_result = TransactionWrite::open(database, TransactionOptions::default());
+    assert_ok!(open_result);
+    open_result.unwrap()
+}
+
+fn open_read(database: Arc<Database<WALClient>>) -> TransactionRead<WALClient> {
+    let open_result = TransactionRead::open(database, TransactionOptions::default());
+    assert_ok!(open_result);
+    open_result.unwrap()
+}
+
+fn transaction_sleep_timeout() -> Duration {
+    let lock_timeout_millis = TransactionOptions::default().schema_lock_acquire_timeout_millis;
+    let timeout_diff_millis = 5000;
+    assert!(
+        lock_timeout_millis > timeout_diff_millis,
+        "The transaction timeout has changed, tweak the test's sleep duration!"
+    );
+    Duration::from_millis(lock_timeout_millis - timeout_diff_millis)
+}
+
+////////////////////////////////
+// OPEN-CLOSE-COMMIT-ROLLBACK //
+////////////////////////////////
+
+#[test]
+fn open_close_schema_transaction() {
+    init_logging();
+    let databases_path = create_tmp_dir();
+    let database = create_database(&databases_path);
+    let mut tx_schema = open_schema(database.clone());
+    tx_schema.close()
+}
+
+#[test]
+fn open_rollback_schema_transaction() {
+    init_logging();
+    let databases_path = create_tmp_dir();
+    let database = create_database(&databases_path);
+    let mut tx_schema = open_schema(database.clone());
+    tx_schema.rollback()
+}
+
+#[test]
+fn open_commit_schema_transaction() {
+    init_logging();
+    let databases_path = create_tmp_dir();
+    let database = create_database(&databases_path);
+    let mut tx_schema = open_schema(database.clone());
+    let commit_result = tx_schema.commit();
+    assert_ok!(commit_result);
+}
+
+#[test]
+fn open_close_write_transaction() {
+    init_logging();
+    let databases_path = create_tmp_dir();
+    let database = create_database(&databases_path);
+    let mut tx_write = open_write(database.clone());
+    tx_write.close()
+}
+
+#[test]
+fn open_rollback_write_transaction() {
+    init_logging();
+    let databases_path = create_tmp_dir();
+    let database = create_database(&databases_path);
+    let mut tx_write = open_write(database.clone());
+    tx_write.rollback()
+}
+
+#[test]
+fn open_commit_write_transaction() {
+    init_logging();
+    let databases_path = create_tmp_dir();
+    let database = create_database(&databases_path);
+    let mut tx_write = open_write(database.clone());
+    let commit_result = tx_write.commit();
+    assert_ok!(commit_result);
+}
+
+#[test]
+fn open_close_read_transaction() {
+    init_logging();
+    let databases_path = create_tmp_dir();
+    let database = create_database(&databases_path);
+    let mut tx_read = open_read(database.clone());
+    tx_read.close()
+}
+
+/////////////////////////////
+// SCHEMA TRANSACTION LOCK //
+/////////////////////////////
+
+#[test]
+fn schema_transaction_blocks_concurrent_schema_transactions() {
+    init_logging();
+    let databases_path = create_tmp_dir();
+    let database = create_database(&databases_path);
+
+    let runtime = Runtime::new().expect("Expected runtime");
+    runtime.block_on(async move {
+        let database_clone = database.clone();
+        let _tx_schema = open_schema(database_clone);
+
+        tokio::spawn(async move {
+            let error = TransactionSchema::open(database, TransactionOptions::default()).unwrap_err();
+            assert_transaction_timeout!(error);
+        })
+        .await
+        .unwrap();
+    });
+}
+
+#[test]
+fn schema_transaction_blocks_concurrent_write_transactions() {
+    init_logging();
+    let databases_path = create_tmp_dir();
+    let database = create_database(&databases_path);
+
+    let _tx_schema = open_schema(database.clone());
+    let write_error = TransactionWrite::open(database, TransactionOptions::default()).unwrap_err();
+    let error_str = format!("{write_error:?}");
+    assert!(error_str.contains("Transaction timeout"));
+}
+
+#[test]
+fn schema_transaction_does_not_block_concurrent_read_transactions() {
+    init_logging();
+    let databases_path = create_tmp_dir();
+    let database = create_database(&databases_path);
+
+    let runtime = Runtime::new().expect("Expected runtime");
+    runtime
+        .block_on(async move {
+            let database_clone = database.clone();
+            let notify_transaction1_ready = Arc::new(Notify::new());
+            let notify_transaction1_ready_clone = notify_transaction1_ready.clone();
+
+            let task1 = tokio::spawn(async move {
+                let _tx_schema = open_schema(database);
+                notify_transaction1_ready.notify_one();
+            });
+
+            let task2 = tokio::spawn(async move {
+                notify_transaction1_ready_clone.notified().await;
+                let _tx_read = open_read(database_clone);
+            });
+
+            tokio::try_join!(task1, task2)
+        })
+        .unwrap();
+}
+
+#[test]
+fn schema_transaction_can_be_opened_after_prior_timeout_error() {
+    init_logging();
+    let databases_path = create_tmp_dir();
+    let database = create_database(&databases_path);
+
+    let runtime = Runtime::new().expect("Expected runtime");
+    runtime
+        .block_on(async move {
+            let database_clone = database.clone();
+            let notify_transaction2_failed = Arc::new(Notify::new());
+            let notify_transaction2_failed_clone = notify_transaction2_failed.clone();
+            let notify_transaction1_done = Arc::new(Notify::new());
+            let notify_transaction1_done_clone = notify_transaction1_done.clone();
+
+            let mut tx_schema = open_schema(database_clone);
+            let task1 = tokio::spawn(async move {
+                notify_transaction2_failed_clone.notified().await;
+                tx_schema.close();
+                notify_transaction1_done.notify_one();
+            });
+
+            let task2 = tokio::spawn(async move {
+                let database_clone = database.clone();
+                let error = TransactionSchema::open(database_clone, TransactionOptions::default()).unwrap_err();
+                assert_transaction_timeout!(error);
+                notify_transaction2_failed.notify_one();
+                notify_transaction1_done_clone.notified().await;
+                let _tx_schema = open_schema(database);
+            });
+
+            tokio::try_join!(task1, task2)
+        })
+        .unwrap();
+}
+
+#[test]
+fn schema_transaction_close_unblocks_concurrent_schema_transactions() {
+    init_logging();
+    let databases_path = create_tmp_dir();
+    let database = create_database(&databases_path);
+
+    let runtime = Runtime::new().expect("Expected runtime");
+    runtime
+        .block_on(async move {
+            let database_clone = database.clone();
+            let notify_transaction1_ready = Arc::new(Notify::new());
+            let notify_transaction1_ready_clone = notify_transaction1_ready.clone();
+
+            let task1 = tokio::spawn(async move {
+                let mut tx_schema = open_schema(database);
+                notify_transaction1_ready.notify_one();
+                sleep(transaction_sleep_timeout()).await;
+                tx_schema.close();
+            });
+
+            let task2 = tokio::spawn(async move {
+                notify_transaction1_ready_clone.notified().await;
+                let _tx_schema = open_schema(database_clone);
+            });
+
+            tokio::try_join!(task1, task2)
+        })
+        .unwrap();
+}
+
+#[test]
+fn schema_transaction_commit_unblocks_concurrent_schema_transactions() {
+    init_logging();
+    let databases_path = create_tmp_dir();
+    let database = create_database(&databases_path);
+
+    let runtime = Runtime::new().expect("Expected runtime");
+    runtime
+        .block_on(async move {
+            let database_clone = database.clone();
+            let notify_transaction1_ready = Arc::new(Notify::new());
+            let notify_transaction1_ready_clone = notify_transaction1_ready.clone();
+
+            let task1 = tokio::spawn(async move {
+                let mut tx_schema = open_schema(database);
+                notify_transaction1_ready.notify_one();
+                sleep(transaction_sleep_timeout()).await;
+                tx_schema.commit().expect("Expected commit");
+            });
+
+            let task2 = tokio::spawn(async move {
+                notify_transaction1_ready_clone.notified().await;
+                let _tx_schema = open_schema(database_clone);
+            });
+
+            tokio::try_join!(task1, task2)
+        })
+        .unwrap();
+}
+
+#[test]
+fn schema_transaction_rollback_does_not_unblock_concurrent_schema_transactions() {
+    init_logging();
+    let databases_path = create_tmp_dir();
+    let database = create_database(&databases_path);
+
+    let runtime = Runtime::new().expect("Expected runtime");
+    runtime
+        .block_on(async move {
+            let database_clone = database.clone();
+            let notify_transaction1_ready = Arc::new(Notify::new());
+            let notify_transaction1_ready_clone = notify_transaction1_ready.clone();
+
+            let task1 = tokio::spawn(async move {
+                let mut tx_schema = open_schema(database);
+                notify_transaction1_ready.notify_one();
+                sleep(transaction_sleep_timeout()).await;
+                tx_schema.rollback();
+            });
+
+            let task2 = tokio::spawn(async move {
+                notify_transaction1_ready_clone.notified().await;
+                let error = TransactionSchema::open(database_clone, TransactionOptions::default()).unwrap_err();
+                assert_transaction_timeout!(error);
+            });
+
+            tokio::try_join!(task1, task2)
+        })
+        .unwrap();
+}
+
+#[test]
+fn schema_transaction_close_unblocks_concurrent_write_transactions() {
+    init_logging();
+    let databases_path = create_tmp_dir();
+    let database = create_database(&databases_path);
+
+    let runtime = Runtime::new().expect("Expected runtime");
+    runtime
+        .block_on(async move {
+            let database_clone = database.clone();
+            let notify_transaction1_ready = Arc::new(Notify::new());
+            let notify_transaction1_ready_clone = notify_transaction1_ready.clone();
+
+            let task1 = tokio::spawn(async move {
+                let mut tx_schema = open_schema(database);
+                notify_transaction1_ready.notify_one();
+                sleep(transaction_sleep_timeout()).await;
+                tx_schema.close();
+            });
+
+            let task2 = tokio::spawn(async move {
+                notify_transaction1_ready_clone.notified().await;
+                let _tx_write = open_write(database_clone);
+            });
+
+            tokio::try_join!(task1, task2)
+        })
+        .unwrap();
+}
+
+#[test]
+fn schema_transaction_commit_unblocks_concurrent_write_transactions() {
+    init_logging();
+    let databases_path = create_tmp_dir();
+    let database = create_database(&databases_path);
+
+    let runtime = Runtime::new().expect("Expected runtime");
+    runtime
+        .block_on(async move {
+            let database_clone = database.clone();
+            let notify_transaction1_ready = Arc::new(Notify::new());
+            let notify_transaction1_ready_clone = notify_transaction1_ready.clone();
+
+            let task1 = tokio::spawn(async move {
+                let mut tx_schema = open_schema(database);
+                notify_transaction1_ready.notify_one();
+                sleep(transaction_sleep_timeout()).await;
+                tx_schema.commit().expect("Expected commit");
+            });
+
+            let task2 = tokio::spawn(async move {
+                notify_transaction1_ready_clone.notified().await;
+                let _tx_write = open_write(database_clone);
+            });
+
+            tokio::try_join!(task1, task2)
+        })
+        .unwrap();
+}
+
+#[test]
+fn schema_transaction_rollback_does_not_unblock_concurrent_write_transactions() {
+    init_logging();
+    let databases_path = create_tmp_dir();
+    let database = create_database(&databases_path);
+
+    let runtime = Runtime::new().expect("Expected runtime");
+    runtime
+        .block_on(async move {
+            let database_clone = database.clone();
+            let notify_transaction1_ready = Arc::new(Notify::new());
+            let notify_transaction1_ready_clone = notify_transaction1_ready.clone();
+
+            let task1 = tokio::spawn(async move {
+                let mut tx_schema = open_schema(database);
+                notify_transaction1_ready.notify_one();
+                sleep(transaction_sleep_timeout()).await;
+                tx_schema.rollback();
+            });
+
+            let task2 = tokio::spawn(async move {
+                notify_transaction1_ready_clone.notified().await;
+                let error = TransactionWrite::open(database_clone, TransactionOptions::default()).unwrap_err();
+                assert_transaction_timeout!(error);
+            });
+
+            tokio::try_join!(task1, task2)
+        })
+        .unwrap();
+}
+
+/////////////////////////////
+// WRITE TRANSACTIONS LOCK //
+/////////////////////////////
+
+#[test]
+fn write_transaction_blocks_concurrent_schema_transactions() {
+    init_logging();
+    let databases_path = create_tmp_dir();
+    let database = create_database(&databases_path);
+
+    let runtime = Runtime::new().expect("Expected runtime");
+    runtime.block_on(async move {
+        let database_clone = database.clone();
+        let notify_transaction1_ready = Arc::new(Notify::new());
+        let notify_transaction1_ready_clone = notify_transaction1_ready.clone();
+
+        tokio::spawn(async move {
+            let _tx_write = open_write(database);
+            notify_transaction1_ready.notify_one();
+        })
+        .await
+        .unwrap();
+
+        tokio::spawn(async move {
+            notify_transaction1_ready_clone.notified().await;
+            let error = TransactionSchema::open(database_clone, TransactionOptions::default()).unwrap_err();
+            assert_transaction_timeout!(error);
+        })
+        .await
+        .unwrap();
+    });
+}
+
+#[test]
+fn write_transaction_close_unblocks_concurrent_schema_transactions() {
+    init_logging();
+    let databases_path = create_tmp_dir();
+    let database = create_database(&databases_path);
+
+    let runtime = Runtime::new().expect("Expected runtime");
+    runtime
+        .block_on(async move {
+            let database_clone = database.clone();
+            let notify_transaction1_ready = Arc::new(Notify::new());
+            let notify_transaction1_ready_clone = notify_transaction1_ready.clone();
+
+            let task1 = tokio::spawn(async move {
+                let mut tx_write = open_write(database);
+                notify_transaction1_ready.notify_one();
+                sleep(transaction_sleep_timeout()).await;
+                tx_write.close();
+            });
+
+            let task2 = tokio::spawn(async move {
+                notify_transaction1_ready_clone.notified().await;
+                let _tx_schema = open_schema(database_clone);
+            });
+
+            tokio::try_join!(task1, task2)
+        })
+        .unwrap();
+}
+
+#[test]
+fn write_transaction_commit_unblocks_concurrent_schema_transactions() {
+    init_logging();
+    let databases_path = create_tmp_dir();
+    let database = create_database(&databases_path);
+
+    let runtime = Runtime::new().expect("Expected runtime");
+    runtime
+        .block_on(async move {
+            let database_clone = database.clone();
+            let notify_transaction1_ready = Arc::new(Notify::new());
+            let notify_transaction1_ready_clone = notify_transaction1_ready.clone();
+
+            let task1 = tokio::spawn(async move {
+                let mut tx_write = open_write(database);
+                notify_transaction1_ready.notify_one();
+                sleep(transaction_sleep_timeout()).await;
+                tx_write.commit().expect("Expected commit");
+            });
+
+            let task2 = tokio::spawn(async move {
+                notify_transaction1_ready_clone.notified().await;
+                let _tx_schema = open_schema(database_clone);
+            });
+
+            tokio::try_join!(task1, task2)
+        })
+        .unwrap();
+}
+
+#[test]
+fn write_transaction_rollback_does_not_unblock_concurrent_schema_transactions() {
+    init_logging();
+    let databases_path = create_tmp_dir();
+    let database = create_database(&databases_path);
+
+    let runtime = Runtime::new().expect("Expected runtime");
+    runtime
+        .block_on(async move {
+            let database_clone = database.clone();
+            let notify_transaction1_ready = Arc::new(Notify::new());
+            let notify_transaction1_ready_clone = notify_transaction1_ready.clone();
+
+            let task1 = tokio::spawn(async move {
+                let mut tx_write = open_write(database);
+                notify_transaction1_ready.notify_one();
+                sleep(transaction_sleep_timeout()).await;
+                tx_write.rollback();
+            });
+
+            let task2 = tokio::spawn(async move {
+                notify_transaction1_ready_clone.notified().await;
+                let error = TransactionSchema::open(database_clone, TransactionOptions::default()).unwrap_err();
+                assert_transaction_timeout!(error);
+            });
+
+            tokio::try_join!(task1, task2)
+        })
+        .unwrap();
+}
+
+#[test]
+fn write_transaction_does_not_block_concurrent_write_transactions() {
+    init_logging();
+    let databases_path = create_tmp_dir();
+    let database = create_database(&databases_path);
+
+    let runtime = Runtime::new().expect("Expected runtime");
+    runtime
+        .block_on(async move {
+            let database_clone = database.clone();
+            let task1 = tokio::spawn(async move {
+                let _tx_write = open_write(database);
+            });
+
+            let task2 = tokio::spawn(async move {
+                let _tx_write = open_write(database_clone);
+            });
+
+            tokio::try_join!(task1, task2)
+        })
+        .unwrap();
+}
+
+#[test]
+fn write_transaction_does_not_block_concurrent_read_transactions() {
+    init_logging();
+    let databases_path = create_tmp_dir();
+    let database = create_database(&databases_path);
+
+    let _tx_write = open_write(database.clone());
+    let _tx_read = open_read(database);
+}
+
+/////////////////////////////
+// READ TRANSACTIONS LOCK? //
+/////////////////////////////
+
+#[test]
+fn read_transaction_does_not_block_concurrent_schema_transactions() {
+    init_logging();
+    let databases_path = create_tmp_dir();
+    let database = create_database(&databases_path);
+    let _tx_read = open_read(database.clone());
+    let _tx_schema = open_schema(database);
+}
+
+#[test]
+fn read_transaction_does_not_block_concurrent_write_transactions() {
+    init_logging();
+    let databases_path = create_tmp_dir();
+    let database = create_database(&databases_path);
+    let _tx_read = open_read(database.clone());
+    let _tx_write = open_write(database);
+}
+
+#[test]
+fn read_transaction_does_not_block_concurrent_read_transactions() {
+    init_logging();
+    let databases_path = create_tmp_dir();
+    let database = create_database(&databases_path);
+
+    let runtime = Runtime::new().expect("Expected runtime");
+    runtime
+        .block_on(async move {
+            let database_clone = database.clone();
+            let task1 = tokio::spawn(async move {
+                let _tx_read = open_read(database);
+            });
+
+            let task2 = tokio::spawn(async move {
+                let _tx_read = open_read(database_clone);
+            });
+
+            tokio::try_join!(task1, task2)
+        })
+        .unwrap();
+}
+
+////////////////////////////////////
+// COMPLICATED TRANSACTION QUEUES //
+////////////////////////////////////
+
+#[test]
+fn blocked_schema_transactions_progress_one_at_a_time() {
+    init_logging();
+    let databases_path = create_tmp_dir();
+    let database = create_database(&databases_path);
+
+    let runtime = Runtime::new().expect("Expected runtime");
+    runtime.block_on(async move {
+        let database_clone = database.clone();
+        let database_clone_2 = database.clone();
+        let database_clone_3 = database.clone();
+        let database_clone_4 = database.clone();
+        let (sender, mut receiver2) = broadcast::channel(1);
+        let mut receiver3 = sender.subscribe();
+        let mut receiver4 = sender.subscribe();
+        let mut receiver5 = sender.subscribe();
+
+        const MULTIPLIER: u64 = 6;
+        let full_timeout_millis = TransactionOptions::default().schema_lock_acquire_timeout_millis;
+        let timeout_millis = Duration::from_millis(full_timeout_millis / MULTIPLIER);
+
+        let task2 = tokio::spawn(async move {
+            receiver2.recv().await.expect("Expected receiver2");
+            let tx_schema = open_schema(database_clone);
+            sleep(timeout_millis).await;
+            tx_schema.close();
+            Instant::now()
+        });
+
+        let task3 = tokio::spawn(async move {
+            receiver3.recv().await.expect("Expected receiver3");
+            let tx_schema = open_schema(database_clone_2);
+            sleep(timeout_millis).await;
+            tx_schema.close();
+            Instant::now()
+        });
+
+        let task4 = tokio::spawn(async move {
+            receiver4.recv().await.expect("Expected receiver4");
+            let tx_schema = open_schema(database_clone_3);
+            sleep(timeout_millis).await;
+            tx_schema.close();
+            Instant::now()
+        });
+
+        let task5 = tokio::spawn(async move {
+            receiver5.recv().await.expect("Expected receiver5");
+            let tx_schema = open_schema(database_clone_4);
+            sleep(timeout_millis).await;
+            tx_schema.close();
+            Instant::now()
+        });
+
+        let task_main = tokio::spawn(async move {
+            let mut tx_write = open_write(database);
+            sender.send(()).expect("Expected send");;
+            sleep(timeout_millis).await;
+            tx_write.close();
+        });
+
+        let (_, result2, result3, result4, result5) = tokio::join!(task_main, task2, task3, task4, task5);
+        let mut opened = vec![
+            result2.expect("expected result2"),
+            result3.expect("expected result3"),
+            result4.expect("expected result4"),
+            result5.expect("expected result5"),
+        ];
+        opened.sort();
+        assert!(opened.get(1).unwrap().duration_since(*opened.get(0).unwrap()) >= timeout_millis);
+        assert!(opened.get(2).unwrap().duration_since(*opened.get(1).unwrap()) >= timeout_millis);
+        assert!(opened.get(3).unwrap().duration_since(*opened.get(2).unwrap()) >= timeout_millis);
+    });
+}
+
+#[test]
+fn blocked_write_transactions_progress_together() {
+    init_logging();
+    let databases_path = create_tmp_dir();
+    let database = create_database(&databases_path);
+
+    let runtime = Runtime::new().expect("Expected runtime");
+    runtime.block_on(async move {
+        let database_clone = database.clone();
+        let database_clone_2 = database.clone();
+        let database_clone_3 = database.clone();
+        let database_clone_4 = database.clone();
+        let (sender, mut receiver2) = broadcast::channel(1);
+        let mut receiver3 = sender.subscribe();
+        let mut receiver4 = sender.subscribe();
+        let mut receiver5 = sender.subscribe();
+
+        const MULTIPLIER: u64 = 6;
+        let full_timeout_millis = TransactionOptions::default().schema_lock_acquire_timeout_millis;
+        let timeout_millis = Duration::from_millis(full_timeout_millis / MULTIPLIER);
+
+        let task2 = tokio::spawn(async move {
+            receiver2.recv().await.expect("Expected receiver2");
+            let tx_write = open_write(database_clone);
+            sleep(timeout_millis).await;
+            tx_write.close();
+            Instant::now()
+        });
+
+        let task3 = tokio::spawn(async move {
+            receiver3.recv().await.expect("Expected receiver3");
+            let tx_write = open_write(database_clone_2);
+            sleep(timeout_millis).await;
+            tx_write.close();
+            Instant::now()
+        });
+
+        let task4 = tokio::spawn(async move {
+            receiver4.recv().await.expect("Expected receiver4");
+            let tx_write = open_write(database_clone_3);
+            sleep(timeout_millis).await;
+            tx_write.close();
+            Instant::now()
+        });
+
+        let task5 = tokio::spawn(async move {
+            receiver5.recv().await.expect("Expected receiver5");
+            let tx_write = open_write(database_clone_4);
+            sleep(timeout_millis).await;
+            tx_write.close();
+            Instant::now()
+        });
+
+        let task_main = tokio::spawn(async move {
+            let mut tx_schema = open_schema(database);
+            sender.send(()).expect("Expected send");;
+            sleep(timeout_millis).await;
+            tx_schema.close();
+        });
+
+        let (_, result2, result3, result4, result5) = tokio::join!(task_main, task2, task3, task4, task5);
+        let mut opened = vec![
+            result2.expect("expected result2"),
+            result3.expect("expected result3"),
+            result4.expect("expected result4"),
+            result5.expect("expected result5"),
+        ];
+        opened.sort();
+        assert!(opened.get(1).unwrap().duration_since(*opened.get(0).unwrap()) < timeout_millis);
+        assert!(opened.get(2).unwrap().duration_since(*opened.get(1).unwrap()) < timeout_millis);
+        assert!(opened.get(3).unwrap().duration_since(*opened.get(2).unwrap()) < timeout_millis);
+    });
+}
+
+#[test]
+fn blocked_schema_and_write_transactions_can_progress_in_different_orders() {
+    init_logging();
+    let databases_path = create_tmp_dir();
+    let database = create_database(&databases_path);
+
+    let runtime = Runtime::new().expect("Expected runtime");
+    runtime
+        .block_on(async move {
+            let database_clone = database.clone();
+            let database_clone_2 = database.clone();
+            let database_clone_3 = database.clone();
+            let database_clone_4 = database.clone();
+            let (sender, mut receiver2) = broadcast::channel(1);
+            let mut receiver3 = sender.subscribe();
+            let mut receiver4 = sender.subscribe();
+            let mut receiver5 = sender.subscribe();
+
+            const MULTIPLIER: u64 = 6;
+            let full_timeout_millis = TransactionOptions::default().schema_lock_acquire_timeout_millis;
+            let timeout_millis = Duration::from_millis(full_timeout_millis / MULTIPLIER);
+
+            let task_write = tokio::spawn(async move {
+                receiver2.recv().await.expect("Expected receiver2");
+                let tx_write = open_write(database_clone);
+                sleep(timeout_millis).await;
+                tx_write.close();
+                Instant::now()
+            });
+
+            let task_schema = tokio::spawn(async move {
+                receiver3.recv().await.expect("Expected receiver3");
+                let tx_schema = open_schema(database_clone_2);
+                sleep(timeout_millis).await;
+                tx_schema.close();
+                Instant::now()
+            });
+
+            let task_write_2 = tokio::spawn(async move {
+                receiver4.recv().await.expect("Expected receiver4");
+                let tx_write = open_write(database_clone_3);
+                sleep(timeout_millis).await;
+                tx_write.close();
+                Instant::now()
+            });
+
+            let task_schema_2 = tokio::spawn(async move {
+                receiver5.recv().await.expect("Expected receiver5");
+                let tx_schema = open_schema(database_clone_4);
+                sleep(timeout_millis).await;
+                tx_schema.close();
+                Instant::now()
+            });
+
+            let task_main = tokio::spawn(async move {
+                let mut tx_schema = open_schema(database);
+                sender.send(()).expect("Expected send");
+                sleep(timeout_millis).await;
+                tx_schema.close();
+            });
+
+            // We don't care what's the order and the specific timings.
+            // All tasks should eventually progress before the timeout
+            tokio::try_join!(task_main, task_write, task_schema, task_write_2, task_schema_2)
+        })
+        .unwrap();
+}

--- a/diagnostics/Cargo.toml
+++ b/diagnostics/Cargo.toml
@@ -61,7 +61,7 @@ features = {}
 
 	[dependencies.typeql]
 		features = []
-		rev = "5ccc1da728b381286b66cf059df010586eb60b48"
+		rev = "d1ef6785b27681bc2296c00e61db793d41f7f018"
 		git = "https://github.com/typedb/typeql"
 		default-features = false
 

--- a/encoding/Cargo.toml
+++ b/encoding/Cargo.toml
@@ -113,7 +113,7 @@ features = {}
 
 	[dependencies.typeql]
 		features = []
-		rev = "5ccc1da728b381286b66cf059df010586eb60b48"
+		rev = "d1ef6785b27681bc2296c00e61db793d41f7f018"
 		git = "https://github.com/typedb/typeql"
 		default-features = false
 

--- a/executor/Cargo.toml
+++ b/executor/Cargo.toml
@@ -128,7 +128,7 @@ features = {}
 
 	[dependencies.typeql]
 		features = []
-		rev = "5ccc1da728b381286b66cf059df010586eb60b48"
+		rev = "d1ef6785b27681bc2296c00e61db793d41f7f018"
 		git = "https://github.com/typedb/typeql"
 		default-features = false
 

--- a/executor/instruction/mod.rs
+++ b/executor/instruction/mod.rs
@@ -32,8 +32,8 @@ use ir::{
     pipeline::ParameterRegistry,
 };
 use itertools::{Itertools, MinMaxResult};
-use unicase::UniCase;
 use storage::snapshot::ReadableSnapshot;
+use unicase::UniCase;
 
 use crate::{
     instruction::{

--- a/function/Cargo.toml
+++ b/function/Cargo.toml
@@ -93,7 +93,7 @@ features = {}
 
 	[dependencies.typeql]
 		features = []
-		rev = "5ccc1da728b381286b66cf059df010586eb60b48"
+		rev = "d1ef6785b27681bc2296c00e61db793d41f7f018"
 		git = "https://github.com/typedb/typeql"
 		default-features = false
 

--- a/ir/Cargo.toml
+++ b/ir/Cargo.toml
@@ -93,7 +93,7 @@ features = {}
 
 	[dependencies.typeql]
 		features = []
-		rev = "5ccc1da728b381286b66cf059df010586eb60b48"
+		rev = "d1ef6785b27681bc2296c00e61db793d41f7f018"
 		git = "https://github.com/typedb/typeql"
 		default-features = false
 

--- a/query/Cargo.toml
+++ b/query/Cargo.toml
@@ -128,7 +128,7 @@ features = {}
 
 	[dependencies.typeql]
 		features = []
-		rev = "5ccc1da728b381286b66cf059df010586eb60b48"
+		rev = "d1ef6785b27681bc2296c00e61db793d41f7f018"
 		git = "https://github.com/typedb/typeql"
 		default-features = false
 

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -86,7 +86,7 @@ features = {}
 
 	[dependencies.typeql]
 		features = []
-		rev = "5ccc1da728b381286b66cf059df010586eb60b48"
+		rev = "d1ef6785b27681bc2296c00e61db793d41f7f018"
 		git = "https://github.com/typedb/typeql"
 		default-features = false
 

--- a/storage/Cargo.toml
+++ b/storage/Cargo.toml
@@ -133,7 +133,7 @@ features = {}
 
 	[dependencies.typeql]
 		features = []
-		rev = "5ccc1da728b381286b66cf059df010586eb60b48"
+		rev = "d1ef6785b27681bc2296c00e61db793d41f7f018"
 		git = "https://github.com/typedb/typeql"
 		default-features = false
 

--- a/system/Cargo.toml
+++ b/system/Cargo.toml
@@ -76,7 +76,7 @@ features = {}
 
 	[dependencies.typeql]
 		features = []
-		rev = "5ccc1da728b381286b66cf059df010586eb60b48"
+		rev = "d1ef6785b27681bc2296c00e61db793d41f7f018"
 		git = "https://github.com/typedb/typeql"
 		default-features = false
 

--- a/tests/behaviour/steps/Cargo.toml
+++ b/tests/behaviour/steps/Cargo.toml
@@ -81,7 +81,7 @@ features = {}
 
 	[dependencies.typeql]
 		features = []
-		rev = "5ccc1da728b381286b66cf059df010586eb60b48"
+		rev = "d1ef6785b27681bc2296c00e61db793d41f7f018"
 		git = "https://github.com/typedb/typeql"
 		default-features = false
 

--- a/user/Cargo.toml
+++ b/user/Cargo.toml
@@ -46,7 +46,7 @@ features = {}
 
 	[dependencies.typeql]
 		features = []
-		rev = "5ccc1da728b381286b66cf059df010586eb60b48"
+		rev = "d1ef6785b27681bc2296c00e61db793d41f7f018"
 		git = "https://github.com/typedb/typeql"
 		default-features = false
 


### PR DESCRIPTION
## Release notes: product changes
Fix concurrent transactions locking issues, allowing multiple users to open schema and write transactions in parallel with guaranteed safety and availability whenever it's possible.
* When a transaction opening failure originated from the schema lock being held by an existing schema transaction, a deadlock situation appeared, preventing new transactions from being opened after the schema lock release. This does not happen anymore. 
* Schema transaction opening requests could be ignored and rejected on timeout because of preceding write transactions in the request queue, even if they were closed in time. The retry mechanism has been corrected to prevent any request from being ignored. 

## Motivation

## Implementation
See comments.