### PR TITLE
Better type-inference errors by pre-checking constraints for empty type annotations

### DIFF
--- a/compiler/annotation/match_inference.rs
+++ b/compiler/annotation/match_inference.rs
@@ -195,7 +195,11 @@ fn construct_error_message_for_unsatisfiable_edge(
 fn pre_check_edges_for_trivial_unsatisfiability<'a>(
     graph: &'a TypeInferenceGraph<'a>,
 ) -> Result<(), &'a TypeInferenceEdge<'a>> {
-    if let Some(edge) = graph.edges.iter().find(|edge| edge.left_to_right.is_empty() || edge.right_to_left.is_empty()) {
+    let mut thing_edges = graph.edges.iter().filter(|edge| match &edge.constraint {
+        Constraint::Links(_) | Constraint::Has(_) | Constraint::Isa(_) => true,
+        _ => false,
+    });
+    if let Some(edge) = thing_edges.find(|edge| edge.left_to_right.is_empty() || edge.right_to_left.is_empty()) {
         return Err(edge);
     }
     graph

--- a/compiler/annotation/match_inference.rs
+++ b/compiler/annotation/match_inference.rs
@@ -11,7 +11,7 @@ use std::{
     sync::Arc,
 };
 
-use answer::{variable::Variable, Type as TypeAnnotation, Type};
+use answer::{variable::Variable, Type as TypeAnnotation};
 use concept::type_::type_manager::TypeManager;
 use ir::{
     pattern::{conjunction::Conjunction, constraint::Constraint, variable_category::VariableCategory, Vertex},
@@ -164,14 +164,14 @@ fn construct_error_message_for_unsatisfiable_edge(
     graph: &TypeInferenceGraph<'_>,
     edge: &TypeInferenceEdge<'_>,
 ) -> TypeInferenceError {
-    let resolve_vertex = (|vertex: &Vertex<Variable>| match vertex {
+    let resolve_vertex = |vertex: &Vertex<Variable>| match vertex {
         Vertex::Variable(v) => variable_registry
             .get_variable_name(*v)
             .cloned()
             .unwrap_or(VariableRegistry::UNNAMED_VARIABLE_DISPLAY_NAME.to_string()),
         Vertex::Label(label) => label.scoped_name().as_str().to_string(),
         Vertex::Parameter(_) => unreachable!("Parameters can't be involved in TypeInferenceEdges"),
-    });
+    };
     let resolve_type_label = |type_: &answer::Type| {
         type_
             .get_label(snapshot, type_manager)

--- a/compiler/annotation/match_inference.rs
+++ b/compiler/annotation/match_inference.rs
@@ -183,7 +183,6 @@ fn construct_error_message_for_unsatisfiable_edge(
     let left_types = graph.vertices.annotations.get(&edge.left).unwrap().iter().map(resolve_type_label).join(", ");
     let right_types = graph.vertices.annotations.get(&edge.right).unwrap().iter().map(resolve_type_label).join(", ");
     TypeInferenceError::DetectedUnsatisfiableEdge {
-        constraint: edge.constraint.clone(),
         left_variable,
         right_variable,
         left_types,

--- a/compiler/annotation/mod.rs
+++ b/compiler/annotation/mod.rs
@@ -205,8 +205,7 @@ typedb_error!(
         ),
         DetectedUnsatisfiableEdge(
             11,
-            "Type-inference was unable to find compatible types for the pair of variables '{left_variable}' & '{right_variable}' across the constraint '{constraint}'. Types were:\n- {left_variable}: [{left_types}]\n- {right_variable}: [{right_types}]",
-            constraint: ir::pattern::constraint::Constraint<Variable>,
+            "Type-inference was unable to find compatible types for the pair of variables '{left_variable}' & '{right_variable}' across a constraint. Types were:\n- {left_variable}: [{left_types}]\n- {right_variable}: [{right_types}]",
             left_variable: String,
             right_variable: String,
             left_types: String,

--- a/compiler/annotation/mod.rs
+++ b/compiler/annotation/mod.rs
@@ -205,7 +205,7 @@ typedb_error!(
         ),
         DetectedUnsatisfiableEdge(
             11,
-            "Type-inference was unable to find compatible types for the pair of variables '{left_variable}' & '{right_variable}' across the constraint. Types were:\n- {left_variable}: [{left_types}]\n- {right_variable}: [{right_types}]",
+            "Type-inference was unable to find compatible types for the pair of variables '{left_variable}' & '{right_variable}' across the constraint '{constraint}'. Types were:\n- {left_variable}: [{left_types}]\n- {right_variable}: [{right_types}]",
             constraint: ir::pattern::constraint::Constraint<Variable>,
             left_variable: String,
             right_variable: String,

--- a/compiler/annotation/mod.rs
+++ b/compiler/annotation/mod.rs
@@ -203,6 +203,16 @@ typedb_error!(
             variable: Variable,
             source_span: Option<Span>,
         ),
+        DetectedUnsatisfiableEdge(
+            11,
+            "Type-inference was unable to find compatible types for the pair of variables '{left_variable}' & '{right_variable}' across the constraint. Types were:\n- {left_variable}: [{left_types}]\n- {right_variable}: [{right_types}]",
+            constraint: ir::pattern::constraint::Constraint<Variable>,
+            left_variable: String,
+            right_variable: String,
+            left_types: String,
+            right_types: String,
+            source_span: Option<Span>,
+        ),
         OptionalTypesUnsupported(255, "Optional types are not yet supported."),
         ListTypesUnsupported(256, "List types are not yet supported."),
     }

--- a/compiler/annotation/type_inference.rs
+++ b/compiler/annotation/type_inference.rs
@@ -597,7 +597,12 @@ pub mod tests {
             )
             .unwrap_err();
 
-            assert_matches!(err, TypeInferenceError::DetectedUnsatisfiablePattern {})
+            assert!(match err {
+                TypeInferenceError::DetectedUnsatisfiableEdge { left_variable, right_variable, .. } => {
+                    left_variable == "animal" && right_variable == "name"
+                }
+                _ => false,
+            });
         }
 
         {
@@ -1440,7 +1445,12 @@ pub mod tests {
                 false,
             )
             .unwrap_err();
-            assert_matches!(err, TypeInferenceError::DetectedUnsatisfiablePattern {});
+            assert!(match err {
+                TypeInferenceError::DetectedUnsatisfiableEdge { left_variable, right_variable, .. } => {
+                    left_variable == "animal" && right_variable == "name"
+                }
+                _ => false,
+            });
         }
 
         {

--- a/compiler/annotation/type_inference.rs
+++ b/compiler/annotation/type_inference.rs
@@ -77,7 +77,6 @@ pub mod tests {
         translation::{pipeline::TranslatedStage, TranslationContext},
     };
     use itertools::Itertools;
-    use test_utils::assert_matches;
 
     use crate::annotation::{
         function::{

--- a/dependencies/typedb/repositories.bzl
+++ b/dependencies/typedb/repositories.bzl
@@ -35,6 +35,6 @@ def typedb_protocol():
 def typedb_behaviour():
     git_repository(
         name = "typedb_behaviour",
-        remote = "https://github.com/typedb/typedb-behaviour",
-        commit = "373659bb6799ba61de0dcc8cd5f151a18fcbdf35",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @typedb_behaviour
+        remote = "https://github.com/krishnangovindraj/typedb-behaviour",
+        commit = "c8d21562ff2af9b9101dc2101aeff502788a72b8",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @typedb_behaviour
     )

--- a/dependencies/typedb/repositories.bzl
+++ b/dependencies/typedb/repositories.bzl
@@ -35,6 +35,6 @@ def typedb_protocol():
 def typedb_behaviour():
     git_repository(
         name = "typedb_behaviour",
-        remote = "https://github.com/krishnangovindraj/typedb-behaviour",
-        commit = "c8d21562ff2af9b9101dc2101aeff502788a72b8",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @typedb_behaviour
+        remote = "https://github.com/typedb/typedb-behaviour",
+        commit = "8912362644425c355ded267a0703cc583c53425d",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @typedb_behaviour
     )

--- a/ir/pattern/constraint.rs
+++ b/ir/pattern/constraint.rs
@@ -732,7 +732,7 @@ impl<ID: IrID> Constraint<ID> {
         }
     }
 
-    pub(crate) fn source_span(&self) -> Option<Span> {
+    pub fn source_span(&self) -> Option<Span> {
         match self {
             Constraint::Is(inner) => inner.source_span(),
             Constraint::Kind(inner) => None,


### PR DESCRIPTION
## Release notes: product changes
Add a pre-check to see if type-seeding could not annotate some edge. Since such an error is localised to a pattern rather than an edge, it lets us have more descriptive errors. Such trivial cases are likely to account for most type-inference errors.
Sample:
```
mydb::read> match $c isa cat; $n isa dog-name; $c has $n;
           
INF11 
[INF11] Type-inference was unable to find compatible types for the pair of variables 'c' & 'n' across the constraint '$0 has $1'. Types were:
- c: [cat]
- n: [dog-name]
Caused: [QUA1] Type inference error while compiling query annotations.
Caused: [QEX8] Error analysing query.
Near 1:39
-----
--> match $c isa cat; $n isa dog-name; $c has $n;
                                          ^
-----
```

Since type-seeding is non-deterministic when annotating variables without explicit labels, the edge flagged may vary.
```
INF11 
[INF11] Type-inference was unable to find compatible types for the pair of variables 'n' & 'dog-name' across the constraint '$1 isa dog-name'. Types were:
- n: [name, cat-name]
- dog-name: [dog-name]
Caused: [QUA1] Type inference error while compiling query annotations.
Caused: [QEX8] Error analysing query.
Near 1:23
-----
--> match $c isa cat, has dog-name $n;
                          ^
-----
```

In cases where every edge (in isolation) can be annotated, the existing & less-descriptive "unsatisfiable pattern" error will still be returned. 

## Motivation
Better error messages for trivial cases of type-inference errors.

## Implementation
Given a set of valid vertex annotations for the left & right vertices, `TypeSeeder::seed_edges` annotates the edge with valid combinations of `left_right` & `right_left`. When there are no valid combinations, these sets are empty. 
A simple pre-check can flag such edges and return a descriptive error.

