### PR TITLE
Add 'z' parsing for datetime-tz

### DIFF
--- a/ir/translation/literal.rs
+++ b/ir/translation/literal.rs
@@ -6,7 +6,7 @@
 
 use std::{borrow::Cow, str::FromStr};
 
-use chrono::{FixedOffset, NaiveDate, NaiveDateTime, NaiveTime};
+use chrono::{FixedOffset, NaiveDate, NaiveDateTime, NaiveTime, Offset, Utc};
 use chrono_tz::Tz;
 use concept::type_::annotation::AnnotationRegex;
 use encoding::value::{
@@ -217,11 +217,10 @@ impl FromTypeQLLiteral for TimeZone {
                     .map_err(|_| LiteralParseError::InvalidTimezoneNamed { name: name.clone(), source_span })?,
             )),
             typeql::value::TimeZone::ISO(value) => {
-                if value.ends_with("z") || value.ends_with("Z") {
-                    // TODO: is this correct?
-                    Ok(TimeZone::Fixed(FixedOffset::east_opt(0).unwrap()))
+                if value.ends_with("Z") {
+                    Ok(TimeZone::Fixed(Utc.fix()))
                 } else {
-                    // Note: this parser doesn't recognise "z" ending!
+                    // Note: this parser doesn't recognise "Z" ending!
                     Ok(TimeZone::Fixed(FixedOffset::from_str(value).map_err(|_| {
                         LiteralParseError::InvalidTimezoneFixedOffset { offset: value.clone(), source_span }
                     })?))

--- a/ir/translation/literal.rs
+++ b/ir/translation/literal.rs
@@ -217,9 +217,15 @@ impl FromTypeQLLiteral for TimeZone {
                     .map_err(|_| LiteralParseError::InvalidTimezoneNamed { name: name.clone(), source_span })?,
             )),
             typeql::value::TimeZone::ISO(value) => {
-                Ok(TimeZone::Fixed(FixedOffset::from_str(value).map_err(|_| {
-                    LiteralParseError::InvalidTimezoneFixedOffset { offset: value.clone(), source_span }
-                })?))
+                if value.ends_with("z") || value.ends_with("Z") {
+                    // TODO: is this correct?
+                    Ok(TimeZone::Fixed(FixedOffset::east_opt(0).unwrap()))
+                } else {
+                    // Note: this parser doesn't recognise "z" ending!
+                    Ok(TimeZone::Fixed(FixedOffset::from_str(value).map_err(|_| {
+                        LiteralParseError::InvalidTimezoneFixedOffset { offset: value.clone(), source_span }
+                    })?))
+                }
             }
         }
     }


### PR DESCRIPTION
## Product change and motivation

We fix a bug where TypeDB server failed to recognise "Z" as a valid timezone specifier. According to ISO 8601 (https://en.wikipedia.org/wiki/ISO_8601#Coordinated_Universal_Time_(UTC)), this is valid timezone specifier equal to the 0 offset. The underlying time-zone library the server utilised did not accept it as a valid timezone. 

Note that TypeQL already accepted 'z' as a valid timezone specifier in its grammar.

## Implementation

We check for the 'z' timezone explicitly, and set the fixed timezone to the `0` fixed offset explicitly.