### PR TITLE
Print non-typedb source errors

### DIFF
--- a/common/error/error.rs
+++ b/common/error/error.rs
@@ -83,6 +83,9 @@ pub trait TypeDBError {
             error = source;
             stack_trace.push(error.format_code_and_description());
         }
+        if let Some(source) = error.source_error() {
+            stack_trace.push(format!("{}", source));
+        }
         stack_trace.reverse();
         stack_trace
     }

--- a/concept/type_/annotation.rs
+++ b/concept/type_/annotation.rs
@@ -21,7 +21,7 @@ use encoding::{
     value::{value::Value, value_type::ValueType, ValueEncodable},
 };
 use error::typedb_error;
-use regex::Regex;
+use regex::{Regex};
 use resource::constants::snapshot::BUFFER_VALUE_INLINE;
 use serde::{Deserialize, Serialize};
 
@@ -243,8 +243,15 @@ impl AnnotationRegex {
         &self.regex
     }
 
-    pub fn valid(&self) -> bool {
-        !self.regex.is_empty() && Regex::new(&self.regex).is_ok()
+    pub fn validate(&self) -> Result<(), regex::Error> {
+        if !self.regex.is_empty() {
+            match Regex::new(&self.regex) {
+                Ok(_) => Ok(()),
+                Err(err) => Err(err)
+            }
+        } else {
+            Err(regex::Error::Syntax(String::from("Unexpected empty regex")))
+        }
     }
 
     pub fn value_valid(&self, value: &str) -> bool {

--- a/concept/type_/type_manager/validation/mod.rs
+++ b/concept/type_/type_manager/validation/mod.rs
@@ -56,7 +56,7 @@ typedb_error!(
         CannotSetAnnotationToInterfaceBecauseItsConstraintIsNotNarrowedByItsCapabilityConstraint(28, "Cannot set annotation to interface '{interface}' because its constraint is not narrowed by its capability constraint.", interface: Label, typedb_source: Box<ConstraintError>),
         CannotSetAnnotationToCapabilityBecauseItsConstraintDoesNotNarrowItsInterfaceConstraint(29, "Cannot set annotation on capability '{cap}' of '{interface}' on type '{label}' because its constraint does not narrow its interface constraint.", cap: CapabilityKind, interface: Label, label: Label, typedb_source: Box<ConstraintError>),
         InvalidCardinalityArguments(30, "Invalid arguments for cardinality annotation '{card}'.", card: AnnotationCardinality),
-        InvalidRegexArguments(31, "Invalid arguments for regex annotation '{regex}'.", regex: AnnotationRegex),
+        InvalidRegexArguments(31, "Invalid arguments for regex annotation '{regex}'.", regex: AnnotationRegex, source: regex::Error),
         InvalidRangeArgumentsForValueType(32, "Invalid arguments for range annotation '{range}' for value type '{value_type:?}'.", range: AnnotationRange, value_type: Option<ValueType>),
         InvalidValuesArgumentsForValueType(33, "Invalid arguments for values annotation '{values}' for value type '{value_type:?}'.", values: AnnotationValues, value_type: Option<ValueType>),
         SubtypeConstraintDoesNotNarrowSupertypeConstraint(34, "Subtype constraint on '{subtype}' does not narrow supertype constraint on '{supertype}'.", subtype: Label, supertype: Label, typedb_source: Box<ConstraintError>),

--- a/concept/type_/type_manager/validation/operation_time_validation.rs
+++ b/concept/type_/type_manager/validation/operation_time_validation.rs
@@ -1574,10 +1574,9 @@ impl OperationTimeValidation {
     }
 
     pub(crate) fn validate_regex_arguments(regex: AnnotationRegex) -> Result<(), Box<SchemaValidationError>> {
-        if regex.valid() {
-            Ok(())
-        } else {
-            Err(Box::new(SchemaValidationError::InvalidRegexArguments { regex }))
+        match regex.validate() {
+            Ok(_) => Ok(()),
+            Err(err) => Err(Box::new(SchemaValidationError::InvalidRegexArguments { regex, source: err})),
         }
     }
 


### PR DESCRIPTION
## Product change and motivation

Print source of error when it's not a TypeDB error as well as part of the generated stack trace.

## Implementation

- Add regex validation error to regex validation error
- Noticed that this source error was not printing when it was not a typedb-error, so we add to that into the stack trace