### PR TITLE
Remove "no open transaction" errors from HTTP transaction close endpoint

### DIFF
--- a/server/service/http/typedb_service.rs
+++ b/server/service/http/typedb_service.rs
@@ -152,7 +152,10 @@ impl TypeDBService {
 
         match timeout(Duration::from_millis(transaction.transaction_timeout_millis), result_receiver).await {
             Ok(Ok(response)) => Ok(response),
-            Ok(Err(_)) => Err(HttpServiceError::no_open_transaction()),
+            Ok(Err(_)) => match error_if_closed {
+                false => Ok(TransactionServiceResponse::Ok),
+                true => Err(HttpServiceError::no_open_transaction()),
+            },
             Err(_) => Err(HttpServiceError::transaction_timeout()),
         }
     }


### PR DESCRIPTION
## Product change and motivation
Remove the last possible and very rare case of the "no open transaction" error after calling `/transactions/:transaction-id/close` when the transaction is closed in parallel without answering the current request. 

## Implementation
Transaction requests create a channel:
```
let (result_sender, result_receiver) = oneshot::channel();
```
and then await the result in `result_receiver`. It can return an error if `result_sender` is dropped -> if `TransactionService`'s `request_stream` is dropped -> if `TransactionService` is dropped -> if `TransactionService` is closed -> transaction is closed or committed.