### PR TITLE
Support inserting attributes from values of other attributes 

### DIFF
--- a/answer/variable_value.rs
+++ b/answer/variable_value.rs
@@ -47,7 +47,6 @@ impl<'a> VariableValue<'a> {
     pub fn as_value(&self) -> &Value<'a> {
         match self {
             VariableValue::Value(value) => value,
-            // TODO: Do we want to implicit cast from attributes?
             _ => panic!("VariableValue is not a value: {:?}", self),
         }
     }

--- a/dependencies/typedb/repositories.bzl
+++ b/dependencies/typedb/repositories.bzl
@@ -36,5 +36,5 @@ def typedb_behaviour():
     git_repository(
         name = "typedb_behaviour",
         remote = "https://github.com/typedb/typedb-behaviour",
-        commit = "b89d74a8652753ec96494f8b1608ff1f85aefd8a",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @typedb_behaviour
+        commit = "53029e88ca6550818891f2b41f622edfc062bd67",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @typedb_behaviour
     )


### PR DESCRIPTION
## Product change and motivation
Support inserting attributes from values of other attributes 

```typeql
match $x isa src-attr;
insert $y isa dst-attr == $x;
```

fixes #7551 