### PR TITLE
Fix variable id allocator overflow crash

### DIFF
--- a/executor/tests/execute_expression.rs
+++ b/executor/tests/execute_expression.rs
@@ -52,7 +52,8 @@ fn compile_expression_via_match(
     // Avoid unbound variable errors
     let input_variable_categories =
         variable_types.iter().map(|(name, _)| ((*name).to_owned(), None, VariableCategory::Value)).collect();
-    let (mut translation_context, _) = TranslationContext::new_with_function_arguments(input_variable_categories);
+    let (mut translation_context, _) = TranslationContext::new_with_function_arguments(input_variable_categories)
+        .expect("Expected function transaction context");
     let mut value_parameters = ParameterRegistry::new();
     if let Stage::Match(match_) =
         typeql::parse_query(query.as_str()).unwrap().into_structure().into_pipeline().stages.first().unwrap()

--- a/ir/lib.rs
+++ b/ir/lib.rs
@@ -257,7 +257,7 @@ typedb_error! {
         ),
         VariablesOverflow(
             52,
-            "The query is too big and exceeds the limit of {variable_count} declared and anonymous variables. Please split it in parts and execute separately for better performance.",
+            "The query is too big and exceeds the limit of {variable_count} declared and anonymous variables. Please split it into parts and execute separately for better performance.",
             variable_count: u16,
             source_span: Option<Span>,
         ),

--- a/ir/lib.rs
+++ b/ir/lib.rs
@@ -255,6 +255,12 @@ typedb_error! {
             source: regex::Error,
             source_span: Option<Span>,
         ),
+        VariablesOverflow(
+            52,
+            "The query is too big and exceeds the limit of {variable_count} declared and anonymous variables. Please split it in parts and execute separately for better performance.",
+            variable_count: u16,
+            source_span: Option<Span>,
+        ),
         UnimplementedLanguageFeature(
             254,
             "The language feature is not yet implemented: {feature}.",

--- a/ir/pipeline/block.rs
+++ b/ir/pipeline/block.rs
@@ -371,7 +371,7 @@ impl<'a> BlockBuilderContext<'a> {
     ) -> Result<Variable, Box<RepresentationError>> {
         match self.variable_names_index.get(name) {
             None => {
-                let variable = self.variable_registry.register_variable_named(name.to_string(), source_span);
+                let variable = self.variable_registry.register_variable_named(name.to_string(), source_span)?;
                 self.block_context.add_variable_declaration(variable, scope);
                 self.variable_names_index.insert(name.to_string(), variable);
                 Ok(variable)
@@ -393,7 +393,7 @@ impl<'a> BlockBuilderContext<'a> {
         scope: ScopeId,
         source_span: Option<Span>,
     ) -> Result<Variable, Box<RepresentationError>> {
-        let variable = self.variable_registry.register_anonymous_variable(source_span);
+        let variable = self.variable_registry.register_anonymous_variable(source_span)?;
         self.block_context.add_variable_declaration(variable, scope);
         Ok(variable)
     }

--- a/ir/pipeline/mod.rs
+++ b/ir/pipeline/mod.rs
@@ -170,9 +170,16 @@ impl VariableRegistry {
         } else {
             Variable::new(self.variable_id_allocator)
         };
-        self.variable_id_allocator.checked_add(1).map(|_| variable).ok_or(Box::new(
-            RepresentationError::VariablesOverflow { variable_count: self.variable_id_allocator, source_span },
-        ))
+
+        if let Some(variable_id_allocator) = self.variable_id_allocator.checked_add(1) {
+            self.variable_id_allocator = variable_id_allocator;
+            Ok(variable)
+        } else {
+            Err(Box::new(RepresentationError::VariablesOverflow {
+                variable_count: self.variable_id_allocator,
+                source_span,
+            }))
+        }
     }
 
     pub fn set_assigned_value_variable_category(

--- a/ir/translation/function.rs
+++ b/ir/translation/function.rs
@@ -82,7 +82,8 @@ pub fn translate_function_from(
             ))
         })
         .collect::<Result<Vec<_>, _>>()?;
-    let (mut context, arguments) = TranslationContext::new_with_function_arguments(args_sources_categories);
+    let (mut context, arguments) = TranslationContext::new_with_function_arguments(args_sources_categories)
+        .map_err(|typedb_source| FunctionRepresentationError::BlockDefinition { typedb_source })?;
     let mut value_parameters = ParameterRegistry::new();
     let body = translate_function_block(snapshot, function_index, &mut context, &mut value_parameters, block)?;
 

--- a/ir/translation/reduce.rs
+++ b/ir/translation/reduce.rs
@@ -30,8 +30,13 @@ pub fn translate_reduce(
             reduce_assign.variable.name().ok_or(Box::new(RepresentationError::NonAnonymousVariableExpected {
                 source_span: reduce_assign.variable.span(),
             }))?;
-        let assigned_var =
-            context.register_reduced_variable(var_name, category, is_optional, reduce_assign.variable.span(), reducer);
+        let assigned_var = context.register_reduced_variable(
+            var_name,
+            category,
+            is_optional,
+            reduce_assign.variable.span(),
+            reducer,
+        )?;
         reductions.push(AssignedReduction::new(assigned_var, reducer));
     }
 


### PR DESCRIPTION
## Product change and motivation
Return a representation error instead of a crash for queries overflowing the variable number limit. Fixes https://github.com/typedb/typedb/issues/7482.

Rust driver's error example:
```
called `Result::unwrap()` on an `Err` value: Server(
[REP52] The query is too big and exceeds the limit of 65535 declared and anonymous variables. Please split it into parts and execute separately for better performance.
Caused: [QEX7] Error in provided query.
Near 16385:97
-----
    $p15460 isa person, has name "XdelwJ-5275984974011080378", has id 13954001766678618073, has bio "Bio: 0R9641h09e3kGdTbHN4t";
    (friend: $p5460, friend: $p15460) isa friendship, has bio "Friendship#1568388083:Tn1VORIS-ZUwdem";
--> $p5461 isa person, has name "k6HFQW-10247636131927110182", has id 14336185473951253852, has bio "Bio: OPPgVhYFdncrGBQ0xVv6";
                                                                                                    ^
    $p15461 isa person, has name "Fll5rq-125886840531597973", has id 10540830226431637304, has bio "Bio: KoJly7fs0HEPDiHiUBoz";
    (friend: $p5461, friend: $p15461) isa friendship, has bio "Friendship#3113679880:m6GqBBwt-144TBF";
-----)
```

## Implementation
