### PR TITLE
Fix provenance updates from function calls

### DIFF
--- a/executor/read/nested_pattern_executor.rs
+++ b/executor/read/nested_pattern_executor.rs
@@ -115,6 +115,8 @@ impl InlinedCallExecutor {
                             .enumerate()
                             .filter_map(|(src, &dst)| Some((VariablePosition::new(src as u32), dst?))),
                     );
+                    // Fix provenance:
+                    output_row.set_provenance(input.provenance());
                 });
             }
         }

--- a/executor/read/tabled_call_executor.rs
+++ b/executor/read/tabled_call_executor.rs
@@ -104,6 +104,7 @@ impl TabledCallExecutor {
                             .enumerate()
                             .filter_map(|(src, &dst)| Some((VariablePosition::new(src as u32), dst?))),
                     );
+                    output_row.set_provenance(input.provenance())
                 });
             }
         }


### PR DESCRIPTION
## Product change and motivation
A function call wrongly copied the provenance of the returned function row. Instead, we copy the provenance of the row input to the call.