### PR TITLE
Reenable Sentry crash reporting

### DIFF
--- a/concept/type_/annotation.rs
+++ b/concept/type_/annotation.rs
@@ -21,7 +21,7 @@ use encoding::{
     value::{value::Value, value_type::ValueType, ValueEncodable},
 };
 use error::typedb_error;
-use regex::{Regex};
+use regex::Regex;
 use resource::constants::snapshot::BUFFER_VALUE_INLINE;
 use serde::{Deserialize, Serialize};
 
@@ -247,7 +247,7 @@ impl AnnotationRegex {
         if !self.regex.is_empty() {
             match Regex::new(&self.regex) {
                 Ok(_) => Ok(()),
-                Err(err) => Err(err)
+                Err(err) => Err(err),
             }
         } else {
             Err(regex::Error::Syntax(String::from("Unexpected empty regex")))

--- a/concept/type_/type_manager/validation/operation_time_validation.rs
+++ b/concept/type_/type_manager/validation/operation_time_validation.rs
@@ -1576,7 +1576,7 @@ impl OperationTimeValidation {
     pub(crate) fn validate_regex_arguments(regex: AnnotationRegex) -> Result<(), Box<SchemaValidationError>> {
         match regex.validate() {
             Ok(_) => Ok(()),
-            Err(err) => Err(Box::new(SchemaValidationError::InvalidRegexArguments { regex, source: err})),
+            Err(err) => Err(Box::new(SchemaValidationError::InvalidRegexArguments { regex, source: err })),
         }
     }
 

--- a/executor/read/stream_modifier.rs
+++ b/executor/read/stream_modifier.rs
@@ -274,9 +274,7 @@ impl LastMapper {
 impl StreamModifierResultMapperTrait for LastMapper {
     fn map_output(&mut self, subquery_result: Option<FixedBatch>) -> Option<FixedBatch> {
         if let Some(input_batch) = subquery_result {
-            self.last_row = (!input_batch.is_empty()).then(|| {
-                input_batch.get_row(input_batch.len() - 1).into_owned()
-            });
+            self.last_row = (!input_batch.is_empty()).then(|| input_batch.get_row(input_batch.len() - 1).into_owned());
             Some(FixedBatch::EMPTY) // Retry this instruction without returning any rows
         } else {
             self.last_row.take().map(FixedBatch::from)

--- a/main.rs
+++ b/main.rs
@@ -12,6 +12,7 @@ use std::path::PathBuf;
 use clap::Parser;
 use logger::initialise_logging_global;
 use resource::constants::server::{DEFAULT_CONFIG_PATH, SENTRY_REPORTING_URI, SERVER_INFO};
+use sentry::ClientInitGuard as SentryGuard;
 use server::{
     parameters::{
         cli::CLIArgs,
@@ -32,7 +33,9 @@ fn main() {
     config_builder.override_with_cliargs(cli_args);
     let config = config_builder.build().expect("Error validating config file overridden with cli args");
     initialise_logging_global(&config.logging.directory);
-    may_initialise_error_reporting(&config);
+    // This guard sends Sentry reports when it's dropped. It has to be alive while the server is running.
+    // DO NOT delete!
+    let _guard = may_initialise_error_reporting(&config);
     create_tokio_runtime().block_on(async {
         let server = ServerBuilder::default().server_info(SERVER_INFO).build(config).await.unwrap();
         match server.serve().await {
@@ -52,13 +55,15 @@ fn initialise_abort_on_panic() {
     });
 }
 
-fn may_initialise_error_reporting(config: &Config) {
+fn may_initialise_error_reporting(config: &Config) -> Option<SentryGuard> {
     if config.diagnostics.reporting.report_errors && !config.development_mode.enabled {
-        let opts = (
+        let options = (
             SENTRY_REPORTING_URI,
             sentry::ClientOptions { release: Some(SERVER_INFO.version.into()), ..Default::default() },
         );
-        let _ = sentry::init(opts);
+        Some(sentry::init(options))
+    } else {
+        None
     }
 }
 


### PR DESCRIPTION
## Product change and motivation
Fix a bug when TypeDB Server did not send crash reports for diagnostics even when `--diagnostics.reporting.errors` was enabled.

## Implementation
Fixes the bug introduced in https://github.com/typedb/typedb/pull/7391.

Preserve the ownership of the Sentry's `Guard` until the `main` function is exited. To avoid the same mistake, we encapsulate all the guards and other things required to remain alive while the App is running inside a new struct called `ServerApplication`.