### PR TITLE
Variable categories restrict applicable types throughout the query

### DIFF
--- a/compiler/annotation/type_seeder.rs
+++ b/compiler/annotation/type_seeder.rs
@@ -623,10 +623,11 @@ impl<'this, Snapshot: ReadableSnapshot> TypeGraphSeedingContext<'this, Snapshot>
             let category = self.variable_registry.get_variable_category(*id);
             if category.map_or(false, |cat| cat.is_category_thing()) {
                 match category.unwrap() {
+                    VariableCategory::Attribute => annotations.retain(|type_| type_.is_attribute_type()),
+                    VariableCategory::Relation => annotations.retain(|type_| type_.is_relation_type()),
                     VariableCategory::Object => {
                         annotations.retain(|type_| type_.is_entity_type() || type_.is_relation_type())
                     },
-                    VariableCategory::Attribute => annotations.retain(|type_| type_.is_attribute_type()),
                     _ => {}
                 };
             }

--- a/compiler/executable/match_/planner/plan.rs
+++ b/compiler/executable/match_/planner/plan.rs
@@ -334,7 +334,7 @@ impl<'a> ConjunctionPlanBuilder<'a> {
                 | VariableCategory::AttributeType
                 | VariableCategory::RoleType => self.register_type_var(variable),
 
-                | VariableCategory::Thing | VariableCategory::Object | VariableCategory::Attribute => {
+                | VariableCategory::Thing | VariableCategory::Object | VariableCategory::Attribute | VariableCategory::Relation => {
                     self.register_thing_var(variable)
                 }
 
@@ -343,7 +343,8 @@ impl<'a> ConjunctionPlanBuilder<'a> {
                 | VariableCategory::ObjectList
                 | VariableCategory::ThingList
                 | VariableCategory::AttributeList
-                | VariableCategory::ValueList => unimplemented_feature!(Lists),
+                | VariableCategory::ValueList
+                | VariableCategory::RelationList => unimplemented_feature!(Lists),
                 VariableCategory::AttributeOrValue => {
                     unreachable!("Insufficiently bound variable should have been flagged earlier")
                 }
@@ -361,12 +362,13 @@ impl<'a> ConjunctionPlanBuilder<'a> {
                 | VariableCategory::AttributeType
                 | VariableCategory::RoleType => self.register_type_var(variable),
 
-                VariableCategory::Thing | VariableCategory::Object | VariableCategory::Attribute => {
+                VariableCategory::Thing | VariableCategory::Object | VariableCategory::Relation | VariableCategory::Attribute => {
                     self.register_thing_var(variable)
                 }
 
                 VariableCategory::Value => self.register_value_var(variable),
 
+                VariableCategory::RelationList
                 | VariableCategory::ObjectList
                 | VariableCategory::ThingList
                 | VariableCategory::AttributeList

--- a/ir/pattern/constraint.rs
+++ b/ir/pattern/constraint.rs
@@ -155,9 +155,9 @@ impl<'cx, 'reg> ConstraintsBuilder<'cx, 'reg> {
     ) -> Result<&Kind<Variable>, Box<RepresentationError>> {
         debug_assert!(self.context.is_variable_available(self.constraints.scope, variable));
         let category = match kind {
-            typeql::token::Kind::Entity => VariableCategory::ThingType,
-            typeql::token::Kind::Relation => VariableCategory::ThingType,
-            typeql::token::Kind::Attribute => VariableCategory::ThingType,
+            typeql::token::Kind::Entity => VariableCategory::ObjectType,
+            typeql::token::Kind::Relation => VariableCategory::RelationType,
+            typeql::token::Kind::Attribute => VariableCategory::AttributeType,
             typeql::token::Kind::Role => VariableCategory::RoleType,
         };
         let kind = Kind::new(kind, variable, source_span);
@@ -421,7 +421,7 @@ impl<'cx, 'reg> ConstraintsBuilder<'cx, 'reg> {
 
         if let Some(owner_type) = owner_type_var {
             debug_assert!(self.context.is_variable_available(self.constraints.scope, owner_type));
-            self.context.set_variable_category(owner_type, VariableCategory::ThingType, owns.clone())?;
+            self.context.set_variable_category(owner_type, VariableCategory::ObjectType, owns.clone())?;
         };
 
         if let Some(attribute_type) = attribute_type_var {
@@ -445,7 +445,7 @@ impl<'cx, 'reg> ConstraintsBuilder<'cx, 'reg> {
 
         if let Some(relation_type) = relation_type_var {
             debug_assert!(self.context.is_variable_available(self.constraints.scope, relation_type));
-            self.context.set_variable_category(relation_type, VariableCategory::ThingType, relates.clone())?;
+            self.context.set_variable_category(relation_type, VariableCategory::RelationType, relates.clone())?;
         };
 
         if let Some(role_type) = role_type_var {
@@ -469,7 +469,7 @@ impl<'cx, 'reg> ConstraintsBuilder<'cx, 'reg> {
 
         if let Some(player_type) = player_type_var {
             debug_assert!(self.context.is_variable_available(self.constraints.scope, player_type));
-            self.context.set_variable_category(player_type, VariableCategory::ThingType, plays.clone())?;
+            self.context.set_variable_category(player_type, VariableCategory::ObjectType, plays.clone())?;
         };
 
         if let Some(role_type) = role_type_var {

--- a/ir/pattern/constraint.rs
+++ b/ir/pattern/constraint.rs
@@ -272,7 +272,7 @@ impl<'cx, 'reg> ConstraintsBuilder<'cx, 'reg> {
                 && self.context.is_variable_available(self.constraints.scope, role_type)
         );
 
-        self.context.set_variable_category(relation, VariableCategory::Object, links.clone())?;
+        self.context.set_variable_category(relation, VariableCategory::Relation, links.clone())?;
         self.context.set_variable_category(player, VariableCategory::Object, links.clone())?;
 
         self.context.set_variable_category(role_type, VariableCategory::RoleType, links.clone())?;

--- a/ir/pattern/variable_category.rs
+++ b/ir/pattern/variable_category.rs
@@ -11,6 +11,8 @@ pub enum VariableCategory {
     Type,
     ThingType,
     AttributeType,
+    ObjectType,
+    RelationType,
     RoleType,
 
     Thing,
@@ -42,6 +44,24 @@ impl VariableCategory {
             }
             (Self::AttributeType, Self::AttributeType) => Some(Self::AttributeType),
             (Self::AttributeType, _) | (_, Self::AttributeType) => None,
+
+            (Self::Type, Self::RelationType) | (Self::RelationType, Self::Type) => Some(Self::RelationType),
+            (Self::ThingType, Self::RelationType) | (Self::RelationType, Self::ThingType) => {
+                Some(Self::RelationType)
+            }
+            (Self::ObjectType, Self::RelationType) | (Self::RelationType, Self::ObjectType) => {
+                Some(Self::RelationType)
+            }
+            (Self::RelationType, Self::RelationType) => Some(Self::RelationType),
+            (Self::RelationType, _) | (_, Self::RelationType) => None,
+
+            (Self::Type, Self::ObjectType) | (Self::ObjectType, Self::Type) => Some(Self::ObjectType),
+            (Self::ThingType, Self::ObjectType) | (Self::ObjectType, Self::ThingType) => {
+                Some(Self::ObjectType)
+            }
+            (Self::ObjectType, Self::ObjectType) => Some(Self::RelationType),
+            (Self::ObjectType, _) | (_, Self::ObjectType) => None,
+
 
             (Self::ThingType, Self::ThingType) => Some(Self::ThingType),
             (Self::ThingType, Self::Type) | (Self::Type, Self::ThingType) => Some(Self::ThingType),

--- a/ir/pattern/variable_category.rs
+++ b/ir/pattern/variable_category.rs
@@ -15,6 +15,7 @@ pub enum VariableCategory {
 
     Thing,
     Object,
+    Relation,
 
     AttributeOrValue,
     Attribute,
@@ -22,6 +23,7 @@ pub enum VariableCategory {
 
     ThingList,
     ObjectList,
+    RelationList,
 
     AttributeList,
     ValueList,
@@ -52,10 +54,15 @@ impl VariableCategory {
             (Self::Thing, Self::Object) | (Self::Object, Self::Thing) => Some(Self::Object),
             (Self::Thing, Self::AttributeOrValue) | (Self::AttributeOrValue, Self::Thing) => Some(Self::Attribute),
             (Self::Thing, Self::Attribute) | (Self::Attribute, Self::Thing) => Some(Self::Attribute),
+            (Self::Thing, Self::Relation) | (Self::Relation, Self::Thing) => Some(Self::Relation),
             (_, Self::Thing) | (Self::Thing, _) => None,
 
             (Self::Object, Self::Object) => Some(Self::Object),
+            (Self::Relation, Self::Object) | (Self::Object, Self::Relation) => Some(Self::Relation),
             (_, Self::Object) | (Self::Object, _) => None,
+
+            (Self::Relation, Self::Relation) => Some(Self::Relation),
+            (Self::Relation, _) | (_, Self::Relation) => None,
 
             (Self::AttributeOrValue, Self::AttributeOrValue) => Some(Self::AttributeOrValue),
             (Self::AttributeOrValue, Self::Attribute) | (Self::Attribute, Self::AttributeOrValue) => {
@@ -69,6 +76,11 @@ impl VariableCategory {
 
             (Self::Value, Self::Value) => Some(Self::Value),
             (_, Self::Value) | (Self::Value, _) => None,
+
+            (Self::RelationList, Self::RelationList) => Some(Self::RelationList),
+            (Self::ObjectList, Self::RelationList) | (Self::RelationList, Self::ObjectList) => Some(Self::RelationList),
+            (Self::ThingList, Self::RelationList) | (Self::RelationList, Self::ThingList) => Some(Self::RelationList),
+            (Self::RelationList, _) | (_, Self::RelationList) => None,
 
             (Self::ObjectList, Self::ObjectList) => Some(Self::ObjectList),
             (Self::ThingList, Self::ObjectList) | (Self::ObjectList, Self::ThingList) => Some(Self::ObjectList),


### PR DESCRIPTION
This change causes unintuitive behaviour (which currently shows up only in loosely typed queries). It should guarantee safe casts during execution, but there's a bigger problem to be solved wrt annotations varying in across nested patterns.

## Release notes: product changes
Variable categories now restrict applicable types throughout the query. This can lead to unintuitive behaviour for loosely typed queries.
` $x has name $n; ` will return entities with names as well.
` $x has name $n; not { $x links ($y);` will not return entities.

The benefit is simpler code as we can guarantee all casts done during execution are safe.

## Motivation
Prevent bad casts during execution.

## Implementation
* TypeSeeder prunes VertexAnnotations which have mismatched categories.
* Introduces `VariableCategory::{Relation, RelationType, ObjectType}`