### PR TITLE
Enable RocksDB Prefix bloom filters

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5140,7 +5140,7 @@ dependencies = [
 [[package]]
 name = "typedb-protocol"
 version = "0.0.0"
-source = "git+https://github.com/typedb/typedb-protocol?rev=38f66a1cc4db3b7a301676f50800e9530ac5c8a3#38f66a1cc4db3b7a301676f50800e9530ac5c8a3"
+source = "git+https://github.com/typedb/typedb-protocol?tag=3.4.0#3fc4c0fe0ac37c517af0e31415347299cff0307c"
 dependencies = [
  "prost",
  "tonic",

--- a/executor/tests/efficiency.rs
+++ b/executor/tests/efficiency.rs
@@ -1343,7 +1343,7 @@ fn intersection_seeks() {
     // total advance: 25 (24 ? off by one...)
     // for each person, we should skip directly to the person + owned name
     assert_eq!(storage_counters.get_raw_seek().unwrap(), 4);
-    assert_eq!(storage_counters.get_raw_advance().unwrap(), 24);
+    assert_eq!(storage_counters.get_raw_advance().unwrap(), 23);
 }
 
 #[test]
@@ -1515,5 +1515,5 @@ fn intersections_seeks_with_extra_values() {
     //      ==> TODO: this should be optimisable with a short-circuit, but it is currently impossible due to iterators skipping values internally!
 
     assert_eq!(storage_counters.get_raw_seek().unwrap(), 3);
-    assert_eq!(storage_counters.get_raw_advance().unwrap(), 10)
+    assert_eq!(storage_counters.get_raw_advance().unwrap(), 9)
 }

--- a/storage/benches/bench_mvcc_storage.rs
+++ b/storage/benches/bench_mvcc_storage.rs
@@ -40,6 +40,9 @@ macro_rules! test_keyspace_set {
             fn name(&self) -> &'static str {
                 match *self { $(Self::$variant => $name),* }
             }
+            fn prefix_length(&self) -> Option<usize> {
+                None
+            }
         }
     };
 }

--- a/storage/isolation_manager.rs
+++ b/storage/isolation_manager.rs
@@ -870,6 +870,9 @@ mod tests {
                 fn name(&self) -> &'static str {
                     match *self { $(Self::$variant => $name),* }
                 }
+                fn prefix_length(&self) -> Option<usize> {
+                    None
+                }
             }
         };
     }

--- a/storage/iterator.rs
+++ b/storage/iterator.rs
@@ -9,7 +9,6 @@ use std::{cmp::Ordering, error::Error, fmt, sync::Arc};
 use bytes::byte_array::ByteArray;
 use lending_iterator::{LendingIterator, Peekable, Seekable};
 use resource::profile::StorageCounters;
-use tracing::log::Log;
 
 use super::{MVCCKey, MVCCStorage, StorageOperation, MVCC_KEY_INLINE_SIZE};
 use crate::{

--- a/storage/iterator.rs
+++ b/storage/iterator.rs
@@ -9,6 +9,7 @@ use std::{cmp::Ordering, error::Error, fmt, sync::Arc};
 use bytes::byte_array::ByteArray;
 use lending_iterator::{LendingIterator, Peekable, Seekable};
 use resource::profile::StorageCounters;
+use tracing::log::Log;
 
 use super::{MVCCKey, MVCCStorage, StorageOperation, MVCC_KEY_INLINE_SIZE};
 use crate::{

--- a/storage/keyspace/iterator.rs
+++ b/storage/keyspace/iterator.rs
@@ -35,9 +35,6 @@ impl KeyspaceRangeIterator {
         range: &KeyRange<Bytes<'a, INLINE_BYTES>>,
         storage_counters: StorageCounters,
     ) -> Self {
-        // TODO: if self.has_prefix_extractor_for(prefix), we can enable bloom filters
-        // read_opts.set_prefix_same_as_start(true);
-
         let start_prefix = match range.start() {
             RangeStart::Inclusive(bytes) => Bytes::Reference(bytes.as_ref()),
             RangeStart::ExcludeFirstWithPrefix(bytes) => Bytes::Reference(bytes.as_ref()),
@@ -47,12 +44,12 @@ impl KeyspaceRangeIterator {
                 Bytes::Array(cloned)
             }
         };
-
-        let mut iterator = raw_iterator::DBIterator::new_from(
-            iterpool.get_iterator(keyspace),
-            start_prefix.as_ref(),
-            storage_counters,
-        );
+        let raw_iterator = if Self::can_use_prefix(keyspace, range) {
+            iterpool.get_iterator_prefixed(keyspace)
+        } else {
+            iterpool.get_iterator_unprefixed(keyspace)
+        };
+        let mut iterator = DBIterator::new_from(raw_iterator, start_prefix.as_ref(), storage_counters);
         if matches!(range.start(), RangeStart::ExcludeFirstWithPrefix(_)) {
             Self::may_skip_start(&mut iterator, range.start().get_value());
         }
@@ -95,6 +92,29 @@ impl KeyspaceRangeIterator {
                 }
             }
             Err(_err) => true,
+        }
+    }
+
+    fn can_use_prefix<const INLINE_BYTES: usize>(
+        keyspace: &Keyspace,
+        range: &KeyRange<Bytes<'_, INLINE_BYTES>>,
+    ) -> bool {
+        let Some(prefix_length) = keyspace.prefix_length() else {
+            return false;
+        };
+        let start = range.start().get_value();
+        if start.length() < prefix_length {
+            return false;
+        };
+        match range.end() {
+            RangeEnd::WithinStartAsPrefix => true,
+            RangeEnd::EndPrefixInclusive(end) => {
+                end.length() >= prefix_length && end[0..prefix_length] == start[0..prefix_length]
+            }
+            RangeEnd::EndPrefixExclusive(end) => {
+                end.length() >= prefix_length && end[0..prefix_length] == start[0..prefix_length]
+            }
+            RangeEnd::Unbounded => false,
         }
     }
 }

--- a/storage/keyspace/iterator.rs
+++ b/storage/keyspace/iterator.rs
@@ -152,7 +152,9 @@ impl LendingIterator for KeyspaceRangeIterator {
 
 impl Seekable<[u8]> for KeyspaceRangeIterator {
     fn seek(&mut self, key: &[u8]) {
-        self.iterator.seek(key);
+        if !self.is_finished {
+            self.iterator.seek(key);
+        }
     }
 
     fn compare_key(&self, item: &Self::Item<'_>, key: &[u8]) -> Ordering {

--- a/storage/keyspace/keyspace.rs
+++ b/storage/keyspace/keyspace.rs
@@ -219,7 +219,7 @@ impl Keyspace {
 
     pub(super) fn new_read_options(&self) -> ReadOptions {
         let mut options = ReadOptions::default();
-        options.set_total_order_seek(true); // Override this to false to use bloom-filters
+        options.set_total_order_seek(true); // Set this to 'false' to use bloom-filters
         options
     }
 

--- a/storage/keyspace/keyspace.rs
+++ b/storage/keyspace/keyspace.rs
@@ -51,6 +51,7 @@ pub trait KeyspaceSet: Copy {
         options.create_if_missing(true);
         options
     }
+    fn prefix_length(&self) -> Option<usize>;
 }
 
 #[derive(Debug)]
@@ -191,6 +192,7 @@ pub(crate) struct Keyspace {
     pub(super) kv_storage: DB,
     read_options: ReadOptions,
     write_options: WriteOptions,
+    prefix_length: Option<usize>,
 }
 
 impl Keyspace {
@@ -211,12 +213,13 @@ impl Keyspace {
         let read_options = ReadOptions::default();
         let mut write_options = WriteOptions::default();
         write_options.disable_wal(true);
-        Self { path, name: keyspace.name(), id: keyspace.id(), kv_storage, read_options, write_options }
+        let prefix_length = keyspace.prefix_length();
+        Self { path, name: keyspace.name(), id: keyspace.id(), kv_storage, read_options, write_options, prefix_length }
     }
 
     pub(super) fn new_read_options(&self) -> ReadOptions {
         let mut options = ReadOptions::default();
-        options.set_total_order_seek(false);
+        options.set_total_order_seek(true); // Override this to false to use bloom-filters
         options
     }
 
@@ -226,6 +229,10 @@ impl Keyspace {
 
     pub(crate) fn name(&self) -> &'static str {
         self.name
+    }
+
+    pub(crate) fn prefix_length(&self) -> Option<usize> {
+        self.prefix_length.clone()
     }
 
     pub(crate) fn put(&self, key: &[u8], value: &[u8]) -> Result<(), KeyspaceError> {

--- a/storage/storage.rs
+++ b/storage/storage.rs
@@ -683,6 +683,9 @@ mod tests {
                 fn name(&self) -> &'static str {
                     match *self { $(Self::$variant => $name),* }
                 }
+                fn prefix_length(&self) -> Option<usize> {
+                    None
+                }
             }
         };
     }

--- a/storage/tests/test_utils_storage/lib.rs
+++ b/storage/tests/test_utils_storage/lib.rs
@@ -27,6 +27,9 @@ macro_rules! test_keyspace_set {
             fn name(&self) -> &'static str {
                 match *self { $(Self::$variant => $name),* }
             }
+            fn prefix_length(&self) -> Option {
+                None
+            }
         }
     };
 }

--- a/storage/tests/test_utils_storage/lib.rs
+++ b/storage/tests/test_utils_storage/lib.rs
@@ -27,7 +27,7 @@ macro_rules! test_keyspace_set {
             fn name(&self) -> &'static str {
                 match *self { $(Self::$variant => $name),* }
             }
-            fn prefix_length(&self) -> Option {
+            fn prefix_length(&self) -> Option<usize> {
                 None
             }
         }


### PR DESCRIPTION
## Product change and motivation
Enable [RocksDB bloom filters](https://github.com/facebook/rocksdb/wiki/RocksDB-Bloom-Filter), reducing avoidable disk-reads in large databases.

## Implementation
* Splits the IteratorPool into two: One for iterators which use a prefix, and one for those which do not .
  - The prefix-iterator sets `options.set_total_order_seek(false)`
  - If the limits of the range being iterated have the same prefix (of the length specified by the keyspace), then we use the prefix iterators

To verify that the filters are working, turn on statistics and check the `rocksdb.[non.]last.level.seek.filtered COUNT`
 