### PR TITLE
Handle assignment to anonymous variables

### DIFF
--- a/compiler/executable/match_/planner/match_executable.rs
+++ b/compiler/executable/match_/planner/match_executable.rs
@@ -491,7 +491,7 @@ impl fmt::Display for OptionalStep {
 pub struct FunctionCallStep {
     // TODO: Deduplication, selection counting etc.
     pub function_id: FunctionID,
-    pub assigned: Vec<VariablePosition>,
+    pub assigned: Vec<Option<VariablePosition>>,
     pub arguments: Vec<VariablePosition>,
     pub selected_variables: Vec<VariablePosition>,
     pub output_width: u32,

--- a/compiler/executable/match_/planner/mod.rs
+++ b/compiler/executable/match_/planner/mod.rs
@@ -134,7 +134,7 @@ impl DisjunctionBuilder {
 struct FunctionCallBuilder {
     function_id: FunctionID,
     arguments: Vec<VariablePosition>,
-    assigned: Vec<VariablePosition>,
+    assigned: Vec<Option<VariablePosition>>,
     output_width: u32,
 }
 

--- a/compiler/executable/match_/planner/plan.rs
+++ b/compiler/executable/match_/planner/plan.rs
@@ -1474,9 +1474,7 @@ impl ConjunctionPlan<'_> {
                     let assigned = call_binding
                         .assigned()
                         .iter()
-                        .map(|variable| {
-                            match_builder.index[&variable.as_variable().unwrap()].clone().as_position().unwrap()
-                        })
+                        .map(|variable| match_builder.index[&variable.as_variable().unwrap()].clone().as_position())
                         .collect();
                     let arguments = call_binding
                         .function_call()
@@ -1513,13 +1511,7 @@ impl ConjunctionPlan<'_> {
                     .assigned()
                     .iter()
                     .map(|variable| {
-                        match_builder
-                            .index
-                            .get(&variable.as_variable().unwrap())
-                            .unwrap()
-                            .clone()
-                            .as_position()
-                            .unwrap()
+                        match_builder.index.get(&variable.as_variable().unwrap()).unwrap().clone().as_position()
                     })
                     .collect();
                 let arguments = call_binding

--- a/dependencies/typedb/repositories.bzl
+++ b/dependencies/typedb/repositories.bzl
@@ -35,6 +35,6 @@ def typedb_protocol():
 def typedb_behaviour():
     git_repository(
         name = "typedb_behaviour",
-        remote = "https://github.com/dmitrii-ubskii/typedb-behaviour",
-        commit = "056a8d7ede9b552d23dcfdc2d47b9395510652f4",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @typedb_behaviour
+        remote = "https://github.com/typedb/typedb-behaviour",
+        commit = "3e4fe8c38e5a01ea9b198ee23c31cc832e003086",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @typedb_behaviour
     )

--- a/dependencies/typedb/repositories.bzl
+++ b/dependencies/typedb/repositories.bzl
@@ -35,6 +35,6 @@ def typedb_protocol():
 def typedb_behaviour():
     git_repository(
         name = "typedb_behaviour",
-        remote = "https://github.com/typedb/typedb-behaviour",
-        commit = "3e4fe8c38e5a01ea9b198ee23c31cc832e003086",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @typedb_behaviour
+        remote = "https://github.com/dmitrii-ubskii/typedb-behaviour",
+        commit = "056a8d7ede9b552d23dcfdc2d47b9395510652f4",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @typedb_behaviour
     )

--- a/executor/read/nested_pattern_executor.rs
+++ b/executor/read/nested_pattern_executor.rs
@@ -44,7 +44,7 @@ pub struct Negation {
 pub struct InlinedFunction {
     pub inner: PatternExecutor,
     pub arg_mapping: Vec<VariablePosition>,
-    pub assignment_positions: Vec<VariablePosition>,
+    pub assignment_positions: Vec<Option<VariablePosition>>,
     pub output_width: u32,
     pub parameter_registry: Arc<ParameterRegistry>,
 }
@@ -56,7 +56,7 @@ impl InlinedFunction {
             .assignment_positions
             .iter()
             .enumerate()
-            .map(|(src, &dst)| (VariablePosition::new(src as u32), dst))
+            .filter_map(|(src, &dst)| Some((VariablePosition::new(src as u32), dst?)))
             .filter(|(_src, dst)| dst.as_usize() < input.len() && input.get(*dst) != &VariableValue::Empty)
             .collect(); // TODO: Can we move this to compilation?
         for return_index in 0..batch.len() {
@@ -69,7 +69,7 @@ impl InlinedFunction {
                         self.assignment_positions
                             .iter()
                             .enumerate()
-                            .map(|(src, &dst)| (VariablePosition::new(src as u32), dst)),
+                            .filter_map(|(src, &dst)| Some((VariablePosition::new(src as u32), dst?))),
                     );
                 });
             }

--- a/executor/read/tabled_call_executor.rs
+++ b/executor/read/tabled_call_executor.rs
@@ -87,7 +87,7 @@ impl TabledCallExecutor {
             .iter()
             .enumerate()
             .filter_map(|(src, &dst)| Some((VariablePosition::new(src as u32), dst?)))
-            .filter(|(src, dst)| dst.as_usize() < input.len() && input.get(*dst) != &VariableValue::Empty)
+            .filter(|(_, dst)| dst.as_usize() < input.len() && input.get(*dst) != &VariableValue::Empty)
             .collect(); // TODO: Can we move this to compilation?
 
         for return_index in 0..returned_batch.len() {
@@ -95,13 +95,14 @@ impl TabledCallExecutor {
             let returned_row = returned_batch.get_row(return_index);
             if check_indices.iter().all(|(src, dst)| returned_row.get(*src) == input.get(*dst)) {
                 output_batch.append(|mut output_row| {
-                    for (i, element) in input.iter().enumerate() {
-                        output_row.set(VariablePosition::new(i as u32), element.clone());
-                    }
-                    for (returned_index, &output_position) in self.assignment_positions.iter().enumerate() {
-                        let Some(output_position) = output_position else { continue };
-                        output_row.set(output_position, returned_row[returned_index].clone().into_owned());
-                    }
+                    output_row.copy_from_row(input.as_reference());
+                    output_row.copy_mapped(
+                        returned_row,
+                        self.assignment_positions
+                            .iter()
+                            .enumerate()
+                            .filter_map(|(src, &dst)| Some((VariablePosition::new(src as u32), dst?))),
+                    );
                 });
             }
         }

--- a/executor/row.rs
+++ b/executor/row.rs
@@ -69,7 +69,7 @@ impl<'a> Row<'a> {
         *self.multiplicity = *row.multiplicity;
     }
 
-    pub(crate) fn get_multiplicity(&self) -> u64 {
+    pub fn get_multiplicity(&self) -> u64 {
         *self.multiplicity
     }
 

--- a/tests/behaviour/steps/query/typeql.rs
+++ b/tests/behaviour/steps/query/typeql.rs
@@ -4,7 +4,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-use std::{collections::HashMap, str::FromStr, sync::Arc};
+use std::{collections::HashMap, iter, str::FromStr, sync::Arc};
 
 use answer::{variable_value::VariableValue, Thing};
 use compiler::VariablePosition;
@@ -50,8 +50,10 @@ fn row_batch_result_to_answer(
                 .iter()
                 .map(|(v, p)| (v.clone().to_owned(), row.get(*p).clone().into_owned()))
                 .collect::<HashMap<_, _>>();
-            answer_map
+            iter::repeat(answer_map).take(row.get_multiplicity() as usize)
         })
+        .into_iter()
+        .flatten()
         .collect::<Vec<HashMap<String, VariableValue<'static>>>>()
 }
 


### PR DESCRIPTION
## Release notes: product changes

We allow function assignment to discard values assigned to anonymous variables (such as in `let $_ = f($x);`) as there is no space allocated for those outputs. Previously the compilation would crash as it could not find the allocated slot for the value.

## Motivation

## Implementation
