### PR TITLE
Fix forcing development mode in the config

### DIFF
--- a/server/parameters/config.rs
+++ b/server/parameters/config.rs
@@ -164,6 +164,7 @@ impl ConfigBuilder {
             .map_err(|source| ConfigError::ErrorParsingYaml { source })
             .map(|config| Self { config })
     }
+
     pub fn override_with_cliargs(&mut self, cliargs: CLIArgs) {
         let CLIArgs {
             config_file_override: _,
@@ -185,11 +186,10 @@ impl ConfigBuilder {
         } = cliargs;
         let Self { config } = self;
         override_config! {
-            config.development_mode.enabled => development_mode_enabled;
-
             config.server.address => server_address;
             config.server.http_enabled => server_http_enabled;
             config.server.http_address => server_http_address;
+            config.server.authentication.token_expiration => server_authentication_token_ttl_seconds.map(|secs| Duration::new(secs, 0));
 
             config.server.encryption.enabled => server_encryption_enabled;
             config.server.encryption.certificate => server_encryption_certificate.map(|cert| Some(cert.into()));
@@ -197,14 +197,14 @@ impl ConfigBuilder {
             config.server.encryption.ca_certificate => server_encryption_ca_certificate.map(|cert| Some(cert.into()));
 
             config.storage.data_directory => storage_data.map(|p| CLIArgs::resolve_path_from_pwd(&p.into()));
-
             config.logging.directory => logging_logdir.map(|p| CLIArgs::resolve_path_from_pwd(&p.into()));
 
-            config.diagnostics.reporting.report_errors => diagnostics_reporting_errors;
             config.diagnostics.reporting.report_metrics => diagnostics_reporting_metrics;
+            config.diagnostics.reporting.report_errors => diagnostics_reporting_errors;
             config.diagnostics.monitoring.enabled => diagnostics_monitoring_enabled;
             config.diagnostics.monitoring.port => diagnostics_monitoring_port;
-            config.server.authentication.token_expiration => server_authentication_token_ttl_seconds.map(|secs| Duration::new(secs, 0));
+
+            config.development_mode.enabled => development_mode_enabled;
         }
     }
 

--- a/server/parameters/config.rs
+++ b/server/parameters/config.rs
@@ -236,10 +236,6 @@ impl ConfigBuilder {
         typedb_dir_or_current.join(path)
     }
 
-    fn is_development_mode_default() -> bool {
-        false
-    }
-
     // Overrides
     pub fn server_address(mut self, address: impl Into<String>) -> Self {
         self.config.server.address = address.into();

--- a/server/parameters/config.rs
+++ b/server/parameters/config.rs
@@ -283,11 +283,7 @@ pub mod tests {
     use crate::parameters::config::ConfigBuilder;
 
     fn config_path() -> PathBuf {
-        #[cfg(feature = "bazel")]
         return std::env::current_dir().unwrap().join("server/config.yml");
-
-        #[cfg(not(feature = "bazel"))]
-        return std::env::current_dir().unwrap().join("config.yml");
     }
 
     fn load_and_parse(yaml: PathBuf, args: Vec<&str>) -> Result<Config, ConfigError> {

--- a/server/parameters/config.rs
+++ b/server/parameters/config.rs
@@ -66,6 +66,7 @@ impl Config {
         // finalise:
         self.storage.data_directory = Self::resolve_path_from_executable(&self.storage.data_directory);
         self.logging.directory = Self::resolve_path_from_executable(&self.logging.directory);
+        self.development_mode = self.development_mode | Self::IS_DEVELOPMENT_MODE_FORCED;
         Ok(())
     }
 

--- a/server/parameters/config.rs
+++ b/server/parameters/config.rs
@@ -284,6 +284,7 @@ pub mod tests {
     use clap::Parser;
 
     use crate::parameters::{cli::CLIArgs, config::Config, ConfigError};
+    use crate::parameters::config::ConfigBuilder;
 
     fn config_path() -> PathBuf {
         #[cfg(feature = "bazel")]
@@ -297,10 +298,10 @@ pub mod tests {
         let mut args_with_binary_infront = Vec::with_capacity(args.len() + 1);
         args_with_binary_infront.push("dummy");
         args_with_binary_infront.extend(args);
-        let mut config = Config::from_file(yaml)?;
+        let mut config = ConfigBuilder::from_file(yaml)?;
         let cli_args: CLIArgs = CLIArgs::parse_from(args_with_binary_infront);
-        cli_args.override_config(&mut config)?;
-        Ok(config)
+        config.override_with_cliargs(cli_args);
+        config.finish()
     }
 
     #[test]

--- a/tests/behaviour/query/BUILD
+++ b/tests/behaviour/query/BUILD
@@ -38,7 +38,7 @@ rust_test(
         "@typedb_behaviour//query/language:update.feature",
         "@typedb_behaviour//query/language:validation.feature",
 
-
+        "//server:config.yml",
     ],
     crate_features = ["bazel"],
     env = {"RUST_MIN_STACK" : "40960000"}, # for recursion.feature

--- a/tests/behaviour/service/http/http_steps/BUILD
+++ b/tests/behaviour/service/http/http_steps/BUILD
@@ -38,6 +38,7 @@ rust_library(
 
         "@typeql//rust:typeql",
     ],
+    data = ["//server:config.yml"]
 )
 
 checkstyle_test(

--- a/tests/behaviour/service/http/http_steps/connection/mod.rs
+++ b/tests/behaviour/service/http/http_steps/connection/mod.rs
@@ -31,11 +31,7 @@ const HTTP_ADDRESS: &str = "0.0.0.0:8000";
 const SERVER_INFO: ServerInfo = ServerInfo { logo: "logo", distribution: "TypeDB CE TEST", version: "0.0.0" };
 
 fn config_path() -> PathBuf {
-    #[cfg(feature = "bazel")]
     return std::env::current_dir().unwrap().join("server/config.yml");
-
-    #[cfg(not(feature = "bazel"))]
-    return std::env::current_dir().unwrap().join("config.yml");
 }
 
 pub(crate) async fn start_typedb(

--- a/tests/behaviour/service/http/http_steps/connection/mod.rs
+++ b/tests/behaviour/service/http/http_steps/connection/mod.rs
@@ -11,7 +11,7 @@ use params::check_boolean;
 use resource::server_info::ServerInfo;
 use server::{
     error::ServerOpenError,
-    parameters::config::{AuthenticationConfig, Config},
+    parameters::config::{AuthenticationConfig, ConfigBuilderForTests},
     server::Server,
 };
 use test_utils::create_tmp_dir;
@@ -37,7 +37,8 @@ pub(crate) async fn start_typedb(
     let handle = std::thread::spawn(move || {
         let rt = tokio::runtime::Runtime::new().expect("Failed to create runtime");
         let server_dir = create_tmp_dir();
-        let config = Config::new(GRPC_ADDRESS)
+        let config = ConfigBuilderForTests::default()
+            .server_address(GRPC_ADDRESS)
             .server_http_address(HTTP_ADDRESS)
             .data_directory(server_dir.as_ref())
             .development_mode(true)

--- a/tests/behaviour/service/http/http_steps/connection/mod.rs
+++ b/tests/behaviour/service/http/http_steps/connection/mod.rs
@@ -3,7 +3,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
-use std::collections::HashMap;
+use std::{collections::HashMap, path::PathBuf};
 
 use itertools::Either;
 use macro_rules_attribute::apply;
@@ -11,7 +11,7 @@ use params::check_boolean;
 use resource::server_info::ServerInfo;
 use server::{
     error::ServerOpenError,
-    parameters::config::{AuthenticationConfig, ConfigBuilderForTests},
+    parameters::config::{AuthenticationConfig, ConfigBuilder},
     server::Server,
 };
 use test_utils::create_tmp_dir;
@@ -30,6 +30,14 @@ const GRPC_ADDRESS: &str = "0.0.0.0:1729";
 const HTTP_ADDRESS: &str = "0.0.0.0:8000";
 const SERVER_INFO: ServerInfo = ServerInfo { logo: "logo", distribution: "TypeDB CE TEST", version: "0.0.0" };
 
+fn config_path() -> PathBuf {
+    #[cfg(feature = "bazel")]
+    return std::env::current_dir().unwrap().join("server/config.yml");
+
+    #[cfg(not(feature = "bazel"))]
+    return std::env::current_dir().unwrap().join("config.yml");
+}
+
 pub(crate) async fn start_typedb(
 ) -> (tokio::sync::watch::Sender<()>, std::thread::JoinHandle<Result<(), ServerOpenError>>) {
     let (shutdown_sender, shutdown_receiver) = tokio::sync::watch::channel(());
@@ -37,13 +45,14 @@ pub(crate) async fn start_typedb(
     let handle = std::thread::spawn(move || {
         let rt = tokio::runtime::Runtime::new().expect("Failed to create runtime");
         let server_dir = create_tmp_dir();
-        let config = ConfigBuilderForTests::default()
+        let config = ConfigBuilder::from_file(config_path())
+            .expect("Failed to load config file")
             .server_address(GRPC_ADDRESS)
             .server_http_address(HTTP_ADDRESS)
             .data_directory(server_dir.as_ref())
             .development_mode(true)
             .authentication(AuthenticationConfig { token_expiration: TEST_TOKEN_EXPIRATION })
-            .build()
+            .finish()
             .unwrap();
 
         let server_future = async {

--- a/tests/behaviour/steps/BUILD
+++ b/tests/behaviour/steps/BUILD
@@ -44,6 +44,7 @@ rust_library(
         "@crates//:serde_json",
         "@crates//:tokio",
     ],
+    data = ["//server:config.yml"]
 )
 
 checkstyle_test(

--- a/tests/behaviour/steps/connection/mod.rs
+++ b/tests/behaviour/steps/connection/mod.rs
@@ -15,6 +15,7 @@ use resource::constants::server::SERVER_INFO;
 use server::{parameters::config::Config, server::Server};
 use test_utils::{create_tmp_dir, TempDir};
 use tokio::sync::OnceCell;
+use server::parameters::config::ConfigBuilderForTests;
 
 use crate::{generic_step, Context};
 
@@ -32,8 +33,12 @@ pub async fn typedb_starts(context: &mut Context) {
     TYPEDB
         .get_or_init(|| async {
             let server_dir = create_tmp_dir();
-            let config =
-                Config::new(ADDRESS).data_directory(server_dir.as_ref()).development_mode(true).build().unwrap();
+            let config = ConfigBuilderForTests::default()
+                .server_address(ADDRESS)
+                .data_directory(server_dir.as_ref())
+                .development_mode(true)
+                .build()
+                .unwrap();
             let server = Server::new(SERVER_INFO, config, None).await.unwrap();
             (server_dir, Arc::new(Mutex::new(server)))
         })

--- a/tests/behaviour/steps/connection/mod.rs
+++ b/tests/behaviour/steps/connection/mod.rs
@@ -31,11 +31,7 @@ const VERSION: &str = "0.0.0";
 static TYPEDB: OnceCell<(TempDir, Arc<Mutex<Server>>)> = OnceCell::const_new();
 
 fn config_path() -> PathBuf {
-    #[cfg(feature = "bazel")]
     return std::env::current_dir().unwrap().join("server/config.yml");
-
-    #[cfg(not(feature = "bazel"))]
-    return std::env::current_dir().unwrap().join("config.yml");
 }
 
 #[apply(generic_step)]


### PR DESCRIPTION
## Product change and motivation
Fix the compilation time forcing of development mode for local and snapshot builds

## Implementation
Wraps `ConfigBuilder` around `Config` as we do with Blocks