### PR TITLE
Enforce stratification through single return functions

### DIFF
--- a/dependencies/typedb/repositories.bzl
+++ b/dependencies/typedb/repositories.bzl
@@ -35,6 +35,6 @@ def typedb_protocol():
 def typedb_behaviour():
     git_repository(
         name = "typedb_behaviour",
-        remote = "https://github.com/krishnangovindraj/typedb-behaviour",
-        commit = "c611b83af954b8639d7ead5c0b2d39a079327d81",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @typedb_behaviour
+        remote = "https://github.com/typedb/typedb-behaviour",
+        commit = "b89d74a8652753ec96494f8b1608ff1f85aefd8a",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @typedb_behaviour
     )

--- a/dependencies/typedb/repositories.bzl
+++ b/dependencies/typedb/repositories.bzl
@@ -35,6 +35,6 @@ def typedb_protocol():
 def typedb_behaviour():
     git_repository(
         name = "typedb_behaviour",
-        remote = "https://github.com/typedb/typedb-behaviour",
-        commit = "87348ee136df8bacdd01ff19a7d5ae7c1e7b8c90",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @typedb_behaviour
+        remote = "https://github.com/krishnangovindraj/typedb-behaviour",
+        commit = "c611b83af954b8639d7ead5c0b2d39a079327d81",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @typedb_behaviour
     )

--- a/function/function_manager.rs
+++ b/function/function_manager.rs
@@ -353,12 +353,16 @@ fn validate_no_cycles_impl<ID: FunctionIDAPI + Ord + Eq>(
                 | TranslatedStage::Reduce(_)
         )
     });
-    let has_aggregate_return = match function.function_body.return_operation {
-        ReturnOperation::Stream(_, _) | ReturnOperation::Single(_, _, _) => false,
+    let has_non_stream_return = match function.function_body.return_operation {
+        ReturnOperation::Stream(_, _) => false,
+        ReturnOperation::Single(_, _, _) => true,
         ReturnOperation::ReduceCheck(_) | ReturnOperation::ReduceReducer(_, _) => true,
     };
-    let unnegated_stratum =
-        if has_aggregate_stage || has_aggregate_return { current_stratum.add(1, 1) } else { current_stratum.add(0, 1) };
+    let unnegated_stratum = if has_aggregate_stage || has_non_stream_return {
+        current_stratum.add(1, 1)
+    } else {
+        current_stratum.add(0, 1)
+    };
     for called_id in unnegated_function_calls(function) {
         validate_no_cycles_impl(called_id, functions, active, complete, unnegated_stratum)?;
     }

--- a/function/lib.rs
+++ b/function/lib.rs
@@ -29,6 +29,6 @@ typedb_error! {
         CreateFunctionEncoding(6, "Encoding error while trying to create function.", source: EncodingError),
         FunctionRetrieval(7, "Error retrieving function.", typedb_source: FunctionReadError),
         CommittedFunctionParseError(8, "Error while parsing committed function.", typedb_source: typeql::Error),
-        StratificationViolation(9, "Detected a recursive cycle through a negation or reduction: [{cycle_names}]", cycle_names: String),
+        StratificationViolation(9, "Detected a recursive cycle through a negation, reduction or single return: [{cycle_names}]", cycle_names: String),
     }
 }


### PR DESCRIPTION
## Product change and motivation
Single return functions may not call themselves recursively.  Addresses #7550 

This will now fail:
```typeql
  define
    fun last_number() -> integer:
    match
      let $number = last_number() + 1;
    return last $number;
```
