### PR TITLE
Fix variable category check for 'is' constraints

### DIFF
--- a/dependencies/typedb/repositories.bzl
+++ b/dependencies/typedb/repositories.bzl
@@ -35,6 +35,6 @@ def typedb_protocol():
 def typedb_behaviour():
     git_repository(
         name = "typedb_behaviour",
-        remote = "https://github.com/krishnangovindraj/typedb-behaviour",
-        commit = "fb7ac82423e07dcd0dc9b0bc96c84c3b54affb0c",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @typedb_behaviour
+        remote = "https://github.com/typedb/typedb-behaviour",
+        commit = "1d67e7ee6f282e812f13bd5d0cea270f2250de3e",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @typedb_behaviour
     )

--- a/dependencies/typedb/repositories.bzl
+++ b/dependencies/typedb/repositories.bzl
@@ -35,6 +35,6 @@ def typedb_protocol():
 def typedb_behaviour():
     git_repository(
         name = "typedb_behaviour",
-        remote = "https://github.com/typedb/typedb-behaviour",
-        commit = "d28a47f06de9990767510f8e86a96850a6efe362",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @typedb_behaviour
+        remote = "https://github.com/krishnangovindraj/typedb-behaviour",
+        commit = "fb7ac82423e07dcd0dc9b0bc96c84c3b54affb0c",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @typedb_behaviour
     )

--- a/ir/pipeline/block.rs
+++ b/ir/pipeline/block.rs
@@ -150,7 +150,11 @@ fn validate_conjunction(
             }));
         }
     }
+    validate_is_variables_have_same_category(conjunction, variable_registry)?;
+    Ok(())
+}
 
+fn validate_is_variables_have_same_category(conjunction: &Conjunction, variable_registry: &VariableRegistry) -> Result<(), Box<RepresentationError>> {
     let is_with_mismatched_category = conjunction.constraints().iter().filter_map(|c| c.as_is()).find(|is| {
         let lhs_category = variable_registry.get_variable_category(is.lhs().as_variable().unwrap()).unwrap();
         let rhs_category = variable_registry.get_variable_category(is.rhs().as_variable().unwrap()).unwrap();
@@ -163,15 +167,16 @@ fn validate_conjunction(
         let rhs_category = variable_registry.get_variable_category(rhs).unwrap();
         let lhs_variable = variable_registry.get_variable_name(lhs).map_or("_", |s| s.as_str()).to_owned();
         let rhs_variable = variable_registry.get_variable_name(rhs).map_or("_", |s| s.as_str()).to_owned();
-        return Err(Box::new(RepresentationError::VariableCategoryMismatchInIs {
+        Err(Box::new(RepresentationError::VariableCategoryMismatchInIs {
             lhs_variable,
             rhs_variable,
             lhs_category,
             rhs_category,
             source_span: is.source_span(),
-        }));
+        }))
+    } else {
+        Ok(())
     }
-    Ok(())
 }
 
 #[derive(Debug, Clone, Default, Eq, PartialEq)]

--- a/ir/pipeline/block.rs
+++ b/ir/pipeline/block.rs
@@ -151,7 +151,7 @@ fn validate_conjunction(
         }
     }
 
-    let is_with_mismatched_category = conjunction.constraints().iter().filter_map(|c| c.as_is()).find_or_first(|is| {
+    let is_with_mismatched_category = conjunction.constraints().iter().filter_map(|c| c.as_is()).find(|is| {
         let lhs_category = variable_registry.get_variable_category(is.lhs().as_variable().unwrap()).unwrap();
         let rhs_category = variable_registry.get_variable_category(is.rhs().as_variable().unwrap()).unwrap();
         lhs_category.narrowest(rhs_category).is_none()


### PR DESCRIPTION
## Product change and motivation
Fix the variable category check for 'is' constraints which would always fail, &  makes it recursive to catch more cases.

## Implementation
Replace faulty `find_or_first` with `find`.