### PR TITLE
Lock attributes on updating connections

### DIFF
--- a/compiler/annotation/match_inference.rs
+++ b/compiler/annotation/match_inference.rs
@@ -130,7 +130,7 @@ pub fn infer_types(
         &mut type_annotations_by_scope,
     )?;
     // Copy over any input variables that haven't been included (and refined)
-    let mut root_annotations = type_annotations_by_scope.get_mut(&ScopeId::ROOT).unwrap().vertex_annotations_mut();
+    let root_annotations = type_annotations_by_scope.get_mut(&ScopeId::ROOT).unwrap().vertex_annotations_mut();
     let annotations_passing_through = previous_stage_variable_annotations
         .iter()
         .filter(|(k, _)| !root_annotations.contains_key(&Vertex::Variable(**k)))

--- a/compiler/executable/match_/planner/mod.rs
+++ b/compiler/executable/match_/planner/mod.rs
@@ -13,7 +13,7 @@ use answer::variable::Variable;
 use concept::thing::statistics::Statistics;
 use error::typedb_error;
 use ir::{
-    pattern::{constraint::ExpressionBinding, variable_category::VariableOptionality, BranchID, Vertex},
+    pattern::{constraint::ExpressionBinding, BranchID, Vertex},
     pipeline::{block::Block, function_signature::FunctionID, VariableRegistry},
 };
 use itertools::Itertools;

--- a/compiler/executable/match_/planner/plan.rs
+++ b/compiler/executable/match_/planner/plan.rs
@@ -9,7 +9,7 @@ use std::{
     cmp::{Ordering, Reverse},
     collections::{BTreeMap, BTreeSet, BinaryHeap, HashMap, HashSet},
     fmt,
-    hash::{Hash},
+    hash::Hash,
     sync::Arc,
 };
 

--- a/compiler/executable/match_/planner/plan.rs
+++ b/compiler/executable/match_/planner/plan.rs
@@ -9,7 +9,7 @@ use std::{
     cmp::{Ordering, Reverse},
     collections::{BTreeMap, BTreeSet, BinaryHeap, HashMap, HashSet},
     fmt,
-    hash::{DefaultHasher, Hash},
+    hash::{Hash},
     sync::Arc,
 };
 
@@ -52,7 +52,6 @@ use crate::{
                 CheckInstruction, CheckVertex, ConstraintInstruction, Inputs, IsInstruction,
             },
             planner::{
-                conjunction_executable::ExecutionStep,
                 vertex::{
                     constraint::{
                         ConstraintVertex, HasPlanner, IidPlanner, IndexedRelationPlanner, IsaPlanner, LinksPlanner,
@@ -63,7 +62,7 @@ use crate::{
                     FunctionCallVertex, Input, IsVertex, LinksDeduplicationVertex, NegationVertex, OptionalVertex,
                     PlannerVertex, UnsatisfiableVertex,
                 },
-                CheckBuilder, ConjunctionExecutableBuilder, DisjunctionBuilder, ExpressionBuilder, FunctionCallBuilder,
+                ConjunctionExecutableBuilder, DisjunctionBuilder, ExpressionBuilder, FunctionCallBuilder,
                 IntersectionBuilder, NegationBuilder, OptionalBuilder, StepBuilder, StepInstructionsBuilder,
             },
         },
@@ -2296,7 +2295,7 @@ impl<'a> Graph<'a> {
     pub(super) fn constraint_variables(&self) -> impl Iterator<Item = Variable> + '_ {
         self.elements
             .iter()
-            .filter(|(vertex_id, planner_vertex)| {
+            .filter(|(_vertex_id, planner_vertex)| {
                 match planner_vertex {
                 PlannerVertex::Constraint(_)
                 | PlannerVertex::Is(_)

--- a/concept/thing/attribute.rs
+++ b/concept/thing/attribute.rs
@@ -24,7 +24,7 @@ use encoding::{
         Typed,
     },
     layout::prefix::Prefix,
-    value::{value::Value},
+    value::value::Value,
     AsBytes, Keyable,
 };
 use iterator::State;

--- a/concept/thing/entity.rs
+++ b/concept/thing/entity.rs
@@ -22,7 +22,7 @@ use resource::{constants::snapshot::BUFFER_KEY_INLINE, profile::StorageCounters}
 use storage::snapshot::{ReadableSnapshot, WritableSnapshot};
 
 use crate::{
-    error::{ConceptWriteError},
+    error::ConceptWriteError,
     thing::{
         object::{Object, ObjectAPI},
         thing_manager::ThingManager,

--- a/concept/thing/entity.rs
+++ b/concept/thing/entity.rs
@@ -22,7 +22,7 @@ use resource::{constants::snapshot::BUFFER_KEY_INLINE, profile::StorageCounters}
 use storage::snapshot::{ReadableSnapshot, WritableSnapshot};
 
 use crate::{
-    error::{ConceptReadError, ConceptWriteError},
+    error::{ConceptWriteError},
     thing::{
         object::{Object, ObjectAPI},
         thing_manager::ThingManager,
@@ -80,11 +80,10 @@ impl ThingAPI for Entity {
         snapshot: &mut impl WritableSnapshot,
         thing_manager: &ThingManager,
         storage_counters: StorageCounters,
-    ) -> Result<(), Box<ConceptReadError>> {
+    ) {
         if matches!(self.get_status(snapshot, thing_manager, storage_counters), ConceptStatus::Persisted) {
             thing_manager.lock_existing_object(snapshot, *self);
         }
-        Ok(())
     }
 
     fn get_status(

--- a/concept/thing/mod.rs
+++ b/concept/thing/mod.rs
@@ -18,7 +18,7 @@ use resource::{
 use storage::snapshot::{ReadableSnapshot, WritableSnapshot};
 
 use crate::{
-    error::{ConceptReadError, ConceptWriteError},
+    error::{ConceptWriteError},
     thing::thing_manager::ThingManager,
     type_::TypeAPI,
     ConceptStatus,
@@ -51,7 +51,7 @@ pub trait ThingAPI: Sized + Clone {
         snapshot: &mut impl WritableSnapshot,
         thing_manager: &ThingManager,
         storage_counters: StorageCounters,
-    ) -> Result<(), Box<ConceptReadError>>;
+    );
 
     // TODO: implementers could cache the status in a OnceCell if we do many operations on the same Thing at once
     fn get_status(

--- a/concept/thing/mod.rs
+++ b/concept/thing/mod.rs
@@ -17,12 +17,7 @@ use resource::{
 };
 use storage::snapshot::{ReadableSnapshot, WritableSnapshot};
 
-use crate::{
-    error::{ConceptWriteError},
-    thing::thing_manager::ThingManager,
-    type_::TypeAPI,
-    ConceptStatus,
-};
+use crate::{error::ConceptWriteError, thing::thing_manager::ThingManager, type_::TypeAPI, ConceptStatus};
 
 pub mod attribute;
 pub mod entity;

--- a/concept/thing/object.rs
+++ b/concept/thing/object.rs
@@ -111,7 +111,7 @@ impl ThingAPI for Object {
         snapshot: &mut impl WritableSnapshot,
         thing_manager: &ThingManager,
         storage_counters: StorageCounters,
-    ) -> Result<(), Box<ConceptReadError>> {
+    ) {
         match self {
             Object::Entity(entity) => entity.set_required(snapshot, thing_manager, storage_counters),
             Object::Relation(relation) => relation.set_required(snapshot, thing_manager, storage_counters),

--- a/concept/thing/relation.rs
+++ b/concept/thing/relation.rs
@@ -390,11 +390,10 @@ impl ThingAPI for Relation {
         snapshot: &mut impl WritableSnapshot,
         thing_manager: &ThingManager,
         storage_counters: StorageCounters,
-    ) -> Result<(), Box<ConceptReadError>> {
+    ) {
         if matches!(self.get_status(snapshot, thing_manager, storage_counters), ConceptStatus::Persisted) {
             thing_manager.lock_existing_object(snapshot, *self);
         }
-        Ok(())
     }
 
     fn get_status(

--- a/concept/thing/thing_manager.rs
+++ b/concept/thing/thing_manager.rs
@@ -52,6 +52,7 @@ use encoding::{
 };
 use iterator::minmax_or;
 use itertools::Itertools;
+use typeql::parser::Rule::thing_constraint;
 use lending_iterator::Peekable;
 use primitive::either::Either;
 use resource::{
@@ -3094,8 +3095,10 @@ impl ThingManager {
         storage_counters: StorageCounters,
     ) -> Result<(), Box<ConceptWriteError>> {
         let count: u64 = 1;
-        // must be idempotent, so no lock required -- cannot fail
+        relation.set_required(snapshot, self, storage_counters.clone());
+        player.set_required(snapshot, self, storage_counters);
 
+        // must be idempotent, so no lock required -- cannot fail
         let links = ThingEdgeLinks::new(relation.vertex(), player.vertex(), role_type.vertex());
         snapshot.put_val(links.into_storage_key().into_owned_array(), ByteArray::copy(&encode_u64(count)));
 

--- a/concept/thing/thing_manager.rs
+++ b/concept/thing/thing_manager.rs
@@ -7,7 +7,6 @@
 use std::{
     borrow::Cow,
     collections::{Bound, HashMap, HashSet},
-    io::Read,
     iter::{once, Map},
     ops::RangeBounds,
     sync::Arc,
@@ -2455,7 +2454,7 @@ impl ThingManager {
         modified_owns: &mut HashMap<ObjectType, HashSet<AttributeType>>,
         modified_plays: &mut HashMap<ObjectType, HashSet<RoleType>>,
         modified_relates: &mut HashMap<RelationType, HashSet<RoleType>>,
-        storage_counters: StorageCounters,
+        _storage_counters: StorageCounters,
     ) -> Result<(), Box<ConceptReadError>> {
         // New / deleted capabilities
 
@@ -3011,8 +3010,8 @@ impl ThingManager {
             let has = ThingEdgeHas::new(owner.vertex(), attribute.vertex());
             let has_reverse = ThingEdgeHasReverse::new(attribute.vertex(), owner.vertex());
 
-            owner.set_required(snapshot, self, storage_counters.clone())?;
-            attribute.set_required(snapshot, self, storage_counters.clone())?;
+            owner.set_required(snapshot, self, storage_counters.clone());
+            attribute.set_required(snapshot, self, storage_counters.clone());
             snapshot.put_val(has.into_storage_key().into_owned_array(), ByteArray::copy(&encode_u64(count)));
             snapshot.put_val(has_reverse.into_storage_key().into_owned_array(), ByteArray::copy(&encode_u64(count)));
             Ok(())
@@ -3150,8 +3149,8 @@ impl ThingManager {
             let links = ThingEdgeLinks::new(relation.vertex(), player.vertex(), role_type.vertex());
             let links_reverse = ThingEdgeLinks::new_reverse(player.vertex(), relation.vertex(), role_type.vertex());
 
-            relation.set_required(snapshot, self, storage_counters.clone())?;
-            player.set_required(snapshot, self, storage_counters.clone())?;
+            relation.set_required(snapshot, self, storage_counters.clone());
+            player.set_required(snapshot, self, storage_counters.clone());
 
             snapshot.put_val(links.into_storage_key().into_owned_array(), ByteArray::copy(&encode_u64(count)));
             snapshot.put_val(links_reverse.into_storage_key().into_owned_array(), ByteArray::copy(&encode_u64(count)));

--- a/concept/thing/thing_manager.rs
+++ b/concept/thing/thing_manager.rs
@@ -52,7 +52,6 @@ use encoding::{
 };
 use iterator::minmax_or;
 use itertools::Itertools;
-use typeql::parser::Rule::thing_constraint;
 use lending_iterator::Peekable;
 use primitive::either::Either;
 use resource::{
@@ -3096,7 +3095,7 @@ impl ThingManager {
     ) -> Result<(), Box<ConceptWriteError>> {
         let count: u64 = 1;
         relation.set_required(snapshot, self, storage_counters.clone());
-        player.set_required(snapshot, self, storage_counters);
+        player.set_required(snapshot, self, storage_counters.clone());
 
         // must be idempotent, so no lock required -- cannot fail
         let links = ThingEdgeLinks::new(relation.vertex(), player.vertex(), role_type.vertex());

--- a/concept/type_/attribute_type.rs
+++ b/concept/type_/attribute_type.rs
@@ -7,7 +7,6 @@
 use std::{
     collections::{HashMap, HashSet},
     fmt,
-    fmt::Write,
     sync::Arc,
 };
 

--- a/concept/type_/role_type.rs
+++ b/concept/type_/role_type.rs
@@ -199,9 +199,9 @@ impl KindAPI for RoleType {
 
     fn capabilities_syntax(
         &self,
-        f: &mut impl Write,
-        snapshot: &impl ReadableSnapshot,
-        type_manager: &TypeManager,
+        _f: &mut impl Write,
+        _snapshot: &impl ReadableSnapshot,
+        _type_manager: &TypeManager,
     ) -> Result<(), Box<ConceptReadError>> {
         Ok(())
     }

--- a/database/database_manager.rs
+++ b/database/database_manager.rs
@@ -5,23 +5,18 @@
  */
 
 use std::{
-    collections::{HashMap, HashSet},
+    collections::HashMap,
     fs,
     path::{Path, PathBuf},
-    sync::{Arc, LockResult, RwLock, RwLockReadGuard, RwLockWriteGuard},
+    sync::{Arc, RwLock, RwLockReadGuard, RwLockWriteGuard},
 };
 
 use cache::CACHE_DB_NAME_PREFIX;
-use itertools::Itertools;
-use logger::debug;
 use resource::{constants::database::INTERNAL_DATABASE_PREFIX, internal_database_prefix};
 use storage::durability_client::WALClient;
 use tracing::{event, Level};
 
-use crate::{
-    database::DatabaseCreateError, migration::database_importer::DatabaseImporter, Database, DatabaseDeleteError,
-    DatabaseOpenError, DatabaseResetError,
-};
+use crate::{database::DatabaseCreateError, Database, DatabaseDeleteError, DatabaseOpenError, DatabaseResetError};
 
 type DatabasesMap = HashMap<String, Arc<Database<WALClient>>>;
 type Databases = RwLock<DatabasesMap>;

--- a/database/migration/database_importer.rs
+++ b/database/migration/database_importer.rs
@@ -6,7 +6,6 @@
 
 use std::{
     collections::{HashMap, HashSet},
-    io::Read,
     marker::PhantomData,
     path::PathBuf,
     sync::Arc,

--- a/database/transaction.rs
+++ b/database/transaction.rs
@@ -24,12 +24,10 @@ use query::query_manager::QueryManager;
 use resource::profile::TransactionProfile;
 use storage::{
     durability_client::DurabilityClient,
-    isolation_manager::CommitRecord,
     snapshot::{
         CommittableSnapshot, ReadSnapshot, SchemaSnapshot, SnapshotDropGuard, SnapshotError, WritableSnapshot,
         WriteSnapshot,
     },
-    MVCCStorage,
 };
 use tracing::Level;
 

--- a/ir/pattern/constraint.rs
+++ b/ir/pattern/constraint.rs
@@ -27,9 +27,7 @@ use crate::{
         IrID, ParameterID, Pattern, ScopeId, ValueType, VariableBindingMode, Vertex,
     },
     pipeline::{
-        block::{BlockBuilderContext},
-        function_signature::FunctionSignature,
-        ParameterRegistry, VariableRegistry,
+        block::BlockBuilderContext, function_signature::FunctionSignature, ParameterRegistry, VariableRegistry,
     },
     LiteralParseError, RepresentationError,
 };

--- a/ir/pattern/constraint.rs
+++ b/ir/pattern/constraint.rs
@@ -27,7 +27,9 @@ use crate::{
         IrID, ParameterID, Pattern, ScopeId, ValueType, VariableBindingMode, Vertex,
     },
     pipeline::{
-        block::BlockBuilderContext, function_signature::FunctionSignature, ParameterRegistry, VariableRegistry,
+        block::{BlockBuilderContext},
+        function_signature::FunctionSignature,
+        ParameterRegistry, VariableRegistry,
     },
     LiteralParseError, RepresentationError,
 };

--- a/ir/translation/function.rs
+++ b/ir/translation/function.rs
@@ -9,7 +9,7 @@ use error::{needs_update_when_feature_is_implemented, UnimplementedFeature};
 use itertools::Itertools;
 use storage::snapshot::ReadableSnapshot;
 use typeql::{
-    common::{Span, Spanned},
+    common::{Spanned},
     schema::definable::function::{
         FunctionBlock, Output, ReturnReduction, ReturnSingle, ReturnStatement, ReturnStream,
     },

--- a/ir/translation/function.rs
+++ b/ir/translation/function.rs
@@ -9,7 +9,7 @@ use error::{needs_update_when_feature_is_implemented, UnimplementedFeature};
 use itertools::Itertools;
 use storage::snapshot::ReadableSnapshot;
 use typeql::{
-    common::{Spanned},
+    common::Spanned,
     schema::definable::function::{
         FunctionBlock, Output, ReturnReduction, ReturnSingle, ReturnStatement, ReturnStream,
     },

--- a/query/query_manager.rs
+++ b/query/query_manager.rs
@@ -29,7 +29,7 @@ use compiler::{
 use concept::{
     error::ConceptReadError,
     thing::thing_manager::ThingManager,
-    type_::{attribute_type::AttributeType, type_manager::TypeManager, OwnerAPI, TypeAPI},
+    type_::{attribute_type::AttributeType, type_manager::TypeManager, OwnerAPI},
 };
 use encoding::value::value_type::ValueType;
 use executor::{

--- a/storage/durability_client.rs
+++ b/storage/durability_client.rs
@@ -5,7 +5,6 @@
  */
 
 use std::{
-    borrow::Cow,
     io::{self, Read, Write},
     sync::{mpsc, Arc},
 };

--- a/storage/keyspace/mod.rs
+++ b/storage/keyspace/mod.rs
@@ -8,11 +8,7 @@ pub(crate) use keyspace::{Keyspace, KeyspaceCheckpointError, KeyspaceError, Keys
 pub use keyspace::{KeyspaceDeleteError, KeyspaceId, KeyspaceOpenError, KeyspaceSet, KeyspaceValidationError};
 use rocksdb::{DBRawIterator, DB};
 
-use crate::{
-    key_range::{KeyRange, RangeEnd},
-    key_value::StorageKey,
-    snapshot::pool::{PoolRecycleGuard, Poolable, SinglePool},
-};
+use crate::snapshot::pool::{PoolRecycleGuard, Poolable, SinglePool};
 
 mod constants;
 pub mod iterator;


### PR DESCRIPTION
## Product change and motivation

We fix an Isolation bug that is exposed under concurrent update (adding an ownership) + concurrent delete transactions. This is a relatively uncommon conflict, and is fixed  by locking attributes that are edited in order to conflict with concurrent deletes of the same attribute. Under highly concurrent operations that include `delete`s, this change might manifest itself as more transaction conflicts `STC2` (Storage Commit 2) errors, which can be resolved with a retry.

## Implementation

We mark attributes that are modified (eg. given new ownerships) as required by locking them, rather than re-putting them into the snapshot.

We also fix a similar issue with links edges, by marking the player and the relation as locked so a concurrent delete of either will not lead a dangling edge.

## Details

Scenario: attribute A exists beforehand with 1 owner X

Tx1: opens at SeqNr 2
  --> deletes last ownership it sees from X to A
  --> commits
  --> auto-delete dependent attribute A
  --> commits, gets sequence number 8

Tx2: opens at SeqNr 4
  --> adds ownership of A from owner Y, and re-puts A
  --> commits
  --> commits at seq nr 6
  --> NO ERROR, and commits first !

Tx1: NO ERROR. Even though we delete attribute A, we only conflict "locks" and "deletes". We didn't set attributes as "locked" when we add attribute ownerships to them, but we do re-insert them - but this isn't enough!