### PR TITLE
Reduce usages of assert! that don't need to be assert!

### DIFF
--- a/common/error/error.rs
+++ b/common/error/error.rs
@@ -347,6 +347,7 @@ pub enum UnimplementedFeature {
     PipelineStageInFunction(&'static str),
 
     IrrelevantUnboundInvertedMode(&'static str),
+    QueryingAnnotations,
 }
 impl std::fmt::Display for UnimplementedFeature {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/compiler/annotation/type_inference.rs
+++ b/compiler/annotation/type_inference.rs
@@ -95,6 +95,7 @@ pub mod tests {
         type_seeder::TypeGraphSeedingContext,
         TypeInferenceError,
     };
+    use assert as assert_true;
 
     #[test]
     fn test_functions() {
@@ -493,7 +494,7 @@ pub mod tests {
             )
             .unwrap_err();
 
-            assert!(match err {
+            assert_true!(match err {
                 TypeInferenceError::DetectedUnsatisfiableEdge { left_variable, right_variable, .. } => {
                     left_variable == "animal" && right_variable == "name"
                 }
@@ -1341,7 +1342,7 @@ pub mod tests {
                 false,
             )
             .unwrap_err();
-            assert!(match err {
+            assert_true!(match err {
                 TypeInferenceError::DetectedUnsatisfiableEdge { left_variable, right_variable, .. } => {
                     left_variable == "animal" && right_variable == "name"
                 }

--- a/compiler/annotation/type_seeder.rs
+++ b/compiler/annotation/type_seeder.rs
@@ -268,7 +268,7 @@ impl<'this, Snapshot: ReadableSnapshot> TypeGraphSeedingContext<'this, Snapshot>
                     }
                 }
                 &Vertex::Parameter(_) => {
-                    assert!(!graph.vertices.contains_key(vertex));
+                    debug_assert!(!graph.vertices.contains_key(vertex));
                 }
             }
         }

--- a/durability/wal.rs
+++ b/durability/wal.rs
@@ -613,7 +613,7 @@ mod test {
 
     use super::WAL;
     use crate::{DurabilityRecordType, DurabilitySequenceNumber, DurabilityService, RawRecord};
-
+    use assert as assert_true;
     #[derive(Debug, PartialEq, Eq, Clone, Copy)]
     struct TestRecord {
         bytes: [u8; 4],
@@ -795,7 +795,7 @@ mod test {
         let wal = load_wal(&directory);
         let read_records =
             wal.iter_any_from(DurabilitySequenceNumber::MAX).unwrap().map(|res| res.unwrap()).collect_vec();
-        assert!(read_records.is_empty());
+        assert_true!(read_records.is_empty());
     }
 
     #[test]
@@ -814,7 +814,7 @@ mod test {
         wal.sequenced_write(TestRecord::RECORD_TYPE, sequenced_2.bytes()).unwrap();
 
         let found = wal.find_last_type(UnsequencedTestRecord::RECORD_TYPE).unwrap().unwrap();
-        assert!(
+        assert_true!(
             matches!(found, RawRecord { bytes: Cow::Owned(bytes), record_type: UnsequencedTestRecord::RECORD_TYPE, .. } if bytes == unsequenced_2.bytes())
         );
 
@@ -823,7 +823,7 @@ mod test {
         let wal = load_wal(&directory);
 
         let found = wal.find_last_type(UnsequencedTestRecord::RECORD_TYPE).unwrap().unwrap();
-        assert!(
+        assert_true!(
             matches!(found, RawRecord { bytes: Cow::Owned(bytes), record_type: UnsequencedTestRecord::RECORD_TYPE, .. } if bytes == unsequenced_2.bytes())
         );
     }

--- a/ir/translation/constraints.rs
+++ b/ir/translation/constraints.rs
@@ -134,7 +134,11 @@ fn add_type_statement(
         add_typeql_kind(constraints, var, kind, type_statement.span())?;
     }
     for constraint in &type_statement.constraints {
-        assert!(constraint.annotations.is_empty(), "TODO: handle type statement annotations");
+        if !constraint.annotations.is_empty() {
+            return Err(Box::new(RepresentationError::UnimplementedLanguageFeature {
+                feature: UnimplementedFeature::QueryingAnnotations
+            }));
+        }
         match &constraint.base {
             typeql::statement::type_::ConstraintBase::Sub(sub) => add_typeql_sub(constraints, type_.clone(), sub)?,
             typeql::statement::type_::ConstraintBase::Label(label) => match label {

--- a/server/parameters/config.rs
+++ b/server/parameters/config.rs
@@ -287,6 +287,9 @@ pub mod tests {
     use assert as assert_true;
 
     fn config_path() -> PathBuf {
+        #[cfg(feature = "bazel")]
+        return std::env::current_dir().unwrap().join("server/config.yml");
+        #[cfg(not(feature = "bazel"))]
         return std::env::current_dir().unwrap().join("config.yml");
     }
 

--- a/server/parameters/config.rs
+++ b/server/parameters/config.rs
@@ -284,9 +284,10 @@ pub mod tests {
         config::{Config, ConfigBuilder},
         ConfigError,
     };
+    use assert as assert_true;
 
     fn config_path() -> PathBuf {
-        return std::env::current_dir().unwrap().join("server/config.yml");
+        return std::env::current_dir().unwrap().join("config.yml");
     }
 
     fn load_and_parse(yaml: PathBuf, args: Vec<&str>) -> Result<Config, ConfigError> {
@@ -301,7 +302,7 @@ pub mod tests {
 
     #[test]
     fn server_toml_parser_properly() {
-        assert!(load_and_parse(config_path(), vec![]).is_ok());
+        assert_true!(load_and_parse(config_path(), vec![]).is_ok());
     }
 
     #[test]
@@ -316,7 +317,7 @@ pub mod tests {
         {
             // Check pre-conditions
             let config = load_and_parse(config_path(), vec![]).unwrap();
-            assert!(
+            assert_true!(
                 config.server.encryption.enabled == false
                     && config.server.encryption.certificate_key.is_none()
                     && config.server.encryption.certificate.is_none()
@@ -325,7 +326,7 @@ pub mod tests {
 
         {
             let args = vec!["--server.encryption.enabled", "true"];
-            assert!(matches!(load_and_parse(config_path(), args), Err(ConfigError::ValidationError { .. })));
+            assert_true!(matches!(load_and_parse(config_path(), args), Err(ConfigError::ValidationError { .. })));
         }
 
         {
@@ -337,17 +338,17 @@ pub mod tests {
                 "--server.encryption.certificate",
                 "somecert.pem",
             ];
-            assert!(load_and_parse(config_path(), args).is_ok());
+            assert_true!(load_and_parse(config_path(), args).is_ok());
         }
 
         {
             let args = vec!["--server.encryption.enabled", "true", "--server.encryption.certificate", "somecert.pem"];
-            assert!(matches!(load_and_parse(config_path(), args), Err(ConfigError::ValidationError { .. })));
+            assert_true!(matches!(load_and_parse(config_path(), args), Err(ConfigError::ValidationError { .. })));
         }
 
         {
             let args = vec!["--server.encryption.enabled", "true", "--server.encryption.certificate-key", "somekey"];
-            assert!(matches!(load_and_parse(config_path(), args), Err(ConfigError::ValidationError { .. })));
+            assert_true!(matches!(load_and_parse(config_path(), args), Err(ConfigError::ValidationError { .. })));
         }
     }
 }

--- a/storage/isolation_manager.rs
+++ b/storage/isolation_manager.rs
@@ -857,7 +857,7 @@ mod tests {
         sequence_number::SequenceNumber,
         snapshot::buffer::OperationsBuffer,
     };
-
+    use assert as assert_true;
     macro_rules! test_keyspace_set {
         {$($variant:ident => $id:literal : $name: literal),* $(,)?} => {
             #[derive(Clone, Copy)]
@@ -985,12 +985,12 @@ mod tests {
             let tx = &MockTransaction::new(_seq(0), _seq(i as u64));
             tx_finalise_commit_status(timeline, tx, true);
         }
-        assert!(timeline.try_get_window(_seq(1)).is_some());
+        assert_true!(timeline.try_get_window(_seq(1)).is_some());
         for i in stop_at..tx_count {
             let tx = &MockTransaction::new(_seq(0), _seq(i as u64));
             tx_finalise_commit_status(timeline, tx, true);
         }
-        assert!(timeline.try_get_window(_seq(1)).is_none());
+        assert_true!(timeline.try_get_window(_seq(1)).is_none());
     }
 
     #[test]
@@ -1002,7 +1002,7 @@ mod tests {
         tx_finalise_commit_status(&timeline, tx1, true);
 
         let got_window = timeline.try_get_window(tx1.commit_sequence_number);
-        assert!(got_window.is_some());
+        assert_true!(got_window.is_some());
 
         let mut i = tx1.commit_sequence_number + 1;
         while timeline.try_get_window(i).is_some() {
@@ -1047,6 +1047,6 @@ mod tests {
         let (timeline, _) = &*timeline_and_counter;
         assert_eq!(expected_watermark, timeline.watermark());
         let some_index_in_penultimate_window = expected_watermark - TIMELINE_WINDOW_SIZE - 1;
-        assert!(timeline.try_get_window(some_index_in_penultimate_window).is_none());
+        assert_true!(timeline.try_get_window(some_index_in_penultimate_window).is_none());
     }
 }


### PR DESCRIPTION
## Product change and motivation
Allow `assert!` only in unrecoverable cases where we must crash the server.

## Implementation
To facilitate searching (Ctrl+F) for these cases, we replace usages of `assert!` in unit tests to `assert_true!` (via `use assert as assert_true`)