### PR TITLE
Fix incorrect set of input variables to nested patterns

### DIFF
--- a/compiler/executable/match_/planner/mod.rs
+++ b/compiler/executable/match_/planner/mod.rs
@@ -415,13 +415,13 @@ impl MatchExecutableBuilder {
         self.steps.push(step);
     }
 
-    fn row_variables(&self) -> impl Iterator<Item = Variable> + Clone + '_ {
+    fn row_variables(&self) -> &[Variable] {
         if let Some(current) = &self.current {
-            current.selected_variables.iter().copied()
+            &current.selected_variables
         } else if let Some(last) = self.steps.last() {
-            last.selected_variables.iter().copied()
+            &last.selected_variables
         } else {
-            self.input_variables.iter().copied()
+            &self.input_variables
         }
     }
 

--- a/compiler/executable/match_/planner/mod.rs
+++ b/compiler/executable/match_/planner/mod.rs
@@ -266,6 +266,7 @@ impl StepBuilder {
 #[derive(Debug)]
 struct MatchExecutableBuilder {
     selected_variables: Vec<Variable>,
+    input_variables: Vec<Variable>,
     current_outputs: HashSet<Variable>,
     produced_so_far: HashSet<Variable>,
 
@@ -299,6 +300,7 @@ impl MatchExecutableBuilder {
         let next_output = VariablePosition::new(next_position);
         Self {
             selected_variables,
+            input_variables,
             current_outputs,
             produced_so_far,
             steps: Vec::new(),
@@ -411,6 +413,16 @@ impl MatchExecutableBuilder {
         step.selected_variables = Vec::from_iter(self.current_outputs.iter().copied());
 
         self.steps.push(step);
+    }
+
+    fn row_variables(&self) -> impl Iterator<Item = Variable> + Clone + '_ {
+        if let Some(current) = &self.current {
+            current.selected_variables.iter().copied()
+        } else if let Some(last) = self.steps.last() {
+            last.selected_variables.iter().copied()
+        } else {
+            self.input_variables.iter().copied()
+        }
     }
 
     fn position_mapping(&self) -> &HashMap<Variable, ExecutorVariable> {

--- a/compiler/executable/match_/planner/plan.rs
+++ b/compiler/executable/match_/planner/plan.rs
@@ -1459,7 +1459,7 @@ impl ConjunctionPlan<'_> {
                         .clone() // FIXME
                         .plan(match_builder.produced_so_far.iter().filter(|&&v| v != variable).copied())?
                         .lower(
-                            match_builder.produced_so_far.iter().copied(),
+                            match_builder.row_variables(),
                             match_builder.current_outputs.iter().copied(),
                             match_builder.position_mapping(),
                             variable_registry,
@@ -1530,7 +1530,7 @@ impl ConjunctionPlan<'_> {
 
             PlannerVertex::Negation(negation) => {
                 let negation = negation.plan().lower(
-                    match_builder.current_outputs.iter().copied(),
+                    match_builder.row_variables(),
                     match_builder.selected_variables.iter().copied(),
                     match_builder.position_mapping(),
                     variable_registry,
@@ -1610,7 +1610,7 @@ impl ConjunctionPlan<'_> {
                     .clone() // FIXME
                     .plan(match_builder.position_mapping().keys().copied())?
                     .lower(
-                        match_builder.produced_so_far.iter().copied(),
+                        match_builder.row_variables(),
                         match_builder.current_outputs.iter().copied(),
                         match_builder.position_mapping(),
                         variable_registry,

--- a/compiler/executable/match_/planner/plan.rs
+++ b/compiler/executable/match_/planner/plan.rs
@@ -1459,7 +1459,7 @@ impl ConjunctionPlan<'_> {
                         .clone() // FIXME
                         .plan(match_builder.produced_so_far.iter().filter(|&&v| v != variable).copied())?
                         .lower(
-                            match_builder.row_variables(),
+                            match_builder.row_variables().iter().copied(),
                             match_builder.current_outputs.iter().copied(),
                             match_builder.position_mapping(),
                             variable_registry,
@@ -1530,7 +1530,7 @@ impl ConjunctionPlan<'_> {
 
             PlannerVertex::Negation(negation) => {
                 let negation = negation.plan().lower(
-                    match_builder.row_variables(),
+                    match_builder.row_variables().iter().copied(),
                     match_builder.selected_variables.iter().copied(),
                     match_builder.position_mapping(),
                     variable_registry,
@@ -1610,7 +1610,7 @@ impl ConjunctionPlan<'_> {
                     .clone() // FIXME
                     .plan(match_builder.position_mapping().keys().copied())?
                     .lower(
-                        match_builder.row_variables(),
+                        match_builder.row_variables().iter().copied(),
                         match_builder.current_outputs.iter().copied(),
                         match_builder.position_mapping(),
                         variable_registry,

--- a/compiler/executable/match_/planner/plan.rs
+++ b/compiler/executable/match_/planner/plan.rs
@@ -2024,6 +2024,24 @@ impl fmt::Debug for Graph<'_> {
     }
 }
 
+impl fmt::Display for Graph<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        writeln!(f, "{}:", type_name_of_val(self))?;
+        write!(f, "    variable index: {:?}", self.variable_index)?;
+
+        writeln!(f, "    patterns: ")?;
+        for (vertex, elt) in &self.elements {
+            writeln!(f, "        {vertex:?}: {elt:?}")?;
+        }
+
+        for (p, vars) in &self.pattern_to_variable {
+            writeln!(f, "    {p:?} -> {vars:?}")?;
+        }
+
+        Ok(())
+    }
+}
+
 impl<'a> Graph<'a> {
     fn push_variable(&mut self, variable: Variable, vertex: VariableVertex) {
         let index = self.next_variable_index();

--- a/concept/thing/attribute.rs
+++ b/concept/thing/attribute.rs
@@ -39,11 +39,7 @@ use storage::{
 use crate::{
     edge_iterator,
     error::{ConceptReadError, ConceptWriteError},
-    thing::{
-        object::Object,
-        thing_manager::ThingManager,
-        HKInstance, ThingAPI,
-    },
+    thing::{object::Object, thing_manager::ThingManager, HKInstance, ThingAPI},
     type_::{attribute_type::AttributeType, ObjectTypeAPI},
     ConceptAPI, ConceptStatus,
 };

--- a/dependencies/typedb/repositories.bzl
+++ b/dependencies/typedb/repositories.bzl
@@ -35,6 +35,6 @@ def typedb_protocol():
 def typedb_behaviour():
     git_repository(
         name = "typedb_behaviour",
-        remote = "https://github.com/typedb/typedb-behaviour",
-        commit = "0de401a692d024a993e4916e581c3624981b4828",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @typedb_behaviour
+        remote = "https://github.com/dmitrii-ubskii/typedb-behaviour",
+        commit = "afe7e8bf039937c11038b65e67adea306328a4d2",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @typedb_behaviour
     )

--- a/dependencies/typedb/repositories.bzl
+++ b/dependencies/typedb/repositories.bzl
@@ -35,6 +35,6 @@ def typedb_protocol():
 def typedb_behaviour():
     git_repository(
         name = "typedb_behaviour",
-        remote = "https://github.com/dmitrii-ubskii/typedb-behaviour",
-        commit = "afe7e8bf039937c11038b65e67adea306328a4d2",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @typedb_behaviour
+        remote = "https://github.com/typedb/typedb-behaviour",
+        commit = "2da63cd257352eddc3d6036ee9de59dbe1c3160d",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @typedb_behaviour
     )


### PR DESCRIPTION
## Release notes: product changes

During query plan lowering, we separate the current output variables (which represent the output variables of the plan being lowered) from variables available to the pattern being lowered, dubbed the row variables. 

## Motivation

## Implementation
