### PR TITLE
Type inference of negations & optionals is no longer interleaved with that of the conjunction

### DIFF
--- a/compiler/annotation/type_inference.rs
+++ b/compiler/annotation/type_inference.rs
@@ -354,7 +354,8 @@ pub mod tests {
             let constraints = block.conjunction().constraints();
             let graph = compute_type_inference_graph(
                 &snapshot,
-                &block,
+                block.block_context(),
+        block.conjunction(),
                 &translation_context.variable_registry,
                 &type_manager,
                 &BTreeMap::new(),
@@ -420,7 +421,8 @@ pub mod tests {
             let constraints = block.conjunction().constraints();
             let graph = compute_type_inference_graph(
                 &snapshot,
-                &block,
+                block.block_context(),
+        block.conjunction(),
                 &translation_context.variable_registry,
                 &type_manager,
                 &BTreeMap::new(),
@@ -482,7 +484,8 @@ pub mod tests {
             let block = builder.finish().unwrap();
             let err = compute_type_inference_graph(
                 &snapshot,
-                &block,
+                block.block_context(),
+        block.conjunction(),
                 &translation_context.variable_registry,
                 &type_manager,
                 &BTreeMap::new(),
@@ -524,7 +527,8 @@ pub mod tests {
             let constraints = block.conjunction().constraints();
             let graph = compute_type_inference_graph(
                 &snapshot,
-                &block,
+                block.block_context(),
+        block.conjunction(),
                 &translation_context.variable_registry,
                 &type_manager,
                 &BTreeMap::new(),
@@ -614,7 +618,8 @@ pub mod tests {
         let snapshot = storage.clone().open_snapshot_write();
         let graph = compute_type_inference_graph(
             &snapshot,
-            &block,
+            block.block_context(),
+        block.conjunction(),
             &translation_context.variable_registry,
             &type_manager,
             &BTreeMap::new(),
@@ -722,7 +727,8 @@ pub mod tests {
         let constraints = conjunction.constraints();
         let graph = compute_type_inference_graph(
             &snapshot,
-            &block,
+            block.block_context(),
+        block.conjunction(),
             &translation_context.variable_registry,
             &type_manager,
             &BTreeMap::new(),
@@ -809,7 +815,8 @@ pub mod tests {
 
         let graph = compute_type_inference_graph(
             &snapshot,
-            &block,
+            block.block_context(),
+        block.conjunction(),
             &translation_context.variable_registry,
             &type_manager,
             &BTreeMap::new(),
@@ -921,7 +928,8 @@ pub mod tests {
             let constraints = block.conjunction().constraints();
             let graph = compute_type_inference_graph(
                 &snapshot,
-                &block,
+                block.block_context(),
+        block.conjunction(),
                 &translation_context.variable_registry,
                 &type_manager,
                 &BTreeMap::new(),
@@ -990,7 +998,8 @@ pub mod tests {
             let constraints = block.conjunction().constraints();
             let graph = compute_type_inference_graph(
                 &snapshot,
-                &block,
+                block.block_context(),
+        block.conjunction(),
                 &translation_context.variable_registry,
                 &type_manager,
                 &BTreeMap::new(),
@@ -1111,7 +1120,8 @@ pub mod tests {
             let constraints = block.conjunction().constraints();
             let graph = compute_type_inference_graph(
                 &snapshot,
-                &block,
+                block.block_context(),
+        block.conjunction(),
                 &translation_context.variable_registry,
                 &type_manager,
                 &BTreeMap::new(),
@@ -1189,7 +1199,8 @@ pub mod tests {
             let constraints = block.conjunction().constraints();
             let graph = compute_type_inference_graph(
                 &snapshot,
-                &block,
+                block.block_context(),
+        block.conjunction(),
                 &translation_context.variable_registry,
                 &type_manager,
                 &BTreeMap::new(),
@@ -1255,7 +1266,8 @@ pub mod tests {
             let constraints = block.conjunction().constraints();
             let graph = compute_type_inference_graph(
                 &snapshot,
-                &block,
+                block.block_context(),
+        block.conjunction(),
                 &translation_context.variable_registry,
                 &type_manager,
                 &BTreeMap::new(),
@@ -1316,7 +1328,8 @@ pub mod tests {
             let block = builder.finish().unwrap();
             let err = compute_type_inference_graph(
                 &snapshot,
-                &block,
+                block.block_context(),
+        block.conjunction(),
                 &translation_context.variable_registry,
                 &type_manager,
                 &BTreeMap::new(),
@@ -1355,7 +1368,8 @@ pub mod tests {
             let constraints = block.conjunction().constraints();
             let graph = compute_type_inference_graph(
                 &snapshot,
-                &block,
+                block.block_context(),
+        block.conjunction(),
                 &translation_context.variable_registry,
                 &type_manager,
                 &BTreeMap::new(),

--- a/compiler/annotation/type_inference.rs
+++ b/compiler/annotation/type_inference.rs
@@ -389,8 +389,6 @@ pub mod tests {
                     expected_edge(&constraints[4], var_animal.into(), var_name.into(), vec![(type_cat, type_catname)]),
                 ],
                 nested_disjunctions: Vec::new(),
-                nested_negations: Vec::new(),
-                nested_optionals: Vec::new(),
             };
 
             assert_eq!(expected_graph.vertices, graph.vertices);
@@ -457,8 +455,7 @@ pub mod tests {
                     expected_edge(&constraints[4], var_animal.into(), var_name.into(), vec![(type_cat, type_catname)]),
                 ],
                 nested_disjunctions: Vec::new(),
-                nested_negations: Vec::new(),
-                nested_optionals: Vec::new(),
+                
             };
             assert_eq!(expected_graph, graph);
         }
@@ -567,8 +564,7 @@ pub mod tests {
                     ),
                 ],
                 nested_disjunctions: Vec::new(),
-                nested_negations: Vec::new(),
-                nested_optionals: Vec::new(),
+                
             };
             assert_eq!(expected_graph.edges, graph.edges);
             assert_eq!(expected_graph, graph);
@@ -647,8 +643,7 @@ pub mod tests {
                     vec![(type_cat, type_cat)],
                 )],
                 nested_disjunctions: Vec::new(),
-                nested_negations: Vec::new(),
-                nested_optionals: Vec::new(),
+                
             },
             TypeInferenceGraph {
                 conjunction: b2,
@@ -664,8 +659,7 @@ pub mod tests {
                     vec![(type_dog, type_dog)],
                 )],
                 nested_disjunctions: Vec::new(),
-                nested_negations: Vec::new(),
-                nested_optionals: Vec::new(),
+                
             },
         ];
 
@@ -696,8 +690,6 @@ pub mod tests {
                 shared_variables: BTreeSet::new(),
                 shared_vertex_annotations: VertexAnnotations::default(),
             }],
-            nested_negations: Vec::new(),
-            nested_optionals: Vec::new(),
         };
 
         assert_eq!(expected_graph, graph);
@@ -752,8 +744,6 @@ pub mod tests {
                 vec![(type_cat, type_catname), (type_dog, type_dogname)],
             )],
             nested_disjunctions: Vec::new(),
-            nested_negations: Vec::new(),
-            nested_optionals: Vec::new(),
         };
 
         assert_eq!(expected_graph, graph);
@@ -891,8 +881,6 @@ pub mod tests {
                 ),
             ],
             nested_disjunctions: Vec::new(),
-            nested_negations: Vec::new(),
-            nested_optionals: Vec::new(),
         };
 
         assert_eq!(expected_graph, graph);
@@ -972,8 +960,7 @@ pub mod tests {
                     ),
                 ],
                 nested_disjunctions: Vec::new(),
-                nested_negations: Vec::new(),
-                nested_optionals: Vec::new(),
+                
             };
 
             assert_eq!(expected_graph, graph);
@@ -1042,8 +1029,7 @@ pub mod tests {
                     ),
                 ],
                 nested_disjunctions: Vec::new(),
-                nested_negations: Vec::new(),
-                nested_optionals: Vec::new(),
+                
             };
             assert_eq!(expected_graph, graph);
         }
@@ -1097,8 +1083,7 @@ pub mod tests {
                     expected_edge(&constraints[4], var_animal_type.into(), var_name_type.into(), Vec::new()),
                 ],
                 nested_disjunctions: Vec::new(),
-                nested_negations: Vec::new(),
-                nested_optionals: Vec::new(),
+                
             };
             assert_eq!(expected_graph, graph);
         }
@@ -1164,8 +1149,7 @@ pub mod tests {
                     ),
                 ],
                 nested_disjunctions: Vec::new(),
-                nested_negations: Vec::new(),
-                nested_optionals: Vec::new(),
+                
             };
 
             assert_eq!(expected_graph, graph);
@@ -1238,8 +1222,7 @@ pub mod tests {
                     expected_edge(&constraints[2], var_animal.into(), var_name.into(), vec![(type_cat, type_catname)]),
                 ],
                 nested_disjunctions: Vec::new(),
-                nested_negations: Vec::new(),
-                nested_optionals: Vec::new(),
+                
             };
 
             assert_eq!(expected_graph.vertices, graph.vertices);
@@ -1305,8 +1288,7 @@ pub mod tests {
                     expected_edge(&constraints[2], var_animal.into(), var_name.into(), vec![(type_cat, type_catname)]),
                 ],
                 nested_disjunctions: Vec::new(),
-                nested_negations: Vec::new(),
-                nested_optionals: Vec::new(),
+                
             };
             assert_eq!(expected_graph, graph);
         }
@@ -1411,8 +1393,7 @@ pub mod tests {
                     ),
                 ],
                 nested_disjunctions: Vec::new(),
-                nested_negations: Vec::new(),
-                nested_optionals: Vec::new(),
+                
             };
             assert_eq!(expected_graph.vertices, graph.vertices);
             assert_eq!(expected_graph.edges, graph.edges);
@@ -1457,8 +1438,6 @@ pub mod tests {
                 vec![(type_cat, type_catname), (type_dog, type_dogname)],
             )],
             nested_disjunctions: vec![],
-            nested_negations: vec![],
-            nested_optionals: vec![],
         };
 
         let snapshot = storage.clone().open_snapshot_write();

--- a/compiler/annotation/type_seeder.rs
+++ b/compiler/annotation/type_seeder.rs
@@ -62,13 +62,13 @@ impl<'this, Snapshot: ReadableSnapshot> TypeGraphSeedingContext<'this, Snapshot>
     pub(crate) fn create_graph<'graph>(
         &self,
         context: &BlockContext,
-        upstream_annotations: &BTreeMap<Variable, Arc<BTreeSet<TypeAnnotation>>>,
+        upstream_annotations: &BTreeMap<Vertex<Variable>, BTreeSet<TypeAnnotation>>,
         conjunction: &'graph Conjunction,
     ) -> Result<TypeInferenceGraph<'graph>, TypeInferenceError> {
         let mut graph = self.build_recursive(context, conjunction);
         // Pre-seed with upstream variable annotations.
-        for variable in context.referenced_variables() {
-            if let Some(annotations) = upstream_annotations.get(&variable) {
+        for variable in conjunction.referenced_variables() {
+            if let Some(annotations) = upstream_annotations.get(&Vertex::Variable(variable)) {
                 graph.vertices.add_or_intersect(&Vertex::Variable(variable), Cow::Borrowed(annotations));
             }
         }

--- a/compiler/annotation/type_seeder.rs
+++ b/compiler/annotation/type_seeder.rs
@@ -123,29 +123,7 @@ impl<'this, Snapshot: ReadableSnapshot> TypeGraphSeedingContext<'this, Snapshot>
         self.prune_abstract_types_from_thing_vertex_annotations_recursive(graph)?;
 
         // Seed edges in root & disjunctions
-        self.seed_edges(graph).map_err(|source| TypeInferenceError::ConceptRead { typedb_source: source })?;
-
-        // Now we recurse into the nested negations & optionals
-        self.seed_types_in_nested_negations_and_optionals(graph, context)
-    }
-
-    fn seed_types_in_nested_negations_and_optionals(
-        &self,
-        graph: &mut TypeInferenceGraph<'_>,
-        context: &BlockContext,
-    ) -> Result<(), TypeInferenceError> {
-        let TypeInferenceGraph { vertices, nested_disjunctions, nested_negations, nested_optionals, .. } = graph;
-        for nested_graph in nested_disjunctions.iter_mut().flat_map(|disjunction| disjunction.disjunction.iter_mut()) {
-            self.seed_types_in_nested_negations_and_optionals(nested_graph, context)?;
-        }
-        for nested_graph in nested_negations {
-            self.seed_types(nested_graph, context, vertices)?;
-        }
-        for nested_graph in nested_optionals {
-            self.seed_types(nested_graph, context, vertices)?;
-        }
-
-        Ok(())
+        self.seed_edges(graph).map_err(|source| TypeInferenceError::ConceptRead { typedb_source: source })
     }
 
     fn build_recursive<'conj>(
@@ -154,18 +132,13 @@ impl<'this, Snapshot: ReadableSnapshot> TypeGraphSeedingContext<'this, Snapshot>
         conjunction: &'conj Conjunction,
     ) -> TypeInferenceGraph<'conj> {
         let mut nested_disjunctions = Vec::new();
-        let mut nested_optionals = Vec::new();
-        let mut nested_negations = Vec::new();
         for pattern in conjunction.nested_patterns() {
             match pattern {
                 NestedPattern::Disjunction(disjunction) => {
                     nested_disjunctions.push(self.build_disjunction_recursive(context, conjunction, disjunction));
                 }
-                NestedPattern::Negation(negation) => {
-                    nested_negations.push(self.build_recursive(context, negation.conjunction()));
-                }
-                NestedPattern::Optional(optional) => {
-                    nested_optionals.push(self.build_recursive(context, optional.conjunction()));
+                NestedPattern::Negation(_) | NestedPattern::Optional(_) => {
+                    // Done after full type-inference for the conjunctions & disjunctions.
                 }
             }
         }
@@ -175,8 +148,6 @@ impl<'this, Snapshot: ReadableSnapshot> TypeGraphSeedingContext<'this, Snapshot>
             vertices: VertexAnnotations::default(),
             edges: Vec::new(),
             nested_disjunctions,
-            nested_negations,
-            nested_optionals,
         }
     }
 
@@ -592,12 +563,6 @@ impl<'this, Snapshot: ReadableSnapshot> TypeGraphSeedingContext<'this, Snapshot>
             }
         }
         for nested in graph.nested_disjunctions.iter_mut().flat_map(|nested| nested.disjunction.iter_mut()) {
-            self.prune_abstract_types_from_thing_vertex_annotations_recursive(nested)?;
-        }
-        for nested in &mut graph.nested_negations {
-            self.prune_abstract_types_from_thing_vertex_annotations_recursive(nested)?;
-        }
-        for nested in &mut graph.nested_optionals {
             self.prune_abstract_types_from_thing_vertex_annotations_recursive(nested)?;
         }
         Ok(())
@@ -1752,8 +1717,6 @@ pub mod tests {
                 expected_edge(&constraints[4], var_animal.into(), var_name.into(), vec![(type_cat, type_catname)]),
             ],
             nested_disjunctions: vec![],
-            nested_negations: vec![],
-            nested_optionals: vec![],
         };
 
         let snapshot = storage.clone().open_snapshot_write();
@@ -1888,8 +1851,6 @@ pub mod tests {
                     ),
                 ],
                 nested_disjunctions: vec![],
-                nested_negations: vec![],
-                nested_optionals: vec![],
             };
 
             let snapshot = storage.clone().open_snapshot_write();


### PR DESCRIPTION
## Product change and motivation
Since negated & optional patterns cannot influence the type-annotations of the containing conjunction, we need not interleave their type-inference  with that of the parent conjunction. Hence, We refactor the type-inference procedure so that type-inference on a conjunction & its disjunctions is completed before we begin the process on negated & optional subpatterns. 

## Implementation
* Rip out `nested_negations` & `nested_optionals` from `TypeInferenceGraph`, the type-seeding process, and the pruning process.
* For brevity,  disjunctions means a root conjunction and all its nested disjunctions (recursively). negations means any negation (or optional) in the root conjunction or any of its nested disjunctions.  negations may contain more disjunctions.
  - infer_types used to do seeding, pruning & validation of disjunctions & negations interleaved.
  - Now infer_types is first done on all the disjunctions, followed by the negations.
  - This makes the logic easier to follow & makes it obvious that negations don't influence disjunctions.