### PR TITLE
Add cmake to Windows CI dependencies

### DIFF
--- a/.circleci/windows/dependencies.config
+++ b/.circleci/windows/dependencies.config
@@ -13,6 +13,7 @@
     <!-- Already present on circleci -->
     <!-- <package id="visualstudio2022buildtools" version="117.12.2" /> -->
     <!-- <package id="visualstudio2022-workload-vctools" version="1.0.0" /> -->
+    <package id="cmake" version="4.0.1" />
     <package id="rust-ms" version="1.81.0" />
     <package id="git" version="2.47.1" />
     <package id="llvm" version="19.1.0" />


### PR DESCRIPTION
## Release notes: product changes
Install `cmake` through chocolatey for Windows CI machines to build TypeDB.
 
## Motivation
The newest version of TypeDB started depending on `cmake` due to the introduction of an implicit dependency on the cryptographic crate `aws-lc-sys`. 
[Diff](https://github.com/typedb/typedb/commit/5b69152bf864db9b5bf1662e60a8d64b5dbec0fe#diff-13ee4b2252c9e516a0547f2891aa2105c3ca71c6d7a1e682c69be97998dfc87eR870)
[Failed build](https://app.circleci.com/pipelines/github/typedb/typedb/1839/workflows/77956d0f-39e2-43c9-955a-0c255bfc17de/jobs/4538):
```
--- stderr
  Missing dependency: cmake
  thread 'main' panicked at C:\Users\circleci\.cargo\registry\src\index.crates.io-6f17d22bba15001f\aws-lc-sys-0.28.0\builder/main.rs:382:40:
  called `Result::unwrap()` on an `Err` value: "Required build dependency is missing. Halting build."
  note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

## Implementation
Update `dependencies.config` with the latest version of `cmake`.
