### PR TITLE
Simplify resolving role-types in writes

### DIFF
--- a/compiler/executable/delete/executable.rs
+++ b/compiler/executable/delete/executable.rs
@@ -20,7 +20,7 @@ use crate::{
     executable::{
         delete::instructions::{ConnectionInstruction, Has, Links, ThingInstruction},
         insert::{
-            executable::{resolve_role_types, get_thing_position},
+            executable::{get_thing_position, resolve_links_roles},
             ThingPosition,
         },
         next_executable_id, WriteCompilationError,
@@ -45,7 +45,7 @@ pub fn compile(
     deleted_concepts: &[Variable],
     source_span: Option<Span>,
 ) -> Result<DeleteExecutable, Box<WriteCompilationError>> {
-    let resolved_roles = resolve_role_types(constraints, type_annotations, input_variables, variable_registry)?;
+    let resolved_roles = resolve_links_roles(constraints, type_annotations, input_variables, variable_registry)?;
     let mut connection_deletes = Vec::new();
     for constraint in constraints {
         match constraint {

--- a/compiler/executable/insert/executable.rs
+++ b/compiler/executable/insert/executable.rs
@@ -451,12 +451,11 @@ pub(crate) fn resolve_links_roles(
                 if let Ok((type_)) = annotations.iter().exactly_one() {
                     Ok((role_type.clone(), TypeSource::Constant(*type_)))
                 } else {
-                    let variable = variable_registry
-                        .get_variable_name(role_type)
+                    let player_variable = variable_registry
                         .cloned()
                         .unwrap_or_else(|| VariableRegistry::UNNAMED_VARIABLE_DISPLAY_NAME.to_string());
-                    Err(Box::new(WriteCompilationError::AmbiguousRoleType {
-                        variable,
+                    Err(Box::new(WriteCompilationError::InsertLinksAmbiguousRoleType {
+                        player_variable,
                         role_types: annotations.iter().join(", "),
                         source_span: role_type_vertex.source_span(variable_registry),
                     }))

--- a/compiler/executable/insert/executable.rs
+++ b/compiler/executable/insert/executable.rs
@@ -441,8 +441,8 @@ pub(crate) fn resolve_links_roles(
     variable_registry: &VariableRegistry,
 ) -> Result<HashMap<Variable, TypeSource>, Box<WriteCompilationError>> {
     filter_variants!(Constraint::Links : constraints)
-        .map(|links| links.role_type())
-        .map(|role_type_vertex| {
+        .map(|links| {
+            let role_type_vertex = links.role_type();
             let role_type = role_type_vertex.as_variable().expect("links.role_type is always a variable");
             if let Some(input_position) = input_variables.get(&role_type) {
                 Ok((role_type.clone(), TypeSource::InputVariable(*input_position)))
@@ -452,6 +452,7 @@ pub(crate) fn resolve_links_roles(
                     Ok((role_type.clone(), TypeSource::Constant(*type_)))
                 } else {
                     let player_variable = variable_registry
+                        .get_variable_name(links.player().as_variable().unwrap())
                         .cloned()
                         .unwrap_or_else(|| VariableRegistry::UNNAMED_VARIABLE_DISPLAY_NAME.to_string());
                     Err(Box::new(WriteCompilationError::InsertLinksAmbiguousRoleType {

--- a/compiler/executable/insert/executable.rs
+++ b/compiler/executable/insert/executable.rs
@@ -273,7 +273,7 @@ fn add_links(
     variable_registry: &VariableRegistry,
     instructions: &mut Vec<ConnectionInstruction>,
 ) -> Result<(), Box<WriteCompilationError>> {
-    let resolved_role_types = resolve_role_types(constraints, type_annotations, input_variables, variable_registry)?;
+    let resolved_role_types = resolve_links_roles(constraints, type_annotations, input_variables, variable_registry)?;
     for links in filter_variants!(Constraint::Links: constraints) {
         let relation = get_thing_position(
             variable_positions,
@@ -434,7 +434,7 @@ fn collect_type_bindings(
         .collect()
 }
 
-pub(crate) fn resolve_role_types(
+pub(crate) fn resolve_links_roles(
     constraints: &[Constraint<Variable>],
     type_annotations: &TypeAnnotations,
     input_variables: &HashMap<Variable, VariablePosition>,
@@ -451,7 +451,8 @@ pub(crate) fn resolve_role_types(
                 if let Ok((type_)) = annotations.iter().exactly_one() {
                     Ok((role_type.clone(), TypeSource::Constant(*type_)))
                 } else {
-                    let variable = variable_registry.get_variable_name(role_type)
+                    let variable = variable_registry
+                        .get_variable_name(role_type)
                         .cloned()
                         .unwrap_or_else(|| VariableRegistry::UNNAMED_VARIABLE_DISPLAY_NAME.to_string());
                     Err(Box::new(WriteCompilationError::AmbiguousRoleType {

--- a/compiler/executable/match_/planner/plan.rs
+++ b/compiler/executable/match_/planner/plan.rs
@@ -25,13 +25,12 @@ use ir::{
         },
         nested_pattern::NestedPattern,
         variable_category::VariableCategory,
-        Vertex,
+        Scope, Vertex,
     },
     pipeline::{block::BlockContext, VariableRegistry},
 };
 use itertools::{chain, Itertools};
 use tracing::{event, Level};
-use ir::pattern::Scope;
 
 use crate::{
     annotation::{
@@ -129,7 +128,8 @@ fn make_builder<'a>(
                         .conjunctions()
                         .iter()
                         .map(|branch| {
-                            let branch_shared_variables = branch.referenced_variables()
+                            let branch_shared_variables = branch
+                                .referenced_variables()
                                 .filter(|var| block_context.is_variable_available(conjunction.scope_id(), *var))
                                 .collect();
                             make_builder(

--- a/compiler/executable/mod.rs
+++ b/compiler/executable/mod.rs
@@ -89,13 +89,6 @@ typedb_error! {
             variable: String,
             source_span: Option<Span>,
         ),
-        AmbiguousRoleType(
-            8,
-            "Could not uniquely resolve the role type for variable '{variable}'. Possible role types are: {role_types}.",
-            variable: String,
-            role_types: String,
-            source_span: Option<Span>,
-        ),
         InsertLinksAmbiguousRoleType(
             9,
             "Links insert for player '{player_variable}' requires unambiguous role type, but inferred: {role_types}.",

--- a/compiler/executable/update/executable.rs
+++ b/compiler/executable/update/executable.rs
@@ -14,9 +14,7 @@ use crate::{
     annotation::type_annotations::TypeAnnotations,
     executable::{
         insert::{
-            executable::{
-                add_inserted_concepts, resolve_role_types, get_thing_position, prepare_output_row_schema,
-            },
+            executable::{add_inserted_concepts, get_thing_position, prepare_output_row_schema, resolve_links_roles},
             instructions::ConceptInstruction,
             VariableSource,
         },
@@ -111,7 +109,7 @@ fn add_links(
     variable_registry: &VariableRegistry,
     instructions: &mut Vec<ConnectionInstruction>,
 ) -> Result<(), Box<WriteCompilationError>> {
-    let resolved_role_types = resolve_role_types(constraints, type_annotations, input_variables, variable_registry)?;
+    let resolved_role_types = resolve_links_roles(constraints, type_annotations, input_variables, variable_registry)?;
     for links in filter_variants!(Constraint::Links: constraints) {
         let relation = get_thing_position(
             variable_positions,

--- a/compiler/executable/update/executable.rs
+++ b/compiler/executable/update/executable.rs
@@ -15,8 +15,7 @@ use crate::{
     executable::{
         insert::{
             executable::{
-                add_inserted_concepts, collect_named_role_type_bindings, get_thing_position, prepare_output_row_schema,
-                resolve_links_role,
+                add_inserted_concepts, resolve_role_types, get_thing_position, prepare_output_row_schema,
             },
             instructions::ConceptInstruction,
             VariableSource,
@@ -112,7 +111,7 @@ fn add_links(
     variable_registry: &VariableRegistry,
     instructions: &mut Vec<ConnectionInstruction>,
 ) -> Result<(), Box<WriteCompilationError>> {
-    let named_role_types = collect_named_role_type_bindings(constraints, type_annotations, variable_registry)?;
+    let resolved_role_types = resolve_role_types(constraints, type_annotations, input_variables, variable_registry)?;
     for links in filter_variants!(Constraint::Links: constraints) {
         let relation = get_thing_position(
             variable_positions,
@@ -126,7 +125,7 @@ fn add_links(
             variable_registry,
             links.source_span(),
         )?;
-        let role = resolve_links_role(type_annotations, input_variables, variable_registry, &named_role_types, links)?;
+        let role = resolved_role_types.get(&links.role_type().as_variable().unwrap()).unwrap().clone();
         instructions.push(ConnectionInstruction::Links(Links { relation, player, role }));
     }
     Ok(())

--- a/executor/instruction/mod.rs
+++ b/executor/instruction/mod.rs
@@ -4,12 +4,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-use std::{
-    collections::HashMap,
-    fmt,
-    marker::PhantomData,
-    ops::Bound,
-};
+use std::{collections::HashMap, fmt, marker::PhantomData, ops::Bound};
 
 use ::iterator::minmax_or;
 use answer::{variable_value::VariableValue, Thing, Type};


### PR DESCRIPTION
## Release notes: product changes
Refactors role-type resolution in insert, update & delete stages to be done in a single function.

## Implementation
Combines `collect_named_role_type_bindings ` and `resolve_links_role` into a single `resolve_links_role` function.