### PR TITLE
Simplify Batch by letting Vec do the work

### DIFF
--- a/executor/batch.rs
+++ b/executor/batch.rs
@@ -64,7 +64,7 @@ impl FixedBatch {
     }
 
     pub(crate) fn get_row(&self, index: u32) -> MaybeOwnedRow<'_> {
-        debug_assert!(index <= self.entries);
+        debug_assert!(index < self.entries);
         let start = (index * self.width) as usize;
         let end = ((index + 1) * self.width) as usize;
         let slice = &self.data[start..end];
@@ -72,7 +72,7 @@ impl FixedBatch {
     }
 
     pub(crate) fn get_row_mut(&mut self, index: u32) -> Row<'_> {
-        debug_assert!(index <= self.entries);
+        debug_assert!(index < self.entries);
         self.row_internal_mut(index)
     }
 
@@ -180,7 +180,7 @@ impl Batch {
     }
 
     pub(crate) fn get_row(&self, index: usize) -> MaybeOwnedRow<'_> {
-        debug_assert!(index <= self.len());
+        debug_assert!(index < self.len());
         let start = index * self.width as usize;
         let end = (index + 1) * self.width as usize;
         let slice = &self.data[start..end];
@@ -188,7 +188,7 @@ impl Batch {
     }
 
     pub(crate) fn get_row_mut(&mut self, index: usize) -> Row<'_> {
-        debug_assert!(index <= self.len());
+        debug_assert!(index < self.len());
         self.row_internal_mut(index)
     }
 

--- a/executor/batch.rs
+++ b/executor/batch.rs
@@ -64,9 +64,7 @@ impl FixedBatch {
 
     pub(crate) fn get_row(&self, index: u32) -> MaybeOwnedRow<'_> {
         debug_assert!(index < self.entries);
-        let start = (index * self.width) as usize;
-        let end = ((index + 1) * self.width) as usize;
-        let slice = &self.data[start..end];
+        let slice = &self.data[row_range(index as usize, self.width)];
         MaybeOwnedRow::new_borrowed(slice, &self.multiplicities[index as usize])
     }
 
@@ -84,9 +82,7 @@ impl FixedBatch {
     }
 
     fn row_internal_mut(&mut self, index: u32) -> Row<'_> {
-        let start = (index * self.width) as usize;
-        let end = ((index + 1) * self.width) as usize;
-        let slice = &mut self.data[start..end];
+        let slice = &mut self.data[row_range(index as usize, self.width)];
         Row::new(slice, &mut self.multiplicities[index as usize])
     }
 }
@@ -180,17 +176,13 @@ impl Batch {
 
     pub(crate) fn get_row(&self, index: usize) -> MaybeOwnedRow<'_> {
         debug_assert!(index < self.len());
-        let start = index * self.width as usize;
-        let end = (index + 1) * self.width as usize;
-        let slice = &self.data[start..end];
+        let slice = &self.data[row_range(index, self.width)];
         MaybeOwnedRow::new_borrowed(slice, &self.multiplicities[index])
     }
 
     pub(crate) fn get_row_mut(&mut self, index: usize) -> Row<'_> {
         debug_assert!(index < self.len());
-        let start = index * self.width as usize;
-        let end = start + self.width as usize;
-        let slice = &mut self.data[start..end];
+        let slice = &mut self.data[row_range(index, self.width)];
         Row::new(slice, &mut self.multiplicities[index])
     }
 
@@ -266,4 +258,10 @@ impl LendingIterator for BatchRowIterator {
             Some(row)
         }
     }
+}
+
+fn row_range(index: usize, width: u32) -> std::ops::Range<usize> {
+    let start = index * width as usize;
+    let end = start + width as usize;
+    start..end
 }

--- a/executor/batch.rs
+++ b/executor/batch.rs
@@ -192,12 +192,17 @@ impl Batch {
         self.row_internal_mut(index)
     }
 
+    fn append_one_row(&mut self) -> Row<'_> {
+        self.data.resize(self.data.len() + self.width as usize, VariableValue::Empty);
+        self.multiplicities.push(1);
+        debug_assert!(self.data.len() == self.multiplicities.len() * self.width as usize);
+        self.get_row_mut(self.len()-1)
+    }
+
     // We keep the implementation of append & append_mapped separate
     // hoping copy_from_row does a memcpy that's better for large rows
     pub(crate) fn append(&mut self, row: MaybeOwnedRow<'_>) {
-        self.data.resize(self.data.len() + self.width as usize, VariableValue::Empty);
-        self.multiplicities.push(1);
-        let mut destination_row = self.row_internal_mut(self.len() - 1);
+        let mut destination_row = self.append_one_row();
         destination_row.copy_from_row(row);
     }
 
@@ -206,10 +211,7 @@ impl Batch {
         row: MaybeOwnedRow<'_>,
         mapping: impl Iterator<Item = (VariablePosition, VariablePosition)>,
     ) {
-        self.data.resize(self.data.len() + self.width as usize, VariableValue::Empty);
-        self.multiplicities.push(1);
-        debug_assert!(self.data.len() == self.multiplicities.len() * self.width as usize);
-        let mut destination_row = self.row_internal_mut(self.len() - 1);
+        let mut destination_row = self.append_one_row();
         destination_row.copy_mapped(row, mapping);
     }
 

--- a/executor/batch.rs
+++ b/executor/batch.rs
@@ -194,7 +194,7 @@ impl Batch {
         self.data.resize(self.data.len() + self.width as usize, VariableValue::Empty);
         self.multiplicities.push(1);
         debug_assert!(self.data.len() == self.multiplicities.len() * self.width as usize);
-        writer(self.get_row_mut(self.len()-1))
+        writer(self.get_row_mut(self.len() - 1))
     }
 
     pub fn into_iterator_mut(self) -> MutableBatchRowIterator {

--- a/executor/pipeline/insert.rs
+++ b/executor/pipeline/insert.rs
@@ -116,12 +116,12 @@ pub(crate) fn prepare_output_rows(
 ) -> Result<Batch, Box<PipelineExecutionError>> {
     let initial_output_batch_size = input_iterator
         .multiplicity_sum_if_collected()
-        .map(|sum| 10 + sum + (sum / 8)) // Some breathing room to avoid re-allocation
         .unwrap_or(BATCH_DEFAULT_CAPACITY);
     let mut output_batch = Batch::new(output_width, initial_output_batch_size);
     while let Some(row) = input_iterator.next().transpose()? {
         append_row_for_insert_mapped(&mut output_batch, row.as_reference(), mapping);
     }
+    debug_assert!(initial_output_batch_size == BATCH_DEFAULT_CAPACITY || initial_output_batch_size == output_batch.len());
     Ok(output_batch)
 }
 

--- a/executor/pipeline/insert.rs
+++ b/executor/pipeline/insert.rs
@@ -114,14 +114,14 @@ pub(crate) fn prepare_output_rows(
     mut input_iterator: impl StageIterator,
     mapping: &Vec<(VariablePosition, VariablePosition)>,
 ) -> Result<Batch, Box<PipelineExecutionError>> {
-    let initial_output_batch_size = input_iterator
-        .multiplicity_sum_if_collected()
-        .unwrap_or(BATCH_DEFAULT_CAPACITY);
+    let initial_output_batch_size = input_iterator.multiplicity_sum_if_collected().unwrap_or(BATCH_DEFAULT_CAPACITY);
     let mut output_batch = Batch::new(output_width, initial_output_batch_size);
     while let Some(row) = input_iterator.next().transpose()? {
         append_row_for_insert_mapped(&mut output_batch, row.as_reference(), mapping);
     }
-    debug_assert!(initial_output_batch_size == BATCH_DEFAULT_CAPACITY || initial_output_batch_size == output_batch.len());
+    debug_assert!(
+        initial_output_batch_size == BATCH_DEFAULT_CAPACITY || initial_output_batch_size == output_batch.len()
+    );
     Ok(output_batch)
 }
 

--- a/executor/pipeline/insert.rs
+++ b/executor/pipeline/insert.rs
@@ -134,7 +134,9 @@ pub(crate) fn append_row_for_insert_mapped(
     let one = 1;
     let with_multiplicity_one = MaybeOwnedRow::new_borrowed(unmapped_row.row(), &one);
     for _ in 0..unmapped_row.multiplicity() {
-        output_batch.append_mapped(with_multiplicity_one.as_reference(), mapping.iter().copied())
+        output_batch.append(|mut appended| {
+            appended.copy_mapped(with_multiplicity_one.as_reference(), mapping.iter().copied());
+        })
     }
 }
 

--- a/executor/pipeline/mod.rs
+++ b/executor/pipeline/mod.rs
@@ -60,6 +60,10 @@ impl StageIterator for WrittenRowsIterator {
         debug_assert!(self.index == 0, "Truncating start of rows is not implemented");
         Ok(self.rows)
     }
+
+    fn multiplicity_sum_if_collected(&self) -> Option<usize> {
+        Some(self.rows.get_multiplicities().iter().sum::<u64>() as usize)
+    }
 }
 
 typedb_error! {

--- a/executor/pipeline/put.rs
+++ b/executor/pipeline/put.rs
@@ -97,7 +97,7 @@ fn into_iterator_impl<Snapshot: WritableSnapshot + 'static>(
             match_iterator_for_row(context, interrupt, executable, function_registry.clone(), input_row.clone())?;
         match_iterator
             .try_for_each(|row_result| {
-                output_batch.append(row_result?);
+                output_batch.append_row(row_result?);
                 must_insert.push(false);
                 Ok(())
             })

--- a/executor/pipeline/put.rs
+++ b/executor/pipeline/put.rs
@@ -10,7 +10,8 @@ use compiler::{
     executable::{function::ExecutableFunctionRegistry, insert::VariableSource, put::PutExecutable},
     VariablePosition,
 };
-use resource::constants::traversal::BATCH_DEFAULT_LENGTH;
+use lending_iterator::LendingIterator;
+use resource::constants::traversal::BATCH_DEFAULT_CAPACITY;
 use storage::snapshot::{ReadableSnapshot, WritableSnapshot};
 
 use crate::{
@@ -77,7 +78,7 @@ fn into_iterator_impl<Snapshot: WritableSnapshot + 'static>(
     function_registry: Arc<ExecutableFunctionRegistry>,
     mut previous_iterator: impl StageIterator,
 ) -> Result<WrittenRowsIterator, Box<PipelineExecutionError>> {
-    let mut output_batch = Batch::new(executable.output_width() as u32, BATCH_DEFAULT_LENGTH);
+    let mut output_batch = Batch::new(executable.output_width() as u32, BATCH_DEFAULT_CAPACITY);
     let mut must_insert = Vec::new();
     let input_output_mapping = executable
         .insert

--- a/executor/pipeline/stage.rs
+++ b/executor/pipeline/stage.rs
@@ -108,8 +108,7 @@ pub trait StageIterator:
         let first = self.next();
         let mut batch = match first {
             None => {
-                let batch = Batch::new(0, 0);
-                return Ok(batch);
+                return Ok(Batch::new(0, 0));
             }
             Some(row) => {
                 let row = row?;

--- a/executor/pipeline/stage.rs
+++ b/executor/pipeline/stage.rs
@@ -114,13 +114,13 @@ pub trait StageIterator:
             Some(row) => {
                 let row = row?;
                 let mut batch = Batch::new(row.len() as u32, BATCH_DEFAULT_CAPACITY);
-                batch.append(row);
+                batch.append_row(row);
                 batch
             }
         };
         while let Some(row) = self.next() {
             let row = row?;
-            batch.append(row);
+            batch.append_row(row);
         }
         Ok(batch)
     }

--- a/executor/read/collecting_stage_executor.rs
+++ b/executor/read/collecting_stage_executor.rs
@@ -278,7 +278,7 @@ impl CollectorTrait for SortCollector {
             if self.collector.is_none() {
                 self.collector = Some(Batch::new(row.len() as u32, 0usize))
             }
-            self.collector.as_mut().unwrap().append(row);
+            self.collector.as_mut().unwrap().append_row(row);
         }
     }
 
@@ -359,7 +359,7 @@ impl CollectorTrait for DistinctCollector {
             if self.collector.is_none() {
                 self.collector = Some(Batch::new(row.len() as u32, 0usize))
             }
-            self.collector.as_mut().unwrap().append(row);
+            self.collector.as_mut().unwrap().append_row(row);
         }
     }
 

--- a/executor/reduce_executor.rs
+++ b/executor/reduce_executor.rs
@@ -86,7 +86,7 @@ impl GroupedReducer {
             for reducer in reducers.into_iter() {
                 reused_row.push(reducer.finalise().unwrap_or(VariableValue::Empty));
             }
-            batch.append(MaybeOwnedRow::new_borrowed(reused_row.as_slice(), &reused_multiplicity))
+            batch.append_row(MaybeOwnedRow::new_borrowed(reused_row.as_slice(), &reused_multiplicity))
         }
         batch
     }

--- a/resource/constants.rs
+++ b/resource/constants.rs
@@ -87,7 +87,7 @@ pub mod concept {
 pub mod traversal {
     pub const CONSTANT_CONCEPT_LIMIT: usize = 1000;
     pub const FIXED_BATCH_ROWS_MAX: u32 = 64;
-    pub const BATCH_DEFAULT_LENGTH: usize = 10;
+    pub const BATCH_DEFAULT_CAPACITY: usize = 10;
 }
 
 pub mod snapshot {


### PR DESCRIPTION
## Release notes: product changes
Simplify Batch by letting Vec do the work

## Motivation
We don't seem to gain much from handling it ourselves. I felt it opened us up to bugs like [this one](https://github.com/typedb/typedb/pull/7381/files#r2013673000)

## Implementation

Refactoring  `Batch` (This might be making it worse, so please feel free to tell me to revert):
* Batch with data & `entries` was re-implementing what `Vec` already gives us.

 An optimisation for the insert executor, and a simplification for `Batch`:
* Avoids the 2x collect motivated in a TODO during prepare_rows for insert queries.
* moves constants to constants, though they're somewhat internal.
