### PR TITLE
Change encoding of provenance in HTTP api to be collection of branch indexes

### DIFF
--- a/executor/lib.rs
+++ b/executor/lib.rs
@@ -119,8 +119,10 @@ impl Provenance {
         }
     }
 
-    pub(crate) fn branch_ids(&self) -> impl Iterator<Item = BranchID> {
+    pub fn branch_ids(&self) -> impl Iterator<Item = BranchID> {
         let provenance = self.0;
-        (0..64).filter(move |id| 0 != provenance & (1 << id)).map(|id| BranchID(id))
+        (0..64).filter(move |id| {
+            *id == 0 || 0 != provenance & (1 << id)
+        }).map(|id| BranchID(id))
     }
 }


### PR DESCRIPTION
## Product change and motivation
Instead of using the more compact bit-array representation, the `provenanceBitArray` field for each answer is now renamed to `involvedBranches` and encoded as a list of branch indexes.

The set of constraints satisfied by an answer[i] is easily computed by:
`result.answer[i].involvedBranches.flatMap(branchIndex => result.queryStructure.branches[branchIndex])`
