### PR TITLE
Rename 'queryStructure' field in HTTP response to 'query'

### DIFF
--- a/server/service/http/message/query/mod.rs
+++ b/server/service/http/message/query/mod.rs
@@ -75,12 +75,12 @@ pub struct QueryAnswerResponse {
     pub query_type: QueryType,
     pub answer_type: AnswerType,
     pub answers: Option<Vec<serde_json::Value>>,
-    pub query_structure: Option<QueryStructureResponse>,
+    pub query: Option<QueryStructureResponse>,
     pub warning: Option<String>,
 }
 
 pub(crate) fn encode_query_ok_answer(query_type: QueryType) -> QueryAnswerResponse {
-    QueryAnswerResponse { query_type, answer_type: AnswerType::Ok, answers: None, query_structure: None, warning: None }
+    QueryAnswerResponse { query_type, answer_type: AnswerType::Ok, answers: None, query: None, warning: None }
 }
 
 pub(crate) fn encode_query_rows_answer(
@@ -93,7 +93,7 @@ pub(crate) fn encode_query_rows_answer(
         query_type,
         answer_type: AnswerType::ConceptRows,
         answers: Some(rows),
-        query_structure,
+        query: query_structure,
         warning,
     }
 }
@@ -107,7 +107,7 @@ pub(crate) fn encode_query_documents_answer(
         query_type,
         answer_type: AnswerType::ConceptDocuments,
         answers: Some(documents),
-        query_structure: None,
+        query: None,
         warning,
     }
 }


### PR DESCRIPTION
## Product change and motivation
Rename 'queryStructure' field in HTTP response to 'query'
