### PR TITLE
Refactor HTTP API output to include the structure of the pipeline

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -871,6 +871,7 @@ dependencies = [
  "ir",
  "itertools 0.10.5",
  "resource",
+ "serde",
  "storage",
  "test_utils",
  "test_utils_concept",

--- a/compiler/Cargo.toml
+++ b/compiler/Cargo.toml
@@ -35,8 +35,9 @@ features = {}
 		default-features = false
 
 [dependencies]
+serde = { version = "1.0.219", features = ["derive"] }
 
-	[dependencies.tracing]
+[dependencies.tracing]
 		features = ["attributes", "default", "log", "std", "tracing-attributes"]
 		version = "0.1.41"
 		default-features = false

--- a/compiler/query_structure.rs
+++ b/compiler/query_structure.rs
@@ -17,11 +17,51 @@ use ir::{
     pipeline::{ParameterRegistry, VariableRegistry},
 };
 use itertools::Itertools;
+use serde::{Deserialize, Serialize};
 
-use crate::annotation::pipeline::AnnotatedStage;
+use crate::annotation::{
+    pipeline::AnnotatedStage,
+    type_annotations::{BlockAnnotations, TypeAnnotations},
+};
+
+#[derive(Debug, Clone)]
+pub struct QueryStructureBlock {
+    pub constraints: Vec<Constraint<Variable>>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct QueryStructureBlockID(pub u16);
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct QueryStructureConjunction {
+    conjunction: Vec<QueryStructureConjunct>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum QueryStructureConjunct {
+    Block(QueryStructureBlockID),
+    Or { branches: Vec<QueryStructureConjunction> },
+    Not(QueryStructureConjunction),
+    Try(QueryStructureConjunction),
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum QueryStructureStage {
+    Match(QueryStructureConjunction),
+    Insert { block: QueryStructureBlockID },
+    Put { block: QueryStructureBlockID },
+    Update { block: QueryStructureBlockID },
+    // Select { variables: Vec<Variable> },
+    // TODO...
+}
+
 #[derive(Debug, Clone)]
 pub struct ParametrisedQueryStructure {
-    pub branches: [Option<Vec<Constraint<Variable>>>; 64],
+    pub stages: Vec<QueryStructureStage>,
+    pub blocks: Vec<QueryStructureBlock>,
     pub resolved_labels: HashMap<Label, answer::Type>,
     pub calls_syntax: HashMap<Constraint<Variable>, String>,
 }
@@ -34,6 +74,155 @@ impl ParametrisedQueryStructure {
         available_variables: HashSet<Variable>,
     ) -> QueryStructure {
         QueryStructure { parametrised_structure: self, parameters, variable_names, available_variables }
+    }
+
+    pub fn always_taken_blocks(&self) -> Vec<QueryStructureBlockID> {
+        self.stages
+            .iter()
+            .filter_map(|stage| match stage {
+                QueryStructureStage::Match(QueryStructureConjunction { conjunction }) => match conjunction.first() {
+                    Some(QueryStructureConjunct::Block(block)) => Some(block),
+                    Some(_) | None => {
+                        debug_assert!(!conjunction.iter().any(|c| matches!(c, QueryStructureConjunct::Block { .. })));
+                        None
+                    }
+                },
+                QueryStructureStage::Insert { block }
+                | QueryStructureStage::Put { block }
+                | QueryStructureStage::Update { block } => Some(block),
+            })
+            .cloned()
+            .collect()
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct ParametrisedQueryStructureBuilder<'a> {
+    inner: ParametrisedQueryStructure,
+    source_query: &'a str,
+}
+
+impl<'a> ParametrisedQueryStructureBuilder<'a> {
+    fn new(source_query: &'a str, branch_ids_allocated: u16) -> Self {
+        // Pre-allocate for the optional branches. They come first
+        let blocks = vec![QueryStructureBlock { constraints: Vec::new() }; branch_ids_allocated as usize];
+        Self {
+            source_query,
+            inner: ParametrisedQueryStructure {
+                stages: Vec::new(),
+                blocks,
+                resolved_labels: HashMap::new(),
+                calls_syntax: HashMap::new(),
+            },
+        }
+    }
+
+    pub fn add_stage(&mut self, stage: &AnnotatedStage) {
+        match stage {
+            AnnotatedStage::Match { block, block_annotations, .. } => {
+                let conjunction = self.add_block(None, block.conjunction(), &block_annotations);
+                self.inner.stages.push(QueryStructureStage::Match(conjunction));
+            }
+            AnnotatedStage::Insert { block, annotations, .. } => {
+                debug_assert!(block.conjunction().nested_patterns().is_empty());
+                let block = self.add_block_impl(None, block.conjunction().constraints(), &annotations);
+                self.inner.stages.push(QueryStructureStage::Insert { block });
+            }
+            AnnotatedStage::Put { block, insert_annotations: annotations, .. } => {
+                debug_assert!(block.conjunction().nested_patterns().is_empty());
+                let block = self.add_block_impl(None, block.conjunction().constraints(), &annotations);
+                self.inner.stages.push(QueryStructureStage::Put { block });
+            }
+            AnnotatedStage::Update { block, annotations, .. } => {
+                debug_assert!(block.conjunction().nested_patterns().is_empty());
+                let block = self.add_block_impl(None, block.conjunction().constraints(), &annotations);
+                self.inner.stages.push(QueryStructureStage::Update { block });
+            }
+            AnnotatedStage::Delete { .. }
+            | AnnotatedStage::Select(_)
+            | AnnotatedStage::Sort(_)
+            | AnnotatedStage::Offset(_)
+            | AnnotatedStage::Limit(_)
+            | AnnotatedStage::Require(_)
+            | AnnotatedStage::Distinct(_)
+            | AnnotatedStage::Reduce(_, _) => {}
+        }
+    }
+
+    fn add_block(
+        &mut self,
+        existing_branch_id: Option<BranchID>,
+        conjunction: &Conjunction,
+        block_annotations: &BlockAnnotations,
+    ) -> QueryStructureConjunction {
+        let mut conjuncts = Vec::new();
+        let block_id = self.add_block_impl(
+            existing_branch_id,
+            conjunction.constraints(),
+            block_annotations.type_annotations_of(conjunction).unwrap(),
+        );
+        conjuncts.push(QueryStructureConjunct::Block(block_id));
+        conjunction.nested_patterns().iter().for_each(|nested| match nested {
+            NestedPattern::Disjunction(disjunction) => {
+                let branches = disjunction
+                    .branch_ids()
+                    .iter()
+                    .zip(disjunction.conjunctions().iter())
+                    .map(|(id, branch)| self.add_block(Some(*id), branch, block_annotations))
+                    .collect::<Vec<_>>();
+                conjuncts.push(QueryStructureConjunct::Or { branches });
+            }
+            NestedPattern::Negation(negation) => {
+                let inner = self.add_block(None, negation.conjunction(), block_annotations);
+                conjuncts.push(QueryStructureConjunct::Not(inner));
+            }
+            NestedPattern::Optional(_) => {
+                unimplemented_feature!(Optionals);
+            }
+        });
+        QueryStructureConjunction { conjunction: conjuncts }
+    }
+
+    fn add_block_impl(
+        &mut self,
+        existing_branch_id: Option<BranchID>,
+        constraints: &[Constraint<Variable>],
+        annotations: &TypeAnnotations,
+    ) -> QueryStructureBlockID {
+        self.extend_labels_from(annotations);
+        self.extend_function_calls_syntax_from(constraints);
+        let branch_id = if let Some(BranchID(id)) = existing_branch_id {
+            debug_assert!((id as usize) < self.inner.blocks.len());
+            self.inner.blocks[id as usize] = QueryStructureBlock { constraints: Vec::from(constraints) };
+            QueryStructureBlockID(id)
+        } else {
+            self.inner.blocks.push(QueryStructureBlock { constraints: Vec::from(constraints) });
+            QueryStructureBlockID(self.inner.blocks.len() as u16 - 1)
+        };
+        branch_id
+    }
+
+    fn extend_function_calls_syntax_from(&mut self, constraints: &[Constraint<Variable>]) {
+        constraints
+            .iter()
+            .filter(|constraint| {
+                matches!(constraint, Constraint::ExpressionBinding(_) | Constraint::FunctionCallBinding(_))
+            })
+            .for_each(|constraint| {
+                if let Some(span) = constraint.source_span() {
+                    let syntax = self.source_query[span.begin_offset..span.end_offset].to_owned();
+                    self.inner.calls_syntax.insert(constraint.clone(), syntax);
+                }
+            });
+    }
+
+    fn extend_labels_from(&mut self, type_annotations: &TypeAnnotations) {
+        self.inner.resolved_labels.extend(type_annotations.vertex_annotations().iter().filter_map(
+            |(vertex, type_)| match (vertex.as_label(), type_.iter().exactly_one()) {
+                (Some(label), Ok(type_)) => Some((label.clone(), type_.clone())),
+                _ => None,
+            },
+        ));
     }
 }
 
@@ -50,101 +239,12 @@ pub fn extract_query_structure_from(
     annotated_stages: &[AnnotatedStage],
     source_query: &str,
 ) -> Option<ParametrisedQueryStructure> {
-    if variable_registry.highest_branch_id_allocated() > 63 {
+    let branch_ids_allocated = variable_registry.branch_ids_allocated();
+    if branch_ids_allocated < 64 {
+        let mut builder = ParametrisedQueryStructureBuilder::new(source_query, branch_ids_allocated);
+        annotated_stages.into_iter().for_each(|stage| builder.add_stage(stage));
+        Some(builder.inner)
+    } else {
         return None;
     }
-    let mut branches: [Option<_>; 64] = [(); 64].map(|_| None);
-    let mut resolved_labels = HashMap::new();
-    let mut function_calls_syntax = HashMap::new();
-    annotated_stages.into_iter().for_each(|stage| {
-        match stage {
-            AnnotatedStage::Match { block, block_annotations, .. } => {
-                extract_query_structure_from_branch(&mut branches, BranchID(0), block.conjunction());
-                let block_label_annotations = block_annotations
-                    .type_annotations()
-                    .values()
-                    .flat_map(|annotations| annotations.vertex_annotations().iter());
-                extend_labels_from(&mut resolved_labels, block_label_annotations);
-                extend_function_calls_syntax_from(block.conjunction(), &mut function_calls_syntax, source_query);
-            }
-            AnnotatedStage::Insert { block, annotations, .. }
-            | AnnotatedStage::Put { block, insert_annotations: annotations, .. }
-            | AnnotatedStage::Update { block, annotations, .. } => {
-                // May change with try-insert
-                debug_assert!(block.conjunction().nested_patterns().is_empty());
-                extract_query_structure_from_branch(&mut branches, BranchID(0), block.conjunction());
-                extend_labels_from(&mut resolved_labels, annotations.vertex_annotations().iter());
-            }
-            AnnotatedStage::Delete { .. }
-            | AnnotatedStage::Select(_)
-            | AnnotatedStage::Sort(_)
-            | AnnotatedStage::Offset(_)
-            | AnnotatedStage::Limit(_)
-            | AnnotatedStage::Require(_)
-            | AnnotatedStage::Distinct(_)
-            | AnnotatedStage::Reduce(_, _) => {}
-        }
-    });
-    Some(ParametrisedQueryStructure { branches, resolved_labels, calls_syntax: function_calls_syntax })
-}
-
-fn extract_query_structure_from_branch(
-    branches: &mut [Option<Vec<Constraint<Variable>>>; 64],
-    branch_id: BranchID,
-    conjunction: &Conjunction,
-) {
-    if branches[branch_id.0 as usize].is_none() {
-        branches[branch_id.0 as usize] = Some(Vec::new());
-    }
-    branches[branch_id.0 as usize].as_mut().unwrap().extend_from_slice(conjunction.constraints());
-    conjunction.nested_patterns().iter().for_each(|nested| match nested {
-        NestedPattern::Disjunction(disjunction) => {
-            disjunction.branch_ids().iter().zip(disjunction.conjunctions().iter()).for_each(|(id, branch)| {
-                extract_query_structure_from_branch(branches, *id, branch);
-            })
-        }
-        NestedPattern::Negation(_) => {}
-        NestedPattern::Optional(_) => {
-            unimplemented_feature!(Optionals);
-        }
-    })
-}
-
-fn extend_labels_from<'a>(
-    resolved_labels: &mut HashMap<Label, Type>,
-    vertex_annotations: impl Iterator<Item = (&'a Vertex<Variable>, &'a Arc<BTreeSet<answer::Type>>)>,
-) {
-    resolved_labels.extend(vertex_annotations.filter_map(|(vertex, type_)| {
-        match (vertex.as_label(), type_.iter().exactly_one()) {
-            (Some(label), Ok(type_)) => Some((label.clone(), type_.clone())),
-            _ => None,
-        }
-    }));
-}
-
-fn extend_function_calls_syntax_from(
-    conjunction: &Conjunction,
-    function_calls_syntax: &mut HashMap<Constraint<Variable>, String>,
-    source_query: &str,
-) {
-    conjunction.constraints().iter().for_each(|constraint| {
-        if matches!(constraint, Constraint::ExpressionBinding(_) | Constraint::FunctionCallBinding(_)) {
-            if let Some(span) = constraint.source_span() {
-                function_calls_syntax
-                    .insert(constraint.clone(), source_query[span.begin_offset..span.end_offset].to_owned());
-            }
-        }
-    });
-    conjunction.nested_patterns().iter().for_each(|nested| match nested {
-        NestedPattern::Disjunction(disj) => disj
-            .conjunctions()
-            .iter()
-            .for_each(|conj| extend_function_calls_syntax_from(conj, function_calls_syntax, source_query)),
-        NestedPattern::Negation(inner) => {
-            extend_function_calls_syntax_from(inner.conjunction(), function_calls_syntax, source_query)
-        }
-        NestedPattern::Optional(inner) => {
-            extend_function_calls_syntax_from(inner.conjunction(), function_calls_syntax, source_query)
-        }
-    })
 }

--- a/compiler/query_structure.rs
+++ b/compiler/query_structure.rs
@@ -39,9 +39,9 @@ pub struct QueryStructureConjunction {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[serde(rename_all = "camelCase", tag = "tag")]
 pub enum QueryStructureConjunct {
-    Block(QueryStructureBlockID),
+    Block { index: QueryStructureBlockID },
     Or { branches: Vec<QueryStructureConjunction> },
     Not(QueryStructureConjunction),
     Try(QueryStructureConjunction),
@@ -81,7 +81,7 @@ impl ParametrisedQueryStructure {
             .iter()
             .filter_map(|stage| match stage {
                 QueryStructureStage::Match(QueryStructureConjunction { conjunction }) => match conjunction.first() {
-                    Some(QueryStructureConjunct::Block(block)) => Some(block),
+                    Some(QueryStructureConjunct::Block { index }) => Some(index),
                     Some(_) | None => {
                         debug_assert!(!conjunction.iter().any(|c| matches!(c, QueryStructureConjunct::Block { .. })));
                         None
@@ -161,7 +161,7 @@ impl<'a> ParametrisedQueryStructureBuilder<'a> {
             conjunction.constraints(),
             block_annotations.type_annotations_of(conjunction).unwrap(),
         );
-        conjuncts.push(QueryStructureConjunct::Block(block_id));
+        conjuncts.push(QueryStructureConjunct::Block { index: block_id });
         conjunction.nested_patterns().iter().for_each(|nested| match nested {
             NestedPattern::Disjunction(disjunction) => {
                 let branches = disjunction

--- a/executor/lib.rs
+++ b/executor/lib.rs
@@ -121,6 +121,6 @@ impl Provenance {
 
     pub fn branch_ids(&self) -> impl Iterator<Item = BranchID> {
         let provenance = self.0;
-        (0..64).filter(move |id| *id == 0 || 0 != provenance & (1 << id)).map(|id| BranchID(id))
+        (0..64).filter(move |id| 0 != provenance & (1 << id)).map(|id| BranchID(id))
     }
 }

--- a/ir/pipeline/mod.rs
+++ b/ir/pipeline/mod.rs
@@ -124,7 +124,7 @@ impl VariableRegistry {
 
     pub(crate) fn new() -> VariableRegistry {
         Self {
-            branch_id_allocator: 1, // 0 is reserved for the path through the query that's always taken
+            branch_id_allocator: 0,
             variable_names: HashMap::new(),
             variable_id_allocator: 0,
             variable_categories: HashMap::new(),
@@ -133,8 +133,8 @@ impl VariableRegistry {
         }
     }
 
-    pub fn highest_branch_id_allocated(&self) -> u16 {
-        self.branch_id_allocator - 1
+    pub fn branch_ids_allocated(&self) -> u16 {
+        self.branch_id_allocator
     }
 
     pub(crate) fn next_branch_id(&mut self) -> BranchID {

--- a/server/service/http/message/query/query_structure.rs
+++ b/server/service/http/message/query/query_structure.rs
@@ -7,7 +7,7 @@
 use std::collections::HashMap;
 
 use answer::variable::Variable;
-use compiler::query_structure::QueryStructure;
+use compiler::query_structure::{ParametrisedQueryStructure, QueryStructure, QueryStructureStage};
 use concept::{error::ConceptReadError, type_::type_manager::TypeManager};
 use encoding::value::{label::Label, value::Value};
 use ir::pattern::{
@@ -56,6 +56,13 @@ impl<'a, Snapshot: ReadableSnapshot> QueryStructureContext<'a, Snapshot> {
 #[serde(rename_all = "camelCase")]
 pub struct QueryStructureResponse {
     blocks: Vec<QueryStructureBlockResponse>,
+    structure: QueryStructureStructureResponse,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct QueryStructureStructureResponse {
+    stages: Vec<QueryStructureStage>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -161,17 +168,14 @@ pub(crate) fn encode_query_structure(
     type_manager: &TypeManager,
     query_structure: &QueryStructure,
 ) -> Result<QueryStructureResponse, Box<ConceptReadError>> {
-    let blocks = query_structure
-        .parametrised_structure
-        .branches
+    let ParametrisedQueryStructure { stages, blocks, .. } = &*query_structure.parametrised_structure;
+    let blocks = blocks
         .iter()
-        .filter_map(|branch_opt| {
-            branch_opt
-                .as_ref()
-                .map(|branch| encode_query_structure_block(snapshot, type_manager, &query_structure, branch))
+        .map(|block| {
+            encode_query_structure_block(snapshot, type_manager, &query_structure, block.constraints.as_slice())
         })
         .collect::<Result<Vec<_>, _>>()?;
-    Ok(QueryStructureResponse { blocks })
+    Ok(QueryStructureResponse { blocks, structure: QueryStructureStructureResponse { stages: stages.clone() } })
 }
 
 fn encode_query_structure_block(

--- a/server/service/http/transaction_service.rs
+++ b/server/service/http/transaction_service.rs
@@ -853,6 +853,7 @@ impl TransactionService {
         let mut warning = None;
         let encode_query_structure_result =
             query_structure.as_ref().map(|qs| encode_query_structure(&*snapshot, &type_manager, qs)).transpose();
+        let always_taken_blocks = query_structure.map(|qs| qs.parametrised_structure.always_taken_blocks());
         let query_structure_response = match encode_query_structure_result {
             Ok(structure_opt) => structure_opt,
             Err(typedb_source) => {
@@ -883,6 +884,7 @@ impl TransactionService {
                 &thing_manager,
                 query_options.include_instance_types,
                 storage_counters.clone(),
+                always_taken_blocks.as_ref(),
             );
             match encoded_row {
                 Ok(encoded_row) => result.push(encoded_row),
@@ -1079,6 +1081,8 @@ impl TransactionService {
 
             let encode_query_structure_result =
                 pipeline.query_structure().map(|qs| encode_query_structure(&*snapshot, &type_manager, qs)).transpose();
+            let always_taken_blocks =
+                pipeline.query_structure().map(|qs| qs.parametrised_structure.always_taken_blocks());
             let query_structure_response = match encode_query_structure_result {
                 Ok(structure_opt) => structure_opt,
                 Err(typedb_source) => {
@@ -1128,6 +1132,7 @@ impl TransactionService {
                     &thing_manager,
                     query_options.include_instance_types,
                     storage_counters.clone(),
+                    always_taken_blocks.as_ref(),
                 );
                 match encoded_row {
                     Ok(encoded_row) => result.push(encoded_row),


### PR DESCRIPTION
## Product change and motivation
Adds the structure of the pipeline to the query structure returned by the HTTP API. Previously, we would just return a flat list of blocks without any information of how these blocks were connected (through stages and connectives such as or/not)

## Implementation


Having a fixed-width provenance removes the need for executors to be aware of the provenance width. Though this can usually be inferred from input rows, tracking it is a lot of moving parts. So we'd like to stick to fixed-width.
