### PR TITLE
Add WAL truncation methods 

### DIFF
--- a/durability/durability.rs
+++ b/durability/durability.rs
@@ -48,6 +48,8 @@ pub trait DurabilityService {
         record_type: DurabilityRecordType,
     ) -> Result<Option<RawRecord<'static>>, DurabilityServiceError>;
 
+    fn truncate_from(&self, sequence_number: DurabilitySequenceNumber) -> Result<(), DurabilityServiceError>;
+
     fn delete_durability(self) -> Result<(), DurabilityServiceError>;
 
     fn reset(&mut self) -> Result<(), DurabilityServiceError>;

--- a/storage/durability_client.rs
+++ b/storage/durability_client.rs
@@ -5,7 +5,6 @@
  */
 
 use std::{
-    borrow::Cow,
     io::{self, Read, Write},
     sync::{mpsc, Arc},
 };
@@ -95,6 +94,8 @@ pub trait DurabilityClient {
     fn find_last_unsequenced_type<Record: UnsequencedDurabilityRecord>(
         &self,
     ) -> Result<Option<Record>, DurabilityClientError>;
+
+    fn truncate_from(&self, sequence_number: SequenceNumber) -> Result<(), DurabilityClientError>;
 
     fn delete_durability(self) -> Result<(), DurabilityClientError>;
 
@@ -200,6 +201,10 @@ impl DurabilityClient for WALClient {
             Ok(None) => Ok(None),
             Err(err) => Err(DurabilityClientError::ServiceError { source: err }),
         }
+    }
+
+    fn truncate_from(&self, sequence_number: SequenceNumber) -> Result<(), DurabilityClientError> {
+        self.wal.truncate_from(sequence_number).map_err(|err| DurabilityClientError::ServiceError { source: err })
     }
 
     fn delete_durability(self) -> Result<(), DurabilityClientError> {


### PR DESCRIPTION
## Product change and motivation
Expose public interfaces to request WAL's truncation starting from a sequential number. This is a required feature to use WAL as a serial storage for TypeDB Cluster's Raft log, which allows and expects record overriding.

## Implementation
