### PR TITLE
Sync behaviour tests transaction management based on query errors with the gRPC service

### DIFF
--- a/dependencies/typedb/repositories.bzl
+++ b/dependencies/typedb/repositories.bzl
@@ -34,12 +34,8 @@ def typedb_protocol():
 
 def typedb_behaviour():
     # TODO: Return typedb
-    native.local_repository(
+    git_repository(
         name = "typedb_behaviour",
-        path = "../typedb-behaviour",
+        remote = "https://github.com/farost/typedb-behaviour",
+        commit = "5343c9c3a926a8ffd8ab9a623e22a1f026969d2a",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @typedb_behaviour
     )
-#    git_repository(
-#        name = "typedb_behaviour",
-#        remote = "https://github.com/typedb/typedb-behaviour",
-#        commit = "a5ca738d691e7e7abec0a69e68f6b06310ac2168",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @typedb_behaviour
-#    )

--- a/dependencies/typedb/repositories.bzl
+++ b/dependencies/typedb/repositories.bzl
@@ -33,8 +33,13 @@ def typedb_protocol():
     )
 
 def typedb_behaviour():
-    git_repository(
+    # TODO: Return typedb
+    native.local_repository(
         name = "typedb_behaviour",
-        remote = "https://github.com/typedb/typedb-behaviour",
-        commit = "a5ca738d691e7e7abec0a69e68f6b06310ac2168",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @typedb_behaviour
+        path = "../typedb-behaviour",
     )
+#    git_repository(
+#        name = "typedb_behaviour",
+#        remote = "https://github.com/typedb/typedb-behaviour",
+#        commit = "a5ca738d691e7e7abec0a69e68f6b06310ac2168",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @typedb_behaviour
+#    )

--- a/dependencies/typedb/repositories.bzl
+++ b/dependencies/typedb/repositories.bzl
@@ -33,9 +33,8 @@ def typedb_protocol():
     )
 
 def typedb_behaviour():
-    # TODO: Return typedb
     git_repository(
         name = "typedb_behaviour",
-        remote = "https://github.com/farost/typedb-behaviour",
-        commit = "ab4700ca82cc83c53c1640a42cd790d1c14cf9cb",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @typedb_behaviour
+        remote = "https://github.com/typedb/typedb-behaviour",
+        commit = "3e4fe8c38e5a01ea9b198ee23c31cc832e003086",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @typedb_behaviour
     )

--- a/dependencies/typedb/repositories.bzl
+++ b/dependencies/typedb/repositories.bzl
@@ -37,5 +37,5 @@ def typedb_behaviour():
     git_repository(
         name = "typedb_behaviour",
         remote = "https://github.com/farost/typedb-behaviour",
-        commit = "5343c9c3a926a8ffd8ab9a623e22a1f026969d2a",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @typedb_behaviour
+        commit = "047d08f20cf502ab229fca98a2fae57dbc1e6294",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @typedb_behaviour
     )

--- a/dependencies/typedb/repositories.bzl
+++ b/dependencies/typedb/repositories.bzl
@@ -37,5 +37,5 @@ def typedb_behaviour():
     git_repository(
         name = "typedb_behaviour",
         remote = "https://github.com/farost/typedb-behaviour",
-        commit = "047d08f20cf502ab229fca98a2fae57dbc1e6294",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @typedb_behaviour
+        commit = "ab4700ca82cc83c53c1640a42cd790d1c14cf9cb",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @typedb_behaviour
     )


### PR DESCRIPTION
## Release notes: product changes
Behaviour tests now close the active transaction when a logical error is found in write and schema transactions, and leave transactions opened in case of a parsing error, which is how the real gRPC service acts.

## Motivation
Make tests work in any mocked or real environment. Support the [BDDs update](https://github.com/typedb/typedb-behaviour/pull/349).

## Implementation
