### PR TITLE
Update the lower bound for output size of a step to be a small fraction instead of 1

### DIFF
--- a/compiler/executable/match_/planner/vertex/constraint.rs
+++ b/compiler/executable/match_/planner/vertex/constraint.rs
@@ -31,7 +31,7 @@ use crate::{
     },
 };
 
-const MIN_SCAN_SIZE: f64 = 1.0;
+const MIN_SCAN_SIZE: f64 = 0.000000001;
 const MAX_SCAN_SIZE: f64 = 10e15;
 
 #[derive(Clone, Debug)]


### PR DESCRIPTION
## Product change and motivation
Updates the lower bound that the planner uses for estimating the (average) output size of a step to be a small fraction instead of 1 - allowing it to better model highly selective constraints. Clamping the value to 1.0 prevented the planner from using its otherwise accurate estimates .

## Implementation
Update `MIN_SCAN_SIZE` to `0.000000001`, the value used for `Cost::MIN_IO_RATIO`.
