### PR TITLE
Publicly expose GRPC error traits to reuse in cluster

### DIFF
--- a/server/service/grpc/error.rs
+++ b/server/service/grpc/error.rs
@@ -85,7 +85,7 @@ impl IntoGrpcStatus for ProtocolError {
     }
 }
 
-pub(crate) trait IntoProtocolErrorMessage {
+pub trait IntoProtocolErrorMessage {
     fn into_error_message(self) -> typedb_protocol::Error;
 }
 
@@ -100,7 +100,7 @@ impl<T: TypeDBError + Sync> IntoProtocolErrorMessage for T {
     }
 }
 
-pub(crate) trait IntoGrpcStatus {
+pub trait IntoGrpcStatus {
     fn into_status(self) -> Status;
 }
 

--- a/server/service/grpc/mod.rs
+++ b/server/service/grpc/mod.rs
@@ -4,6 +4,8 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
+pub use error::{IntoGrpcStatus, IntoProtocolErrorMessage};
+
 pub(crate) mod authenticator;
 pub(crate) mod concept;
 mod diagnostics;

--- a/server/service/http/message/mod.rs
+++ b/server/service/http/message/mod.rs
@@ -11,7 +11,7 @@ pub mod error;
 pub mod query;
 pub mod transaction;
 pub mod user;
-pub(crate) mod version;
+pub mod version;
 
 macro_rules! stringify_kebab_case {
     ($t:tt) => {

--- a/server/service/http/message/version.rs
+++ b/server/service/http/message/version.rs
@@ -24,8 +24,8 @@ use crate::service::http::error::HttpServiceError;
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ServerVersionResponse {
-    distribution: String,
-    version: String,
+    pub distribution: String,
+    pub version: String,
 }
 
 pub(crate) fn encode_server_version(distribution: String, version: String) -> ServerVersionResponse {

--- a/server/service/mod.rs
+++ b/server/service/mod.rs
@@ -3,8 +3,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
-use serde::{Deserialize, Serialize};
 pub use grpc::{IntoGrpcStatus, IntoProtocolErrorMessage};
+use serde::{Deserialize, Serialize};
 
 pub(crate) mod export_service;
 pub(crate) mod grpc;

--- a/server/service/mod.rs
+++ b/server/service/mod.rs
@@ -4,6 +4,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 use serde::{Deserialize, Serialize};
+pub use grpc::{IntoGrpcStatus, IntoProtocolErrorMessage};
 
 pub(crate) mod export_service;
 pub(crate) mod grpc;

--- a/tests/behaviour/service/http/http_steps/connection/mod.rs
+++ b/tests/behaviour/service/http/http_steps/connection/mod.rs
@@ -18,7 +18,7 @@ use test_utils::create_tmp_dir;
 
 use crate::{
     generic_step,
-    message::{authenticate, authenticate_default, check_health, databases, send_get_request, users},
+    message::{authenticate, authenticate_default, check_health, databases, send_get_request, version,users},
     Context, HttpBehaviourTestError, TEST_TOKEN_EXPIRATION,
 };
 
@@ -156,6 +156,22 @@ async fn connection_opens_with_a_wrong_port(context: &mut Context, may_error: pa
         )
         .await,
     );
+}
+
+#[apply(generic_step)]
+#[step(expr = r"connection contains distribution{may_error}")]
+async fn connection_has_distribution(context: &mut Context, may_error: params::MayError) {
+    if let Either::Left(server_version) = may_error.check(version(context.http_client()).await) {
+        assert!(!server_version.distribution.is_empty());
+    }
+}
+
+#[apply(generic_step)]
+#[step(expr = r"connection contains version{may_error}")]
+async fn connection_has_version(context: &mut Context, may_error: params::MayError) {
+    if let Either::Left(server_version) = may_error.check(version(context.http_client()).await) {
+        assert!(!server_version.version.is_empty());
+    }
 }
 
 #[apply(generic_step)]

--- a/tests/behaviour/service/http/http_steps/connection/mod.rs
+++ b/tests/behaviour/service/http/http_steps/connection/mod.rs
@@ -160,7 +160,7 @@ async fn connection_opens_with_a_wrong_port(context: &mut Context, may_error: pa
 
 #[apply(generic_step)]
 #[step(expr = r"connection contains distribution{may_error}")]
-async fn connection_has_distribution(context: &mut Context, may_error: params::MayError) {
+async fn connection_contains_distribution(context: &mut Context, may_error: params::MayError) {
     if let Either::Left(server_version) = may_error.check(version(context.http_client()).await) {
         assert!(!server_version.distribution.is_empty());
     }
@@ -168,7 +168,7 @@ async fn connection_has_distribution(context: &mut Context, may_error: params::M
 
 #[apply(generic_step)]
 #[step(expr = r"connection contains version{may_error}")]
-async fn connection_has_version(context: &mut Context, may_error: params::MayError) {
+async fn connection_contains_version(context: &mut Context, may_error: params::MayError) {
     if let Either::Left(server_version) = may_error.check(version(context.http_client()).await) {
         assert!(!server_version.version.is_empty());
     }

--- a/tests/behaviour/service/http/http_steps/connection/mod.rs
+++ b/tests/behaviour/service/http/http_steps/connection/mod.rs
@@ -18,7 +18,7 @@ use test_utils::create_tmp_dir;
 
 use crate::{
     generic_step,
-    message::{authenticate, authenticate_default, check_health, databases, send_get_request, version,users},
+    message::{authenticate, authenticate_default, check_health, databases, send_get_request, users, version},
     Context, HttpBehaviourTestError, TEST_TOKEN_EXPIRATION,
 };
 

--- a/tests/behaviour/service/http/http_steps/message.rs
+++ b/tests/behaviour/service/http/http_steps/message.rs
@@ -25,7 +25,7 @@ use server::service::http::message::{
     user::{UserResponse, UsersResponse},
 };
 use url::form_urlencoded;
-
+use server::service::http::message::version::ServerVersionResponse;
 use crate::{Context, HttpBehaviourTestError};
 
 async fn send_request(
@@ -131,6 +131,14 @@ pub async fn authenticate(
     });
     let response =
         send_request(http_client, None::<&str>, Method::POST, &url, Some(json_body.to_string().as_str())).await?;
+    Ok(serde_json::from_str(&response).expect("Expected a json body"))
+}
+
+pub async fn version(
+    http_client: &Client<HttpConnector>
+) -> Result<ServerVersionResponse, HttpBehaviourTestError> {
+    let url = format!("{}/version", Context::default_versioned_endpoint());
+    let response = send_request(http_client, None::<&str>, Method::GET, &url, None).await?;
     Ok(serde_json::from_str(&response).expect("Expected a json body"))
 }
 

--- a/tests/behaviour/service/http/http_steps/message.rs
+++ b/tests/behaviour/service/http/http_steps/message.rs
@@ -23,9 +23,10 @@ use server::service::http::message::{
     },
     transaction::{TransactionOptionsPayload, TransactionResponse},
     user::{UserResponse, UsersResponse},
+    version::ServerVersionResponse,
 };
 use url::form_urlencoded;
-use server::service::http::message::version::ServerVersionResponse;
+
 use crate::{Context, HttpBehaviourTestError};
 
 async fn send_request(
@@ -134,9 +135,7 @@ pub async fn authenticate(
     Ok(serde_json::from_str(&response).expect("Expected a json body"))
 }
 
-pub async fn version(
-    http_client: &Client<HttpConnector>
-) -> Result<ServerVersionResponse, HttpBehaviourTestError> {
+pub async fn version(http_client: &Client<HttpConnector>) -> Result<ServerVersionResponse, HttpBehaviourTestError> {
     let url = format!("{}/version", Context::default_versioned_endpoint());
     let response = send_request(http_client, None::<&str>, Method::GET, &url, None).await?;
     Ok(serde_json::from_str(&response).expect("Expected a json body"))


### PR DESCRIPTION
## Product change and motivation
Allow external crate's users to use `IntoGrpcStatus` and `IntoProtocolErrorMessage` traits to convert `TypeDBError`s into typedb protocol errors and, then, GRPC statuses.

## Implementation
Instead of exposing the whole `service/grpc` mod or its `error` submod with service-specific errors, we safely expose only the traits required.

Additionally, for convenience, add version BDD step implementation to handle new `typedb-driver`'s public API tests, affecting the HTTP endpoint.