### PR TITLE
Enable GRPC transaction and query options

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4969,7 +4969,7 @@ dependencies = [
 [[package]]
 name = "typedb-protocol"
 version = "0.0.0"
-source = "git+https://github.com/typedb/typedb-protocol?rev=a6d5a8e6fe8460426d7b55fb9d69dc851b157bdd#a6d5a8e6fe8460426d7b55fb9d69dc851b157bdd"
+source = "git+https://github.com/typedb/typedb-protocol?rev=580dc015979cc9e538ee2319bd2167ffc1e508f0#580dc015979cc9e538ee2319bd2167ffc1e508f0"
 dependencies = [
  "prost",
  "tonic",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4969,7 +4969,7 @@ dependencies = [
 [[package]]
 name = "typedb-protocol"
 version = "0.0.0"
-source = "git+https://github.com/typedb/typedb-protocol?tag=3.2.0-rc0#195a37a3d28a6058ea501d75b276cadf6a38ad84"
+source = "git+https://github.com/typedb/typedb-protocol?rev=a6d5a8e6fe8460426d7b55fb9d69dc851b157bdd#a6d5a8e6fe8460426d7b55fb9d69dc851b157bdd"
 dependencies = [
  "prost",
  "tonic",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -195,6 +195,10 @@ features = {}
 	name = "test_http_transaction"
 
 [[test]]
+	path = "tests/behaviour/service/http/http.rs"
+	name = "test_http"
+
+[[test]]
 	path = "tests/behaviour/service/http/user.rs"
 	name = "test_http_user"
 

--- a/common/options/options.rs
+++ b/common/options/options.rs
@@ -6,7 +6,8 @@
 
 use resource::constants::server::{
     DEFAULT_ANSWER_COUNT_LIMIT_GRPC, DEFAULT_ANSWER_COUNT_LIMIT_HTTP, DEFAULT_INCLUDE_INSTANCE_TYPES,
-    DEFAULT_SCHEMA_LOCK_ACQUIRE_TIMEOUT_MILLIS, DEFAULT_TRANSACTION_PARALLEL, DEFAULT_TRANSACTION_TIMEOUT_MILLIS,
+    DEFAULT_PREFETCH_SIZE, DEFAULT_SCHEMA_LOCK_ACQUIRE_TIMEOUT_MILLIS, DEFAULT_TRANSACTION_PARALLEL,
+    DEFAULT_TRANSACTION_TIMEOUT_MILLIS,
 };
 
 #[derive(Debug)]
@@ -30,6 +31,7 @@ impl Default for TransactionOptions {
 pub struct QueryOptions {
     pub include_instance_types: bool,
     pub answer_count_limit: Option<usize>,
+    pub prefetch_size: usize,
 }
 
 impl QueryOptions {
@@ -37,6 +39,7 @@ impl QueryOptions {
         Self {
             include_instance_types: DEFAULT_INCLUDE_INSTANCE_TYPES,
             answer_count_limit: DEFAULT_ANSWER_COUNT_LIMIT_GRPC,
+            prefetch_size: DEFAULT_PREFETCH_SIZE,
         }
     }
 
@@ -44,6 +47,7 @@ impl QueryOptions {
         Self {
             include_instance_types: DEFAULT_INCLUDE_INSTANCE_TYPES,
             answer_count_limit: DEFAULT_ANSWER_COUNT_LIMIT_HTTP,
+            prefetch_size: DEFAULT_PREFETCH_SIZE,
         }
     }
 }

--- a/dependencies/typedb/repositories.bzl
+++ b/dependencies/typedb/repositories.bzl
@@ -34,8 +34,9 @@ def typedb_protocol():
     )
 
 def typedb_behaviour():
+    # TODO: Return typedb
     git_repository(
         name = "typedb_behaviour",
-        remote = "https://github.com/typedb/typedb-behaviour",
-        commit = "974fdb0f45c561a82796a388cab7c16f18c646ee",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @typedb_behaviour
+        remote = "https://github.com/farost/typedb-behaviour",
+        commit = "d53edaaa04946b882dbe3d24e5ecdb1eae6bb36d",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @typedb_behaviour
     )

--- a/dependencies/typedb/repositories.bzl
+++ b/dependencies/typedb/repositories.bzl
@@ -26,10 +26,11 @@ def typeql():
     )
 
 def typedb_protocol():
+    # TODO: return typedb
     git_repository(
         name = "typedb_protocol",
-        remote = "https://github.com/typedb/typedb-protocol",
-        tag = "3.2.0-rc0",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @typedb_protocol
+        remote = "https://github.com/farost/typedb-protocol",
+        commit = "a6d5a8e6fe8460426d7b55fb9d69dc851b157bdd",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @typedb_protocol
     )
 
 def typedb_behaviour():

--- a/dependencies/typedb/repositories.bzl
+++ b/dependencies/typedb/repositories.bzl
@@ -30,7 +30,7 @@ def typedb_protocol():
     git_repository(
         name = "typedb_protocol",
         remote = "https://github.com/farost/typedb-protocol",
-        commit = "a6d5a8e6fe8460426d7b55fb9d69dc851b157bdd",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @typedb_protocol
+        commit = "580dc015979cc9e538ee2319bd2167ffc1e508f0",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @typedb_protocol
     )
 
 def typedb_behaviour():
@@ -38,5 +38,5 @@ def typedb_behaviour():
     git_repository(
         name = "typedb_behaviour",
         remote = "https://github.com/farost/typedb-behaviour",
-        commit = "d53edaaa04946b882dbe3d24e5ecdb1eae6bb36d",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @typedb_behaviour
+        commit = "5f9fe40307d7f0a9b66a79bd069274eca85e1ba4",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @typedb_behaviour
     )

--- a/resource/constants.rs
+++ b/resource/constants.rs
@@ -32,7 +32,7 @@ pub mod server {
     pub const GRPC_CONNECTION_KEEPALIVE: Duration = Duration::from_secs(2 * SECONDS_IN_HOUR);
 
     // TODO: Maybe we start moving these options to separate crates?
-    pub const DEFAULT_PREFETCH_SIZE: u64 = 32;
+    pub const DEFAULT_PREFETCH_SIZE: usize = 32;
     pub const DEFAULT_SCHEMA_LOCK_ACQUIRE_TIMEOUT_MILLIS: u64 = Duration::from_secs(10).as_millis() as u64;
     pub const DEFAULT_TRANSACTION_TIMEOUT_MILLIS: u64 = Duration::from_secs(5 * SECONDS_IN_MINUTE).as_millis() as u64;
     pub const DEFAULT_TRANSACTION_PARALLEL: bool = true;

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -94,8 +94,8 @@
 
 	[dependencies.typedb-protocol]
 		features = []
+		rev = "a6d5a8e6fe8460426d7b55fb9d69dc851b157bdd"
 		git = "https://github.com/typedb/typedb-protocol"
-		tag = "3.2.0-rc0"
 		default-features = false
 
 	[dependencies.resource]

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -94,7 +94,7 @@
 
 	[dependencies.typedb-protocol]
 		features = []
-		rev = "a6d5a8e6fe8460426d7b55fb9d69dc851b157bdd"
+		rev = "580dc015979cc9e538ee2319bd2167ffc1e508f0"
 		git = "https://github.com/typedb/typedb-protocol"
 		default-features = false
 

--- a/server/service/grpc/mod.rs
+++ b/server/service/grpc/mod.rs
@@ -10,6 +10,7 @@ mod diagnostics;
 mod document;
 pub(crate) mod encryption;
 mod error;
+mod options;
 mod request_parser;
 mod response_builders;
 mod row;

--- a/server/service/grpc/options.rs
+++ b/server/service/grpc/options.rs
@@ -1,0 +1,37 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+use options::{QueryOptions, TransactionOptions};
+use resource::constants::server::{
+    DEFAULT_ANSWER_COUNT_LIMIT_GRPC, DEFAULT_INCLUDE_INSTANCE_TYPES, DEFAULT_SCHEMA_LOCK_ACQUIRE_TIMEOUT_MILLIS,
+    DEFAULT_TRANSACTION_PARALLEL, DEFAULT_TRANSACTION_TIMEOUT_MILLIS,
+};
+use typedb_protocol::options::{Query as QueryOptionsProto, Transaction as TransactionOptionsProto};
+
+pub(crate) fn transaction_options_from_proto(proto: Option<TransactionOptionsProto>) -> TransactionOptions {
+    let Some(proto) = proto else {
+        return TransactionOptions::default();
+    };
+
+    TransactionOptions {
+        parallel: proto.parallel.unwrap_or(DEFAULT_TRANSACTION_PARALLEL),
+        schema_lock_acquire_timeout_millis: proto
+            .schema_lock_acquire_timeout_millis
+            .unwrap_or(DEFAULT_SCHEMA_LOCK_ACQUIRE_TIMEOUT_MILLIS),
+        transaction_timeout_millis: proto.transaction_timeout_millis.unwrap_or(DEFAULT_TRANSACTION_TIMEOUT_MILLIS),
+    }
+}
+
+pub(crate) fn query_options_from_proto(proto: Option<QueryOptionsProto>) -> QueryOptions {
+    let Some(proto) = proto else {
+        return QueryOptions::default_grpc();
+    };
+
+    QueryOptions {
+        include_instance_types: proto.include_instance_types.unwrap_or(DEFAULT_INCLUDE_INSTANCE_TYPES),
+        answer_count_limit: DEFAULT_ANSWER_COUNT_LIMIT_GRPC,
+    }
+}

--- a/server/service/grpc/options.rs
+++ b/server/service/grpc/options.rs
@@ -6,8 +6,8 @@
 
 use options::{QueryOptions, TransactionOptions};
 use resource::constants::server::{
-    DEFAULT_ANSWER_COUNT_LIMIT_GRPC, DEFAULT_INCLUDE_INSTANCE_TYPES, DEFAULT_SCHEMA_LOCK_ACQUIRE_TIMEOUT_MILLIS,
-    DEFAULT_TRANSACTION_PARALLEL, DEFAULT_TRANSACTION_TIMEOUT_MILLIS,
+    DEFAULT_ANSWER_COUNT_LIMIT_GRPC, DEFAULT_INCLUDE_INSTANCE_TYPES, DEFAULT_PREFETCH_SIZE,
+    DEFAULT_SCHEMA_LOCK_ACQUIRE_TIMEOUT_MILLIS, DEFAULT_TRANSACTION_PARALLEL, DEFAULT_TRANSACTION_TIMEOUT_MILLIS,
 };
 use typedb_protocol::options::{Query as QueryOptionsProto, Transaction as TransactionOptionsProto};
 
@@ -33,5 +33,6 @@ pub(crate) fn query_options_from_proto(proto: Option<QueryOptionsProto>) -> Quer
     QueryOptions {
         include_instance_types: proto.include_instance_types.unwrap_or(DEFAULT_INCLUDE_INSTANCE_TYPES),
         answer_count_limit: DEFAULT_ANSWER_COUNT_LIMIT_GRPC,
+        prefetch_size: proto.prefetch_size.map(|value| value as usize).unwrap_or(DEFAULT_PREFETCH_SIZE),
     }
 }

--- a/server/service/http/message/error.rs
+++ b/server/service/http/message/error.rs
@@ -62,6 +62,7 @@ impl IntoResponse for HttpServiceError {
                 TransactionServiceError::ServiceFailedQueueCleanup { .. } => StatusCode::BAD_REQUEST,
                 TransactionServiceError::PipelineExecution { .. } => StatusCode::BAD_REQUEST,
                 TransactionServiceError::TransactionTimeout { .. } => StatusCode::REQUEST_TIMEOUT,
+                TransactionServiceError::InvalidPrefetchSize { .. } => StatusCode::BAD_REQUEST,
             },
             HttpServiceError::QueryClose { .. } => StatusCode::BAD_REQUEST,
             HttpServiceError::QueryCommit { .. } => StatusCode::BAD_REQUEST,

--- a/server/service/http/message/query/mod.rs
+++ b/server/service/http/message/query/mod.rs
@@ -5,7 +5,9 @@
  */
 use axum::response::{IntoResponse, Response};
 use options::QueryOptions;
-use resource::constants::server::{DEFAULT_ANSWER_COUNT_LIMIT_HTTP, DEFAULT_INCLUDE_INSTANCE_TYPES};
+use resource::constants::server::{
+    DEFAULT_ANSWER_COUNT_LIMIT_HTTP, DEFAULT_INCLUDE_INSTANCE_TYPES, DEFAULT_PREFETCH_SIZE,
+};
 use serde::{Deserialize, Serialize};
 
 use crate::service::{
@@ -27,7 +29,7 @@ pub mod row;
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct QueryOptionsPayload {
     pub include_instance_types: Option<bool>,
-    pub answer_count_limit: Option<usize>,
+    pub answer_count_limit: Option<u64>,
 }
 
 impl Default for QueryOptionsPayload {
@@ -42,8 +44,9 @@ impl Into<QueryOptions> for QueryOptionsPayload {
             include_instance_types: self.include_instance_types.unwrap_or(DEFAULT_INCLUDE_INSTANCE_TYPES),
             answer_count_limit: self
                 .answer_count_limit
-                .map(|option| Some(option))
+                .map(|option| Some(option as usize))
                 .unwrap_or(DEFAULT_ANSWER_COUNT_LIMIT_HTTP),
+            prefetch_size: DEFAULT_PREFETCH_SIZE as usize,
         }
     }
 }

--- a/server/service/http/message/transaction.rs
+++ b/server/service/http/message/transaction.rs
@@ -6,7 +6,7 @@
 
 use axum::response::{IntoResponse, Response};
 use http::StatusCode;
-use options::TransactionOptions;
+use options::{QueryOptions, TransactionOptions};
 use resource::constants::server::{
     DEFAULT_SCHEMA_LOCK_ACQUIRE_TIMEOUT_MILLIS, DEFAULT_TRANSACTION_PARALLEL, DEFAULT_TRANSACTION_TIMEOUT_MILLIS,
 };

--- a/server/service/http/transaction_service.rs
+++ b/server/service/http/transaction_service.rs
@@ -144,7 +144,6 @@ pub(crate) struct TransactionService {
 
     timeout_at: Instant,
     schema_lock_acquire_timeout_millis: Option<u64>,
-    prefetch_size: Option<u64>,
 
     transaction: Option<Transaction>,
     query_queue: VecDeque<(TransactionResponder, QueryOptions, typeql::query::Pipeline, String)>,
@@ -232,7 +231,6 @@ impl TransactionService {
 
             timeout_at: init_transaction_timeout(None),
             schema_lock_acquire_timeout_millis: None,
-            prefetch_size: None,
 
             transaction: None,
             query_queue: VecDeque::with_capacity(20),

--- a/server/service/transaction_service.rs
+++ b/server/service/transaction_service.rs
@@ -413,5 +413,6 @@ typedb_error! {
         ServiceFailedQueueCleanup(15, "The operation failed since the service is closing."),
         PipelineExecution(16, "Pipeline execution failed.", typedb_source: PipelineExecutionError),
         TransactionTimeout(17, "Operation failed: transaction timeout."),
+        InvalidPrefetchSize(18, "Invalid query option: prefetch size should be >= 1, got {value} instead.", value: usize),
     }
 }

--- a/tests/behaviour/service/http/http_steps/lib.rs
+++ b/tests/behaviour/service/http/http_steps/lib.rs
@@ -227,7 +227,7 @@ impl Context {
     }
 
     fn is_ignore_tag(t: &String) -> bool {
-        t == "ignore" || t == "ignore-http"
+        t == "ignore" || t == "ignore-typedb-http"
     }
 
     pub async fn after_scenario(&mut self) {

--- a/tests/behaviour/service/http/http_steps/query.rs
+++ b/tests/behaviour/service/http/http_steps/query.rs
@@ -271,7 +271,7 @@ pub async fn set_query_option_include_instance_types(context: &mut Context, valu
 
 #[apply(generic_step)]
 #[step(expr = "set query option answer_count_limit to: {int}")]
-pub async fn set_query_option_answer_count_limit(context: &mut Context, value: usize) {
+pub async fn set_query_option_answer_count_limit(context: &mut Context, value: u64) {
     context.init_query_options_if_needed();
     context.query_options.as_mut().unwrap().answer_count_limit = Some(value);
 }


### PR DESCRIPTION
## Release notes: product changes
Enable options provided by the TypeDB GRPC protocol.

**Enable transaction options:**
* `transaction_timeout`: If set, specifies a timeout for killing transactions automatically, preventing memory leaks in unclosed transactions,
* `schema_lock_acquire_timeout`: If set, specifies how long the driver should wait if opening a transaction is blocked by an exclusive schema write lock. 

**Enable query options:**
* `include_instance_types`: If set, specifies if types should be included in instance structs returned in ConceptRow answers,
* `prefetch_size`: If set, specifies the number of extra query responses sent before the client side has to re-request more responses. Increasing this may increase performance for queries with a huge number of answers, as it can reduce the number of network round-trips at the cost of more resources on the server side.

## Motivation
Allow default transaction and query behaviors to be overridden by GRPC clients.

## Implementation
While the logic has already been propagated to the whole GRPC transaction service, there were desired refinements of the protocol structure's processing. Additionally, to ensure that the BDD tests updates are in sync with the server, the relevant Bazel references are updated.