### PR TITLE
Fix write transactions left open and blocking other transactions after receiving errors

### DIFF
--- a/server/service/transaction_service.rs
+++ b/server/service/transaction_service.rs
@@ -887,7 +887,7 @@ impl TransactionService {
 
                     return Ok(ImmediateQueryResponse::ok(message_ok_done));
                 }
-                transaction @ _ => self.transaction = Some(transaction),
+                transaction => self.transaction = Some(transaction),
             }
         }
 

--- a/tests/behaviour/steps/connection/mod.rs
+++ b/tests/behaviour/steps/connection/mod.rs
@@ -9,9 +9,9 @@ use std::{
     fmt,
     sync::{Arc, Mutex},
 };
-use resource::constants::server::ASCII_LOGO;
 
 use macro_rules_attribute::apply;
+use resource::constants::server::ASCII_LOGO;
 use server::{parameters::config::Config, server::Server};
 use test_utils::{create_tmp_dir, TempDir};
 use tokio::sync::OnceCell;


### PR DESCRIPTION
## Release notes: product changes
The gRPC service no longer leaves any of the transactions open after receiving transaction or query errors. This eliminates scenarios where schema transactions cannot open due to other hanging schema or write transactions and where read transactions can crash the server using incorrect operations (commits, rollbacks, ...). Additionally, it ensures the correctness of the load diagnostics data.

## Motivation
Lost hanging transactions cause temporary transaction deadlocks, can lead to server crashes on `unwrap`s, and pollute the diagnostics data. 

## Implementation
For every `transaction.take()` call, we always have to set the transaction back again. This approach still introduces the risk that we'll eventually forget to reassign the taken transaction, so it is not the best, but all the (5) cases are covered now, so it should be fine. Without it, `do_close()` called on the final `Break`s does nothing with the transaction.
I already had an initial step in this direction [in January](https://github.com/typedb/typedb/pull/7300/files#diff-65d0af60103fa2b39e70ecdca66437a8cff5876b62207d98d57f8fabe83ecbd6R591), but I was sure that we are not supposed to return transactions on errors as their closing is additionally handled. Too bad, it was not.

Additional behaviour scenarios will be written to verify this fix through both the Server's tests and the Driver's tests.
