### PR TITLE
Execute deletes in two passes - first constraints, then concepts

### DIFF
--- a/dependencies/typedb/repositories.bzl
+++ b/dependencies/typedb/repositories.bzl
@@ -35,6 +35,6 @@ def typedb_protocol():
 def typedb_behaviour():
     git_repository(
         name = "typedb_behaviour",
-        remote = "https://github.com/typedb/typedb-behaviour",
-        commit = "569b59cad1355bfaaf1ca18a8f4adf40e5d1da4f",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @typedb_behaviour
+        remote = "https://github.com/krishnangovindraj/typedb-behaviour",
+        commit = "a1d906d1040d5ed3ccf13e05cb2d9d3481dbdd55",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @typedb_behaviour
     )

--- a/dependencies/typedb/repositories.bzl
+++ b/dependencies/typedb/repositories.bzl
@@ -35,6 +35,6 @@ def typedb_protocol():
 def typedb_behaviour():
     git_repository(
         name = "typedb_behaviour",
-        remote = "https://github.com/krishnangovindraj/typedb-behaviour",
-        commit = "a1d906d1040d5ed3ccf13e05cb2d9d3481dbdd55",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @typedb_behaviour
+        remote = "https://github.com/typedb/typedb-behaviour",
+        commit = "1a03ff04d8c3e8f7cab97cca2b4fb022dc89834d",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @typedb_behaviour
     )

--- a/executor/pipeline/delete.rs
+++ b/executor/pipeline/delete.rs
@@ -9,6 +9,7 @@ use std::sync::Arc;
 use compiler::executable::delete::{executable::DeleteExecutable, instructions::ConnectionInstruction};
 use concept::thing::thing_manager::ThingManager;
 use ir::pipeline::ParameterRegistry;
+use resource::constants::traversal::CHECK_INTERRUPT_FREQUENCY_ROWS;
 use resource::profile::StageProfile;
 use storage::snapshot::WritableSnapshot;
 
@@ -73,7 +74,7 @@ where
                 return Err((Box::new(PipelineExecutionError::WriteError { typedb_source }), context));
             }
 
-            if index % 100 == 0 {
+            if index % CHECK_INTERRUPT_FREQUENCY_ROWS == 0 {
                 if let Some(interrupt) = interrupt.check() {
                     return Err((Box::new(PipelineExecutionError::Interrupted { interrupt }), context));
                 }
@@ -94,7 +95,7 @@ where
                 return Err((Box::new(PipelineExecutionError::WriteError { typedb_source }), context));
             }
 
-            if index % 100 == 0 {
+            if index % CHECK_INTERRUPT_FREQUENCY_ROWS == 0 {
                 if let Some(interrupt) = interrupt.check() {
                     return Err((Box::new(PipelineExecutionError::Interrupted { interrupt }), context));
                 }

--- a/executor/pipeline/insert.rs
+++ b/executor/pipeline/insert.rs
@@ -17,6 +17,7 @@ use compiler::{
 use concept::thing::thing_manager::ThingManager;
 use ir::pipeline::ParameterRegistry;
 use resource::{constants::traversal::BATCH_DEFAULT_CAPACITY, profile::StageProfile};
+use resource::constants::traversal::CHECK_INTERRUPT_FREQUENCY_ROWS;
 use storage::snapshot::WritableSnapshot;
 
 use crate::{
@@ -97,7 +98,7 @@ where
                 return Err((Box::new(PipelineExecutionError::WriteError { typedb_source }), context));
             }
 
-            if index % 100 == 0 {
+            if index % CHECK_INTERRUPT_FREQUENCY_ROWS == 0 {
                 if let Some(interrupt) = interrupt.check() {
                     return Err((Box::new(PipelineExecutionError::Interrupted { interrupt }), context));
                 }

--- a/executor/pipeline/put.rs
+++ b/executor/pipeline/put.rs
@@ -10,7 +10,7 @@ use compiler::{
     executable::{function::ExecutableFunctionRegistry, insert::VariableSource, put::PutExecutable},
     VariablePosition,
 };
-use resource::constants::traversal::BATCH_DEFAULT_CAPACITY;
+use resource::constants::traversal::{BATCH_DEFAULT_CAPACITY, CHECK_INTERRUPT_FREQUENCY_ROWS};
 use storage::snapshot::{ReadableSnapshot, WritableSnapshot};
 
 use crate::{
@@ -164,7 +164,7 @@ fn perform_inserts<Snapshot: WritableSnapshot>(
             )
             .map_err(|typedb_source| Box::new(PipelineExecutionError::WriteError { typedb_source }))?;
         }
-        if index % 100 == 0 {
+        if index % CHECK_INTERRUPT_FREQUENCY_ROWS == 0 {
             if let Some(interrupt) = interrupt.check() {
                 return Err(Box::new(PipelineExecutionError::Interrupted { interrupt }));
             }

--- a/executor/pipeline/update.rs
+++ b/executor/pipeline/update.rs
@@ -15,6 +15,7 @@ use compiler::{
 };
 use concept::thing::thing_manager::ThingManager;
 use ir::pipeline::ParameterRegistry;
+use resource::constants::traversal::CHECK_INTERRUPT_FREQUENCY_ROWS;
 use resource::profile::StageProfile;
 use storage::snapshot::WritableSnapshot;
 
@@ -95,7 +96,7 @@ where
                 return Err((Box::new(PipelineExecutionError::WriteError { typedb_source }), context));
             }
 
-            if index % 100 == 0 {
+            if index % CHECK_INTERRUPT_FREQUENCY_ROWS == 0 {
                 if let Some(interrupt) = interrupt.check() {
                     return Err((Box::new(PipelineExecutionError::Interrupted { interrupt }), context));
                 }

--- a/resource/constants.rs
+++ b/resource/constants.rs
@@ -103,6 +103,7 @@ pub mod traversal {
     pub const CONSTANT_CONCEPT_LIMIT: usize = 1000;
     pub const FIXED_BATCH_ROWS_MAX: u32 = 64;
     pub const BATCH_DEFAULT_CAPACITY: usize = 10;
+    pub const CHECK_INTERRUPT_FREQUENCY_ROWS: usize = 100;
 }
 
 pub mod snapshot {


### PR DESCRIPTION
## Release notes: product changes
If a delete stage which deletes both constraints and concepts, a certain row may delete a concept referenced by a connection in a subsequent row. We avoid this problem by first deleting constraints for every row in an initial pass, followed by concepts of every row in a second pass.
