### PR TITLE
Filter out unnamed variables in expected variable positions of Put stages

### DIFF
--- a/compiler/executable/insert/executable.rs
+++ b/compiler/executable/insert/executable.rs
@@ -77,7 +77,7 @@ pub fn compile(
     )?;
     let mut connection_inserts = Vec::with_capacity(constraints.len());
     add_has(constraints, &variable_positions, variable_registry, &mut connection_inserts)?;
-    add_links(constraints, type_annotations, &variable_positions, variable_registry, &mut connection_inserts)?;
+    add_links(constraints, type_annotations, input_variables, &variable_positions, variable_registry, &mut connection_inserts)?;
 
     Ok(InsertExecutable {
         executable_id: next_executable_id(),
@@ -263,7 +263,8 @@ fn add_has(
 fn add_links(
     constraints: &[Constraint<Variable>],
     type_annotations: &TypeAnnotations,
-    variable_positions: &HashMap<Variable, VariablePosition>,
+    input_variables:  &HashMap<Variable, VariablePosition>, // Strictly input
+    variable_positions: &HashMap<Variable, VariablePosition>, // Also contains ones inserted.
     variable_registry: &VariableRegistry,
     instructions: &mut Vec<ConnectionInstruction>,
 ) -> Result<(), Box<WriteCompilationError>> {
@@ -282,7 +283,7 @@ fn add_links(
             links.source_span(),
         )?;
         let role =
-            resolve_links_role(type_annotations, variable_positions, variable_registry, &named_role_types, links)?;
+            resolve_links_role(type_annotations, input_variables, variable_registry, &named_role_types, links)?;
         instructions.push(ConnectionInstruction::Links(Links { relation, player, role }));
     }
     Ok(())

--- a/compiler/executable/insert/executable.rs
+++ b/compiler/executable/insert/executable.rs
@@ -75,22 +75,9 @@ pub fn compile(
         &mut variable_positions,
         source_span,
     )?;
-
-    #[cfg(debug_assertions)]
-    let mut variable_positions_tmp = variable_positions
-        .iter()
-        .filter(|(var, _)| {
-            !(variable_registry.get_variable_name(**var).is_none()
-                && variable_registry.get_variable_category(**var).unwrap() == VariableCategory::RoleType)
-        })
-        .map(|(k, v)| (k.clone(), v.clone()))
-        .collect::<HashMap<_, _>>();
-    #[cfg(not(debug_assertions))]
-    compile_error!("Remove the above");
-
     let mut connection_inserts = Vec::with_capacity(constraints.len());
     add_has(constraints, &variable_positions, variable_registry, &mut connection_inserts)?;
-    add_links(constraints, type_annotations, &variable_positions_tmp, variable_registry, &mut connection_inserts)?;
+    add_links(constraints, type_annotations, &variable_positions, variable_registry, &mut connection_inserts)?;
 
     Ok(InsertExecutable {
         executable_id: next_executable_id(),

--- a/compiler/executable/pipeline.rs
+++ b/compiler/executable/pipeline.rs
@@ -275,15 +275,12 @@ fn compile_stage(
                 call_cost_provider,
             )
             .map_err(|source| ExecutableCompilationError::PutMatchCompilation { typedb_source: source })?;
-            let selected_variable_positions = match_plan.variable_positions().iter().filter(|(var, pos)| {
-                match_plan.selected_variables().contains(pos)
-            }).map(|(var, pos)| (*var, *pos)).collect();
             let insert_plan = crate::executable::insert::executable::compile(
                 block.conjunction().constraints(),
                 input_variables,
                 insert_annotations,
                 variable_registry,
-                Some(selected_variable_positions),
+                Some(match_plan.variable_positions().clone()),
                 *source_span,
             )
             .map_err(|typedb_source| ExecutableCompilationError::PutInsertCompilation { typedb_source })?;

--- a/compiler/executable/pipeline.rs
+++ b/compiler/executable/pipeline.rs
@@ -275,12 +275,15 @@ fn compile_stage(
                 call_cost_provider,
             )
             .map_err(|source| ExecutableCompilationError::PutMatchCompilation { typedb_source: source })?;
+            let selected_variable_positions = match_plan.variable_positions().iter().filter(|(var, pos)| {
+                match_plan.selected_variables().contains(pos)
+            }).map(|(var, pos)| (*var, *pos)).collect();
             let insert_plan = crate::executable::insert::executable::compile(
                 block.conjunction().constraints(),
                 input_variables,
                 insert_annotations,
                 variable_registry,
-                Some(match_plan.variable_positions().clone()),
+                Some(selected_variable_positions),
                 *source_span,
             )
             .map_err(|typedb_source| ExecutableCompilationError::PutInsertCompilation { typedb_source })?;

--- a/compiler/executable/put/mod.rs
+++ b/compiler/executable/put/mod.rs
@@ -5,6 +5,7 @@
  */
 
 use std::{collections::HashMap, sync::Arc};
+use itertools::Itertools;
 
 use answer::variable::Variable;
 
@@ -24,16 +25,12 @@ pub struct PutExecutable {
 
 impl PutExecutable {
     pub(crate) fn new(match_: MatchExecutable, insert: InsertExecutable) -> PutExecutable {
-        debug_assert!(
-            match_.variable_positions()
-                == &insert
-                    .output_row_schema
-                    .iter()
-                    .enumerate()
-                    .filter_map(|(i, opt)| opt.map(|(v, _)| (i, v)))
-                    .map(|(i, v)| (v, VariablePosition::new(i as u32)))
-                    .collect::<HashMap<_, _>>()
-        );
+        debug_assert!({
+            let match_positions = match_.variable_positions().clone().into_iter().filter(|(_, pos)| {
+                match_.selected_variables().contains(pos)
+            }).collect::<HashMap<_, _>>();
+            match_positions.iter().all(|(v, pos)| insert.output_row_schema[pos.as_usize()].unwrap().0 == *v)
+        });
         Self { executable_id: next_executable_id(), match_, insert }
     }
 

--- a/compiler/executable/update/executable.rs
+++ b/compiler/executable/update/executable.rs
@@ -64,7 +64,7 @@ pub fn compile(
     let mut connection_inserts = Vec::with_capacity(constraints.len());
 
     add_has(constraints, &variable_positions, variable_registry, &mut connection_inserts)?;
-    add_links(constraints, type_annotations, &variable_positions, variable_registry, &mut connection_inserts)?;
+    add_links(constraints, type_annotations, input_variables, &variable_positions, variable_registry, &mut connection_inserts)?;
 
     Ok(UpdateExecutable {
         executable_id: next_executable_id(),
@@ -101,7 +101,8 @@ fn add_has(
 fn add_links(
     constraints: &[Constraint<Variable>],
     type_annotations: &TypeAnnotations,
-    variable_positions: &HashMap<Variable, VariablePosition>,
+    input_variables:  &HashMap<Variable, VariablePosition>, // Strictly input
+    variable_positions: &HashMap<Variable, VariablePosition>, // Also contains ones inserted.
     variable_registry: &VariableRegistry,
     instructions: &mut Vec<ConnectionInstruction>,
 ) -> Result<(), Box<WriteCompilationError>> {
@@ -120,7 +121,7 @@ fn add_links(
             links.source_span(),
         )?;
         let role =
-            resolve_links_role(type_annotations, variable_positions, variable_registry, &named_role_types, links)?;
+            resolve_links_role(type_annotations, input_variables, variable_registry, &named_role_types, links)?;
         instructions.push(ConnectionInstruction::Links(Links { relation, player, role }));
     }
     Ok(())


### PR DESCRIPTION
## Motivation
Avoids the case where the insert stage sees a named role-type variable as both an input and a locally defined one.

## Implementation
Filter out unnamed variables in expected variable positions of Put stages
