### PR TITLE
Various fixes around variable usage

### DIFF
--- a/compiler/annotation/match_inference.rs
+++ b/compiler/annotation/match_inference.rs
@@ -254,7 +254,11 @@ impl TypeInferenceGraph<'_> {
         &self,
         variable_registry: &VariableRegistry,
     ) -> Result<(), TypeInferenceError> {
-        let thing_variable_present = self.vertices.annotations.iter().filter_map(|(var, _)| var.as_variable())
+        let thing_variable_present = self
+            .vertices
+            .annotations
+            .iter()
+            .filter_map(|(var, _)| var.as_variable())
             .any(|var| variable_registry.get_variable_category(var).unwrap().is_category_thing());
 
         let any_vertex_empty = self.vertices.annotations.iter().any(|(_, types)| types.is_empty());

--- a/compiler/annotation/match_inference.rs
+++ b/compiler/annotation/match_inference.rs
@@ -254,16 +254,11 @@ impl TypeInferenceGraph<'_> {
         &self,
         variable_registry: &VariableRegistry,
     ) -> Result<(), TypeInferenceError> {
-        let mut thing_variable_present = false;
-        let mut any_variable_empty = false;
-        self.vertices.annotations.iter().filter_map(|(var, types)| var.as_variable().map(|v| (v, types))).for_each(
-            |(var, types)| {
-                thing_variable_present =
-                    thing_variable_present || variable_registry.get_variable_category(var).unwrap().is_category_thing();
-                any_variable_empty = any_variable_empty || types.is_empty();
-            },
-        );
-        if any_variable_empty && thing_variable_present {
+        let thing_variable_present = self.vertices.annotations.iter().filter_map(|(var, _)| var.as_variable())
+            .any(|var| variable_registry.get_variable_category(var).unwrap().is_category_thing());
+
+        let any_vertex_empty = self.vertices.annotations.iter().any(|(_, types)| types.is_empty());
+        if any_vertex_empty && thing_variable_present {
             return Err(TypeInferenceError::DetectedUnsatisfiablePattern {});
         }
         self.nested_disjunctions

--- a/compiler/annotation/type_seeder.rs
+++ b/compiler/annotation/type_seeder.rs
@@ -825,15 +825,8 @@ impl UnaryConstraint for FunctionCallBinding<Variable> {
                     graph_vertices.add_or_intersect(assigned_variable, Cow::Borrowed(types));
                 }
             }
-            let args_by_position: Vec<Variable> = self
-                .function_call()
-                .call_id_mapping()
-                .iter()
-                .map(|(var, index)| (index, var))
-                .sorted()
-                .map(|(_, var)| *var)
-                .collect();
-            for (arg_var, arg_annotations) in zip(args_by_position, &annotated_function_signature.arguments) {
+            let args = self.function_call().argument_ids();
+            for (arg_var, arg_annotations) in zip(args, &annotated_function_signature.arguments) {
                 if let FunctionParameterAnnotation::Concept(types) = arg_annotations {
                     graph_vertices.add_or_intersect(&Vertex::Variable(arg_var), Cow::Borrowed(types));
                 }

--- a/dependencies/typedb/repositories.bzl
+++ b/dependencies/typedb/repositories.bzl
@@ -35,6 +35,6 @@ def typedb_protocol():
 def typedb_behaviour():
     git_repository(
         name = "typedb_behaviour",
-        remote = "https://github.com/typedb/typedb-behaviour",
-        commit = "a5ca738d691e7e7abec0a69e68f6b06310ac2168",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @typedb_behaviour
+        remote = "https://github.com/krishnangovindraj/typedb-behaviour",
+        commit = "f655d254144826c359d7d3c6eba22c9604299956",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @typedb_behaviour
     )

--- a/dependencies/typedb/repositories.bzl
+++ b/dependencies/typedb/repositories.bzl
@@ -36,5 +36,5 @@ def typedb_behaviour():
     git_repository(
         name = "typedb_behaviour",
         remote = "https://github.com/krishnangovindraj/typedb-behaviour",
-        commit = "f655d254144826c359d7d3c6eba22c9604299956",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @typedb_behaviour
+        commit = "d57f1127fb5f47d2333b11560873aca30cf60dfe",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @typedb_behaviour
     )

--- a/executor/read/pattern_executor.rs
+++ b/executor/read/pattern_executor.rs
@@ -154,7 +154,7 @@ impl PatternExecutor {
                         Some(batch) => {
                             debug_assert!(!batch.is_empty());
                             inner.reset()
-                        },
+                        }
                     };
                 }
                 ControlInstruction::ExecuteDisjunction(ExecuteDisjunction { index, branch_index, input }) => {

--- a/executor/read/pattern_executor.rs
+++ b/executor/read/pattern_executor.rs
@@ -151,7 +151,10 @@ impl PatternExecutor {
                         None => {
                             self.push_next_instruction(context, index.next(), FixedBatch::from(input.as_reference()))?
                         }
-                        Some(_) => inner.reset(), // fail
+                        Some(batch) => {
+                            debug_assert!(!batch.is_empty());
+                            inner.reset()
+                        },
                     };
                 }
                 ControlInstruction::ExecuteDisjunction(ExecuteDisjunction { index, branch_index, input }) => {

--- a/ir/lib.rs
+++ b/ir/lib.rs
@@ -141,14 +141,14 @@ typedb_error! {
         ),
         OperatorStageVariableUnavailable(
             18,
-            "The variable '{variable_name}' was not available in the stage.",
-            variable_name: String,
+            "The variable '{variable}' was not available in the stage.",
+            variable: String,
             source_span: Option<Span>,
         ),
         ReduceVariableNotAvailable(
             19,
-            "The variable '{variable_name}' was not available in for use in the reduce.",
-            variable_name: String,
+            "The variable '{variable}' was not available in for use in the reduce.",
+            variable: String,
             source_span: Option<Span>,
         ),
         LabelWithKind(
@@ -160,16 +160,6 @@ typedb_error! {
             21,
             "The variable '{variable}' may not be assigned to, as it was already bound in a previous stage",
             variable: String,
-            source_span: Option<Span>,
-        ),
-        LabelWithLabel(
-            30,
-            "Specifying a label constraint on a label is not allowed.",
-            source_span: Option<Span>,
-        ),
-        ScopedLabelWithLabel(
-            31,
-            "Specifying a scoped label constraint on a label is not allowed.",
             source_span: Option<Span>,
         ),
         UnrecognisedClause(
@@ -208,9 +198,14 @@ typedb_error! {
             rhs_category: VariableCategory,
             source_span: Option<Span>,
         ),
-        IllegalAnonymousVariableUsageInWithin(
-            29,
-            "An anonymous variable may not be used in this context.",
+        LabelWithLabel(
+            30,
+            "Specifying a label constraint on a label is not allowed.",
+            source_span: Option<Span>,
+        ),
+        ScopedLabelWithLabel(
+            31,
+            "Specifying a scoped label constraint on a label is not allowed.",
             source_span: Option<Span>,
         ),
         UpdateVariableUnavailable(

--- a/ir/lib.rs
+++ b/ir/lib.rs
@@ -156,6 +156,12 @@ typedb_error! {
             "Specifying a kind on a label is not allowed.",
             source_span: Option<Span>,
         ),
+        AssigningToInputVariable(
+            21,
+            "The variable '{variable}' may not be assigned to, as it was already bound in a previous stage",
+            variable: String,
+            source_span: Option<Span>,
+        ),
         LabelWithLabel(
             30,
             "Specifying a label constraint on a label is not allowed.",

--- a/ir/lib.rs
+++ b/ir/lib.rs
@@ -208,6 +208,11 @@ typedb_error! {
             rhs_category: VariableCategory,
             source_span: Option<Span>,
         ),
+        IllegalAnonymousVariableUsageInWithin(
+            29,
+            "An anonymous variable may not be used in this context.",
+            source_span: Option<Span>,
+        ),
         UpdateVariableUnavailable(
             39,
             "The variable '{variable}' referenced in the update stage is unavailable. It should be bound in the previous stage.",

--- a/ir/pattern/constraint.rs
+++ b/ir/pattern/constraint.rs
@@ -341,10 +341,10 @@ impl<'cx, 'reg> ConstraintsBuilder<'cx, 'reg> {
         for (index, var) in binding.ids_assigned().enumerate() {
             self.context.set_variable_category(var, callee_signature.returns[index].0, binding.clone().into())?;
         }
-        for (caller_var, callee_arg_index) in binding.function_call.call_id_mapping() {
+        for (callee_arg_index, caller_var) in binding.function_call.argument_ids().enumerate() {
             self.context.set_variable_category(
-                *caller_var,
-                callee_signature.arguments[*callee_arg_index],
+                caller_var,
+                callee_signature.arguments[callee_arg_index],
                 binding.clone().into(),
             )?;
         }
@@ -382,9 +382,7 @@ impl<'cx, 'reg> ConstraintsBuilder<'cx, 'reg> {
             })?
         }
 
-        // Construct
-        let call_variable_mapping = arguments.iter().enumerate().map(|(index, variable)| (*variable, index)).collect();
-        Ok(FunctionCall::new(callee_signature.function_id.clone(), call_variable_mapping))
+        Ok(FunctionCall::new(callee_signature.function_id.clone(), arguments))
     }
 
     pub fn add_assignment(

--- a/ir/pattern/function_call.rs
+++ b/ir/pattern/function_call.rs
@@ -37,10 +37,7 @@ impl<ID: IrID> FunctionCall<ID> {
     }
 
     pub fn map<T: Clone + Ord>(self, mapping: &HashMap<ID, T>) -> FunctionCall<T> {
-        FunctionCall::new(
-            self.function_id.clone(),
-            self.arguments.iter().map(|(var)| var.map(mapping)).collect(),
-        )
+        FunctionCall::new(self.function_id.clone(), self.arguments.iter().map(|(var)| var.map(mapping)).collect())
     }
 }
 
@@ -59,11 +56,7 @@ impl<ID: StructuralEquality + Ord> StructuralEquality for FunctionCall<ID> {
 
 impl<ID: IrID> fmt::Display for FunctionCall<ID> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let formatted_args = self
-            .arguments
-            .iter()
-            .map(|call_var| format!("{call_var}"))
-            .join(", ");
+        let formatted_args = self.arguments.iter().map(|call_var| format!("{call_var}")).join(", ");
 
         write!(f, "fn_{}({})", self.function_id, formatted_args)
     }

--- a/ir/pipeline/block.rs
+++ b/ir/pipeline/block.rs
@@ -328,6 +328,10 @@ impl<'a> BlockBuilderContext<'a> {
         self.variable_names_index.get(name)
     }
 
+    pub(crate) fn get_variable_name(&self, variable: Variable) -> Option<&String> {
+        self.variable_registry.get_variable_name(variable)
+    }
+
     pub(crate) fn get_or_declare_variable(
         &mut self,
         name: &str,
@@ -369,6 +373,10 @@ impl<'a> BlockBuilderContext<'a> {
 
     pub fn is_variable_available(&self, scope: ScopeId, variable: Variable) -> bool {
         self.block_context.is_variable_available(scope, variable)
+    }
+
+    pub(crate) fn is_variable_input(&self, variable: Variable) -> bool {
+        self.block_context.variable_declaration.get(&variable) == Some(&ScopeId::INPUT)
     }
 
     pub(crate) fn create_child_scope(&mut self, parent: ScopeId, transparency: ScopeTransparency) -> ScopeId {

--- a/ir/translation/reduce.rs
+++ b/ir/translation/reduce.rs
@@ -41,7 +41,11 @@ pub fn translate_reduce(
         Some(group) => group
             .iter()
             .map(|typeql_var| {
-                let var_name = typeql_var.name().unwrap();
+                let Some(var_name) = typeql_var.name() else {
+                    return Err(RepresentationError::IllegalAnonymousVariableUsage {
+                        source_span: typeql_var.span(),
+                    });
+                };
                 context.visible_variables.get(var_name).map_or_else(
                     || {
                         Err(RepresentationError::OperatorStageVariableUnavailable {

--- a/ir/translation/writes.rs
+++ b/ir/translation/writes.rs
@@ -16,25 +16,10 @@ use crate::{
     pipeline::{block::Block, function_signature::HashMapFunctionSignatureIndex, ParameterRegistry},
     translation::{
         constraints::{add_statement, add_typeql_relation, register_typeql_var},
-        TranslationContext,
+        verify_variable_available, TranslationContext,
     },
     RepresentationError,
 };
-
-macro_rules! verify_variable_available {
-    ($context:ident, $var:expr => $error:ident ) => {
-        match $context.get_variable(
-            $var.name()
-                .ok_or(Box::new(RepresentationError::NonAnonymousVariableExpected { source_span: $var.span() }))?,
-        ) {
-            Some(translated) => Ok(translated),
-            None => Err(Box::new(RepresentationError::$error {
-                variable: $var.name().unwrap().to_owned(),
-                source_span: $var.span(),
-            })),
-        }
-    };
-}
 
 pub fn translate_insert(
     context: &mut TranslationContext,


### PR DESCRIPTION
## Release notes: product changes
* Extend the check for empty type-annotations to include label vertices
* Store function call arguments in a Vec, so they are ordered by argument index. 
* Flag assignments to variables which were already bound in previous stages
* Flag anonymous variables in unexpected pipeline stages instead of assuming named & unwrapping.

## Motivation
Stability

## Implementation
