### PR TITLE
Fix disjoint variable validation logic

### DIFF
--- a/dependencies/typedb/repositories.bzl
+++ b/dependencies/typedb/repositories.bzl
@@ -35,6 +35,6 @@ def typedb_protocol():
 def typedb_behaviour():
     git_repository(
         name = "typedb_behaviour",
-        remote = "https://github.com/dmitrii-ubskii/typedb-behaviour",
-        commit = "5dcc99476a5598a81939b4b5200e4a451ac4f071",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @typedb_behaviour
+        remote = "https://github.com/typedb/typedb-behaviour",
+        commit = "97bfc7368761154ac952a69823c0c7332c6d16de",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @typedb_behaviour
     )

--- a/dependencies/typedb/repositories.bzl
+++ b/dependencies/typedb/repositories.bzl
@@ -35,6 +35,6 @@ def typedb_protocol():
 def typedb_behaviour():
     git_repository(
         name = "typedb_behaviour",
-        remote = "https://github.com/typedb/typedb-behaviour",
-        commit = "8912362644425c355ded267a0703cc583c53425d",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @typedb_behaviour
+        remote = "https://github.com/dmitrii-ubskii/typedb-behaviour",
+        commit = "5dcc99476a5598a81939b4b5200e4a451ac4f071",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @typedb_behaviour
     )

--- a/ir/pattern/disjunction.rs
+++ b/ir/pattern/disjunction.rs
@@ -94,20 +94,9 @@ impl Disjunction {
         dependencies
     }
 
-    pub(crate) fn find_disjoint(
-        &self,
-        block_context: &BlockContext,
-        scope_id: ScopeId,
-    ) -> ControlFlow<(Variable, Option<Span>)> {
-        let dependencies = self.variable_dependency(block_context);
-        let branch_dependencies =
-            self.conjunctions.iter().map(|conj| conj.variable_dependency(block_context)).collect_vec();
-        for (var, dep) in dependencies {
-            if dep.is_referencing() && block_context.get_scope(&var) == Some(scope_id) {
-                if let Err(mut err) = branch_dependencies.iter().filter_map(|d| d.get(&var)).exactly_one() {
-                    return ControlFlow::Break((var, err.next().unwrap().referencing_constraints()[0].source_span()));
-                }
-            }
+    pub(crate) fn find_disjoint(&self, block_context: &BlockContext) -> ControlFlow<(Variable, Option<Span>)> {
+        for conjunction in &self.conjunctions {
+            conjunction.find_disjoint(block_context)?;
         }
         ControlFlow::Continue(())
     }

--- a/ir/pattern/negation.rs
+++ b/ir/pattern/negation.rs
@@ -63,7 +63,7 @@ impl Negation {
     }
 
     pub fn required_inputs(&self, block_context: &BlockContext) -> impl Iterator<Item = Variable> + '_ {
-        self.variable_dependency(block_context).into_iter().filter_map(|(v, mode)| mode.is_required().then_some(v))
+        self.variable_dependency(block_context).into_iter().filter_map(|(v, dep)| dep.is_required().then_some(v))
     }
 }
 

--- a/ir/pattern/nested_pattern.rs
+++ b/ir/pattern/nested_pattern.rs
@@ -4,10 +4,11 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-use std::{collections::HashMap, fmt, mem};
+use std::{collections::HashMap, fmt, mem, ops::ControlFlow};
 
 use answer::variable::Variable;
 use structural_equality::StructuralEquality;
+use typeql::common::Span;
 
 use crate::{
     pattern::{disjunction::Disjunction, negation::Negation, optional::Optional, VariableDependency},
@@ -72,6 +73,14 @@ impl NestedPattern {
             NestedPattern::Disjunction(disjunction) => disjunction.variable_dependency(block_context),
             NestedPattern::Negation(negation) => negation.variable_dependency(block_context),
             NestedPattern::Optional(optional) => optional.variable_dependency(block_context),
+        }
+    }
+
+    pub(crate) fn find_disjoint(&self, block_context: &BlockContext) -> ControlFlow<(Variable, Option<Span>)> {
+        match self {
+            NestedPattern::Disjunction(disjunction) => disjunction.find_disjoint(block_context),
+            NestedPattern::Negation(negation) => negation.conjunction().find_disjoint(block_context),
+            NestedPattern::Optional(optional) => optional.conjunction().find_disjoint(block_context),
         }
     }
 }

--- a/ir/pipeline/block.rs
+++ b/ir/pipeline/block.rs
@@ -140,10 +140,10 @@ fn validate_conjunction(
         return Err(Box::new(RepresentationError::DisjointVariableReuse { name, source_span }));
     }
 
-    for (var, mode) in conjunction.variable_dependency(block_context) {
-        if mode.is_required() && block_context.get_scope(&var) != Some(ScopeId::INPUT) {
+    for (var, dep) in conjunction.variable_dependency(block_context) {
+        if dep.is_required() && block_context.get_scope(&var) != Some(ScopeId::INPUT) {
             let variable = variable_registry.get_variable_name(var).unwrap().clone();
-            let spans = mode.referencing_constraints().iter().map(|s| s.source_span()).collect_vec();
+            let spans = dep.referencing_constraints().iter().map(|s| s.source_span()).collect_vec();
             return Err(Box::new(RepresentationError::UnboundRequiredVariable {
                 variable,
                 source_span: spans[0],


### PR DESCRIPTION
## Release notes: product changes

Fix the condition for the disjoint variable reuse detection (`Variable 'var' is re-used across different branches of the query`).

## Motivation

## Implementation

Previous (incorrect) logic:
A variable is used disjointly if it is referenced by a disjunction, scoped to the containing conjunction, and appears in more than one branch of said disjunction (but not all branches).

This fails if: 
1. the disjunction is referencing a variable produced by a different pattern (false positive):
```php
match { $e isa person; } or { $e isa company; } or { $a isa name; }; $e has $a;
```
2. or if two or more disjunctions are referencing the variable without producing it (false negative):
```php
match { $e isa person; } or { $t sub $t; }; { $e isa company; } or { $u sub $u; };
```

Corrected logic:
A variable is used disjointly if it is referenced (not produced or required) by the conjunction it is scoped to.

