### PR TITLE
Apply the patch for Windows CI jobs only in prepare.bat

### DIFF
--- a/.circleci/windows/deploy_release.bat
+++ b/.circleci/windows/deploy_release.bat
@@ -10,7 +10,6 @@ CALL refreshenv
 REM build file
 cargo build --profile=release --features server/published
 copy target\release\typedb_server_bin.exe  .\
-git apply .circleci\windows\git.patch
 
 SET DEPLOY_ARTIFACT_USERNAME=%REPO_TYPEDB_USERNAME%
 SET DEPLOY_ARTIFACT_PASSWORD=%REPO_TYPEDB_PASSWORD%

--- a/.circleci/windows/deploy_snapshot.bat
+++ b/.circleci/windows/deploy_snapshot.bat
@@ -10,11 +10,7 @@ CALL refreshenv
 REM build file
 cargo build --profile=release
 copy target\release\typedb_server_bin.exe  .\
-git apply .circleci\windows\git.patch
-if %errorlevel% neq 0 (
-    echo "Failed to apply patch. Regenerate it with 'git diff'. Exiting...";
-    exit /b %errorlevel%
-)
+
 
 SET DEPLOY_ARTIFACT_USERNAME=%REPO_TYPEDB_USERNAME%
 SET DEPLOY_ARTIFACT_PASSWORD=%REPO_TYPEDB_PASSWORD%

--- a/.circleci/windows/prepare.bat
+++ b/.circleci/windows/prepare.bat
@@ -5,6 +5,11 @@ REM file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 REM install dependencies needed for build
 git apply .circleci\windows\git.patch
+if %errorlevel% neq 0 (
+    echo "Failed to apply patch. Regenerate it with 'git diff'. Exiting...";
+    exit /b %errorlevel%
+)
+
 choco install .circleci\windows\dependencies.config --yes --no-progress
 
 REM permanently set variables for Bazel build


### PR DESCRIPTION
## Product change and motivation
Fixes a bug where trying to apply the patch a second time fails and fails the script.