### PR TITLE
Overriding config file location via CLI is now relative to working directory

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -27,6 +27,13 @@ exports_files(
     ["VERSION", "deployment.bzl", "LICENSE", "README.md"],
 )
 
+genrule(
+    name = "config_at_root",
+    outs = ["config.yml"],
+    srcs = ["//server:config.yml"],
+    cmd = "cp $(location //server:config.yml) $(location config.yml)",
+)
+
 rust_binary(
     name = "typedb_server_bin",
     srcs = [
@@ -42,6 +49,7 @@ rust_binary(
         "@crates//:sentry",
         "@crates//:tokio",
     ],
+    data = ["//:config_at_root"]
 )
 
 # Assembly

--- a/main.rs
+++ b/main.rs
@@ -7,6 +7,7 @@
 #![deny(unused_must_use)]
 #![deny(elided_lifetimes_in_paths)]
 
+use std::path::PathBuf;
 use clap::Parser;
 use logger::initialise_logging_global;
 use resource::constants::server::{ASCII_LOGO, DEFAULT_CONFIG_PATH, DISTRIBUTION, SENTRY_REPORTING_URI, VERSION};
@@ -19,7 +20,10 @@ use tokio::runtime::Runtime;
 fn main() {
     initialise_abort_on_panic();
     let cli_args: CLIArgs = CLIArgs::parse();
-    let config_file = cli_args.config_file_override.as_ref().map(|x| x.as_str()).unwrap_or(DEFAULT_CONFIG_PATH);
+    let config_file = cli_args.config_file_override.as_ref().map(|path| {
+        // cli override should be relative to pwd:
+        std::env::current_dir().expect("Could not read working directory").join(path)
+    }).unwrap_or_else(|| PathBuf::from(DEFAULT_CONFIG_PATH));
     let mut config = Config::from_file(config_file.into()).expect("Error reading from config file");
     cli_args.override_config(&mut config).expect("Error validating config file overridden with cli args");
     initialise_logging_global(&config.logging.directory);

--- a/main.rs
+++ b/main.rs
@@ -8,6 +8,7 @@
 #![deny(elided_lifetimes_in_paths)]
 
 use std::path::PathBuf;
+
 use clap::Parser;
 use logger::initialise_logging_global;
 use resource::constants::server::{ASCII_LOGO, DEFAULT_CONFIG_PATH, DISTRIBUTION, SENTRY_REPORTING_URI, VERSION};
@@ -20,10 +21,10 @@ use tokio::runtime::Runtime;
 fn main() {
     initialise_abort_on_panic();
     let cli_args: CLIArgs = CLIArgs::parse();
-    let config_file = cli_args.config_file_override.as_ref().map(|path| {
-        // cli override should be relative to pwd:
-        std::env::current_dir().expect("Could not read working directory").join(path)
-    }).unwrap_or_else(|| PathBuf::from(DEFAULT_CONFIG_PATH));
+    let config_file = match cli_args.config_file_override.as_ref() {
+        None => Config::resolve_path_from_executable(&PathBuf::from(DEFAULT_CONFIG_PATH)),
+        Some(path) => std::env::current_dir().expect("Could not read working directory").join(path),
+    };
     let mut config = Config::from_file(config_file.into()).expect("Error reading from config file");
     cli_args.override_config(&mut config).expect("Error validating config file overridden with cli args");
     initialise_logging_global(&config.logging.directory);

--- a/main.rs
+++ b/main.rs
@@ -23,7 +23,7 @@ fn main() {
     let cli_args: CLIArgs = CLIArgs::parse();
     let config_file = match cli_args.config_file_override.as_ref() {
         None => Config::resolve_path_from_executable(&PathBuf::from(DEFAULT_CONFIG_PATH)),
-        Some(path) => std::env::current_dir().expect("Could not read working directory").join(path),
+        Some(path) => CLIArgs::resolve_path_from_pwd(&path.into()),
     };
     let mut config = Config::from_file(config_file.into()).expect("Error reading from config file");
     cli_args.override_config(&mut config).expect("Error validating config file overridden with cli args");

--- a/server/parameters/cli.rs
+++ b/server/parameters/cli.rs
@@ -131,9 +131,9 @@ impl CLIArgs {
             config.server.encryption.certificate_key => server_encryption_cert_key.map(|cert| Some(cert.into()));
             config.server.encryption.ca_certificate => server_encryption_ca_certificate.map(|cert| Some(cert.into()));
 
-            config.storage.data_directory => storage_data.map(|path| path.into());
+            config.storage.data_directory => storage_data.map(|p| Self::resolve_path_from_pwd(&p.into()));
 
-            config.logging.directory => logging_logdir.map(|path| path.into());
+            config.logging.directory => logging_logdir.map(|p| Self::resolve_path_from_pwd(&p.into()));
 
             config.diagnostics.reporting.report_errors => diagnostics_reporting_errors;
             config.diagnostics.reporting.report_metrics => diagnostics_reporting_metrics;
@@ -142,5 +142,9 @@ impl CLIArgs {
             config.server.authentication.token_expiration => server_authentication_token_ttl_seconds.map(|secs| Duration::new(secs, 0));
         }
         config.validate_and_finalise()
+    }
+
+    pub fn resolve_path_from_pwd(path: &PathBuf) -> PathBuf {
+        std::env::current_dir().expect("Could not read working directory").join(path)
     }
 }

--- a/server/parameters/config.rs
+++ b/server/parameters/config.rs
@@ -46,7 +46,7 @@ impl Config {
         let mut config = String::new();
         let resolved_path = Self::resolve_path_from_executable(&path);
         File::open(resolved_path.clone())
-            .map_err(|source| ConfigError::ErrorReadingConfigFile { source, path: path.clone() })?
+            .map_err(|source| ConfigError::ErrorReadingConfigFile { source, path: resolved_path.clone() })?
             .read_to_string(&mut config)
             .map_err(|source| ConfigError::ErrorReadingConfigFile { source, path })?;
         serde_yaml2::from_str::<Config>(config.as_str()).map_err(|source| ConfigError::ErrorParsingYaml { source })

--- a/server/parameters/config.rs
+++ b/server/parameters/config.rs
@@ -70,7 +70,7 @@ impl Config {
         Ok(())
     }
 
-    fn resolve_path_from_executable(path: &PathBuf) -> PathBuf {
+    pub fn resolve_path_from_executable(path: &PathBuf) -> PathBuf {
         let typedb_dir_or_current = std::env::current_exe()
             .map(|path| path.parent().expect("Expected parent directory of: {path}").to_path_buf())
             .unwrap_or(std::env::current_dir().expect("Expected access to the current directory"));


### PR DESCRIPTION
## Product change and motivation
The config file override specified via '--config' is now relative to the working directory. It was previously relative to the server binary.
Makes it easier to run typedb through bazel by copying the config file to the default location, avoiding the need for a CLI override.

## Implementation
Uses a genrule to copy `server/config.yml` to `config.yml`

What works now?
`bazel run //:typedb_server_bin`
`cargo run -- --config server/config.yml`
