### PR TITLE
Don't fetch validation data until required

### DIFF
--- a/resource/profile.rs
+++ b/resource/profile.rs
@@ -57,6 +57,7 @@ impl Display for CommitProfile {
             None => writeln!(f, "  Commit[enabled=false]"),
             Some(data) => {
                 writeln!(f, "  Commit[enabled=true, total timed micros={}]", data.total.as_nanos() as f64 / 1000.0)?;
+                writeln!(f, "    commit size: {}", data.commit_size)?;
                 writeln!(f, "    storage counters: {}", self.storage_counters())?;
                 writeln!(f, "    types validation micros: {}", data.types_validation.as_nanos() as f64 / 1000.0)?;
                 writeln!(f, "    things finalise micros: {}", data.things_finalise.as_nanos() as f64 / 1000.0)?;
@@ -134,6 +135,12 @@ impl CommitProfile {
     pub fn start(&mut self) {
         if let Some(data) = &mut self.data {
             data.stage_start = Instant::now();
+        }
+    }
+
+    pub fn commit_size(&mut self, size: usize) {
+        if let Some(data) = &mut self.data {
+            data.commit_size = size;
         }
     }
 
@@ -282,6 +289,7 @@ impl CommitProfile {
 #[derive(Debug)]
 struct CommitProfileData {
     counters: StorageCounters,
+    commit_size: usize,
     stage_start: Instant,
     types_validation: Duration,
     things_finalise: Duration,
@@ -305,6 +313,7 @@ impl CommitProfileData {
         Self {
             counters: StorageCounters::new_enabled(),
             stage_start: Instant::now(), // DUMMY
+            commit_size: 0,
             types_validation: Duration::ZERO,
             things_finalise: Duration::ZERO,
             functions_finalise: Duration::ZERO,

--- a/storage/snapshot/buffer.rs
+++ b/storage/snapshot/buffer.rs
@@ -88,6 +88,10 @@ impl OperationsBuffer {
             buffer.clear();
         }
     }
+
+    pub(crate) fn len(&self) -> usize {
+        self.write_buffers().map(|w| w.writes().len()).sum()
+    }
 }
 
 impl<'a> IntoIterator for &'a OperationsBuffer {

--- a/storage/storage.rs
+++ b/storage/storage.rs
@@ -233,6 +233,8 @@ impl<Durability> MVCCStorage<Durability> {
         let commit_record = snapshot.into_commit_record();
         commit_profile.snapshot_commit_record_created();
 
+        commit_profile.commit_size(commit_record.operations().len());
+
         let commit_sequence_number = self
             .durability_client
             .sequenced_write(&commit_record)


### PR DESCRIPTION
## Product change and motivation

We delay reading the data necessary for cardinality constraint validation until we have determined that we need to perform any validation.

## Implementation

We also add commit profile logging, enabled by setting log level of `database` to `trace`.