### PR TITLE
Rename involved_branches to involved_blocks 

### DIFF
--- a/dependencies/typedb/repositories.bzl
+++ b/dependencies/typedb/repositories.bzl
@@ -36,5 +36,5 @@ def typedb_behaviour():
     git_repository(
         name = "typedb_behaviour",
         remote = "https://github.com/typedb/typedb-behaviour",
-        commit = "8f9345de853ad7d0ae66e7afefd16be2cfa3dced",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @typedb_behaviour
+        commit = "1586c15268b63b5f5fd33eb59f4bd0e397c2dd61",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @typedb_behaviour
     )

--- a/server/service/http/message/query/query_structure.rs
+++ b/server/service/http/message/query/query_structure.rs
@@ -168,26 +168,26 @@ pub(crate) fn encode_query_structure(
         .filter_map(|branch_opt| {
             branch_opt
                 .as_ref()
-                .map(|branch| encode_query_structure_branch(snapshot, type_manager, &query_structure, branch))
+                .map(|branch| encode_query_structure_block(snapshot, type_manager, &query_structure, branch))
         })
         .collect::<Result<Vec<_>, _>>()?;
     Ok(QueryStructureResponse { blocks })
 }
 
-fn encode_query_structure_branch(
+fn encode_query_structure_block(
     snapshot: &impl ReadableSnapshot,
     type_manager: &TypeManager,
     query_structure: &QueryStructure,
-    branch: &[Constraint<Variable>],
+    block: &[Constraint<Variable>],
 ) -> Result<QueryStructureBlockResponse, Box<ConceptReadError>> {
     let mut constraints = Vec::new();
-    let role_names = branch
+    let role_names = block
         .iter()
         .filter_map(|constraint| constraint.as_role_name())
         .map(|rolename| (rolename.type_().as_variable().unwrap(), rolename.name().to_owned()))
         .collect();
     let context = QueryStructureContext { query_structure, snapshot, type_manager, role_names };
-    branch.iter().enumerate().try_for_each(|(index, constraint)| {
+    block.iter().enumerate().try_for_each(|(index, constraint)| {
         query_structure_constraint(&context, constraint, &mut constraints, index)
     })?;
     Ok(QueryStructureBlockResponse { constraints })

--- a/server/service/http/message/query/row.rs
+++ b/server/service/http/message/query/row.rs
@@ -22,7 +22,7 @@ use crate::service::http::message::query::concept::{encode_thing_concept, encode
 #[serde(rename_all = "camelCase")]
 struct EncodedRow<'a> {
     data: HashMap<&'a str, serde_json::Value>,
-    involved_branches: Vec<u8>,
+    involved_blocks: Vec<u8>,
 }
 
 pub fn encode_row<'a>(
@@ -48,8 +48,8 @@ pub fn encode_row<'a>(
         )?;
         encoded_row.insert(variable.as_str(), row_entry);
     }
-    let involved_branches = row.provenance().branch_ids().map(|b| b.0 as u8).collect();
-    Ok(json!(EncodedRow { data: encoded_row, involved_branches }))
+    let involved_blocks = row.provenance().branch_ids().map(|b| b.0 as u8).collect();
+    Ok(json!(EncodedRow { data: encoded_row, involved_blocks }))
 }
 
 pub fn encode_row_entry(


### PR DESCRIPTION
## Implementation
Rename `involved_branches` to `involved_blocks` in rows returned by the HTTP API 