### PR TITLE
Refactor bazel build dependencies

### DIFF
--- a/durability/BUILD
+++ b/durability/BUILD
@@ -28,7 +28,6 @@ rust_library(
     deps = [
         "//common/error",
         "//common/logger",
-        "//common/primitive",
         "//resource",
 
         "@crates//:itertools",

--- a/durability/tests/BUILD
+++ b/durability/tests/BUILD
@@ -34,7 +34,6 @@ rust_test(
         "//durability/tests/crash/recoverer:recoverer"
     ],
     deps = [
-        "//durability/tests/common:durability_test_common",
         "@crates//:tempdir"
     ],
     use_libtest_harness = False,

--- a/storage/BUILD
+++ b/storage/BUILD
@@ -18,13 +18,11 @@ rust_library(
     deps = [
         "//common/bytes",
         "//common/error",
-        "//common/iterator",
         "//common/lending_iterator",
         "//common/logger",
         "//common/primitive",
         "//durability",
         "//resource",
-        "//util/project",
 
         "@typeql//rust:typeql", # leaky but enables generic TypeDBError
 

--- a/tests/benchmarks/iam/BUILD
+++ b/tests/benchmarks/iam/BUILD
@@ -18,8 +18,6 @@ rust_test(
         "//query",
         "//storage",
 
-        "//concept/tests:test_utils_concept",
-        "//encoding/tests:test_utils_encoding",
         "//util/test:test_utils",
 
         "@typeql//rust:typeql",

--- a/util/project/BUILD
+++ b/util/project/BUILD
@@ -12,9 +12,7 @@ rust_library(
     srcs = glob([
         "*.rs",
     ]),
-    deps = [
-        "//common/logger",
-    ]
+    deps = []
 )
 
 checkstyle_test(


### PR DESCRIPTION
## Product change and motivation

We've identified some redundant dependencies in bazel build scripts, which are harmful to incremental/parallel build. 
We refactored them as part of a research project on dependency reduction.

## Implementation

Edit `deps` in BUILD.

---

Feel free to leave feedback, suggest improvements, or directly edit this PR.
Thanks for your support!