### PR TITLE
Ban assigning to input variables

### DIFF
--- a/dependencies/typedb/repositories.bzl
+++ b/dependencies/typedb/repositories.bzl
@@ -35,6 +35,6 @@ def typedb_protocol():
 def typedb_behaviour():
     git_repository(
         name = "typedb_behaviour",
-        remote = "https://github.com/typedb/typedb-behaviour",
-        commit = "3e4fe8c38e5a01ea9b198ee23c31cc832e003086",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @typedb_behaviour
+        remote = "https://github.com/krishnangovindraj/typedb-behaviour",
+        commit = "5e0ca483c0bb5a342fa8dca130b72ce2b0aab1c1",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @typedb_behaviour
     )

--- a/ir/lib.rs
+++ b/ir/lib.rs
@@ -156,6 +156,12 @@ typedb_error! {
             "Specifying a kind on a label is not allowed.",
             source_span: Option<Span>,
         ),
+        AssigningToInputVariable(
+            21,
+            "The variable '{variable}' may not be assigned to, as it was already bound in a previous stage",
+            variable: String,
+            source_span: Option<Span>,
+        ),
         LabelWithLabel(
             30,
             "Specifying a label constraint on a label is not allowed.",

--- a/ir/pattern/constraint.rs
+++ b/ir/pattern/constraint.rs
@@ -25,7 +25,9 @@ use crate::{
         variable_category::VariableCategory,
         IrID, ParameterID, ScopeId, ValueType, VariableDependency, Vertex,
     },
-    pipeline::{block::BlockBuilderContext, function_signature::FunctionSignature, ParameterRegistry},
+    pipeline::{
+        block::BlockBuilderContext, function_signature::FunctionSignature, ParameterRegistry, VariableRegistry,
+    },
     LiteralParseError, RepresentationError,
 };
 
@@ -335,6 +337,15 @@ impl<'cx, 'reg> ConstraintsBuilder<'cx, 'reg> {
         function_name: &str,
         source_span: Option<Span>,
     ) -> Result<&FunctionCallBinding<Variable>, Box<RepresentationError>> {
+        if let Some(variable) = assigned.iter().find(|var| self.context.is_variable_input(**var)) {
+            let variable = self
+                .context
+                .get_variable_name(*variable)
+                .cloned()
+                .unwrap_or_else(|| VariableRegistry::UNNAMED_VARIABLE_DISPLAY_NAME.to_string());
+            return Err(Box::new(RepresentationError::AssigningToInputVariable { variable, source_span }));
+        }
+
         let function_call =
             self.create_function_call(&assigned, callee_signature, arguments, function_name, source_span)?;
         let binding = FunctionCallBinding::new(assigned, function_call, callee_signature.return_is_stream, source_span);
@@ -394,6 +405,14 @@ impl<'cx, 'reg> ConstraintsBuilder<'cx, 'reg> {
         source_span: Option<Span>,
     ) -> Result<&ExpressionBinding<Variable>, Box<RepresentationError>> {
         debug_assert!(self.context.is_variable_available(self.constraints.scope, variable));
+        if self.context.is_variable_input(variable) {
+            let variable = self
+                .context
+                .get_variable_name(variable)
+                .cloned()
+                .unwrap_or_else(|| VariableRegistry::UNNAMED_VARIABLE_DISPLAY_NAME.to_string());
+            return Err(Box::new(RepresentationError::AssigningToInputVariable { variable, source_span }));
+        }
         let binding = ExpressionBinding::new(variable, expression, source_span);
         binding.validate(self.context).map_err(|typedb_source| RepresentationError::ExpressionRepresentationError {
             typedb_source,

--- a/ir/pipeline/block.rs
+++ b/ir/pipeline/block.rs
@@ -328,6 +328,10 @@ impl<'a> BlockBuilderContext<'a> {
         self.variable_names_index.get(name)
     }
 
+    pub(crate) fn get_variable_name(&self, variable: Variable) -> Option<&String> {
+        self.variable_registry.get_variable_name(variable)
+    }
+
     pub(crate) fn get_or_declare_variable(
         &mut self,
         name: &str,
@@ -369,6 +373,10 @@ impl<'a> BlockBuilderContext<'a> {
 
     pub fn is_variable_available(&self, scope: ScopeId, variable: Variable) -> bool {
         self.block_context.is_variable_available(scope, variable)
+    }
+
+    pub(crate) fn is_variable_input(&self, variable: Variable) -> bool {
+        self.block_context.variable_declaration.get(&variable) == Some(&ScopeId::INPUT)
     }
 
     pub(crate) fn create_child_scope(&mut self, parent: ScopeId, transparency: ScopeTransparency) -> ScopeId {


### PR DESCRIPTION
## Motivation
Re-assignments are usually bugs.

## Implementation
Add the `is_variable_input` method to BlockBuilderContext to allow us to throw errors at IR construction time.