### PR TITLE
Make TypeDB logo configurable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3520,6 +3520,7 @@ dependencies = [
  "options",
  "primitive",
  "query",
+ "resource",
  "serde_json",
  "server",
  "storage",

--- a/main.rs
+++ b/main.rs
@@ -9,7 +9,7 @@
 
 use clap::Parser;
 use logger::initialise_logging_global;
-use resource::constants::server::{DISTRIBUTION, SENTRY_REPORTING_URI, VERSION};
+use resource::constants::server::{ASCII_LOGO, DISTRIBUTION, SENTRY_REPORTING_URI, VERSION};
 use server::{
     parameters::{cli::CLIArgs, config::Config},
     server::Server,
@@ -22,7 +22,7 @@ fn main() {
     initialise_logging_global();
     may_initialise_error_reporting(&config);
     create_tokio_runtime().block_on(async {
-        let server = Server::create(config, DISTRIBUTION, VERSION, None).await.unwrap();
+        let server = Server::create(config, ASCII_LOGO, DISTRIBUTION, VERSION, None).await.unwrap();
         match server.serve().await {
             Ok(_) => println!("Exited."),
             Err(err) => println!("Exited with error: {:?}", err),

--- a/server/server.rs
+++ b/server/server.rs
@@ -46,7 +46,7 @@ pub struct Server {
     database_diagnostics_updater: IntervalRunner,
     user_manager: Arc<UserManager>,
     authenticator_cache: Arc<AuthenticatorCache>,
-    typedb_service: Option<TypeDBService>,
+    typedb_service: TypeDBService,
     shutdown_sender: tokio::sync::watch::Sender<()>,
 }
 
@@ -118,7 +118,7 @@ impl Server {
             ),
             user_manager,
             authenticator_cache,
-            typedb_service: Some(typedb_service),
+            typedb_service,
             shutdown_sender,
             config,
         })
@@ -218,7 +218,7 @@ impl Server {
     }
 
     pub async fn serve(mut self) -> Result<(), ServerOpenError> {
-        let service = typedb_protocol::type_db_server::TypeDbServer::new(self.typedb_service.take().unwrap());
+        let service = typedb_protocol::type_db_server::TypeDbServer::new(self.typedb_service);
         let authenticator = Authenticator::new(
             self.user_manager.clone(),
             self.authenticator_cache.clone(),
@@ -313,6 +313,6 @@ impl Server {
     }
 
     pub fn database_manager(&self) -> &DatabaseManager {
-        self.typedb_service.as_ref().unwrap().database_manager()
+        self.typedb_service.database_manager()
     }
 }

--- a/server/server.rs
+++ b/server/server.rs
@@ -16,7 +16,7 @@ use database::database_manager::DatabaseManager;
 use diagnostics::{diagnostics_manager::DiagnosticsManager, Diagnostics};
 use rand::seq::SliceRandom;
 use resource::constants::server::{
-    ASCII_LOGO, DATABASE_METRICS_UPDATE_INTERVAL, GRPC_CONNECTION_KEEPALIVE, SERVER_ID_ALPHABET, SERVER_ID_FILE_NAME,
+    DATABASE_METRICS_UPDATE_INTERVAL, GRPC_CONNECTION_KEEPALIVE, SERVER_ID_ALPHABET, SERVER_ID_FILE_NAME,
     SERVER_ID_LENGTH,
 };
 use system::initialise_system_database;
@@ -36,6 +36,7 @@ use crate::{
 pub struct Server {
     id: String,
     deployment_id: String,
+    logo: &'static str,
     distribution: &'static str,
     version: &'static str,
     config: Config,
@@ -52,6 +53,7 @@ pub struct Server {
 impl Server {
     pub async fn create(
         config: Config,
+        logo: &'static str,
         distribution: &'static str,
         version: &'static str,
         deployment_id: Option<String>,
@@ -104,6 +106,7 @@ impl Server {
         Ok(Self {
             id: server_id,
             deployment_id,
+            logo,
             distribution,
             version,
             address: server_address,
@@ -222,7 +225,7 @@ impl Server {
             self.diagnostics_manager.clone(),
         );
 
-        Self::print_hello(self.distribution, self.version, self.config.server.is_development_mode);
+        Self::print_hello(self.logo, self.distribution, self.version, self.config.server.is_development_mode);
 
         Self::create_tonic_server(&self.config.server.encryption)?
             .layer(&authenticator)
@@ -281,8 +284,8 @@ impl Server {
             .unwrap_or_else(|| panic!("Unable to map address '{}' to any IP addresses", address))
     }
 
-    fn print_hello(distribution: &'static str, version: &'static str, is_development_mode_enabled: bool) {
-        println!("{ASCII_LOGO}"); // very important
+    fn print_hello(logo: &str, distribution: &str, version: &str, is_development_mode_enabled: bool) {
+        println!("{logo}"); // very important
         if is_development_mode_enabled {
             println!("Running {distribution} {version} in development mode.");
         } else {

--- a/server/server.rs
+++ b/server/server.rs
@@ -178,8 +178,8 @@ impl Server {
     async fn initialise_diagnostics(
         deployment_id: String,
         server_id: String,
-        distribution: &'static str,
-        version: &'static str,
+        distribution: &str,
+        version: &str,
         config: &DiagnosticsConfig,
         storage_directory: PathBuf,
         is_development_mode: bool,

--- a/tests/behaviour/steps/BUILD
+++ b/tests/behaviour/steps/BUILD
@@ -26,6 +26,7 @@ rust_library(
         "//function",
         "//ir:ir",
         "//query:query",
+        "//resource",
         "//server:server",
         "//storage:storage",
         "//durability:durability",

--- a/tests/behaviour/steps/Cargo.toml
+++ b/tests/behaviour/steps/Cargo.toml
@@ -100,6 +100,11 @@ features = {}
 		version = "1.43.0"
 		default-features = false
 
+	[dependencies.resource]
+		path = "../../../resource"
+		features = []
+		default-features = false
+
 	[dependencies.query]
 		path = "../../../query"
 		features = []

--- a/tests/behaviour/steps/connection/mod.rs
+++ b/tests/behaviour/steps/connection/mod.rs
@@ -9,6 +9,7 @@ use std::{
     fmt,
     sync::{Arc, Mutex},
 };
+use resource::constants::server::ASCII_LOGO;
 
 use macro_rules_attribute::apply;
 use server::{parameters::config::Config, server::Server};
@@ -31,7 +32,7 @@ pub async fn typedb_starts(context: &mut Context) {
         .get_or_init(|| async {
             let server_dir = create_tmp_dir();
             let config = Config::new_with_data_directory(server_dir.as_ref(), true);
-            let server = Server::create(config, DISTRIBUTION, VERSION, None).await.unwrap();
+            let server = Server::create(config, ASCII_LOGO, DISTRIBUTION, VERSION, None).await.unwrap();
             (server_dir, Arc::new(Mutex::new(server)))
         })
         .await;


### PR DESCRIPTION
## Release notes: product changes
No visible product changes

## Motivation
Need to be able to display different logo depending on the edition (ie., Core or Cluster)

## Implementation
- Make logo path configurable
- A few cleanups
  - Store `TypeDBService` as is, without wrapping it in an `Option`
  - Remove unnecessary `'static` lifetime qualifier from methods 