### PR TITLE
Compile only the functions referenced in the query

### DIFF
--- a/compiler/executable/pipeline.rs
+++ b/compiler/executable/pipeline.rs
@@ -399,6 +399,7 @@ fn find_referenced_functions(
     }
     referenced_functions
 }
+
 fn find_referenced_functions_in_pipeline(
     annotated_schema_functions: &AnnotatedSchemaFunctions,
     preamble: &AnnotatedPreambleFunctions,

--- a/ir/pattern/constraint.rs
+++ b/ir/pattern/constraint.rs
@@ -840,7 +840,7 @@ impl<ID: IrID> Constraint<ID> {
         }
     }
 
-    pub(crate) fn as_function_call_binding(&self) -> Option<&FunctionCallBinding<ID>> {
+    pub fn as_function_call_binding(&self) -> Option<&FunctionCallBinding<ID>> {
         match self {
             Constraint::FunctionCallBinding(binding) => Some(binding),
             _ => None,


### PR DESCRIPTION
## Release notes: product changes
Updates the compiler to only compile those functions referenced by the query.

## Motivation
Save effort.

## Implementation
Recursively collects all `FunctionID`s from function calls in:
1. Query pipeline, 
2. Query Fetch,
3. Any function referenced by the query.
4. Any function referenced in 3 or 4.

Note, that we don't compile unused preamble functions either. So any errors that would occur at compile time are not raised till the function is used.