### PR TITLE
Send commit responses on commit requests instead of silently closing the stream

### DIFF
--- a/server/service/grpc/response_builders.rs
+++ b/server/service/grpc/response_builders.rs
@@ -288,6 +288,13 @@ pub(crate) mod transaction {
     ) -> typedb_protocol::transaction::Server {
         transaction_server_res(req_id, typedb_protocol::transaction::res::Res::RollbackRes(message))
     }
+
+    pub(crate) fn transaction_server_res_commit_res(
+        req_id: Uuid,
+        message: typedb_protocol::transaction::commit::Res,
+    ) -> typedb_protocol::transaction::Server {
+        transaction_server_res(req_id, typedb_protocol::transaction::res::Res::CommitRes(message))
+    }
 }
 
 pub(crate) mod user_manager {


### PR DESCRIPTION
## Product change and motivation
We utilize the already existing GRPC protocol's "commit" transaction response to explicitly mark that commit requests are successfully executed without errors. Previously, TypeDB clients only relied on either an error or a closure of the transaction stream, understanding the state of the transaction only based on its sent requests.

## Implementation
