### PR TITLE
Release Windows in published mode

### DIFF
--- a/.circleci/windows/deploy_release.bat
+++ b/.circleci/windows/deploy_release.bat
@@ -8,7 +8,7 @@ REM by Chocolatey in prepare.bat is accessible
 CALL refreshenv
 
 REM build file
-cargo build --profile=release
+cargo build --profile=release --features published
 copy target\release\typedb_server_bin.exe  .\
 git apply .circleci\windows\git.patch
 

--- a/.circleci/windows/deploy_release.bat
+++ b/.circleci/windows/deploy_release.bat
@@ -15,5 +15,5 @@ git apply .circleci\windows\git.patch
 SET DEPLOY_ARTIFACT_USERNAME=%REPO_TYPEDB_USERNAME%
 SET DEPLOY_ARTIFACT_PASSWORD=%REPO_TYPEDB_PASSWORD%
 set /p VER=<VERSION
-bazel --windows_enable_symlinks run --define version=%VER%  --enable_runfiles //:deploy-typedb-server -- release
+bazel --windows_enable_symlinks run --define version=%VER% --//server:mode=published --enable_runfiles //:deploy-typedb-server -- release
 


### PR DESCRIPTION
## Release notes: product changes
Fix a bug when Windows release binaries are published in the development mode. 

## Motivation
Windows release binaries were running in the development mode.

## Implementation
Switch the Bazel `--//server:mode=published` build flag.