### PR TITLE
Function call arguments are now stored in a Vec

### DIFF
--- a/compiler/annotation/type_seeder.rs
+++ b/compiler/annotation/type_seeder.rs
@@ -825,15 +825,8 @@ impl UnaryConstraint for FunctionCallBinding<Variable> {
                     graph_vertices.add_or_intersect(assigned_variable, Cow::Borrowed(types));
                 }
             }
-            let args_by_position: Vec<Variable> = self
-                .function_call()
-                .call_id_mapping()
-                .iter()
-                .map(|(var, index)| (index, var))
-                .sorted()
-                .map(|(_, var)| *var)
-                .collect();
-            for (arg_var, arg_annotations) in zip(args_by_position, &annotated_function_signature.arguments) {
+            let args = self.function_call().argument_ids();
+            for (arg_var, arg_annotations) in zip(args, &annotated_function_signature.arguments) {
                 if let FunctionParameterAnnotation::Concept(types) = arg_annotations {
                     graph_vertices.add_or_intersect(&Vertex::Variable(arg_var), Cow::Borrowed(types));
                 }

--- a/executor/read/pattern_executor.rs
+++ b/executor/read/pattern_executor.rs
@@ -151,7 +151,10 @@ impl PatternExecutor {
                         None => {
                             self.push_next_instruction(context, index.next(), FixedBatch::from(input.as_reference()))?
                         }
-                        Some(_) => inner.reset(), // fail
+                        Some(batch) => {
+                            debug_assert!(!batch.is_empty());
+                            inner.reset()
+                        },
                     };
                 }
                 ControlInstruction::ExecuteDisjunction(ExecuteDisjunction { index, branch_index, input }) => {

--- a/ir/pattern/constraint.rs
+++ b/ir/pattern/constraint.rs
@@ -341,10 +341,10 @@ impl<'cx, 'reg> ConstraintsBuilder<'cx, 'reg> {
         for (index, var) in binding.ids_assigned().enumerate() {
             self.context.set_variable_category(var, callee_signature.returns[index].0, binding.clone().into())?;
         }
-        for (caller_var, callee_arg_index) in binding.function_call.call_id_mapping() {
+        for (callee_arg_index, caller_var) in binding.function_call.argument_ids().enumerate() {
             self.context.set_variable_category(
-                *caller_var,
-                callee_signature.arguments[*callee_arg_index],
+                caller_var,
+                callee_signature.arguments[callee_arg_index],
                 binding.clone().into(),
             )?;
         }
@@ -382,9 +382,7 @@ impl<'cx, 'reg> ConstraintsBuilder<'cx, 'reg> {
             })?
         }
 
-        // Construct
-        let call_variable_mapping = arguments.iter().enumerate().map(|(index, variable)| (*variable, index)).collect();
-        Ok(FunctionCall::new(callee_signature.function_id.clone(), call_variable_mapping))
+        Ok(FunctionCall::new(callee_signature.function_id.clone(), arguments))
     }
 
     pub fn add_assignment(


### PR DESCRIPTION
## Release notes: product changes
Function call arguments are now stored in a Vec according to argument index, instead of a mapping from variable to index.

## Motivation
Avoids a bug introduced by assuming `argument_ids()` would return the variables according to their argument indexes.

## Implementation
Replace the `call_variable_mapping: BTreeMap<Variable, usize>` field in `FunctionCall` with `arguments: Vec<Variable>` & propagate.