### PR TITLE
Allow empty define

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -56,6 +56,7 @@ rust_binary(
 assemble_files = {
     "//:LICENSE": "LICENSE",
 }
+
 empty_directories = [
     "server/data",
 ]

--- a/dependencies/typedb/repositories.bzl
+++ b/dependencies/typedb/repositories.bzl
@@ -36,5 +36,5 @@ def typedb_behaviour():
     git_repository(
         name = "typedb_behaviour",
         remote = "https://github.com/typedb/typedb-behaviour",
-        commit = "37e3c823be327ed023ac554a044d2996de10ac3b",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @typedb_behaviour
+        commit = "f74ee6066ccddbbf94618b1c10273c8e5efcfe09",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @typedb_behaviour
     )

--- a/dependencies/typedb/repositories.bzl
+++ b/dependencies/typedb/repositories.bzl
@@ -35,6 +35,6 @@ def typedb_protocol():
 def typedb_behaviour():
     git_repository(
         name = "typedb_behaviour",
-        remote = "https://github.com/typedb/typedb-behaviour",
-        commit = "53029e88ca6550818891f2b41f622edfc062bd67",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @typedb_behaviour
+        remote = "https://github.com/flyingsilverfin/typedb-behaviour",
+        commit = "514f6c6c94ab7872846e9885626142e665a434d8",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @typedb_behaviour
     )

--- a/dependencies/typedb/repositories.bzl
+++ b/dependencies/typedb/repositories.bzl
@@ -22,7 +22,7 @@ def typeql():
     git_repository(
         name = "typeql",
         remote = "https://github.com/typedb/typeql",
-        tag = "3.2.0",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @typedb_driver
+        commit = "4c73ae8089e70cfa88fe0b3879c4564a15474a8f",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @typedb_driver
     )
 
 def typedb_protocol():
@@ -35,6 +35,6 @@ def typedb_protocol():
 def typedb_behaviour():
     git_repository(
         name = "typedb_behaviour",
-        remote = "https://github.com/flyingsilverfin/typedb-behaviour",
-        commit = "514f6c6c94ab7872846e9885626142e665a434d8",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @typedb_behaviour
+        remote = "https://github.com/typedb/typedb-behaviour",
+        commit = "37e3c823be327ed023ac554a044d2996de10ac3b",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @typedb_behaviour
     )

--- a/query/redefine.rs
+++ b/query/redefine.rs
@@ -84,6 +84,9 @@ pub(crate) fn execute(
     redefine: Redefine,
     storage_counters: StorageCounters,
 ) -> Result<(), RedefineError> {
+    if redefine.definables.is_empty() {
+        return Ok(());
+    }
     let redefined_structs = process_struct_redefinitions(snapshot, type_manager, thing_manager, &redefine.definables)?;
     let redefined_types =
         process_type_redefinitions(snapshot, type_manager, thing_manager, &redefine.definables, storage_counters)?;

--- a/server/service/export_service.rs
+++ b/server/service/export_service.rs
@@ -14,14 +14,14 @@ pub(crate) fn get_transaction_schema<D: DurabilityClient>(
 ) -> Result<String, DatabaseExportError> {
     let types_syntax = get_types_syntax(transaction)?;
     let functions_syntax = get_functions_syntax(transaction)?;
-    Ok(format!("{}\n{}{}\n", typeql::token::Clause::Define, types_syntax, functions_syntax))
+    Ok(format!("{}\n{}{}\n", typeql::token::Clause::Define, types_syntax, functions_syntax).trim().to_owned())
 }
 
 pub(crate) fn get_transaction_type_schema<D: DurabilityClient>(
     transaction: &TransactionRead<D>,
 ) -> Result<String, DatabaseExportError> {
     let types_syntax = get_types_syntax(transaction)?;
-    Ok(format!("{}\n{}\n", typeql::token::Clause::Define, types_syntax))
+    Ok(format!("{}\n{}\n", typeql::token::Clause::Define, types_syntax).trim().to_owned())
 }
 
 fn get_types_syntax<D: DurabilityClient>(transaction: &TransactionRead<D>) -> Result<String, DatabaseExportError> {

--- a/server/service/export_service.rs
+++ b/server/service/export_service.rs
@@ -14,24 +14,14 @@ pub(crate) fn get_transaction_schema<D: DurabilityClient>(
 ) -> Result<String, DatabaseExportError> {
     let types_syntax = get_types_syntax(transaction)?;
     let functions_syntax = get_functions_syntax(transaction)?;
-
-    let schema = match types_syntax.is_empty() & functions_syntax.is_empty() {
-        true => String::new(),
-        false => format!("{}\n{}{}\n", typeql::token::Clause::Define, types_syntax, functions_syntax),
-    };
-    Ok(schema)
+    Ok(format!("{}\n{}{}\n", typeql::token::Clause::Define, types_syntax, functions_syntax))
 }
 
 pub(crate) fn get_transaction_type_schema<D: DurabilityClient>(
     transaction: &TransactionRead<D>,
 ) -> Result<String, DatabaseExportError> {
     let types_syntax = get_types_syntax(transaction)?;
-
-    let type_schema = match types_syntax.is_empty() {
-        true => String::new(),
-        false => format!("{}\n{}\n", typeql::token::Clause::Define, types_syntax),
-    };
-    Ok(type_schema)
+    Ok(format!("{}\n{}\n", typeql::token::Clause::Define, types_syntax))
 }
 
 fn get_types_syntax<D: DurabilityClient>(transaction: &TransactionRead<D>) -> Result<String, DatabaseExportError> {


### PR DESCRIPTION
## Product change and motivation

Since https://github.com/typedb/typeql/pull/412 is implemented, empty define queries are allowed. This means that schema export that used to return an empty string for empty schemas can now return an empty `define` query, which is much easier to work with on the client side.

This addresses https://github.com/typedb/typedb/issues/7531

## Implementation

- update dependencies with latest TypeQL and Behaviour changes
- empty schema export uses an empty `define` to indicate an empty schema, instead of an empty string
