### PR TITLE
Filter anonymous variables from insert stage output

### DIFF
--- a/compiler/executable/pipeline.rs
+++ b/compiler/executable/pipeline.rs
@@ -102,6 +102,7 @@ fn insert_row_schema_to_mapping(
         .iter()
         .enumerate()
         .filter_map(|(i, opt)| opt.map(|(v, _)| (i, v)))
+        .filter(|(i,v)| !v.is_anonymous())
         .map(|(i, v)| (v, VariablePosition::new(i as u32)))
         .collect()
 }


### PR DESCRIPTION
## Product change and motivation
Consistent with the behaviour of match stages, we no longer include anonymous variables in the output of an insert, update or put stage.
