### PR TITLE
Update windows CI patch & guard against patching failure

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -432,7 +432,7 @@ workflows:
       - test-deploy-snapshot-windows-x86_64:
           filters:
             branches:
-              only: [ master, fix-windows-patch-202505 ]
+              only: [ master ]
 
       - deploy-docker-snapshot-x86_64:
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -432,7 +432,7 @@ workflows:
       - test-deploy-snapshot-windows-x86_64:
           filters:
             branches:
-              only: [ master ]
+              only: [ master, fix-windows-patch-202505 ]
 
       - deploy-docker-snapshot-x86_64:
           filters:

--- a/.circleci/windows/deploy_snapshot.bat
+++ b/.circleci/windows/deploy_snapshot.bat
@@ -11,6 +11,10 @@ REM build file
 cargo build --profile=release
 copy target\release\typedb_server_bin.exe  .\
 git apply .circleci\windows\git.patch
+if %errorlevel% neq 0 (
+    echo "Failed to apply patch. Regenerate it with 'git diff'. Exiting...";
+    exit /b %errorlevel%
+)
 
 SET DEPLOY_ARTIFACT_USERNAME=%REPO_TYPEDB_USERNAME%
 SET DEPLOY_ARTIFACT_PASSWORD=%REPO_TYPEDB_PASSWORD%

--- a/.circleci/windows/git.patch
+++ b/.circleci/windows/git.patch
@@ -1,18 +1,16 @@
 diff --git a/BUILD b/BUILD
-index c1e6757ca..023ec97b5 100644
+index 8a126f224..46feaff4f 100644
 --- a/BUILD
 +++ b/BUILD
-@@ -69,10 +69,11 @@ alias(
- )
- 
+@@ -71,9 +71,9 @@ alias(
  # The directory structure for distribution
-+exports_files(["typedb_server_bin.exe"])
  pkg_files(
      name = "package-layout-server",
--    srcs = ["//:typedb_server_bin", "//binary:typedb"],
--    renames = {"//:typedb_server_bin" : "server/typedb_server_bin"},
-+    srcs = ["//:typedb_server_bin.exe", "//binary:typedb.bat"],
-+    renames = {"//:typedb_server_bin.exe" : "server/typedb_server_bin.exe"},
+-    srcs = ["//:typedb_server_bin", "//binary:typedb", "//server:config.yml"],
++    srcs = ["//:typedb_server_bin.exe", "//binary:typedb.bat", "//server:config.yml"],
+     renames = {
+-        "//:typedb_server_bin" : "server/typedb_server_bin",
++        "//:typedb_server_bin.exe" : "server/typedb_server_bin.exe",
+         "//server:config.yml" : "server/config.yml",
+     },
      attributes = binary_permissions,
- )
- 


### PR DESCRIPTION
## Product change and motivation
Updates the windows CI patch to reflect a change in the target file & adds a check to fail if the patch was not applied properly
