### PR TITLE
Rename config and CLI fields to align with the naming conventions

### DIFF
--- a/server/config.yml
+++ b/server/config.yml
@@ -4,8 +4,9 @@
 
 server:
     address: 0.0.0.0:1729
-    http-enabled: true
-    http-address: 0.0.0.0:8000
+    http:
+        enabled: true
+        address: 0.0.0.0:8000
 
     authentication:
         token-expiration-seconds: 5000
@@ -13,7 +14,7 @@ server:
     encryption:
         enabled: false
         certificate:
-        certificate_key:
+        certificate-key:
         ca-certificate:
 
 storage:
@@ -29,6 +30,3 @@ diagnostics:
     reporting:
         metrics: true
         errors: true
-
-development-mode:
-    enabled: false

--- a/server/lib.rs
+++ b/server/lib.rs
@@ -96,9 +96,9 @@ impl Server {
         Self::install_default_encryption_provider()?;
 
         let grpc_address = Self::resolve_address(self.config.server.address).await;
-        let http_address_opt = if self.config.server.http_enabled {
+        let http_address_opt = if self.config.server.http.enabled {
             Some(
-                Self::validate_and_resolve_http_address(self.config.server.http_address.clone(), grpc_address.clone())
+                Self::validate_and_resolve_http_address(self.config.server.http.address.clone(), grpc_address.clone())
                     .await?,
             )
         } else {

--- a/server/parameters/cli.rs
+++ b/server/parameters/cli.rs
@@ -46,7 +46,7 @@ pub struct CLIArgs {
 
     /// Encryption certificate key. Must be supplied if encryption is enabled
     #[arg(long = "server.encryption.certificate-key", value_name = "FILE")]
-    pub server_encryption_cert_key: Option<String>,
+    pub server_encryption_certificate_key: Option<String>,
 
     /// Encryption CA in PEM format.
     #[arg(long = "server.encryption.ca-certificate", value_name = "FILE")]
@@ -54,11 +54,11 @@ pub struct CLIArgs {
 
     /// Path to the data directory
     #[arg(long = "storage.data-directory", value_name = "DIR")]
-    pub storage_data: Option<String>,
+    pub storage_data_directory: Option<String>,
 
     /// Path to the log directory
-    #[arg(long = "logging.logdir")]
-    pub logging_logdir: Option<String>,
+    #[arg(long = "logging.directory")]
+    pub logging_directory: Option<String>,
 
     /// Enable usage metrics reporting
     #[arg(long = "diagnostics.reporting.metrics")]


### PR DESCRIPTION
## Product change and motivation
Perform the following renames in config files:
* `server.http-enabled` -> `server.http.enabled`
* `server.http-address` -> `server.http.address`
* `server.encryption.certificate_key` -> `server.encryption.certificate-key`

Perform the following renames in CLI arguments:
* `logging.logdir` -> `logging.directory`

## Implementation