### PR TITLE
Optimize unique constraints operation time checks for write queries

### DIFF
--- a/common/iterator/mod.rs
+++ b/common/iterator/mod.rs
@@ -43,6 +43,8 @@ impl<T: Hash + Eq + PartialEq> Collector<T> for HashSet<T> {
 #[macro_export]
 macro_rules! minmax_or {
     ($iter:expr, $no_elements_expr:expr) => {{
+        use itertools::{Itertools, MinMaxResult};
+
         match $iter.minmax() {
             MinMaxResult::NoElements => $no_elements_expr,
             MinMaxResult::OneElement(element) => (element, element),

--- a/concept/thing/attribute.rs
+++ b/concept/thing/attribute.rs
@@ -98,15 +98,6 @@ impl Attribute {
         thing_manager.get_owners_by_type(snapshot, self, owner_type)
     }
 
-    pub fn get_has_by_owner_types(
-        &self,
-        snapshot: &impl ReadableSnapshot,
-        thing_manager: &ThingManager,
-        owner_type_range: &impl RangeBounds<ObjectType>,
-    ) -> HasReverseIterator {
-        thing_manager.get_has_reverse_by_attribute_and_owner_type_range(snapshot, self, owner_type_range)
-    }
-
     pub fn next_possible(&self) -> Attribute {
         let mut bytes = self.vertex.to_bytes().into_array();
         bytes.increment().unwrap();

--- a/concept/thing/attribute.rs
+++ b/concept/thing/attribute.rs
@@ -10,7 +10,6 @@ use std::{
     fmt,
     hash::{Hash, Hasher},
     iter,
-    ops::RangeBounds,
     sync::{Arc, OnceLock},
 };
 
@@ -41,11 +40,11 @@ use crate::{
     edge_iterator,
     error::{ConceptReadError, ConceptWriteError},
     thing::{
-        object::{HasReverseIterator, Object},
+        object::Object,
         thing_manager::ThingManager,
         HKInstance, ThingAPI,
     },
-    type_::{attribute_type::AttributeType, object_type::ObjectType, ObjectTypeAPI},
+    type_::{attribute_type::AttributeType, ObjectTypeAPI},
     ConceptAPI, ConceptStatus,
 };
 

--- a/concept/thing/attribute.rs
+++ b/concept/thing/attribute.rs
@@ -10,6 +10,7 @@ use std::{
     fmt,
     hash::{Hash, Hasher},
     iter,
+    ops::RangeBounds,
     sync::{Arc, OnceLock},
 };
 
@@ -39,8 +40,12 @@ use storage::{
 use crate::{
     edge_iterator,
     error::{ConceptReadError, ConceptWriteError},
-    thing::{object::Object, thing_manager::ThingManager, HKInstance, ThingAPI},
-    type_::{attribute_type::AttributeType, ObjectTypeAPI},
+    thing::{
+        object::{HasReverseIterator, Object},
+        thing_manager::ThingManager,
+        HKInstance, ThingAPI,
+    },
+    type_::{attribute_type::AttributeType, object_type::ObjectType, ObjectTypeAPI},
     ConceptAPI, ConceptStatus,
 };
 
@@ -91,6 +96,15 @@ impl Attribute {
         owner_type: impl ObjectTypeAPI,
     ) -> AttributeOwnerIterator {
         thing_manager.get_owners_by_type(snapshot, self, owner_type)
+    }
+
+    pub fn get_has_by_owner_types(
+        &self,
+        snapshot: &impl ReadableSnapshot,
+        thing_manager: &ThingManager,
+        owner_type_range: &impl RangeBounds<ObjectType>,
+    ) -> HasReverseIterator {
+        thing_manager.get_has_reverse_by_attribute_and_owner_type_range(snapshot, self, owner_type_range)
     }
 
     pub fn next_possible(&self) -> Attribute {

--- a/concept/thing/thing_manager/validation/operation_time_validation.rs
+++ b/concept/thing/thing_manager/validation/operation_time_validation.rs
@@ -4,7 +4,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-use std::collections::{BTreeMap, Bound, HashMap, HashSet};
+use std::collections::{BTreeMap, Bound, HashMap};
 
 use bytes::util::HexBytesFormatter;
 use encoding::value::{value::Value, value_type::ValueType};

--- a/dependencies/typedb/repositories.bzl
+++ b/dependencies/typedb/repositories.bzl
@@ -33,8 +33,9 @@ def typedb_protocol():
     )
 
 def typedb_behaviour():
+    # TODO: Return typedb
     git_repository(
         name = "typedb_behaviour",
-        remote = "https://github.com/typedb/typedb-behaviour",
-        commit = "3e4fe8c38e5a01ea9b198ee23c31cc832e003086",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @typedb_behaviour
+        remote = "https://github.com/farost/typedb-behaviour",
+        commit = "95638ce23fabf65f04d39a5efac97c47ca385950",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @typedb_behaviour
     )

--- a/dependencies/typedb/repositories.bzl
+++ b/dependencies/typedb/repositories.bzl
@@ -33,9 +33,8 @@ def typedb_protocol():
     )
 
 def typedb_behaviour():
-    # TODO: Return typedb
     git_repository(
         name = "typedb_behaviour",
-        remote = "https://github.com/farost/typedb-behaviour",
-        commit = "95638ce23fabf65f04d39a5efac97c47ca385950",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @typedb_behaviour
+        remote = "https://github.com/typedb/typedb-behaviour",
+        commit = "0de401a692d024a993e4916e581c3624981b4828",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @typedb_behaviour
     )


### PR DESCRIPTION
## Release notes: product changes
Modify the algorithm of attribute uniqueness validation at operation time, performed for each inserted `has` instance of ownerships with `@unique` and `@key` annotations. 
These changes boost the performance of insert operations for constrained `has`es by up to 35 times, resulting in an almost indiscernible effect compared to the operations without uniqueness checks. 

## Motivation
Uniqueness validations for inserts had a disastrous effect on inserts' performance.

## Implementation
The old algorithm iterated over all objects of the suitable object types (with `owns` under the constraint verified). Then, each object was verified as not having an attribute with the value verified. This straightforward search took more and more time with the increased number of objects in the database, even if they didn't have common attributes: it was bound only to the schema.

The new algorithm performs the reversed sequence of actions. First, it searches for attributes with the value verified. Then, these attributes (they can be of different attribute types) are checked on the existence of `has` edges to objects of the verified set of types. This way, we limit the number of elements and storage lookups processed, making better use of the data specifics and the iterator optimizations.

Using a shortened version of [a small benchmark](https://discord.com/channels/665254494820368395/672580553677078548/1354875257382637830), which performs simple insert operations for objects with randomized attributes, we found that a single average insert operation took (*only use this data for relative comparison: these results were gathered in a local environment*):
Non-optimal compilation mode (x35 times better than before):
* 35.65 ms in the old version with uniqueness validations 
* 1.07 ms without uniqueness validations
* 1.09 ms in the new version with uniqueness validations

Optimal compilation mode (x25 times better than before):
* 3.77 ms in the old version with uniqueness validations
* 0.15 ms without uniqueness validations
* 0.15 ms in the new version with uniqueness validations