### PR TITLE
Add quotes to support spaces in windows launcher

### DIFF
--- a/binary/typedb.bat
+++ b/binary/typedb.bat
@@ -23,12 +23,12 @@ goto print_usage
 :startconsole
 
 for /f "tokens=1,* delims= " %%a in ("%*") do set ARGS=%%b
-%TYPEDB_HOME%\console\typedb_console_bin.exe %ARGS%
+"%TYPEDB_HOME%\console\typedb_console_bin.exe" %ARGS%
 goto exit
 
 :startserver
 for /f "tokens=1,* delims= " %%a in ("%*") do set ARGS=%%b
-%TYPEDB_HOME%\server\typedb_server_bin.exe %ARGS%
+"%TYPEDB_HOME%\server\typedb_server_bin.exe" %ARGS%
 goto exit
 
 :exit


### PR DESCRIPTION
## Release notes: product changes
Add quotes in typedb.bat to support spaces in the path to the TypeDB executable.
