### PR TITLE
Prune branch ids when pruning away unsatisfiable disjunction branches

### DIFF
--- a/compiler/executable/pipeline.rs
+++ b/compiler/executable/pipeline.rs
@@ -37,7 +37,7 @@ use crate::{
         update::executable::UpdateExecutable,
         ExecutableCompilationError,
     },
-    query_structure::{extract_query_structure_from, ParametrisedQueryStructure},
+    query_structure::ParametrisedQueryStructure,
     VariablePosition,
 };
 
@@ -114,7 +114,7 @@ pub fn compile_pipeline_and_functions(
     annotated_stages: Vec<AnnotatedStage>,
     annotated_fetch: Option<AnnotatedFetch>,
     input_variables: &HashSet<Variable>,
-    source_query: &str,
+    query_structure: Option<Arc<ParametrisedQueryStructure>>,
 ) -> Result<ExecutablePipeline, ExecutableCompilationError> {
     // TODO: we could cache compiled schema functions so we dont have to re-compile with every query here
     let referenced_functions = find_referenced_functions(
@@ -155,8 +155,6 @@ pub fn compile_pipeline_and_functions(
         input_variables,
     )?;
     debug_assert!(!executable_stages.is_empty());
-    let query_structure = extract_query_structure_from(variable_registry, annotated_stages, source_query)
-        .map(|query_structure| Arc::new(query_structure));
     Ok(ExecutablePipeline {
         query_structure,
         executable_functions: schema_and_preamble_functions,

--- a/compiler/query_structure.rs
+++ b/compiler/query_structure.rs
@@ -45,9 +45,9 @@ pub struct QueryStructure {
     pub parameters: Arc<ParameterRegistry>,
 }
 
-pub(crate) fn extract_query_structure_from(
+pub fn extract_query_structure_from(
     variable_registry: &VariableRegistry,
-    annotated_stages: Vec<AnnotatedStage>,
+    annotated_stages: &[AnnotatedStage],
     source_query: &str,
 ) -> Option<ParametrisedQueryStructure> {
     if variable_registry.highest_branch_id_allocated() > 63 {

--- a/ir/pattern/disjunction.rs
+++ b/ir/pattern/disjunction.rs
@@ -57,7 +57,11 @@ impl Disjunction {
     }
 
     pub fn optimise_away_unsatisfiable_branches(&mut self, unsatisfiable: Vec<ScopeId>) {
-        self.conjunctions.retain(|v| !unsatisfiable.contains(&v.scope_id()))
+        let unsatisfiable_branch_ids = self.conjunctions.iter().zip(self.branch_ids.iter())
+            .filter_map(|(conj, branch_id)| unsatisfiable.contains(&conj.scope_id()).then_some(*branch_id))
+            .collect::<Vec<_>>();
+        self.branch_ids.retain(|branch_id| !unsatisfiable_branch_ids.contains(branch_id));
+        self.conjunctions.retain(|conj| !unsatisfiable.contains(&conj.scope_id()))
     }
 
     pub fn required_inputs(&self, block_context: &BlockContext) -> impl Iterator<Item = Variable> + '_ {

--- a/server/service/http/message/query/query_structure.rs
+++ b/server/service/http/message/query/query_structure.rs
@@ -198,19 +198,6 @@ fn query_structure_edge(
             push_edge!(edges, context, span, relates.relation(), relates.role_type(), Relates)
         }
         Constraint::Plays(plays) => push_edge!(edges, context, span, plays.player(), plays.role_type(), Plays),
-
-        Constraint::IndexedRelation(indexed) => {
-            let role_type_1 = query_structure_role_type_as_vertex(context, indexed.role_type_1())?;
-            let role_type_2 = query_structure_role_type_as_vertex(context, indexed.role_type_2())?;
-            let span_1 = indexed
-                .source_span_1()
-                .map(|span| QueryStructureEdgeSpan { begin: span.begin_offset, end: span.end_offset });
-            let span_2 = indexed
-                .source_span_2()
-                .map(|span| QueryStructureEdgeSpan { begin: span.begin_offset, end: span.end_offset });
-            push_edge!(edges, context, span_1, indexed.relation(), indexed.player_1(), Links(role_type_1));
-            push_edge!(edges, context, span_2, indexed.relation(), indexed.player_2(), Links(role_type_2));
-        }
         Constraint::ExpressionBinding(expr) => {
             let repr =
                 context.get_call_syntax(constraint).map_or_else(|| format!("Expression#{index}"), |text| text.clone());
@@ -278,6 +265,9 @@ fn query_structure_edge(
         | Constraint::Value(_)
         | Constraint::Is(_)
         | Constraint::Iid(_) => {}
+        Constraint::IndexedRelation(indexed) => {
+            unreachable!("This is unreachable since we extract query-structure before we apply transformations");
+        }
         // Optimisations don't represent the structure
         Constraint::LinksDeduplication(_) | Constraint::Unsatisfiable(_) => {}
     };


### PR DESCRIPTION
## Product change and motivation
This fixes a bug where the branch_ids go out of sync with the branches.

## Motivation
fixes #7452 