### PR TITLE
Variables referenced in only some branches of a disjunction are required inputs

### DIFF
--- a/compiler/executable/match_/planner/plan.rs
+++ b/compiler/executable/match_/planner/plan.rs
@@ -123,6 +123,11 @@ fn make_builder<'a>(
     for pattern in conjunction.nested_patterns() {
         match pattern {
             NestedPattern::Disjunction(disjunction) => {
+                let disjunction_dependency_modes = disjunction.variable_dependency(block_context);
+                let required_inputs = disjunction_dependency_modes.iter().filter(|(v,mode)| {
+                        mode.is_referencing() && block_context.is_variable_available(conjunction.scope_id(), **v)
+                    }).map(|(v,_)| *v)
+                    .chain(disjunction.required_inputs(block_context)).collect::<Vec<_>>();
                 let planner = DisjunctionPlanBuilder::new(
                     disjunction.conjunctions_by_branch_id().map(|(id, _)| *id).collect(),
                     disjunction
@@ -146,7 +151,7 @@ fn make_builder<'a>(
                             )
                         })
                         .collect::<Result<Vec<_>, _>>()?,
-                    disjunction.required_inputs(block_context).collect(),
+                    required_inputs,
                 );
                 disjunction_planners.push(planner)
             }

--- a/ir/pattern/disjunction.rs
+++ b/ir/pattern/disjunction.rs
@@ -72,7 +72,7 @@ impl Disjunction {
         self.variable_dependency(block_context).into_iter().filter_map(|(v, dep)| dep.is_required().then_some(v))
     }
 
-    pub(crate) fn variable_dependency(
+    pub fn variable_dependency(
         &self,
         block_context: &BlockContext,
     ) -> HashMap<Variable, VariableBindingMode<'_>> {


### PR DESCRIPTION
## Product change and motivation
Updates the planner to treat variables which are referenced in "some but not all" branches of a disjunction as "required inputs". This means a pattern binding the variable must be bound before the disjunction can be scheduled.

## Implementation
- fixes #7475 