### PR TITLE
Fix how we decide the join variable of consecutive steps during planner

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5140,7 +5140,7 @@ dependencies = [
 [[package]]
 name = "typedb-protocol"
 version = "0.0.0"
-source = "git+https://github.com/typedb/typedb-protocol?rev=38f66a1cc4db3b7a301676f50800e9530ac5c8a3#38f66a1cc4db3b7a301676f50800e9530ac5c8a3"
+source = "git+https://github.com/typedb/typedb-protocol?tag=3.4.0#3fc4c0fe0ac37c517af0e31415347299cff0307c"
 dependencies = [
  "prost",
  "tonic",

--- a/compiler/executable/match_/planner/vertex/constraint.rs
+++ b/compiler/executable/match_/planner/vertex/constraint.rs
@@ -92,7 +92,7 @@ impl ConstraintVertex<'_> {
             Self::Links(_) | Self::Has(_) | Self::IndexedRelation(_) => {
                 let unbound_join_variables: Vec<VariableVertexId> = self
                     .variables()
-                    .filter(|&var| self.can_join_on(var) && (include.contains(&var) && !exclude.contains(&var)))
+                    .filter(|&var| self.can_join_on(var) && (!exclude.contains(&var) && include.contains(&var)))
                     .collect();
                 if unbound_join_variables.len() == 1 {
                     return unbound_join_variables.get(0).cloned();
@@ -133,7 +133,7 @@ impl ConstraintVertex<'_> {
             Self::Links(_) | Self::Has(_) | Self::IndexedRelation(_) => {
                 let unbound_join_variables: Vec<VariableVertexId> = self
                     .variables()
-                    .filter(|&var| self.can_join_on(var) && (!exclude.contains(&var) || include.contains(&var)))
+                    .filter(|&var| self.can_join_on(var) && (!exclude.contains(&var) && include.contains(&var)))
                     .collect();
                 if unbound_join_variables.len() < 2 {
                     return None;

--- a/compiler/executable/match_/planner/vertex/constraint.rs
+++ b/compiler/executable/match_/planner/vertex/constraint.rs
@@ -92,7 +92,7 @@ impl ConstraintVertex<'_> {
             Self::Links(_) | Self::Has(_) | Self::IndexedRelation(_) => {
                 let unbound_join_variables: Vec<VariableVertexId> = self
                     .variables()
-                    .filter(|&var| self.can_join_on(var) && (!exclude.contains(&var) || include.contains(&var)))
+                    .filter(|&var| self.can_join_on(var) && (include.contains(&var) && !exclude.contains(&var)))
                     .collect();
                 if unbound_join_variables.len() == 1 {
                     return unbound_join_variables.get(0).cloned();


### PR DESCRIPTION
## Product change and motivation
Fixes how the join variable (if any) between consecutive steps in a candidate plan is determined.

## Implementation
Simplifies the `determine_joinability` and `join_from_direction_and_inputs` functions 