### PR TITLE
Make type annotations local to a conjunction

### DIFF
--- a/compiler/annotation/expression/block_compiler.rs
+++ b/compiler/annotation/expression/block_compiler.rs
@@ -65,7 +65,7 @@ pub fn compile_expressions<'block, Snapshot: ReadableSnapshot>(
     block: &'block Block,
     variable_registry: &'block mut VariableRegistry,
     parameters: &'block ParameterRegistry,
-    type_annotations: &'block BlockAnnotations,
+    block_annotations: &'block BlockAnnotations,
     input_value_type_annotations: &mut BTreeMap<Variable, ExpressionValueType>,
 ) -> Result<HashMap<ExpressionBinding<Variable>, ExecutableExpression<Variable>>, Box<ExpressionCompileError>> {
     let mut context = BlockExpressionsCompilationContext {
@@ -74,7 +74,7 @@ pub fn compile_expressions<'block, Snapshot: ReadableSnapshot>(
         parameters,
         snapshot,
         type_manager,
-        block_annotations: type_annotations,
+        block_annotations,
         variable_value_types: input_value_type_annotations.iter().map(|(&k, v)| (k, v.clone())).collect(),
         visited_expressions: HashSet::new(),
         compiled_expressions: HashMap::new(),

--- a/compiler/annotation/expression/block_compiler.rs
+++ b/compiler/annotation/expression/block_compiler.rs
@@ -15,14 +15,13 @@ use ir::{
         disjunction::Disjunction,
         nested_pattern::NestedPattern,
         variable_category::VariableCategory,
-        Vertex,
+        Scope, ScopeId, Vertex,
     },
     pipeline::{block::Block, ParameterRegistry, VariableRegistry},
 };
 use itertools::Itertools;
 use storage::snapshot::ReadableSnapshot;
 use typeql::common::Span;
-use ir::pattern::{Scope, ScopeId};
 
 use crate::annotation::{
     expression::{
@@ -204,7 +203,8 @@ fn try_value_type_from_assignments<'a, Snapshot: ReadableSnapshot>(
         let mut return_types = HashSet::new();
         for (scope_id, assignment) in assignments_for_variable {
             assignment.expression().variables().try_for_each(|var| {
-                resolve_type_for_variable(context, *scope_id, var, expression_assignments, assignment.source_span()).map(|_| ())
+                resolve_type_for_variable(context, *scope_id, var, expression_assignments, assignment.source_span())
+                    .map(|_| ())
             })?;
             let compiled = ExpressionCompilationContext::compile(
                 assignment.expression(),

--- a/compiler/annotation/expression/block_compiler.rs
+++ b/compiler/annotation/expression/block_compiler.rs
@@ -22,6 +22,7 @@ use ir::{
 use itertools::Itertools;
 use storage::snapshot::ReadableSnapshot;
 use typeql::common::Span;
+use ir::pattern::{Scope, ScopeId};
 
 use crate::annotation::{
     expression::{
@@ -29,9 +30,11 @@ use crate::annotation::{
         expression_compiler::ExpressionCompilationContext,
         ExpressionCompileError,
     },
-    type_annotations::TypeAnnotations,
+    type_annotations::BlockAnnotations,
     type_inference::resolve_value_types,
 };
+
+type AssignmentIndex<'a> = HashMap<Variable, Vec<(ScopeId, &'a ExpressionBinding<Variable>)>>;
 
 struct BlockExpressionsCompilationContext<'block, Snapshot: ReadableSnapshot> {
     block: &'block Block,
@@ -40,7 +43,7 @@ struct BlockExpressionsCompilationContext<'block, Snapshot: ReadableSnapshot> {
 
     snapshot: &'block Snapshot,
     type_manager: &'block TypeManager,
-    type_annotations: &'block TypeAnnotations,
+    block_annotations: &'block BlockAnnotations,
 
     variable_value_types: HashMap<Variable, ExpressionValueType>,
     compiled_expressions: HashMap<ExpressionBinding<Variable>, ExecutableExpression<Variable>>,
@@ -63,7 +66,7 @@ pub fn compile_expressions<'block, Snapshot: ReadableSnapshot>(
     block: &'block Block,
     variable_registry: &'block mut VariableRegistry,
     parameters: &'block ParameterRegistry,
-    type_annotations: &'block TypeAnnotations,
+    type_annotations: &'block BlockAnnotations,
     input_value_type_annotations: &mut BTreeMap<Variable, ExpressionValueType>,
 ) -> Result<HashMap<ExpressionBinding<Variable>, ExecutableExpression<Variable>>, Box<ExpressionCompileError>> {
     let mut context = BlockExpressionsCompilationContext {
@@ -72,7 +75,7 @@ pub fn compile_expressions<'block, Snapshot: ReadableSnapshot>(
         parameters,
         snapshot,
         type_manager,
-        type_annotations,
+        block_annotations: type_annotations,
         variable_value_types: input_value_type_annotations.iter().map(|(&k, v)| (k, v.clone())).collect(),
         visited_expressions: HashSet::new(),
         compiled_expressions: HashMap::new(),
@@ -105,11 +108,11 @@ pub fn compile_expressions<'block, Snapshot: ReadableSnapshot>(
 fn index_expressions_conjunction<'block, Snapshot: ReadableSnapshot>(
     context: &BlockExpressionsCompilationContext<'_, Snapshot>,
     conjunction: &'block Conjunction,
-    index: &mut HashMap<Variable, Vec<&'block ExpressionBinding<Variable>>>,
+    index: &mut AssignmentIndex<'block>,
 ) -> Result<(), Box<ExpressionCompileError>> {
     for expression_binding in conjunction.constraints().iter().filter_map(|c| c.as_expression_binding()) {
         let left = expression_binding.left().as_variable().unwrap();
-        if index.insert(left, vec![expression_binding]).is_some() {
+        if index.insert(left, vec![(conjunction.scope_id(), expression_binding)]).is_some() {
             return Err(Box::new(ExpressionCompileError::MultipleAssignmentsForVariable {
                 variable: context.variable_name(&left),
                 source_span: expression_binding.source_span(),
@@ -136,9 +139,9 @@ fn index_expressions_conjunction<'block, Snapshot: ReadableSnapshot>(
 fn index_expressions_disjunction<'block, Snapshot: ReadableSnapshot>(
     context: &BlockExpressionsCompilationContext<'_, Snapshot>,
     disjunction: &'block Disjunction,
-    index: &mut HashMap<Variable, Vec<&'block ExpressionBinding<Variable>>>,
+    index: &mut AssignmentIndex<'block>,
 ) -> Result<(), Box<ExpressionCompileError>> {
-    let mut combined_indices = HashMap::<Variable, Vec<&'block ExpressionBinding<Variable>>>::new();
+    let mut combined_indices: AssignmentIndex<'block> = HashMap::new();
     let branch_indices = disjunction
         .conjunctions()
         .iter()
@@ -156,7 +159,7 @@ fn index_expressions_disjunction<'block, Snapshot: ReadableSnapshot>(
             debug_assert!(!index.get(&var).unwrap().is_empty());
             Err(ExpressionCompileError::MultipleAssignmentsForVariable {
                 variable: context.variable_name(&var),
-                source_span: index.get(&var).unwrap().first().unwrap().source_span(),
+                source_span: index.get(&var).unwrap().first().unwrap().1.source_span(),
             })
         }
         None => Ok(()),
@@ -167,15 +170,16 @@ fn index_expressions_disjunction<'block, Snapshot: ReadableSnapshot>(
 #[allow(clippy::map_entry, reason = "false positive, this is not a trivial `contains_key()` followed by `insert()`")]
 fn resolve_type_for_variable<'a, Snapshot: ReadableSnapshot>(
     context: &mut BlockExpressionsCompilationContext<'a, Snapshot>,
+    scope_id: ScopeId,
     variable: Variable,
-    expression_assignments: &HashMap<Variable, Vec<&'a ExpressionBinding<Variable>>>,
+    expression_assignments: &AssignmentIndex<'a>,
     assignment_span: Option<Span>,
 ) -> Result<ExpressionValueType, Box<ExpressionCompileError>> {
     if let Some(value) = context.variable_value_types.get(&variable) {
         Ok(value.clone())
     } else if let Some(value) = try_value_type_from_assignments(context, variable, expression_assignments)? {
         Ok(value)
-    } else if let Some(value) = try_value_type_from_type_annotations(context, variable, assignment_span)? {
+    } else if let Some(value) = try_value_type_from_type_annotations(context, scope_id, variable, assignment_span)? {
         Ok(value)
     } else {
         Err(Box::new(ExpressionCompileError::CouldNotDetermineValueTypeForVariable {
@@ -188,7 +192,7 @@ fn resolve_type_for_variable<'a, Snapshot: ReadableSnapshot>(
 fn try_value_type_from_assignments<'a, Snapshot: ReadableSnapshot>(
     context: &mut BlockExpressionsCompilationContext<'a, Snapshot>,
     variable: Variable,
-    expression_assignments: &HashMap<Variable, Vec<&'a ExpressionBinding<Variable>>>,
+    expression_assignments: &AssignmentIndex<'a>,
 ) -> Result<Option<ExpressionValueType>, Box<ExpressionCompileError>> {
     if let Some(assignments_for_variable) = expression_assignments.get(&variable) {
         if !context.visited_expressions.insert(variable) {
@@ -198,9 +202,9 @@ fn try_value_type_from_assignments<'a, Snapshot: ReadableSnapshot>(
             }));
         }
         let mut return_types = HashSet::new();
-        for assignment in assignments_for_variable {
+        for (scope_id, assignment) in assignments_for_variable {
             assignment.expression().variables().try_for_each(|var| {
-                resolve_type_for_variable(context, var, expression_assignments, assignment.source_span()).map(|_| ())
+                resolve_type_for_variable(context, *scope_id, var, expression_assignments, assignment.source_span()).map(|_| ())
             })?;
             let compiled = ExpressionCompilationContext::compile(
                 assignment.expression(),
@@ -228,10 +232,12 @@ fn try_value_type_from_assignments<'a, Snapshot: ReadableSnapshot>(
 
 fn try_value_type_from_type_annotations<Snapshot: ReadableSnapshot>(
     context: &mut BlockExpressionsCompilationContext<'_, Snapshot>,
+    scope_id: ScopeId,
     variable: Variable,
     source_span: Option<Span>,
 ) -> Result<Option<ExpressionValueType>, Box<ExpressionCompileError>> {
-    let Some(annotations) = context.type_annotations.vertex_annotations_of(&Vertex::Variable(variable)) else {
+    let type_annotations = context.block_annotations.type_annotations_of_scope(scope_id).unwrap();
+    let Some(annotations) = type_annotations.vertex_annotations_of(&Vertex::Variable(variable)) else {
         return Ok(None);
     };
     let variable_category = context.variable_registry.get_variable_category(variable).unwrap();

--- a/compiler/annotation/function.rs
+++ b/compiler/annotation/function.rs
@@ -464,8 +464,9 @@ fn annotate_arguments(
             let body_variable_annotations = annotated_stages
                 .iter()
                 .filter_map(|stage| {
-                    if let AnnotatedStage::Match { block_annotations, .. } = stage {
-                        block_annotations.vertex_annotations_of(&Vertex::Variable(var)).cloned()
+                    if let AnnotatedStage::Match { block, block_annotations, .. } = stage {
+                        let root_annotations = block_annotations.type_annotations_of(block.conjunction()).unwrap();
+                        root_annotations.vertex_annotations_of(&Vertex::Variable(var)).cloned()
                     } else {
                         None
                     }

--- a/compiler/annotation/match_inference.rs
+++ b/compiler/annotation/match_inference.rs
@@ -301,16 +301,19 @@ impl TypeInferenceGraph<'_> {
             .into_iter()
             .map(|(variable, types)| (variable.into(), Arc::new(types)))
             .collect::<BTreeMap<_, _>>();
-        debug_assert!(_variable_registry.is_none() || conjunction
-            .constraints()
-            .iter()
-            .flat_map(|constraint| constraint.ids())
-            .filter(|variable| match _variable_registry.unwrap().get_variable_category(*variable) {
-                None => false,
-                Some(VariableCategory::Value | VariableCategory::ValueList) => false,
-                Some(_) => true,
-            })
-            .all(|var| { vertex_annotations.contains_key(&var.into()) }));
+        debug_assert!(
+            _variable_registry.is_none()
+                || conjunction
+                    .constraints()
+                    .iter()
+                    .flat_map(|constraint| constraint.ids())
+                    .filter(|variable| match _variable_registry.unwrap().get_variable_category(*variable) {
+                        None => false,
+                        Some(VariableCategory::Value | VariableCategory::ValueList) => false,
+                        Some(_) => true,
+                    })
+                    .all(|var| { vertex_annotations.contains_key(&var.into()) })
+        );
 
         let type_annotations = TypeAnnotations::new(vertex_annotations, constraint_annotations);
         type_annotations_by_scope.insert(conjunction.scope_id(), type_annotations);

--- a/compiler/annotation/match_inference.rs
+++ b/compiler/annotation/match_inference.rs
@@ -286,7 +286,11 @@ impl TypeInferenceGraph<'_> {
 
         let vertex_annotations = vertices.into_iter().map(|(variable, types)| {
             (variable.into(), Arc::new(types))
-        }).collect();
+        }).collect::<BTreeMap<_, _>>();
+        debug_assert!(conjunction.constraints().iter().flat_map(|c| c.ids()).all(|var| {
+            vertex_annotations.contains_key(&var.into())
+        }));
+
         let type_annotations = TypeAnnotations::new(vertex_annotations, constraint_annotations);
         type_annotations_by_scope.insert(conjunction.scope_id(), type_annotations);
 

--- a/compiler/annotation/match_inference.rs
+++ b/compiler/annotation/match_inference.rs
@@ -119,7 +119,7 @@ pub fn infer_types(
         is_write_stage,
     )?;
     let mut type_annotations_by_scope = HashMap::new();
-    graph.collect_type_annotations(variable_registry, &mut type_annotations_by_scope);
+    graph.collect_type_annotations(Some(variable_registry), &mut type_annotations_by_scope);
     Ok(BlockAnnotations::new(type_annotations_by_scope))
 }
 
@@ -263,7 +263,7 @@ impl TypeInferenceGraph<'_> {
 
     pub(crate) fn collect_type_annotations(
         self,
-        _variable_registry: &VariableRegistry,
+        _variable_registry: Option<&VariableRegistry>,
         type_annotations_by_scope: &mut HashMap<ScopeId, TypeAnnotations>,
     ) {
         let TypeInferenceGraph {
@@ -301,11 +301,11 @@ impl TypeInferenceGraph<'_> {
             .into_iter()
             .map(|(variable, types)| (variable.into(), Arc::new(types)))
             .collect::<BTreeMap<_, _>>();
-        debug_assert!(conjunction
+        debug_assert!(_variable_registry.is_none() || conjunction
             .constraints()
             .iter()
             .flat_map(|constraint| constraint.ids())
-            .filter(|variable| match _variable_registry.get_variable_category(*variable) {
+            .filter(|variable| match _variable_registry.unwrap().get_variable_category(*variable) {
                 None => false,
                 Some(VariableCategory::Value | VariableCategory::ValueList) => false,
                 Some(_) => true,

--- a/compiler/annotation/match_inference.rs
+++ b/compiler/annotation/match_inference.rs
@@ -480,6 +480,3 @@ impl NestedTypeInferenceGraphDisjunction<'_> {
         is_modified
     }
 }
-
-#[cfg(test)]
-pub mod tests {}

--- a/compiler/annotation/match_inference.rs
+++ b/compiler/annotation/match_inference.rs
@@ -261,7 +261,11 @@ impl TypeInferenceGraph<'_> {
         is_modified
     }
 
-    pub(crate) fn collect_type_annotations(self, _variable_registry: &VariableRegistry, type_annotations_by_scope: &mut HashMap<ScopeId, TypeAnnotations>) {
+    pub(crate) fn collect_type_annotations(
+        self,
+        _variable_registry: &VariableRegistry,
+        type_annotations_by_scope: &mut HashMap<ScopeId, TypeAnnotations>,
+    ) {
         let TypeInferenceGraph {
             vertices,
             edges,
@@ -305,7 +309,8 @@ impl TypeInferenceGraph<'_> {
                 None => false,
                 Some(VariableCategory::Value | VariableCategory::ValueList) => false,
                 Some(_) => true,
-            }).all(|var| { vertex_annotations.contains_key(&var.into()) }));
+            })
+            .all(|var| { vertex_annotations.contains_key(&var.into()) }));
 
         let type_annotations = TypeAnnotations::new(vertex_annotations, constraint_annotations);
         type_annotations_by_scope.insert(conjunction.scope_id(), type_annotations);

--- a/compiler/annotation/pipeline.rs
+++ b/compiler/annotation/pipeline.rs
@@ -10,7 +10,6 @@ use std::{
     iter::zip,
     sync::Arc,
 };
-use itertools::Itertools;
 
 use answer::{variable::Variable, Type};
 use concept::type_::type_manager::TypeManager;
@@ -31,6 +30,7 @@ use ir::{
     },
     translation::pipeline::TranslatedStage,
 };
+use itertools::Itertools;
 use storage::snapshot::ReadableSnapshot;
 use typeql::common::Span;
 
@@ -47,14 +47,13 @@ use crate::{
             AnnotatedPreambleFunctions, AnnotatedSchemaFunctions, FunctionParameterAnnotation,
         },
         match_inference::infer_types,
-        type_annotations::{ConstraintTypeAnnotations, BlockAnnotations},
+        type_annotations::{BlockAnnotations, ConstraintTypeAnnotations, TypeAnnotations},
         type_inference::resolve_value_types,
         write_type_check::check_type_combinations_for_write,
         AnnotationError,
     },
     executable::{reduce::ReduceInstruction, update},
 };
-use crate::annotation::type_annotations::TypeAnnotations;
 
 pub struct AnnotatedPipeline {
     pub annotated_preamble: AnnotatedPreambleFunctions,
@@ -510,7 +509,10 @@ fn annotate_write_stage(
     .map_err(|typedb_source| AnnotationError::TypeInference { typedb_source })?;
     let root_annotations_map = block_annotations.into_parts();
     debug_assert!(1 == root_annotations_map.len()); // Break if we introduce nested-patterns in writes.
-    let root_annotations = root_annotations_map.into_iter().map(|(_, annotations)| annotations).exactly_one()
+    let root_annotations = root_annotations_map
+        .into_iter()
+        .map(|(_, annotations)| annotations)
+        .exactly_one()
         .expect("Writes have only one conjunction");
     // Extend running annotations for variables introduced in this stage.
     block.conjunction().constraints().iter().for_each(|constraint| match constraint {

--- a/compiler/annotation/type_annotations.rs
+++ b/compiler/annotation/type_annotations.rs
@@ -21,12 +21,9 @@ impl BlockAnnotations {
     pub(crate) fn new(by_scope: HashMap<ScopeId, TypeAnnotations>) -> Self {
         Self { by_scope }
     }
-    pub fn type_annotations_of_scope(&self, scope_id: ScopeId) -> Option<&TypeAnnotations> {
-        self.by_scope.get(&scope_id)
-    }
 
     pub fn type_annotations_of(&self, conjunction: &Conjunction) -> Option<&TypeAnnotations> {
-        self.type_annotations_of_scope(conjunction.scope_id())
+        self.by_scope.get(&conjunction.scope_id())
     }
 
     pub fn type_annotations_mut_of(&mut self, conjunction: &Conjunction) -> Option<&mut TypeAnnotations> {

--- a/compiler/annotation/type_annotations.rs
+++ b/compiler/annotation/type_annotations.rs
@@ -10,8 +10,7 @@ use std::{
 };
 
 use answer::{variable::Variable, Type};
-use ir::pattern::{constraint::Constraint, Scope, ScopeId, Vertex};
-use ir::pattern::conjunction::Conjunction;
+use ir::pattern::{conjunction::Conjunction, constraint::Constraint, Scope, ScopeId, Vertex};
 
 #[derive(Debug, Clone)]
 pub struct BlockAnnotations {
@@ -37,7 +36,6 @@ impl BlockAnnotations {
     pub(crate) fn into_parts(self) -> HashMap<ScopeId, TypeAnnotations> {
         self.by_scope
     }
-
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/compiler/annotation/type_annotations.rs
+++ b/compiler/annotation/type_annotations.rs
@@ -14,24 +14,24 @@ use ir::pattern::{conjunction::Conjunction, constraint::Constraint, Scope, Scope
 
 #[derive(Debug, Clone)]
 pub struct BlockAnnotations {
-    by_scope: HashMap<ScopeId, TypeAnnotations>,
+    scope_annotations: HashMap<ScopeId, TypeAnnotations>,
 }
 
 impl BlockAnnotations {
     pub(crate) fn new(by_scope: HashMap<ScopeId, TypeAnnotations>) -> Self {
-        Self { by_scope }
+        Self { scope_annotations: by_scope }
     }
 
     pub fn type_annotations_of(&self, conjunction: &Conjunction) -> Option<&TypeAnnotations> {
-        self.by_scope.get(&conjunction.scope_id())
+        self.scope_annotations.get(&conjunction.scope_id())
     }
 
     pub fn type_annotations_mut_of(&mut self, conjunction: &Conjunction) -> Option<&mut TypeAnnotations> {
-        self.by_scope.get_mut(&conjunction.scope_id())
+        self.scope_annotations.get_mut(&conjunction.scope_id())
     }
 
     pub(crate) fn into_parts(self) -> HashMap<ScopeId, TypeAnnotations> {
-        self.by_scope
+        self.scope_annotations
     }
 }
 

--- a/compiler/annotation/type_annotations.rs
+++ b/compiler/annotation/type_annotations.rs
@@ -10,7 +10,35 @@ use std::{
 };
 
 use answer::{variable::Variable, Type};
-use ir::pattern::{constraint::Constraint, Vertex};
+use ir::pattern::{constraint::Constraint, Scope, ScopeId, Vertex};
+use ir::pattern::conjunction::Conjunction;
+
+#[derive(Debug, Clone)]
+pub struct BlockAnnotations {
+    by_scope: HashMap<ScopeId, TypeAnnotations>,
+}
+
+impl BlockAnnotations {
+    pub(crate) fn new(by_scope: HashMap<ScopeId, TypeAnnotations>) -> Self {
+        Self { by_scope }
+    }
+    pub fn type_annotations_of_scope(&self, scope_id: ScopeId) -> Option<&TypeAnnotations> {
+        self.by_scope.get(&scope_id)
+    }
+
+    pub fn type_annotations_of(&self, conjunction: &Conjunction) -> Option<&TypeAnnotations> {
+        self.type_annotations_of_scope(conjunction.scope_id())
+    }
+
+    pub fn type_annotations_mut_of(&mut self, conjunction: &Conjunction) -> Option<&mut TypeAnnotations> {
+        self.by_scope.get_mut(&conjunction.scope_id())
+    }
+
+    pub(crate) fn into_parts(self) -> HashMap<ScopeId, TypeAnnotations> {
+        self.by_scope
+    }
+
+}
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct TypeAnnotations {

--- a/compiler/annotation/type_inference.rs
+++ b/compiler/annotation/type_inference.rs
@@ -54,9 +54,7 @@ pub mod tests {
 
     use answer::{variable::Variable, Type};
     use encoding::{
-        graph::{
-            definition::definition_key::{DefinitionID, DefinitionKey},
-        },
+        graph::definition::definition_key::{DefinitionID, DefinitionKey},
         layout::prefix::Prefix,
         value::label::Label,
     };
@@ -82,8 +80,8 @@ pub mod tests {
             EmptyAnnotatedFunctionSignatures,
         },
         match_inference::{
-            compute_type_inference_graph, infer_types, NestedTypeInferenceGraphDisjunction, TypeInferenceEdge,
-            TypeInferenceGraph, VertexAnnotations,
+            compute_type_inference_graph, infer_types, prune_types, NestedTypeInferenceGraphDisjunction,
+            TypeInferenceEdge, TypeInferenceGraph, VertexAnnotations,
         },
         pipeline::AnnotatedStage,
         tests::{
@@ -97,7 +95,6 @@ pub mod tests {
         type_seeder::TypeGraphSeedingContext,
         TypeInferenceError,
     };
-    use crate::annotation::match_inference::prune_types;
 
     #[test]
     fn test_functions() {
@@ -184,7 +181,12 @@ pub mod tests {
                 &EmptyAnnotatedFunctionSignatures,
                 false,
             )
-            .unwrap().into_parts().into_iter().exactly_one().unwrap().1;
+            .unwrap()
+            .into_parts()
+            .into_iter()
+            .exactly_one()
+            .unwrap()
+            .1;
             assert_eq!(
                 *annotations_without_schema_cache.vertex_annotations(),
                 BTreeMap::from([(var_animal.into(), Arc::new(BTreeSet::from(all_concrete_instance_types)))])
@@ -204,7 +206,9 @@ pub mod tests {
             let f_var_animal_type =
                 var_from_registry(&f_ir.translation_context().variable_registry, "called_animal_type").unwrap();
             let f_var_name = var_from_registry(&f_ir.translation_context().variable_registry, "called_name").unwrap();
-            let AnnotatedStage::Match { block, block_annotations, .. } = &f_annotations.stages[0] else { unreachable!() };
+            let AnnotatedStage::Match { block, block_annotations, .. } = &f_annotations.stages[0] else {
+                unreachable!()
+            };
             assert_eq!(
                 block_annotations.type_annotations_of(block.conjunction()).unwrap().vertex_annotations(),
                 &BTreeMap::from([
@@ -1473,5 +1477,4 @@ pub mod tests {
             assert_eq!(expected_graph, graph)
         }
     }
-
 }

--- a/compiler/annotation/type_inference.rs
+++ b/compiler/annotation/type_inference.rs
@@ -96,7 +96,7 @@ pub mod tests {
             },
             setup_storage,
         },
-        type_annotations::{ConstraintTypeAnnotations, LinksAnnotations, BlockAnnotations},
+        type_annotations::{BlockAnnotations, ConstraintTypeAnnotations, LinksAnnotations},
         type_seeder::TypeGraphSeedingContext,
         TypeInferenceError,
     };

--- a/compiler/annotation/type_inference.rs
+++ b/compiler/annotation/type_inference.rs
@@ -96,7 +96,7 @@ pub mod tests {
             },
             setup_storage,
         },
-        type_annotations::{ConstraintTypeAnnotations, LinksAnnotations, TypeAnnotations},
+        type_annotations::{ConstraintTypeAnnotations, LinksAnnotations, BlockAnnotations},
         type_seeder::TypeGraphSeedingContext,
         TypeInferenceError,
     };
@@ -178,7 +178,7 @@ pub mod tests {
         let mut vertex_annotations = BTreeMap::new();
         let mut constraint_annotations = HashMap::new();
         graph.collect_type_annotations(&mut vertex_annotations, &mut constraint_annotations);
-        let type_annotations = TypeAnnotations::new(vertex_annotations, constraint_annotations);
+        let type_annotations = BlockAnnotations::new(vertex_annotations, constraint_annotations);
 
         let lra1 = LinksAnnotations {
             relation_to_player: Arc::new(BTreeMap::from([(type_rel_0, vec![type_player_0])])),
@@ -192,7 +192,7 @@ pub mod tests {
             player_to_relation: Arc::new(BTreeMap::from([(type_player_1, vec![type_rel_1])])),
             relation_to_role: Arc::new(BTreeMap::from([(type_rel_1, BTreeSet::from([type_role_1]))])),
         };
-        let expected_annotations = TypeAnnotations::new(
+        let expected_annotations = BlockAnnotations::new(
             BTreeMap::from([
                 (var_relation.into(), Arc::new(BTreeSet::from([type_rel_0, type_rel_1]))),
                 (var_role_type.into(), Arc::new(BTreeSet::from([type_role_0, type_role_1]))),

--- a/compiler/annotation/type_seeder.rs
+++ b/compiler/annotation/type_seeder.rs
@@ -306,6 +306,12 @@ impl<'this, Snapshot: ReadableSnapshot> TypeGraphSeedingContext<'this, Snapshot>
         graph: &mut TypeInferenceGraph<'_>,
         context: &BlockContext,
     ) -> Result<bool, Box<ConceptReadError>> {
+        // TODO: We could look for constraints (instead of variable categories) as a basis for annotation.
+        //  We'd need TypeManager methods to iterate over all owns / relates / plays declarations.
+
+        // If any variables remain that aren't in any producing constraint, seed them with all types
+        //  TODO: This isn't very uncommon - when all disjunction branches produce a variable.
+        //   Ideally, we'd use annotations from the disjunction.
         let unannotated_var = self.local_variables(context, graph.conjunction.scope_id()).find(|&var| {
             let vertex = Vertex::Variable(var);
             self.variable_registry.get_variable_category(var).unwrap_or(VariableCategory::Value)

--- a/compiler/annotation/type_seeder.rs
+++ b/compiler/annotation/type_seeder.rs
@@ -340,10 +340,14 @@ impl<'this, Snapshot: ReadableSnapshot> TypeGraphSeedingContext<'this, Snapshot>
             VariableCategory::Type => (true, true),
             VariableCategory::RoleType => (false, true),
             VariableCategory::ValueList | VariableCategory::Value => (false, false),
-            VariableCategory::ThingType  | VariableCategory::AttributeType
-            | VariableCategory::ThingList | VariableCategory::Thing
-            | VariableCategory::ObjectList | VariableCategory::Object
-            | VariableCategory::AttributeList | VariableCategory::Attribute => (true, false),
+            VariableCategory::ThingType
+            | VariableCategory::AttributeType
+            | VariableCategory::ThingList
+            | VariableCategory::Thing
+            | VariableCategory::ObjectList
+            | VariableCategory::Object
+            | VariableCategory::AttributeList
+            | VariableCategory::Attribute => (true, false),
             VariableCategory::AttributeOrValue => unreachable!("Insufficiently bound variable!"),
         };
         let mut annotations = BTreeSet::new();

--- a/compiler/annotation/type_seeder.rs
+++ b/compiler/annotation/type_seeder.rs
@@ -576,6 +576,8 @@ impl<'this, Snapshot: ReadableSnapshot> TypeGraphSeedingContext<'this, Snapshot>
             inner.annotate_left_to_right(self, vertices.get(&left).unwrap(), vertices.get(&right).unwrap())?;
         let right_to_left =
             inner.annotate_right_to_left(self, vertices.get(&right).unwrap(), vertices.get(&left).unwrap())?;
+        debug_assert!(left_to_right.values().all(|v| !v.is_empty()));
+        debug_assert!(right_to_left.values().all(|v| !v.is_empty()));
         Ok(TypeInferenceEdge::build(constraint, left, right, left_to_right, right_to_left))
     }
 

--- a/compiler/executable/delete/executable.rs
+++ b/compiler/executable/delete/executable.rs
@@ -16,7 +16,7 @@ use itertools::Itertools;
 use typeql::common::Span;
 
 use crate::{
-    annotation::type_annotations::{BlockAnnotations, TypeAnnotations},
+    annotation::type_annotations::TypeAnnotations,
     executable::{
         delete::instructions::{ConnectionInstruction, Has, Links, ThingInstruction},
         insert::{

--- a/compiler/executable/delete/executable.rs
+++ b/compiler/executable/delete/executable.rs
@@ -16,7 +16,7 @@ use itertools::Itertools;
 use typeql::common::Span;
 
 use crate::{
-    annotation::type_annotations::TypeAnnotations,
+    annotation::type_annotations::BlockAnnotations,
     executable::{
         delete::instructions::{ConnectionInstruction, Has, Links, ThingInstruction},
         insert::{
@@ -27,6 +27,7 @@ use crate::{
     },
     VariablePosition,
 };
+use crate::annotation::type_annotations::TypeAnnotations;
 
 #[derive(Debug)]
 pub struct DeleteExecutable {

--- a/compiler/executable/delete/executable.rs
+++ b/compiler/executable/delete/executable.rs
@@ -16,7 +16,7 @@ use itertools::Itertools;
 use typeql::common::Span;
 
 use crate::{
-    annotation::type_annotations::BlockAnnotations,
+    annotation::type_annotations::{BlockAnnotations, TypeAnnotations},
     executable::{
         delete::instructions::{ConnectionInstruction, Has, Links, ThingInstruction},
         insert::{
@@ -27,7 +27,6 @@ use crate::{
     },
     VariablePosition,
 };
-use crate::annotation::type_annotations::TypeAnnotations;
 
 #[derive(Debug)]
 pub struct DeleteExecutable {

--- a/compiler/executable/function/executable.rs
+++ b/compiler/executable/function/executable.rs
@@ -94,7 +94,7 @@ fn compile_function(
         statistics,
         &variable_registry,
         call_cost_provider,
-        stages,
+        &stages,
         arguments.into_iter(),
         Some(&return_.referenced_variables()),
     )?;

--- a/compiler/executable/match_/instructions/mod.rs
+++ b/compiler/executable/match_/instructions/mod.rs
@@ -561,6 +561,10 @@ pub enum CheckInstruction<ID> {
         type_var: ID,
         types: Arc<BTreeSet<Type>>,
     },
+    ThingTypeList {
+        thing_var: ID,
+        types: Arc<BTreeSet<Type>>,
+    },
     Iid {
         var: ID,
         iid: ParameterID,
@@ -628,6 +632,7 @@ impl<ID: IrID> CheckInstruction<ID> {
     pub fn map<T: IrID>(self, mapping: &HashMap<ID, T>) -> CheckInstruction<T> {
         match self {
             Self::TypeList { type_var, types } => CheckInstruction::TypeList { type_var: mapping[&type_var], types },
+            Self::ThingTypeList { thing_var, types } => CheckInstruction::ThingTypeList { thing_var: mapping[&thing_var], types },
             Self::Iid { var, iid } => CheckInstruction::Iid { var: mapping[&var], iid },
             Self::Sub { sub_kind: kind, subtype, supertype } => CheckInstruction::Sub {
                 sub_kind: kind,
@@ -684,6 +689,13 @@ impl<ID: IrID> fmt::Display for CheckInstruction<ID> {
         match self {
             Self::TypeList { type_var, types } => {
                 write!(f, "{type_var} type (")?;
+                for type_ in types.as_ref() {
+                    write!(f, "{type_}, ")?;
+                }
+                write!(f, ")")?;
+            }
+            Self::ThingTypeList { thing_var, types } => {
+                write!(f, "{thing_var} thing_is_of_type (")?;
                 for type_ in types.as_ref() {
                     write!(f, "{type_}, ")?;
                 }

--- a/compiler/executable/match_/instructions/mod.rs
+++ b/compiler/executable/match_/instructions/mod.rs
@@ -632,7 +632,9 @@ impl<ID: IrID> CheckInstruction<ID> {
     pub fn map<T: IrID>(self, mapping: &HashMap<ID, T>) -> CheckInstruction<T> {
         match self {
             Self::TypeList { type_var, types } => CheckInstruction::TypeList { type_var: mapping[&type_var], types },
-            Self::ThingTypeList { thing_var, types } => CheckInstruction::ThingTypeList { thing_var: mapping[&thing_var], types },
+            Self::ThingTypeList { thing_var, types } => {
+                CheckInstruction::ThingTypeList { thing_var: mapping[&thing_var], types }
+            }
             Self::Iid { var, iid } => CheckInstruction::Iid { var: mapping[&var], iid },
             Self::Sub { sub_kind: kind, subtype, supertype } => CheckInstruction::Sub {
                 sub_kind: kind,

--- a/compiler/executable/match_/instructions/type_.rs
+++ b/compiler/executable/match_/instructions/type_.rs
@@ -18,7 +18,7 @@ use ir::pattern::{
 use itertools::Itertools;
 
 use crate::{
-    annotation::type_annotations::{LeftRightAnnotations, TypeAnnotations},
+    annotation::type_annotations::TypeAnnotations,
     executable::match_::instructions::{CheckInstruction, Inputs},
 };
 

--- a/compiler/executable/match_/instructions/type_.rs
+++ b/compiler/executable/match_/instructions/type_.rs
@@ -21,6 +21,7 @@ use crate::{
     annotation::type_annotations::TypeAnnotations,
     executable::match_::instructions::{CheckInstruction, Inputs},
 };
+use crate::annotation::type_annotations::LeftRightAnnotations;
 
 #[derive(Debug, Clone)]
 pub struct TypeListInstruction<ID> {

--- a/compiler/executable/match_/instructions/type_.rs
+++ b/compiler/executable/match_/instructions/type_.rs
@@ -18,10 +18,9 @@ use ir::pattern::{
 use itertools::Itertools;
 
 use crate::{
-    annotation::type_annotations::TypeAnnotations,
+    annotation::type_annotations::{LeftRightAnnotations, TypeAnnotations},
     executable::match_::instructions::{CheckInstruction, Inputs},
 };
-use crate::annotation::type_annotations::LeftRightAnnotations;
 
 #[derive(Debug, Clone)]
 pub struct TypeListInstruction<ID> {

--- a/compiler/executable/match_/planner/mod.rs
+++ b/compiler/executable/match_/planner/mod.rs
@@ -19,7 +19,7 @@ use tracing::{debug, trace};
 use ir::pattern::Vertex;
 
 use crate::{
-    annotation::{expression::compiled_expression::ExecutableExpression, type_annotations::TypeAnnotations},
+    annotation::{expression::compiled_expression::ExecutableExpression, type_annotations::BlockAnnotations},
     executable::{
         function::FunctionCallCostProvider,
         match_::{
@@ -52,7 +52,7 @@ pub fn compile(
     input_variable_annotations: &BTreeMap<Vertex<Variable>, Arc<BTreeSet<answer::Type>>>,
     input_variables: &HashMap<Variable, VariablePosition>,
     selected_variables: &HashSet<Variable>,
-    type_annotations: &TypeAnnotations,
+    type_annotations: &BlockAnnotations,
     variable_registry: &VariableRegistry,
     expressions: &HashMap<ExpressionBinding<Variable>, ExecutableExpression<Variable>>,
     statistics: &Statistics,

--- a/compiler/executable/match_/planner/mod.rs
+++ b/compiler/executable/match_/planner/mod.rs
@@ -4,19 +4,20 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-use std::collections::{BTreeMap, BTreeSet, hash_map, HashMap, HashSet};
-use std::sync::Arc;
+use std::{
+    collections::{hash_map, BTreeMap, BTreeSet, HashMap, HashSet},
+    sync::Arc,
+};
 
 use answer::variable::Variable;
 use concept::thing::statistics::Statistics;
 use error::typedb_error;
 use ir::{
-    pattern::constraint::ExpressionBinding,
+    pattern::{constraint::ExpressionBinding, Vertex},
     pipeline::{block::Block, function_signature::FunctionID, VariableRegistry},
 };
 use itertools::Itertools;
 use tracing::{debug, trace};
-use ir::pattern::Vertex;
 
 use crate::{
     annotation::{expression::compiled_expression::ExecutableExpression, type_annotations::BlockAnnotations},
@@ -78,7 +79,13 @@ pub fn compile(
         call_cost_provider,
     )
     .map_err(|source| MatchCompilationError::PlanningError { typedb_source: source })?
-    .lower(input_variable_annotations, input_variables.keys().copied(), selected_variables.iter().copied(), &assigned_identities, variable_registry)
+    .lower(
+        input_variable_annotations,
+        input_variables.keys().copied(),
+        selected_variables.iter().copied(),
+        &assigned_identities,
+        variable_registry,
+    )
     .map_err(|source| MatchCompilationError::PlanningError { typedb_source: source })?
     .finish(variable_registry);
 

--- a/compiler/executable/match_/planner/mod.rs
+++ b/compiler/executable/match_/planner/mod.rs
@@ -4,7 +4,8 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-use std::collections::{hash_map, HashMap, HashSet};
+use std::collections::{BTreeMap, BTreeSet, hash_map, HashMap, HashSet};
+use std::sync::Arc;
 
 use answer::variable::Variable;
 use concept::thing::statistics::Statistics;
@@ -15,6 +16,7 @@ use ir::{
 };
 use itertools::Itertools;
 use tracing::{debug, trace};
+use ir::pattern::Vertex;
 
 use crate::{
     annotation::{expression::compiled_expression::ExecutableExpression, type_annotations::TypeAnnotations},
@@ -47,6 +49,7 @@ typedb_error! {
 
 pub fn compile(
     block: &Block,
+    input_variable_annotations: &BTreeMap<Vertex<Variable>, Arc<BTreeSet<answer::Type>>>,
     input_variables: &HashMap<Variable, VariablePosition>,
     selected_variables: &HashSet<Variable>,
     type_annotations: &TypeAnnotations,
@@ -75,7 +78,7 @@ pub fn compile(
         call_cost_provider,
     )
     .map_err(|source| MatchCompilationError::PlanningError { typedb_source: source })?
-    .lower(input_variables.keys().copied(), selected_variables.iter().copied(), &assigned_identities, variable_registry)
+    .lower(input_variable_annotations, input_variables.keys().copied(), selected_variables.iter().copied(), &assigned_identities, variable_registry)
     .map_err(|source| MatchCompilationError::PlanningError { typedb_source: source })?
     .finish(variable_registry);
 

--- a/compiler/executable/match_/planner/plan.rs
+++ b/compiler/executable/match_/planner/plan.rs
@@ -178,7 +178,6 @@ fn make_builder<'a>(
     let mut plan_builder =
         ConjunctionPlanBuilder::new(conjunction.required_inputs(block_context).collect(), conjunction_annotations, statistics);
 
-
     #[cfg(debug_assertions)] // Break on purpose. We should fix conjunction.local_variables()
     let TMP__local_variables = conjunction.constraints().iter().flat_map(|c| c.ids()).dedup();
     plan_builder.register_variables(

--- a/compiler/executable/match_/planner/plan.rs
+++ b/compiler/executable/match_/planner/plan.rs
@@ -1965,9 +1965,7 @@ impl ConjunctionPlan<'_> {
             .filter_map(|variable| {
                 let vertex = variable.clone().into();
                 let local_annotations = self.local_annotations.vertex_annotations_of(&vertex)?;
-                input_variable_annotations
-                    .get(&vertex)
-                    .unwrap()
+                input_variable_annotations.get(&vertex)? // Functions don't have any
                     .iter()
                     .any(|type_| !local_annotations.contains(type_))
                     .then(|| (variable, local_annotations.clone()))

--- a/compiler/executable/match_/planner/plan.rs
+++ b/compiler/executable/match_/planner/plan.rs
@@ -126,8 +126,6 @@ fn make_builder<'a>(
                 let mut shared_variables = shared_variables.clone();
                 shared_variables.extend(disjunction.named_producible_variables(block_context));
                 shared_variables.extend(disjunction.required_inputs(block_context));
-                shared_variables =
-                    shared_variables.intersection(&disjunction.referenced_variables().collect()).copied().collect();
                 let planner = DisjunctionPlanBuilder::new(
                     disjunction
                         .conjunctions()
@@ -137,7 +135,7 @@ fn make_builder<'a>(
                                 conj,
                                 block_context,
                                 variable_positions,
-                                &shared_variables,
+                                &shared_variables.intersection(&conj.referenced_variables().collect()).copied().collect(),
                                 block_annotations,
                                 variable_registry,
                                 expressions,

--- a/compiler/executable/match_/planner/plan.rs
+++ b/compiler/executable/match_/planner/plan.rs
@@ -130,12 +130,16 @@ fn make_builder<'a>(
                     disjunction
                         .conjunctions()
                         .iter()
-                        .map(|conj| {
+                        .map(|branch| {
+                            let branch_shared_variables = shared_variables
+                                .intersection(&branch.referenced_variables().collect())
+                                .copied()
+                                .collect();
                             make_builder(
-                                conj,
+                                branch,
                                 block_context,
                                 variable_positions,
-                                &shared_variables.intersection(&conj.referenced_variables().collect()).copied().collect(),
+                                &branch_shared_variables,
                                 block_annotations,
                                 variable_registry,
                                 expressions,

--- a/compiler/executable/match_/planner/plan.rs
+++ b/compiler/executable/match_/planner/plan.rs
@@ -184,11 +184,11 @@ fn make_builder<'a>(
         statistics,
     );
 
-    #[cfg(debug_assertions)] // Break on purpose. We should fix conjunction.local_variables()
+    let local_variables = conjunction.variable_dependency(block_context);
     plan_builder.register_variables(
         variable_positions.keys().copied(),
         shared_variables.iter().copied(),
-        conjunction.local_variables(),
+        local_variables.keys().copied(),
         variable_registry,
     );
     plan_builder.register_constraints(conjunction, expressions, call_cost_provider);

--- a/compiler/executable/match_/planner/plan.rs
+++ b/compiler/executable/match_/planner/plan.rs
@@ -178,10 +178,13 @@ fn make_builder<'a>(
     let mut plan_builder =
         ConjunctionPlanBuilder::new(conjunction.required_inputs(block_context).collect(), conjunction_annotations, statistics);
 
+
+    #[cfg(debug_assertions)] // Break on purpose. We should fix conjunction.local_variables()
+    let TMP__local_variables = conjunction.constraints().iter().flat_map(|c| c.ids()).dedup();
     plan_builder.register_variables(
         variable_positions.keys().copied(),
         shared_variables.iter().copied(),
-        conjunction.local_variables(block_context),
+        TMP__local_variables, // conjunction.local_variables(block_context),
         variable_registry,
     );
     plan_builder.register_constraints(conjunction, expressions, call_cost_provider);

--- a/compiler/executable/match_/planner/plan.rs
+++ b/compiler/executable/match_/planner/plan.rs
@@ -184,11 +184,10 @@ fn make_builder<'a>(
         statistics,
     );
 
-    let local_variables = conjunction.variable_dependency(block_context);
     plan_builder.register_variables(
         variable_positions.keys().copied(),
         shared_variables.iter().copied(),
-        local_variables.keys().copied(),
+        conjunction.local_variables(block_context),
         variable_registry,
     );
     plan_builder.register_constraints(conjunction, expressions, call_cost_provider);

--- a/compiler/executable/match_/planner/plan.rs
+++ b/compiler/executable/match_/planner/plan.rs
@@ -1965,7 +1965,8 @@ impl ConjunctionPlan<'_> {
             .filter_map(|variable| {
                 let vertex = variable.clone().into();
                 let local_annotations = self.local_annotations.vertex_annotations_of(&vertex)?;
-                input_variable_annotations.get(&vertex)? // Functions don't have any
+                input_variable_annotations
+                    .get(&vertex)? // Functions don't have any
                     .iter()
                     .any(|type_| !local_annotations.contains(type_))
                     .then(|| (variable, local_annotations.clone()))

--- a/compiler/executable/match_/planner/plan.rs
+++ b/compiler/executable/match_/planner/plan.rs
@@ -185,11 +185,10 @@ fn make_builder<'a>(
     );
 
     #[cfg(debug_assertions)] // Break on purpose. We should fix conjunction.local_variables()
-    let TMP__local_variables = conjunction.constraints().iter().flat_map(|c| c.ids()).dedup();
     plan_builder.register_variables(
         variable_positions.keys().copied(),
         shared_variables.iter().copied(),
-        TMP__local_variables, // conjunction.local_variables(block_context),
+        conjunction.local_variables(),
         variable_registry,
     );
     plan_builder.register_constraints(conjunction, expressions, call_cost_provider);

--- a/compiler/executable/match_/planner/vertex/constraint.rs
+++ b/compiler/executable/match_/planner/vertex/constraint.rs
@@ -12,9 +12,7 @@ use std::{
 
 use answer::{variable::Variable, Type};
 use concept::thing::statistics::Statistics;
-use ir::pattern::constraint::{
-    Has, Iid, IndexedRelation, Isa, Kind, Label, Links, Owns, Plays, Relates, RoleName, Sub, Value,
-};
+use ir::pattern::constraint::{Constraint, Has, Iid, IndexedRelation, Isa, Kind, Label, Links, Owns, Plays, Relates, RoleName, Sub, Value};
 use itertools::Itertools;
 
 use crate::{

--- a/compiler/executable/match_/planner/vertex/constraint.rs
+++ b/compiler/executable/match_/planner/vertex/constraint.rs
@@ -12,7 +12,9 @@ use std::{
 
 use answer::{variable::Variable, Type};
 use concept::thing::statistics::Statistics;
-use ir::pattern::constraint::{Constraint, Has, Iid, IndexedRelation, Isa, Kind, Label, Links, Owns, Plays, Relates, RoleName, Sub, Value};
+use ir::pattern::constraint::{
+    Constraint, Has, Iid, IndexedRelation, Isa, Kind, Label, Links, Owns, Plays, Relates, RoleName, Sub, Value,
+};
 use itertools::Itertools;
 
 use crate::{

--- a/compiler/executable/pipeline.rs
+++ b/compiler/executable/pipeline.rs
@@ -21,9 +21,7 @@ use crate::{
     annotation::{
         fetch::{AnnotatedFetch, AnnotatedFetchObject, AnnotatedFetchSome},
         function::{AnnotatedPreambleFunctions, AnnotatedSchemaFunctions},
-        match_inference::VertexAnnotations,
         pipeline::AnnotatedStage,
-        type_annotations::BlockAnnotations,
     },
     executable::{
         delete::executable::DeleteExecutable,

--- a/compiler/executable/pipeline.rs
+++ b/compiler/executable/pipeline.rs
@@ -17,6 +17,7 @@ use ir::{
     pattern::{conjunction::Conjunction, nested_pattern::NestedPattern},
     pipeline::{function_signature::FunctionID, reduce::AssignedReduction, VariableRegistry},
 };
+use ir::pattern::Vertex;
 
 use crate::{
     annotation::{
@@ -217,8 +218,8 @@ pub(crate) fn compile_pipeline_stages(
                 &stage,
             )?,
         };
-        if let AnnotatedStage::Match { block_annotations, .. } = stage {
-            last_match_annotations = Some(block_annotations.vertex_annotations())
+        if let AnnotatedStage::Match { block, block_annotations, .. } = stage {
+            last_match_annotations = Some(block_annotations.type_annotations_of(block.conjunction()).unwrap().vertex_annotations())
         }
         executable_stages.push(executable_stage);
     }

--- a/compiler/tests/transformation.rs
+++ b/compiler/tests/transformation.rs
@@ -8,7 +8,7 @@ use std::{collections::BTreeMap, sync::Arc};
 
 use compiler::{
     annotation::{
-        function::EmptyAnnotatedFunctionSignatures, match_inference::infer_types, type_annotations::TypeAnnotations,
+        function::EmptyAnnotatedFunctionSignatures, match_inference::infer_types, type_annotations::BlockAnnotations,
     },
     transformation::{
         redundant_constraints::optimize_away_statically_unsatisfiable_conjunctions,
@@ -345,7 +345,7 @@ fn translate_and_annotate(
     snapshot: &impl ReadableSnapshot,
     type_manager: &TypeManager,
     query: &str,
-) -> (Conjunction, TypeAnnotations) {
+) -> (Conjunction, BlockAnnotations) {
     let parsed = typeql::parse_query(query).unwrap().into_pipeline().stages.remove(0).into_match();
     let mut context = TranslationContext::new();
     let mut parameters = ParameterRegistry::new();

--- a/compiler/transformation/redundant_constraints.rs
+++ b/compiler/transformation/redundant_constraints.rs
@@ -23,20 +23,21 @@ Since this will have been taken into account by type inference.
 
 use ir::pattern::{conjunction::Conjunction, constraint::Constraint, nested_pattern::NestedPattern, Scope};
 
-use crate::annotation::type_annotations::{ConstraintTypeAnnotations, TypeAnnotations};
+use crate::annotation::type_annotations::{ConstraintTypeAnnotations, BlockAnnotations};
 
 pub(super) fn prune_redundant_roleplayer_deduplication(
     conjunction: &mut Conjunction,
-    block_annotations: &mut TypeAnnotations,
+    block_annotations: &mut BlockAnnotations,
 ) {
+    let local_annotations = block_annotations.type_annotations_of(conjunction).unwrap();
     conjunction.constraints_mut().constraints_mut().retain(|constraint| {
         if let Constraint::LinksDeduplication(dedup) = constraint {
-            let first = block_annotations
+            let first = local_annotations
                 .constraint_annotations_of(Constraint::Links(dedup.links1().clone()))
                 .unwrap()
                 .as_links()
                 .player_to_role();
-            let second = block_annotations
+            let second = local_annotations
                 .constraint_annotations_of(Constraint::Links(dedup.links2().clone()))
                 .unwrap()
                 .as_links()
@@ -50,11 +51,20 @@ pub(super) fn prune_redundant_roleplayer_deduplication(
             true
         }
     });
+    conjunction.nested_patterns_mut().iter_mut().for_each(|nested| match  nested {
+        NestedPattern::Negation(inner) => prune_redundant_roleplayer_deduplication(inner.conjunction_mut(), block_annotations),
+        NestedPattern::Optional(inner) => prune_redundant_roleplayer_deduplication(inner.conjunction_mut(), block_annotations),
+        NestedPattern::Disjunction(disjunction) => {
+            disjunction.conjunctions_mut().iter_mut().for_each(|inner| {
+                prune_redundant_roleplayer_deduplication(inner, block_annotations)
+            })
+        }
+    })
 }
 
 pub fn optimize_away_statically_unsatisfiable_conjunctions(
     conjunction: &mut Conjunction,
-    block_annotations: &TypeAnnotations,
+    block_annotations: &BlockAnnotations,
 ) {
     let mut must_optimise_away = false;
     for nested in conjunction.nested_patterns_mut() {
@@ -78,9 +88,10 @@ pub fn optimize_away_statically_unsatisfiable_conjunctions(
             }
         }
     }
-    let must_optimise_away = must_optimise_away
+    let local_annotations = block_annotations.type_annotations_of(conjunction).unwrap();
+    must_optimise_away = must_optimise_away
         || conjunction.constraints().iter().any(|constraint| {
-            if let Some(constraint_annotation) = block_annotations.constraint_annotations_of(constraint.clone()) {
+            if let Some(constraint_annotation) = local_annotations.constraint_annotations_of(constraint.clone()) {
                 match constraint_annotation {
                     ConstraintTypeAnnotations::LeftRight(lr) => {
                         debug_assert!(lr.left_to_right().is_empty() == lr.right_to_left().is_empty());

--- a/compiler/transformation/redundant_constraints.rs
+++ b/compiler/transformation/redundant_constraints.rs
@@ -23,7 +23,7 @@ Since this will have been taken into account by type inference.
 
 use ir::pattern::{conjunction::Conjunction, constraint::Constraint, nested_pattern::NestedPattern, Scope};
 
-use crate::annotation::type_annotations::{ConstraintTypeAnnotations, BlockAnnotations};
+use crate::annotation::type_annotations::{BlockAnnotations, ConstraintTypeAnnotations};
 
 pub(super) fn prune_redundant_roleplayer_deduplication(
     conjunction: &mut Conjunction,
@@ -51,14 +51,17 @@ pub(super) fn prune_redundant_roleplayer_deduplication(
             true
         }
     });
-    conjunction.nested_patterns_mut().iter_mut().for_each(|nested| match  nested {
-        NestedPattern::Negation(inner) => prune_redundant_roleplayer_deduplication(inner.conjunction_mut(), block_annotations),
-        NestedPattern::Optional(inner) => prune_redundant_roleplayer_deduplication(inner.conjunction_mut(), block_annotations),
-        NestedPattern::Disjunction(disjunction) => {
-            disjunction.conjunctions_mut().iter_mut().for_each(|inner| {
-                prune_redundant_roleplayer_deduplication(inner, block_annotations)
-            })
+    conjunction.nested_patterns_mut().iter_mut().for_each(|nested| match nested {
+        NestedPattern::Negation(inner) => {
+            prune_redundant_roleplayer_deduplication(inner.conjunction_mut(), block_annotations)
         }
+        NestedPattern::Optional(inner) => {
+            prune_redundant_roleplayer_deduplication(inner.conjunction_mut(), block_annotations)
+        }
+        NestedPattern::Disjunction(disjunction) => disjunction
+            .conjunctions_mut()
+            .iter_mut()
+            .for_each(|inner| prune_redundant_roleplayer_deduplication(inner, block_annotations)),
     })
 }
 

--- a/compiler/transformation/relation_index.rs
+++ b/compiler/transformation/relation_index.rs
@@ -17,10 +17,11 @@ use ir::pattern::{
 use storage::snapshot::ReadableSnapshot;
 
 use crate::{
-    annotation::type_annotations::{ConstraintTypeAnnotations, IndexedRelationAnnotations, BlockAnnotations},
+    annotation::type_annotations::{
+        BlockAnnotations, ConstraintTypeAnnotations, IndexedRelationAnnotations, TypeAnnotations,
+    },
     transformation::StaticOptimiserError,
 };
-use crate::annotation::type_annotations::TypeAnnotations;
 
 /// Precondition:
 ///   1) $r links $x (role: $role1)

--- a/dependencies/typedb/repositories.bzl
+++ b/dependencies/typedb/repositories.bzl
@@ -35,6 +35,6 @@ def typedb_protocol():
 def typedb_behaviour():
     git_repository(
         name = "typedb_behaviour",
-        remote = "https://github.com/krishnangovindraj/typedb-behaviour",
-        commit = "2ed56da59d0ced9505c83d6fa97f37ff01387dc0",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @typedb_behaviour
+        remote = "https://github.com/typedb/typedb-behaviour",
+        commit = "7c2df22e4378b32e53440df4a7b20d59f2ea0e28",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @typedb_behaviour
     )

--- a/dependencies/typedb/repositories.bzl
+++ b/dependencies/typedb/repositories.bzl
@@ -35,6 +35,6 @@ def typedb_protocol():
 def typedb_behaviour():
     git_repository(
         name = "typedb_behaviour",
-        remote = "https://github.com/typedb/typedb-behaviour",
-        commit = "97bfc7368761154ac952a69823c0c7332c6d16de",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @typedb_behaviour
+        remote = "https://github.com/krishnangovindraj/typedb-behaviour",
+        commit = "2ed56da59d0ced9505c83d6fa97f37ff01387dc0",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @typedb_behaviour
     )

--- a/executor/instruction/mod.rs
+++ b/executor/instruction/mod.rs
@@ -5,11 +5,10 @@
  */
 
 use std::{
-    collections::{BTreeSet, HashMap},
+    collections::HashMap,
     fmt,
     marker::PhantomData,
     ops::Bound,
-    sync::Arc,
 };
 
 use ::iterator::minmax_or;

--- a/executor/instruction/mod.rs
+++ b/executor/instruction/mod.rs
@@ -5,6 +5,8 @@
  */
 
 use std::{collections::HashMap, fmt, marker::PhantomData, ops::Bound};
+use std::collections::BTreeSet;
+use std::sync::Arc;
 
 use ::iterator::minmax_or;
 use answer::{variable_value::VariableValue, Thing, Type};
@@ -524,6 +526,9 @@ impl<T> Checker<T> {
                 &CheckInstruction::TypeList { type_var, ref types } => {
                     self.filter_type_list(context, row, type_var, types)
                 }
+                &CheckInstruction::ThingTypeList { thing_var, ref types } => {
+                    self.filter_thing_type_list(context, row, thing_var, types)
+                }
                 &CheckInstruction::Sub { sub_kind, ref subtype, ref supertype } => {
                     self.filter_sub(context, row, sub_kind, subtype, supertype)
                 }
@@ -608,6 +613,22 @@ impl<T> Checker<T> {
         };
         let types = types.clone();
         Box::new(move |value: &T| Ok(types.contains(&unwrap_or_bail!(type_(value) => Type))))
+    }
+
+    fn filter_thing_type_list(
+        &self,
+        context: &ExecutionContext<impl ReadableSnapshot + 'static>,
+        row: &MaybeOwnedRow<'_>,
+        thing_var: ExecutorVariable,
+        types: &std::sync::Arc<std::collections::BTreeSet<Type>>,
+    ) -> Box<dyn Fn(&T) -> Result<bool, Box<ConceptReadError>>> {
+        let maybe_type_extractor = self.extractors.get(&thing_var);
+        let thing: BoxExtractor<T> = match maybe_type_extractor {
+            Some(&subtype) => Box::new(subtype),
+            None => make_const_extractor(&CheckVertex::Variable(thing_var), row, context),
+        };
+        let types = types.clone();
+        Box::new(move |value: &T| Ok(types.contains(&unwrap_or_bail!(thing(value) => Thing).type_())))
     }
 
     fn filter_sub(

--- a/executor/instruction/mod.rs
+++ b/executor/instruction/mod.rs
@@ -4,9 +4,13 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-use std::{collections::HashMap, fmt, marker::PhantomData, ops::Bound};
-use std::collections::BTreeSet;
-use std::sync::Arc;
+use std::{
+    collections::{BTreeSet, HashMap},
+    fmt,
+    marker::PhantomData,
+    ops::Bound,
+    sync::Arc,
+};
 
 use ::iterator::minmax_or;
 use answer::{variable_value::VariableValue, Thing, Type};

--- a/executor/tests/compile_execute.rs
+++ b/executor/tests/compile_execute.rs
@@ -1021,5 +1021,5 @@ fn test_mismatched_input_types() {
         println!()
     }
 
-   todo!("Add some assert");
+   debug_assert_eq!(rows.len(), 3);
 }

--- a/executor/tests/execute_comparison_check.rs
+++ b/executor/tests/execute_comparison_check.rs
@@ -129,7 +129,7 @@ fn attribute_equality() {
     let (type_manager, thing_manager) = load_managers(storage.clone(), None);
     let variable_registry = &translation_context.variable_registry;
     let previous_stage_variable_annotations = &BTreeMap::new();
-    let entry_annotations = infer_types(
+    let block_annotations = infer_types(
         &snapshot,
         &entry,
         variable_registry,
@@ -139,6 +139,7 @@ fn attribute_equality() {
         false,
     )
     .unwrap();
+    let entry_annotations = block_annotations.type_annotations_of(entry.conjunction()).unwrap();
 
     let (row_vars, variable_positions, mapping, named_variables) =
         position_mapping([var_age_a, var_age_b], [var_age_type_a, var_age_type_b]);

--- a/executor/tests/execute_has.rs
+++ b/executor/tests/execute_has.rs
@@ -171,7 +171,7 @@ fn traverse_has_unbounded_sorted_from() {
 
     let variable_registry = &translation_context.variable_registry;
     let previous_stage_variable_annotations = &BTreeMap::new();
-    let entry_annotations = infer_types(
+    let block_annotations = infer_types(
         &snapshot,
         &entry,
         variable_registry,
@@ -181,6 +181,7 @@ fn traverse_has_unbounded_sorted_from() {
         false,
     )
     .unwrap();
+    let entry_annotations = block_annotations.type_annotations_of(entry.conjunction()).unwrap();
 
     let (row_vars, variable_positions, mapping, named_variables) =
         position_mapping([var_person, var_age], [var_age_type, var_person_type]);
@@ -266,7 +267,7 @@ fn traverse_has_bounded_sorted_from_chain_intersect() {
     let entry = builder.finish().unwrap();
     let variable_registry = &translation_context.variable_registry;
     let previous_stage_variable_annotations = &BTreeMap::new();
-    let entry_annotations = infer_types(
+    let block_annotations = infer_types(
         &snapshot,
         &entry,
         variable_registry,
@@ -276,7 +277,7 @@ fn traverse_has_bounded_sorted_from_chain_intersect() {
         false,
     )
     .unwrap();
-
+    let entry_annotations = block_annotations.type_annotations_of(entry.conjunction()).unwrap();
     let (row_vars, variable_positions, mapping, named_variables) =
         position_mapping([var_person_1, var_person_2, var_name], [var_person_type, var_name_type]);
 
@@ -375,7 +376,7 @@ fn traverse_has_unbounded_sorted_from_intersect() {
     let (type_manager, thing_manager) = load_managers(storage.clone(), None);
     let variable_registry = &translation_context.variable_registry;
     let previous_stage_variable_annotations = &BTreeMap::new();
-    let entry_annotations = infer_types(
+    let block_annotations = infer_types(
         &snapshot,
         &entry,
         variable_registry,
@@ -385,6 +386,7 @@ fn traverse_has_unbounded_sorted_from_intersect() {
         false,
     )
     .unwrap();
+    let entry_annotations = block_annotations.type_annotations_of(entry.conjunction()).unwrap();
 
     let (row_vars, variable_positions, mapping, named_variables) =
         position_mapping([var_person, var_name, var_age], [var_person_type, var_name_type, var_age_type]);
@@ -461,7 +463,7 @@ fn traverse_has_unbounded_sorted_to_merged() {
     let (type_manager, thing_manager) = load_managers(storage.clone(), None);
     let variable_registry = &translation_context.variable_registry;
     let previous_stage_variable_annotations = &BTreeMap::new();
-    let entry_annotations = infer_types(
+    let block_annotations = infer_types(
         &snapshot,
         &entry,
         variable_registry,
@@ -471,6 +473,7 @@ fn traverse_has_unbounded_sorted_to_merged() {
         false,
     )
     .unwrap();
+    let entry_annotations = block_annotations.type_annotations_of(entry.conjunction()).unwrap();
 
     let (row_vars, variable_positions, mapping, named_variables) =
         position_mapping([var_person, var_attribute], [var_person_type]);
@@ -568,7 +571,7 @@ fn traverse_has_reverse_unbounded_sorted_from() {
     let (type_manager, thing_manager) = load_managers(storage.clone(), None);
     let variable_registry = &translation_context.variable_registry;
     let previous_stage_variable_annotations = &BTreeMap::new();
-    let entry_annotations = infer_types(
+    let block_annotations = infer_types(
         &snapshot,
         &entry,
         variable_registry,
@@ -578,6 +581,7 @@ fn traverse_has_reverse_unbounded_sorted_from() {
         false,
     )
     .unwrap();
+    let entry_annotations = block_annotations.type_annotations_of(entry.conjunction()).unwrap();
 
     let (row_vars, variable_positions, mapping, named_variables) =
         position_mapping([var_person, var_age, var_person_type, var_age_type], []);

--- a/executor/tests/execute_isa.rs
+++ b/executor/tests/execute_isa.rs
@@ -122,7 +122,7 @@ fn traverse_isa_unbounded_sorted_thing() {
     let (type_manager, thing_manager) = load_managers(storage.clone(), None);
     let variable_registry = &translation_context.variable_registry;
     let previous_stage_variable_annotations = &BTreeMap::new();
-    let entry_annotations = infer_types(
+    let block_annotations = infer_types(
         &snapshot,
         &entry,
         variable_registry,
@@ -132,6 +132,7 @@ fn traverse_isa_unbounded_sorted_thing() {
         false,
     )
     .unwrap();
+    let entry_annotations = block_annotations.type_annotations_of(entry.conjunction()).unwrap();
 
     let (row_vars, variable_positions, mapping, named_variables) = position_mapping([var_dog, var_dog_type], []);
 
@@ -199,7 +200,7 @@ fn traverse_isa_unbounded_sorted_type() {
     let (type_manager, thing_manager) = load_managers(storage.clone(), None);
     let variable_registry = &translation_context.variable_registry;
     let previous_stage_variable_annotations = &BTreeMap::new();
-    let entry_annotations = infer_types(
+    let block_annotations = infer_types(
         &snapshot,
         &entry,
         variable_registry,
@@ -209,6 +210,7 @@ fn traverse_isa_unbounded_sorted_type() {
         false,
     )
     .unwrap();
+    let entry_annotations = block_annotations.type_annotations_of(entry.conjunction()).unwrap();
 
     let (row_vars, variable_positions, mapping, named_variables) = position_mapping([var_dog, var_dog_type], []);
 
@@ -280,7 +282,7 @@ fn traverse_isa_bounded_thing() {
     let (type_manager, thing_manager) = load_managers(storage.clone(), None);
     let variable_registry = &translation_context.variable_registry;
     let previous_stage_variable_annotations = &BTreeMap::new();
-    let entry_annotations = infer_types(
+    let block_annotations = infer_types(
         &snapshot,
         &entry,
         variable_registry,
@@ -290,6 +292,7 @@ fn traverse_isa_bounded_thing() {
         false,
     )
     .unwrap();
+    let entry_annotations = block_annotations.type_annotations_of(entry.conjunction()).unwrap();
 
     let (row_vars, variable_positions, mapping, named_variables) =
         position_mapping([var_thing, var_type_to], [var_type_from]);
@@ -375,7 +378,7 @@ fn traverse_isa_reverse_unbounded_sorted_thing() {
     let (type_manager, thing_manager) = load_managers(storage.clone(), None);
     let variable_registry = &translation_context.variable_registry;
     let previous_stage_variable_annotations = &BTreeMap::new();
-    let entry_annotations = infer_types(
+    let block_annotations = infer_types(
         &snapshot,
         &entry,
         variable_registry,
@@ -385,6 +388,7 @@ fn traverse_isa_reverse_unbounded_sorted_thing() {
         false,
     )
     .unwrap();
+    let entry_annotations = block_annotations.type_annotations_of(entry.conjunction()).unwrap();
 
     let (row_vars, variable_positions, mapping, named_variables) = position_mapping([var_dog, var_dog_type], []);
 
@@ -452,7 +456,7 @@ fn traverse_isa_reverse_unbounded_sorted_type() {
     let (type_manager, thing_manager) = load_managers(storage.clone(), None);
     let variable_registry = &translation_context.variable_registry;
     let previous_stage_variable_annotations = &BTreeMap::new();
-    let entry_annotations = infer_types(
+    let block_annotations = infer_types(
         &snapshot,
         &entry,
         variable_registry,
@@ -462,6 +466,7 @@ fn traverse_isa_reverse_unbounded_sorted_type() {
         false,
     )
     .unwrap();
+    let entry_annotations = block_annotations.type_annotations_of(entry.conjunction()).unwrap();
 
     let (row_vars, variable_positions, mapping, named_variables) = position_mapping([var_dog, var_dog_type], []);
 
@@ -533,7 +538,7 @@ fn traverse_isa_reverse_bounded_type_exact() {
     let (type_manager, thing_manager) = load_managers(storage.clone(), None);
     let variable_registry = &translation_context.variable_registry;
     let previous_stage_variable_annotations = &BTreeMap::new();
-    let entry_annotations = infer_types(
+    let block_annotations = infer_types(
         &snapshot,
         &entry,
         variable_registry,
@@ -543,6 +548,7 @@ fn traverse_isa_reverse_bounded_type_exact() {
         false,
     )
     .unwrap();
+    let entry_annotations = block_annotations.type_annotations_of(entry.conjunction()).unwrap();
 
     let (row_vars, variable_positions, mapping, named_variables) =
         position_mapping([var_thing_from, var_type, var_thing_to], []);
@@ -630,7 +636,7 @@ fn traverse_isa_reverse_bounded_type_subtype() {
     let (type_manager, thing_manager) = load_managers(storage.clone(), None);
     let variable_registry = &translation_context.variable_registry;
     let previous_stage_variable_annotations = &BTreeMap::new();
-    let entry_annotations = infer_types(
+    let block_annotations = infer_types(
         &snapshot,
         &entry,
         variable_registry,
@@ -640,6 +646,7 @@ fn traverse_isa_reverse_bounded_type_subtype() {
         false,
     )
     .unwrap();
+    let entry_annotations = block_annotations.type_annotations_of(entry.conjunction()).unwrap();
 
     let (row_vars, variable_positions, mapping, named_variables) =
         position_mapping([var_thing_from, var_type, var_thing_to], []);
@@ -727,7 +734,7 @@ fn traverse_isa_reverse_fixed_type_exact() {
     let (type_manager, thing_manager) = load_managers(storage.clone(), None);
     let variable_registry = &translation_context.variable_registry;
     let previous_stage_variable_annotations = &BTreeMap::new();
-    let entry_annotations = infer_types(
+    let block_annotations = infer_types(
         &snapshot,
         &entry,
         variable_registry,
@@ -737,6 +744,7 @@ fn traverse_isa_reverse_fixed_type_exact() {
         false,
     )
     .unwrap();
+    let entry_annotations = block_annotations.type_annotations_of(entry.conjunction()).unwrap();
 
     let (row_vars, variable_positions, mapping, named_variables) = position_mapping([var_thing], []);
     // Plan
@@ -805,7 +813,7 @@ fn traverse_isa_reverse_fixed_type_subtype() {
     let (type_manager, thing_manager) = load_managers(storage.clone(), None);
     let variable_registry = &translation_context.variable_registry;
     let previous_stage_variable_annotations = &BTreeMap::new();
-    let entry_annotations = infer_types(
+    let block_annotations = infer_types(
         &snapshot,
         &entry,
         variable_registry,
@@ -815,6 +823,7 @@ fn traverse_isa_reverse_fixed_type_subtype() {
         false,
     )
     .unwrap();
+    let entry_annotations = block_annotations.type_annotations_of(entry.conjunction()).unwrap();
 
     let (row_vars, variable_positions, mapping, named_variables) = position_mapping([var_thing], []);
 

--- a/executor/tests/execute_links.rs
+++ b/executor/tests/execute_links.rs
@@ -239,7 +239,7 @@ fn traverse_links_unbounded_sorted_from() {
     let (type_manager, thing_manager) = load_managers(storage.clone(), None);
     let variable_registry = &translation_context.variable_registry;
     let previous_stage_variable_annotations = &BTreeMap::new();
-    let entry_annotations = infer_types(
+    let block_annotations = infer_types(
         &snapshot,
         &entry,
         variable_registry,
@@ -249,6 +249,7 @@ fn traverse_links_unbounded_sorted_from() {
         false,
     )
     .unwrap();
+    let entry_annotations = block_annotations.type_annotations_of(entry.conjunction()).unwrap();
 
     let (row_vars, variable_positions, mapping, named_variables) = position_mapping(
         [var_membership, var_group, var_person],
@@ -341,7 +342,7 @@ fn traverse_links_unbounded_sorted_to() {
     let (type_manager, thing_manager) = load_managers(storage.clone(), None);
     let variable_registry = &translation_context.variable_registry;
     let previous_stage_variable_annotations = &BTreeMap::new();
-    let entry_annotations = infer_types(
+    let block_annotations = infer_types(
         &snapshot,
         &entry,
         variable_registry,
@@ -351,6 +352,7 @@ fn traverse_links_unbounded_sorted_to() {
         false,
     )
     .unwrap();
+    let entry_annotations = block_annotations.type_annotations_of(entry.conjunction()).unwrap();
 
     let (row_vars, variable_positions, mapping, named_variables) = position_mapping(
         [var_membership, var_person],
@@ -443,7 +445,7 @@ fn traverse_links_bounded_relation() {
     let (type_manager, thing_manager) = load_managers(storage.clone(), None);
     let variable_registry = &translation_context.variable_registry;
     let previous_stage_variable_annotations = &BTreeMap::new();
-    let entry_annotations = infer_types(
+    let block_annotations = infer_types(
         &snapshot,
         &entry,
         variable_registry,
@@ -453,6 +455,7 @@ fn traverse_links_bounded_relation() {
         false,
     )
     .unwrap();
+    let entry_annotations = block_annotations.type_annotations_of(entry.conjunction()).unwrap();
 
     let (row_vars, variable_positions, mapping, named_variables) = position_mapping(
         [var_membership, var_person],
@@ -561,7 +564,7 @@ fn traverse_links_bounded_relation_player() {
     let (type_manager, thing_manager) = load_managers(storage.clone(), None);
     let variable_registry = &translation_context.variable_registry;
     let previous_stage_variable_annotations = &BTreeMap::new();
-    let entry_annotations = infer_types(
+    let block_annotations = infer_types(
         &snapshot,
         &entry,
         variable_registry,
@@ -571,6 +574,7 @@ fn traverse_links_bounded_relation_player() {
         false,
     )
     .unwrap();
+    let entry_annotations = block_annotations.type_annotations_of(entry.conjunction()).unwrap();
 
     let (row_vars, variable_positions, mapping, named_variables) = position_mapping(
         [var_membership, var_person, var_membership_member_type],
@@ -684,7 +688,7 @@ fn traverse_links_reverse_unbounded_sorted_from() {
     let variable_registry = &translation_context.variable_registry;
     let snapshot1 = &*snapshot;
     let previous_stage_variable_annotations = &BTreeMap::new();
-    let entry_annotations = infer_types(
+    let block_annotations = infer_types(
         snapshot1,
         &entry,
         variable_registry,
@@ -694,6 +698,7 @@ fn traverse_links_reverse_unbounded_sorted_from() {
         false,
     )
     .unwrap();
+    let entry_annotations = block_annotations.type_annotations_of(entry.conjunction()).unwrap();
 
     let (row_vars, variable_positions, mapping, named_variables) = position_mapping(
         [var_membership, var_person],
@@ -783,7 +788,7 @@ fn traverse_links_reverse_unbounded_sorted_to() {
     let variable_registry = &translation_context.variable_registry;
     let snapshot1 = &*snapshot;
     let previous_stage_variable_annotations = &BTreeMap::new();
-    let entry_annotations = infer_types(
+    let block_annotations = infer_types(
         snapshot1,
         &entry,
         variable_registry,
@@ -793,6 +798,7 @@ fn traverse_links_reverse_unbounded_sorted_to() {
         false,
     )
     .unwrap();
+    let entry_annotations = block_annotations.type_annotations_of(entry.conjunction()).unwrap();
 
     let (row_vars, variable_positions, mapping, named_variables) = position_mapping(
         [var_membership, var_person],
@@ -885,7 +891,7 @@ fn traverse_links_reverse_bounded_player() {
     let (type_manager, thing_manager) = load_managers(storage.clone(), None);
     let variable_registry = &translation_context.variable_registry;
     let previous_stage_variable_annotations = &BTreeMap::new();
-    let entry_annotations = infer_types(
+    let block_annotations = infer_types(
         &snapshot,
         &entry,
         variable_registry,
@@ -895,6 +901,7 @@ fn traverse_links_reverse_bounded_player() {
         false,
     )
     .unwrap();
+    let entry_annotations = block_annotations.type_annotations_of(entry.conjunction()).unwrap();
 
     let (row_vars, variable_positions, mapping, named_variables) = position_mapping(
         [var_person, var_membership],
@@ -1003,7 +1010,7 @@ fn traverse_links_reverse_bounded_player_relation() {
     let (type_manager, thing_manager) = load_managers(storage.clone(), None);
     let variable_registry = &translation_context.variable_registry;
     let previous_stage_variable_annotations = &BTreeMap::new();
-    let entry_annotations = infer_types(
+    let block_annotations = infer_types(
         &snapshot,
         &entry,
         variable_registry,
@@ -1013,6 +1020,7 @@ fn traverse_links_reverse_bounded_player_relation() {
         false,
     )
     .unwrap();
+    let entry_annotations = block_annotations.type_annotations_of(entry.conjunction()).unwrap();
 
     let (row_vars, variable_positions, mapping, named_variables) = position_mapping(
         [var_person, var_membership],

--- a/executor/tests/execute_relation_index.rs
+++ b/executor/tests/execute_relation_index.rs
@@ -275,7 +275,7 @@ fn traverse_index_from_unbound() {
     let (type_manager, thing_manager) = load_managers(storage.clone(), None);
     let variable_registry = &translation_context.variable_registry;
     let previous_stage_variable_annotations = &BTreeMap::new();
-    let entry_annotations = infer_types(
+    let block_annotations = infer_types(
         &snapshot,
         &entry,
         variable_registry,
@@ -285,6 +285,7 @@ fn traverse_index_from_unbound() {
         false,
     )
     .unwrap();
+    let entry_annotations = block_annotations.type_annotations_of(entry.conjunction()).unwrap();
 
     let (row_vars, variable_positions, mapping, named_variables) = position_mapping(
         [var_movie, var_character, var_casting],
@@ -529,7 +530,7 @@ fn traverse_index_from_bound() {
     let (type_manager, thing_manager) = load_managers(storage.clone(), None);
     let variable_registry = &translation_context.variable_registry;
     let previous_stage_variable_annotations = &BTreeMap::new();
-    let entry_annotations = infer_types(
+    let block_annotations = infer_types(
         &snapshot,
         &entry,
         variable_registry,
@@ -539,6 +540,7 @@ fn traverse_index_from_bound() {
         false,
     )
     .unwrap();
+    let entry_annotations = block_annotations.type_annotations_of(entry.conjunction()).unwrap();
 
     let (row_vars, variable_positions, mapping, named_variables) = position_mapping(
         [var_id, var_movie, var_person, var_casting],
@@ -694,7 +696,7 @@ fn traverse_index_bound_role_type_filtered_correctly() {
     let (type_manager, thing_manager) = load_managers(storage.clone(), None);
     let variable_registry = &translation_context.variable_registry;
     let previous_stage_variable_annotations = &BTreeMap::new();
-    let entry_annotations = infer_types(
+    let block_annotations = infer_types(
         &snapshot,
         &entry,
         variable_registry,
@@ -704,6 +706,7 @@ fn traverse_index_bound_role_type_filtered_correctly() {
         false,
     )
     .unwrap();
+    let entry_annotations = block_annotations.type_annotations_of(entry.conjunction()).unwrap();
 
     let (row_vars, variable_positions, mapping, named_variables) = position_mapping(
         [var_casting_movie_type, var_casting_other_type, var_movie, var_person, var_casting],

--- a/executor/tests/execute_select.rs
+++ b/executor/tests/execute_select.rs
@@ -185,7 +185,7 @@ fn anonymous_vars_not_enumerated_or_counted() {
     conjunction.constraints_mut().add_label(var_person_type, PERSON_LABEL.clone()).unwrap();
     let entry = builder.finish().unwrap();
 
-    let entry_annotations = {
+    let block_annotations = {
         let snapshot: ReadSnapshot<WALClient> = storage.clone().open_snapshot_read();
         let (type_manager, _) = load_managers(storage.clone(), None);
         let variable_registry = &translation_context.variable_registry;
@@ -201,6 +201,7 @@ fn anonymous_vars_not_enumerated_or_counted() {
         )
         .unwrap()
     };
+    let entry_annotations = block_annotations.type_annotations_of(entry.conjunction()).unwrap();
 
     let (row_vars, variable_positions, mapping) =
         position_mapping([var_person], [var_person_type, var_attribute, var_attribute_type]);
@@ -279,7 +280,7 @@ fn unselected_named_vars_counted() {
     conjunction.constraints_mut().add_label(var_person_type, PERSON_LABEL.clone()).unwrap();
     let entry = builder.finish().unwrap();
 
-    let entry_annotations = {
+    let block_annotations = {
         let snapshot: ReadSnapshot<WALClient> = storage.clone().open_snapshot_read();
         let (type_manager, _) = load_managers(storage.clone(), None);
         let variable_registry = &translation_context.variable_registry;
@@ -295,6 +296,7 @@ fn unselected_named_vars_counted() {
         )
         .unwrap()
     };
+    let entry_annotations = block_annotations.type_annotations_of(entry.conjunction()).unwrap();
 
     let (row_vars, variable_positions, mapping) =
         position_mapping([var_person], [var_attribute, var_person_type, var_attribute_type]);
@@ -386,7 +388,7 @@ fn cartesian_named_counted_checked() {
     conjunction.constraints_mut().add_label(var_email_type, EMAIL_LABEL.clone()).unwrap();
     let entry = builder.finish().unwrap();
 
-    let entry_annotations = {
+    let block_annotations = {
         let snapshot: ReadSnapshot<WALClient> = storage.clone().open_snapshot_read();
         let (type_manager, _) = load_managers(storage.clone(), None);
         let variable_registry = &translation_context.variable_registry;
@@ -402,6 +404,7 @@ fn cartesian_named_counted_checked() {
         )
         .unwrap()
     };
+    let entry_annotations = block_annotations.type_annotations_of(entry.conjunction()).unwrap();
 
     let (row_vars, variable_positions, mapping) = position_mapping(
         [var_person, var_age],

--- a/function/function_manager.rs
+++ b/function/function_manager.rs
@@ -600,11 +600,12 @@ pub mod tests {
             assert_eq!(expected_signature.function_id(), looked_up.function_id());
 
             let function_annotations = cache.get_annotated_function(expected_function_id.clone()).unwrap();
-            let AnnotatedStage::Match { block_annotations: body_annotations, .. } =
+            let AnnotatedStage::Match { block_annotations, block, .. } =
                 function_annotations.stages.first().as_ref().unwrap()
             else {
                 unreachable!()
             };
+            let body_annotations = block_annotations.type_annotations_of(block.conjunction()).unwrap();
             let var_c = function_annotations.arguments[0];
             let var_c_annotations = body_annotations.vertex_annotations_of(&Vertex::Variable(var_c)).unwrap();
             assert_eq!(&Arc::new(BTreeSet::from([type_cat])), var_c_annotations);

--- a/ir/pattern/conjunction.rs
+++ b/ir/pattern/conjunction.rs
@@ -70,7 +70,7 @@ impl Conjunction {
         }
     }
 
-    pub fn local_variables<'a>(&self) -> impl Iterator<Item = Variable> + 'a {
+    pub fn local_variables(&self) -> impl Iterator<Item = Variable> + '_ {
         self.constraints().iter().flat_map(|c| c.ids()).dedup()
     }
 

--- a/ir/pattern/conjunction.rs
+++ b/ir/pattern/conjunction.rs
@@ -70,6 +70,10 @@ impl Conjunction {
         }
     }
 
+    pub fn local_variables<'a>(&'a self, block_context: &'a BlockContext) -> impl Iterator<Item = Variable> + 'a {
+        self.referenced_variables().filter(|var| block_context.is_variable_available(self.scope_id, *var))
+    }
+
     pub fn referenced_variables(&self) -> impl Iterator<Item = Variable> + '_ {
         self.constraints()
             .iter()

--- a/ir/pattern/conjunction.rs
+++ b/ir/pattern/conjunction.rs
@@ -70,10 +70,6 @@ impl Conjunction {
         }
     }
 
-    pub fn local_variables(&self) -> impl Iterator<Item = Variable> + '_ {
-        self.constraints().iter().flat_map(|c| c.ids()).dedup()
-    }
-
     pub fn referenced_variables(&self) -> impl Iterator<Item = Variable> + '_ {
         self.constraints()
             .iter()

--- a/ir/pattern/conjunction.rs
+++ b/ir/pattern/conjunction.rs
@@ -70,15 +70,8 @@ impl Conjunction {
         }
     }
 
-    pub fn local_variables<'a>(&self, block_context: &'a BlockContext) -> impl Iterator<Item = Variable> + 'a {
-        let self_scope = self.scope_id;
-        block_context
-            .get_variable_scopes()
-            .filter(move |&(var, scope)| {
-                scope == self_scope || block_context.is_visible_child(scope, self_scope) && var.is_named()
-            })
-            .map(|(var, _)| var)
-            .unique()
+    pub fn local_variables<'a>(&self) -> impl Iterator<Item = Variable> + 'a {
+        self.constraints().iter().flat_map(|c| c.ids()).dedup()
     }
 
     pub fn referenced_variables(&self) -> impl Iterator<Item = Variable> + '_ {

--- a/ir/pipeline/block.rs
+++ b/ir/pipeline/block.rs
@@ -129,12 +129,6 @@ fn validate_conjunction(
             source_span: variable_registry.source_span(variable),
         }));
     }
-    let is_with_mismatched_category = conjunction.constraints().iter().filter_map(|c| c.as_is()).find_or_first(|is| {
-        let lhs_category = variable_registry.get_variable_category(is.lhs().as_variable().unwrap()).unwrap();
-        let rhs_category = variable_registry.get_variable_category(is.rhs().as_variable().unwrap()).unwrap();
-        lhs_category.narrowest(rhs_category).is_none()
-    });
-
     if let ControlFlow::Break((var, source_span)) = conjunction.find_disjoint(block_context) {
         let name = variable_registry.get_variable_name(var).unwrap().clone();
         return Err(Box::new(RepresentationError::DisjointVariableReuse { name, source_span }));
@@ -152,6 +146,11 @@ fn validate_conjunction(
         }
     }
 
+    let is_with_mismatched_category = conjunction.constraints().iter().filter_map(|c| c.as_is()).find_or_first(|is| {
+        let lhs_category = variable_registry.get_variable_category(is.lhs().as_variable().unwrap()).unwrap();
+        let rhs_category = variable_registry.get_variable_category(is.rhs().as_variable().unwrap()).unwrap();
+        lhs_category.narrowest(rhs_category).is_none()
+    });
     if let Some(is) = is_with_mismatched_category {
         let lhs = is.lhs().as_variable().unwrap();
         let rhs = is.rhs().as_variable().unwrap();


### PR DESCRIPTION
## Release notes: product changes
Making type annotations local to each subpattern leads to cleaner handling of variables which cross into subpatterns or subsequent stages.

## Motivation
More intuitive guarantees 
* VertexAnnotations are reliable
* The same constraints in different branches will not clobber each other's annotations
* Executors can assume they will not encounter input variables with incompatible types. 
  - Fixes a bunch of crashes because this was not true.


## Implementation
**Setting:**  A conjunction is a set of constraints & a set of nested patterns (disjunctions, optionals, etc). 
Although `TypeInferenceGraph` had annotations for each nested pattern - prior to this change, There was only one `TypeAnnotations` for the whole block (= a match-stage = the root conjunction and all its (recursively) nested patterns)

**Problems:**   This means `vertex_annotations` were picked from the root conjunction. The vertex annotations of a variable in a subpattern would be a subset of these annotations. This meant the consumers of TypeAnnotations (compiler & executor) had to always use `constraint_annotations` for accuracy. 
Further, subpatterns may get types from a parent which cannot satisfy the subpattern. In some cases, these would also lead to crashes (e.g. an entity being passed to an executor which only expects relations).

**Motivation**: This change refines type-inference across pattern & stage boundaries for reliability. 

**Changes:**
* Make `TypeAnnotations` local to a subpattern , introduce  `BlockAnnotations` to hold the mapping between subpatterns and their `TypeAnnotations`.
* `MatchExecutableBuilder` will push a `TypeList` or (new) `ThingTypeList` check per input-variable who may have a type that is not satisfiable by the given subpattern. This means every downstream executor will only see variables bound to types it expects.
* TypeSeeder considers coarser VariableCategories when seeding variables who are not connected to any labelled vertex. It only differentiates between `RoleType` & `ThingType`.
- Since `VariableCategory` is global, this avoids the case where a certain branch causes a variable to be a more specific category & the type-annotations in other branches are restricted as a result . VariableCategories were probably never intended to be used this way anyway.
