### PR TITLE
Allow extending the data commit functionality of user update and delete functionality

### DIFF
--- a/database/lib.rs
+++ b/database/lib.rs
@@ -7,6 +7,8 @@
 #![deny(unused_must_use)]
 #![deny(elided_lifetimes_in_paths)]
 
+use storage::snapshot::WriteSnapshot;
+use crate::transaction::DatabaseDropGuard;
 pub use self::database::{Database, DatabaseDeleteError, DatabaseOpenError, DatabaseResetError};
 
 pub mod database;

--- a/database/transaction.rs
+++ b/database/transaction.rs
@@ -369,8 +369,8 @@ macro_rules! with_transaction_parts {
 }
 
 pub struct DataCommitIntent<D> {
-    database_drop_guard: DatabaseDropGuard<D>,
-    write_snapshot: WriteSnapshot<D>
+    pub database_drop_guard: DatabaseDropGuard<D>,
+    pub write_snapshot: WriteSnapshot<D>
 }
 
 pub struct DatabaseDropGuard<D> {

--- a/server/authentication/mod.rs
+++ b/server/authentication/mod.rs
@@ -68,6 +68,10 @@ impl Accessor {
     pub fn from_extensions(extensions: &Extensions) -> Result<Self, AuthenticationError> {
         extensions.get::<Self>().cloned().ok_or_else(|| AuthenticationError::CorruptedAccessor {})
     }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
 }
 
 // CAREFUL: Do not reorder these errors as we depend on errors codes in drivers.

--- a/server/lib.rs
+++ b/server/lib.rs
@@ -223,7 +223,7 @@ impl Server {
         mut shutdown_receiver: Receiver<()>,
     ) -> Result<(), ServerOpenError> {
         let authenticator = grpc::authenticator::Authenticator::new(server_state.clone());
-        let service = grpc::typedb_service::TypeDBService::new(address.clone(), server_state.clone());
+        let service = grpc::typedb_service::GRPCTypeDBService::new(address.clone(), server_state.clone());
         let mut grpc_server =
             tonic::transport::Server::builder().http2_keepalive_interval(Some(GRPC_CONNECTION_KEEPALIVE));
         if let Some(tls_config) = grpc::encryption::prepare_tls_config(encryption_config)? {
@@ -250,13 +250,13 @@ impl Server {
         mut shutdown_receiver: Receiver<()>,
     ) -> Result<(), ServerOpenError> {
         let authenticator = http::authenticator::Authenticator::new(server_state.clone());
-        let service = http::typedb_service::TypeDBService::new(distribution_info, address, server_state.clone());
+        let service = http::typedb_service::HTTPTypeDBService::new(distribution_info, address, server_state.clone());
         let encryption_config = http::encryption::prepare_tls_config(encryption_config)?;
         let http_service = Arc::new(service);
-        let router_service = http::typedb_service::TypeDBService::create_protected_router(http_service.clone())
+        let router_service = http::typedb_service::HTTPTypeDBService::create_protected_router(http_service.clone())
             .layer(authenticator)
-            .merge(http::typedb_service::TypeDBService::create_unprotected_router(http_service))
-            .layer(http::typedb_service::TypeDBService::create_cors_layer())
+            .merge(http::typedb_service::HTTPTypeDBService::create_unprotected_router(http_service))
+            .layer(http::typedb_service::HTTPTypeDBService::create_cors_layer())
             .into_make_service();
 
         let shutdown_handle = Handle::new();

--- a/server/service/grpc/transaction_service.rs
+++ b/server/service/grpc/transaction_service.rs
@@ -518,10 +518,10 @@ impl TransactionService {
                     LoadKind::SchemaTransactions,
                 );
                 let (mut profile, into_commit_record_result) = match transaction.finalise() {
-                    (mut profile, Ok((database, snapshot))) => {
-                        let into_commit_record_result = snapshot
+                    (mut profile, Ok(commit_intent)) => {
+                        let into_commit_record_result = commit_intent.schema_snapshot
                             .finalise(profile.commit_profile())
-                            .map(|commit_record_opt| (database, commit_record_opt))
+                            .map(|commit_record_opt| (commit_intent.database_drop_guard, commit_record_opt))
                             .map_err(|error| SchemaCommitError::SnapshotError { typedb_source: error });
                         (profile, into_commit_record_result)
                     }

--- a/server/service/grpc/transaction_service.rs
+++ b/server/service/grpc/transaction_service.rs
@@ -479,10 +479,10 @@ impl TransactionService {
                     LoadKind::WriteTransactions,
                 );
                 let (mut profile, into_commit_record_result) = match transaction.finalise() {
-                    (mut profile, Ok((database, snapshot))) => {
-                        let into_commit_record_result = snapshot
+                    (mut profile, Ok(commit_intent)) => {
+                        let into_commit_record_result = commit_intent.write_snapshot
                             .finalise(profile.commit_profile())
-                            .map(|commit_record_opt| (database, commit_record_opt))
+                            .map(|commit_record_opt| (commit_intent.database_drop_guard, commit_record_opt))
                             .map_err(|typedb_source| DataCommitError::SnapshotError { typedb_source });
                         (profile, into_commit_record_result)
                     }

--- a/server/service/grpc/typedb_service.rs
+++ b/server/service/grpc/typedb_service.rs
@@ -4,8 +4,6 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-use user::permission_manager::PermissionManager;
-use storage::snapshot::CommittableSnapshot;
 use std::{net::SocketAddr, pin::Pin, time::Instant};
 use std::sync::Arc;
 use diagnostics::metrics::ActionKind;
@@ -21,9 +19,6 @@ use typedb_protocol::{
     transaction::{Client as TransactionClientProto, Server as TransactionServerProto},
 };
 use uuid::Uuid;
-use database::transaction::DataCommitError;
-use resource::profile::CommitProfile;
-use user::errors::{UserCreateError, UserDeleteError, UserUpdateError};
 use crate::{
     authentication::{Accessor, AuthenticationError},
     error::LocalServerStateError,
@@ -52,18 +47,18 @@ use crate::{
             ConnectionID,
         },
         transaction_service::TRANSACTION_REQUEST_BUFFER_SIZE,
+        typedb_service::TypeDBService,
     },
     state::ArcServerState,
 };
-use crate::system_init::SYSTEM_DB;
 
 #[derive(Debug)]
-pub(crate) struct TypeDBService {
+pub(crate) struct GRPCTypeDBService {
     address: SocketAddr,
     server_state: ArcServerState,
 }
 
-impl TypeDBService {
+impl GRPCTypeDBService {
     pub(crate) fn new(address: SocketAddr, server_state: ArcServerState) -> Self {
         Self { address, server_state }
     }
@@ -76,7 +71,7 @@ impl TypeDBService {
 }
 
 #[tonic::async_trait]
-impl typedb_protocol::type_db_server::TypeDb for TypeDBService {
+impl typedb_protocol::type_db_server::TypeDb for GRPCTypeDBService {
     // Update AUTHENTICATION_FREE_METHODS if this method is renamed
     async fn connection_open(
         &self,
@@ -535,42 +530,10 @@ impl typedb_protocol::type_db_server::TypeDb for TypeDBService {
                 let (user, credential) =
                     users_create_req(request).map_err(|err| err.into_error_message().into_status())?;
 
-                if !PermissionManager::exec_user_create_permitted(accessor.0.as_str()) {
-                    return Err(LocalServerStateError::OperationNotPermitted {}.into_error_message().into_status());
-                }
-
-                let (mut transaction_profile, create_result) = match self.server_state.user_manager().await {
-                    Some(user_manager) => {
-                        match user_manager.create(&user, &credential) {
-                            (mut transaction_profile, Ok(commit_intent)) => {
-                                let commit_profile = transaction_profile.commit_profile();
-                                let into_commit_record_result = commit_intent.write_snapshot
-                                    .finalise(commit_profile)
-                                    .map_err(|error|
-                                        LocalServerStateError::UserCannotBeCreated { typedb_source: UserCreateError::Unexpected { } }
-                                    );
-                                (transaction_profile, into_commit_record_result
-                                    .map(|commit_record| (commit_intent.database_drop_guard, commit_record)))
-                            }
-                            (transaction_profile, Err(error)) =>
-                                return Err(LocalServerStateError::UserCannotBeCreated { typedb_source: error }.into_error_message().into_status())
-                        }
-                    },
-                    None => return Err(LocalServerStateError::NotInitialised { }.into_error_message().into_status())
-                };
-
-                let create_result = match create_result {
-                    Ok((_, commit_record_opt)) => {
-                        let commit_profile = transaction_profile.commit_profile();
-                        if let Some(commit_record) = commit_record_opt {
-                            self.server_state.database_data_commit(SYSTEM_DB, commit_record, commit_profile).await.unwrap();
-                        }
-                        Ok(Response::new(user_create_res()))
-                    }
-                    Err(err) => return Err(err.into_error_message().into_status())
-                };
-
-                create_result
+                TypeDBService::create_user(&self.server_state, accessor, user, credential)
+                    .await
+                    .map(|_| Response::new(user_create_res()))
+                    .map_err(|err| err.into_error_message().into_status())
             },
         )
         .await
@@ -590,42 +553,10 @@ impl typedb_protocol::type_db_server::TypeDb for TypeDBService {
                 let (username, user_update, credential_update) =
                     users_update_req(request).map_err(|err| err.into_error_message().into_status())?;
 
-                if !PermissionManager::exec_user_update_permitted(accessor.0.as_str(), &username) {
-                    return Err(LocalServerStateError::OperationNotPermitted {}.into_error_message().into_status());
-                }
-
-                let (mut transaction_profile, update_result) = match self.server_state.user_manager().await {
-                    Some(user_manager) => {
-                        match user_manager.update(&username, &user_update, &credential_update) {
-                            (mut transaction_profile, Ok(commit_intent)) => {
-                                let commit_profile = transaction_profile.commit_profile();
-                                let into_commit_record_result = commit_intent.write_snapshot
-                                    .finalise(commit_profile)
-                                    .map_err(|error|
-                                        LocalServerStateError::UserCannotBeUpdated { typedb_source: UserUpdateError::Unexpected { } }
-                                    );
-                                (transaction_profile, into_commit_record_result
-                                    .map(|commit_record| (commit_intent.database_drop_guard, commit_record)))
-                            }
-                            (transaction_profile, Err(error)) =>
-                                return Err(LocalServerStateError::UserCannotBeUpdated { typedb_source: error }.into_error_message().into_status())
-                        }
-                    },
-                    None => return Err(LocalServerStateError::NotInitialised { }.into_error_message().into_status())
-                };
-
-                let update_result = match update_result {
-                    Ok((_, commit_record_opt)) => {
-                        let commit_profile = transaction_profile.commit_profile();
-                        if let Some(commit_record) = commit_record_opt {
-                            self.server_state.database_data_commit(SYSTEM_DB, commit_record, commit_profile).await.unwrap();
-                        }
-                        Ok(Response::new(user_update_res()))
-                    }
-                    Err(err) => return Err(err.into_error_message().into_status())
-                };
-
-                update_result
+                TypeDBService::update_user(&self.server_state, accessor, &username, user_update, credential_update)
+                    .await
+                    .map(|_| Response::new(user_update_res()))
+                    .map_err(|err| err.into_error_message().into_status())
             },
         )
         .await
@@ -643,44 +574,11 @@ impl typedb_protocol::type_db_server::TypeDb for TypeDBService {
                 let accessor = Accessor::from_extensions(&request.extensions())
                     .map_err(|err| err.into_error_message().into_status())?;
                 let name = request.into_inner().name;
-                if !PermissionManager::exec_user_delete_allowed(accessor.0.as_str(), &name) {
-                    return Err(LocalServerStateError::OperationNotPermitted {}.into_error_message().into_status());
-                }
 
-                let (mut transaction_profile, delete_result) = match self.server_state.user_manager().await {
-                    Some(user_manager) => {
-                        match user_manager.delete(&name) {
-                            (Some(mut transaction_profile), Ok(commit_intent)) => {
-                                let commit_profile = transaction_profile.commit_profile();
-                                let into_commit_record_result = commit_intent.write_snapshot
-                                    .finalise(commit_profile)
-                                    .map_err(|error|
-                                        LocalServerStateError::UserCannotBeDeleted { typedb_source: UserDeleteError::Unexpected { } }
-                                    );
-                                (transaction_profile, into_commit_record_result
-                                    .map(|commit_record| (commit_intent.database_drop_guard, commit_record)))
-                            }
-                            (None, Err(error)) =>
-                                return Err(LocalServerStateError::UserCannotBeDeleted { typedb_source: error }.into_error_message().into_status()),
-                            (None, Ok(_)) => panic!("Unexpected condition"),
-                            (Some(_), Err(_)) => panic!("Unexpected condition"),
-                        }
-                    },
-                    None => return Err(LocalServerStateError::NotInitialised { }.into_error_message().into_status())
-                };
-
-                let delete_result = match delete_result {
-                    Ok((_, commit_record_opt)) => {
-                        let commit_profile = transaction_profile.commit_profile();
-                        if let Some(commit_record) = commit_record_opt {
-                            self.server_state.database_data_commit(SYSTEM_DB, commit_record, commit_profile).await.unwrap();
-                        }
-                        Ok(Response::new(users_delete_res()))
-                    }
-                    Err(err) => return Err(err.into_error_message().into_status())
-                };
-
-                delete_result
+                TypeDBService::delete_user(&self.server_state, accessor, &name)
+                    .await
+                    .map(|_| Response::new(users_delete_res()))
+                    .map_err(|err| err.into_error_message().into_status())
             },
         )
         .await

--- a/server/service/grpc/typedb_service.rs
+++ b/server/service/grpc/typedb_service.rs
@@ -618,7 +618,7 @@ impl typedb_protocol::type_db_server::TypeDb for TypeDBService {
 
                 let (mut transaction_profile, delete_result) = match self.server_state.user_manager().await {
                     Some(user_manager) => {
-                        match user_manager.delete2(&name) {
+                        match user_manager.delete(&name) {
                             (Some(mut transaction_profile), Ok((database, snapshot))) => {
                                 let commit_profile = transaction_profile.commit_profile();
                                 let into_commit_record_result = snapshot

--- a/server/service/grpc/typedb_service.rs
+++ b/server/service/grpc/typedb_service.rs
@@ -596,7 +596,7 @@ impl typedb_protocol::type_db_server::TypeDb for TypeDBService {
 
                 let (mut transaction_profile, update_result) = match self.server_state.user_manager().await {
                     Some(user_manager) => {
-                        match user_manager.update2(&username, &user_update, &credential_update) {
+                        match user_manager.update(&username, &user_update, &credential_update) {
                             (mut transaction_profile, Ok((database, snapshot))) => {
                                 let commit_profile = transaction_profile.commit_profile();
                                 let into_commit_record_result = snapshot

--- a/server/service/grpc/typedb_service.rs
+++ b/server/service/grpc/typedb_service.rs
@@ -624,7 +624,7 @@ impl typedb_protocol::type_db_server::TypeDb for TypeDBService {
                                 let into_commit_record_result = snapshot
                                     .finalise(commit_profile)
                                     .map_err(|error|
-                                        LocalServerStateError::UserCannotBeCreated { typedb_source: UserCreateError::Unexpected { } }
+                                        LocalServerStateError::UserCannotBeDeleted { typedb_source: UserCreateError::Unexpected { } }
                                     );
                                 (transaction_profile, into_commit_record_result
                                     .map(|commit_record| (database, commit_record)))

--- a/server/service/http/typedb_service.rs
+++ b/server/service/http/typedb_service.rs
@@ -4,7 +4,6 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-use user::errors::UserUpdateError;
 use std::{collections::HashMap, net::SocketAddr, sync::Arc, time::Duration};
 
 use axum::{
@@ -29,7 +28,6 @@ use tokio::{
 use tonic::Response;
 use tower_http::cors::CorsLayer;
 use uuid::Uuid;
-use user::errors::{UserCreateError, UserDeleteError};
 use crate::{
     authentication::Accessor,
     http::diagnostics::run_with_diagnostics,
@@ -51,13 +49,11 @@ use crate::{
             },
         },
         transaction_service::TRANSACTION_REQUEST_BUFFER_SIZE,
+        typedb_service::TypeDBService,
         QueryType,
     },
     state::ArcServerState,
 };
-use crate::error::LocalServerStateError;
-use crate::system_init::SYSTEM_DB;
-use storage::snapshot::CommittableSnapshot;
 
 type TransactionRequestSender = Sender<(TransactionRequest, TransactionResponder)>;
 
@@ -70,7 +66,7 @@ struct TransactionInfo {
 }
 
 #[derive(Clone, Debug)]
-pub(crate) struct TypeDBService {
+pub(crate) struct HTTPTypeDBService {
     distribution_info: DistributionInfo,
     address: SocketAddr,
     server_state: ArcServerState,
@@ -78,7 +74,7 @@ pub(crate) struct TypeDBService {
     _transaction_cleanup_job: Arc<TokioIntervalRunner>,
 }
 
-impl TypeDBService {
+impl HTTPTypeDBService {
     const TRANSACTION_CHECK_INTERVAL: Duration = Duration::from_secs(5 * SECONDS_IN_MINUTE);
     const QUERY_ENDPOINT_COMMIT_DEFAULT: bool = true;
 
@@ -117,7 +113,7 @@ impl TypeDBService {
     }
 
     async fn transaction_new(
-        service: &TypeDBService,
+        service: &HTTPTypeDBService,
         owner: String,
         payload: TransactionOpenPayload,
     ) -> Result<(TransactionInfo, u64), HttpServiceError> {
@@ -194,7 +190,7 @@ impl TypeDBService {
         }
     }
 
-    pub(crate) fn create_protected_router<T>(service: Arc<TypeDBService>) -> Router<T> {
+    pub(crate) fn create_protected_router<T>(service: Arc<HTTPTypeDBService>) -> Router<T> {
         Router::new()
             .route("/:version/databases", get(Self::databases))
             .route("/:version/databases/:database-name", get(Self::databases_get))
@@ -217,7 +213,7 @@ impl TypeDBService {
             .with_state(service)
     }
 
-    pub(crate) fn create_unprotected_router<T>(service: Arc<TypeDBService>) -> Router<T> {
+    pub(crate) fn create_unprotected_router<T>(service: Arc<HTTPTypeDBService>) -> Router<T> {
         Router::new()
             .route("/", get(Self::redirect_to_latest_version))
             .route("/:version", get(Self::redirect_to_version))
@@ -236,7 +232,7 @@ impl TypeDBService {
         StatusCode::NO_CONTENT
     }
 
-    async fn version(_version: ProtocolVersion, State(service): State<Arc<TypeDBService>>) -> impl IntoResponse {
+    async fn version(_version: ProtocolVersion, State(service): State<Arc<HTTPTypeDBService>>) -> impl IntoResponse {
         run_with_diagnostics_async(
             service.server_state.diagnostics_manager().await,
             None::<&str>,
@@ -261,7 +257,7 @@ impl TypeDBService {
 
     async fn signin(
         _version: ProtocolVersion,
-        State(service): State<Arc<TypeDBService>>,
+        State(service): State<Arc<HTTPTypeDBService>>,
         JsonBody(payload): JsonBody<SigninPayload>,
     ) -> impl IntoResponse {
         run_with_diagnostics_async(
@@ -280,7 +276,7 @@ impl TypeDBService {
         .await
     }
 
-    async fn databases(_version: ProtocolVersion, State(service): State<Arc<TypeDBService>>) -> impl IntoResponse {
+    async fn databases(_version: ProtocolVersion, State(service): State<Arc<HTTPTypeDBService>>) -> impl IntoResponse {
         run_with_diagnostics_async(
             service.server_state.diagnostics_manager().await,
             None::<&str>,
@@ -299,7 +295,7 @@ impl TypeDBService {
 
     async fn databases_get(
         _version: ProtocolVersion,
-        State(service): State<Arc<TypeDBService>>,
+        State(service): State<Arc<HTTPTypeDBService>>,
         database_path: DatabasePath,
     ) -> impl IntoResponse {
         run_with_diagnostics_async(
@@ -323,7 +319,7 @@ impl TypeDBService {
 
     async fn databases_create(
         _version: ProtocolVersion,
-        State(service): State<Arc<TypeDBService>>,
+        State(service): State<Arc<HTTPTypeDBService>>,
         database_path: DatabasePath,
     ) -> impl IntoResponse {
         run_with_diagnostics_async(
@@ -343,7 +339,7 @@ impl TypeDBService {
 
     async fn databases_delete(
         _version: ProtocolVersion,
-        State(service): State<Arc<TypeDBService>>,
+        State(service): State<Arc<HTTPTypeDBService>>,
         database_path: DatabasePath,
     ) -> impl IntoResponse {
         run_with_diagnostics_async(
@@ -363,7 +359,7 @@ impl TypeDBService {
 
     async fn databases_schema(
         _version: ProtocolVersion,
-        State(service): State<Arc<TypeDBService>>,
+        State(service): State<Arc<HTTPTypeDBService>>,
         database_path: DatabasePath,
     ) -> impl IntoResponse {
         run_with_diagnostics_async(
@@ -384,7 +380,7 @@ impl TypeDBService {
 
     async fn databases_type_schema(
         _version: ProtocolVersion,
-        State(service): State<Arc<TypeDBService>>,
+        State(service): State<Arc<HTTPTypeDBService>>,
         database_path: DatabasePath,
     ) -> impl IntoResponse {
         run_with_diagnostics_async(
@@ -405,7 +401,7 @@ impl TypeDBService {
 
     async fn users(
         _version: ProtocolVersion,
-        State(service): State<Arc<TypeDBService>>,
+        State(service): State<Arc<HTTPTypeDBService>>,
         accessor: Accessor,
     ) -> impl IntoResponse {
         run_with_diagnostics_async(
@@ -426,7 +422,7 @@ impl TypeDBService {
 
     async fn users_get(
         _version: ProtocolVersion,
-        State(service): State<Arc<TypeDBService>>,
+        State(service): State<Arc<HTTPTypeDBService>>,
         accessor: Accessor,
         user_path: UserPath,
     ) -> impl IntoResponse {
@@ -448,7 +444,7 @@ impl TypeDBService {
 
     async fn users_create(
         _version: ProtocolVersion,
-        State(service): State<Arc<TypeDBService>>,
+        State(service): State<Arc<HTTPTypeDBService>>,
         accessor: Accessor,
         user_path: UserPath,
         JsonBody(payload): JsonBody<CreateUserPayload>,
@@ -460,40 +456,10 @@ impl TypeDBService {
             || async {
                 let user = User { name: user_path.username };
                 let credential = Credential::new_password(payload.password.as_str());
-                let (mut transaction_profile, create_result) = match service.server_state.user_manager().await {
-                    Some(user_manager) => {
-                        match user_manager.create(&user, &credential) {
-                            (mut transaction_profile, Ok(commit_intent)) => {
-                                let commit_profile = transaction_profile.commit_profile();
-                                let into_commit_record_result = commit_intent.write_snapshot
-                                    .finalise(commit_profile)
-                                    .map_err(|error|
-                                        LocalServerStateError::UserCannotBeCreated { typedb_source: UserCreateError::Unexpected { } }
-                                    );
-                                (transaction_profile, into_commit_record_result
-                                    .map(|commit_record| (commit_intent.database_drop_guard, commit_record)))
-                            }
-                            (transaction_profile, Err(error)) =>
-                                return Err(
-                                    HttpServiceError::State { typedb_source: Arc::new(LocalServerStateError::UserCannotBeCreated { typedb_source: error }) }
-                                )
-                        }
-                    },
-                    None => return Err(HttpServiceError::State { typedb_source: Arc::new(LocalServerStateError::NotInitialised { })})
-                };
-
-                let create_result = match create_result {
-                    Ok((_, commit_record_opt)) => {
-                        let commit_profile = transaction_profile.commit_profile();
-                        if let Some(commit_record) = commit_record_opt {
-                            service.server_state.database_data_commit(SYSTEM_DB, commit_record, commit_profile).await.unwrap();
-                        }
-                        Ok(())
-                    }
-                    Err(err) => return Err(HttpServiceError::State { typedb_source: Arc::new(err) })
-                };
-
-                create_result
+                
+                TypeDBService::create_user(&service.server_state, accessor, user, credential)
+                    .await
+                    .map_err(|typedb_source| HttpServiceError::State { typedb_source })
             },
         )
         .await
@@ -501,7 +467,7 @@ impl TypeDBService {
 
     async fn users_update(
         _version: ProtocolVersion,
-        State(service): State<Arc<TypeDBService>>,
+        State(service): State<Arc<HTTPTypeDBService>>,
         accessor: Accessor,
         user_path: UserPath,
         JsonBody(payload): JsonBody<UpdateUserPayload>,
@@ -515,40 +481,9 @@ impl TypeDBService {
                 let credential_update = Some(Credential::new_password(&payload.password));
                 let username = user_path.username.as_str();
 
-                let (mut transaction_profile, update_result) = match service.server_state.user_manager().await {
-                    Some(user_manager) => {
-                        match user_manager.update(&username, &user_update, &credential_update) {
-                            (mut transaction_profile, Ok(commit_intent)) => {
-                                let commit_profile = transaction_profile.commit_profile();
-                                let into_commit_record_result = commit_intent.write_snapshot
-                                    .finalise(commit_profile)
-                                    .map_err(|error|
-                                        LocalServerStateError::UserCannotBeUpdated { typedb_source: UserUpdateError::Unexpected { } }
-                                    );
-                                (transaction_profile, into_commit_record_result
-                                    .map(|commit_record| (commit_intent.database_drop_guard, commit_record)))
-                            }
-                            (transaction_profile, Err(error)) =>
-                                return Err(
-                                    HttpServiceError::State { typedb_source: Arc::new(LocalServerStateError::UserCannotBeUpdated { typedb_source: error }) }
-                                )
-                        }
-                    },
-                    None => return Err(HttpServiceError::State { typedb_source: Arc::new(LocalServerStateError::NotInitialised { })})
-                };
-
-                let update_result = match update_result {
-                    Ok((_, commit_record_opt)) => {
-                        let commit_profile = transaction_profile.commit_profile();
-                        if let Some(commit_record) = commit_record_opt {
-                            service.server_state.database_data_commit(SYSTEM_DB, commit_record, commit_profile).await.unwrap();
-                        }
-                        Ok(())
-                    }
-                    Err(err) => return Err(HttpServiceError::State { typedb_source: Arc::new(err) })
-                };
-
-                update_result
+                TypeDBService::update_user(&service.server_state, accessor, username, user_update, credential_update)
+                    .await
+                    .map_err(|typedb_source| HttpServiceError::State { typedb_source })
             },
         )
         .await
@@ -556,7 +491,7 @@ impl TypeDBService {
 
     async fn users_delete(
         _version: ProtocolVersion,
-        State(service): State<Arc<TypeDBService>>,
+        State(service): State<Arc<HTTPTypeDBService>>,
         accessor: Accessor,
         user_path: UserPath,
     ) -> impl IntoResponse {
@@ -566,42 +501,10 @@ impl TypeDBService {
             ActionKind::UsersDelete,
             || async {
                 let username = user_path.username.as_str();
-                let (mut transaction_profile, delete_result) = match service.server_state.user_manager().await {
-                    Some(user_manager) => {
-                        match user_manager.delete(username) {
-                            (Some(mut transaction_profile), Ok(commit_intent)) => {
-                                let commit_profile = transaction_profile.commit_profile();
-                                let into_commit_record_result = commit_intent.write_snapshot
-                                    .finalise(commit_profile)
-                                    .map_err(|error|
-                                        LocalServerStateError::UserCannotBeDeleted { typedb_source: UserDeleteError::Unexpected { } }
-                                    );
-                                (transaction_profile, into_commit_record_result
-                                    .map(|commit_record| (commit_intent.database_drop_guard, commit_record)))
-                            }
-                            (None, Err(typedb_source)) =>
-                                return Err(
-                                    HttpServiceError::State { typedb_source: Arc::new(LocalServerStateError::UserCannotBeDeleted { typedb_source }) }
-                                ),
-                            (None, Ok(_)) => panic!("Unexpected condition"),
-                            (Some(_), Err(_)) => panic!("Unexpected condition"),
-                        }
-                    },
-                    None => return Err(HttpServiceError::State { typedb_source: Arc::new(LocalServerStateError::NotInitialised { })})
-                };
-
-                let delete_result = match delete_result {
-                    Ok((_, commit_record_opt)) => {
-                        let commit_profile = transaction_profile.commit_profile();
-                        if let Some(commit_record) = commit_record_opt {
-                            service.server_state.database_data_commit(SYSTEM_DB, commit_record, commit_profile).await.unwrap();
-                        }
-                        Ok(())
-                    }
-                    Err(err) => return Err(HttpServiceError::State { typedb_source: Arc::new(err) })
-                };
-
-                delete_result
+                
+                TypeDBService::delete_user(&service.server_state, accessor, username)
+                    .await
+                    .map_err(|typedb_source| HttpServiceError::State { typedb_source })
             },
         )
         .await
@@ -609,7 +512,7 @@ impl TypeDBService {
 
     async fn transaction_open(
         _version: ProtocolVersion,
-        State(service): State<Arc<TypeDBService>>,
+        State(service): State<Arc<HTTPTypeDBService>>,
         Accessor(accessor): Accessor,
         JsonBody(payload): JsonBody<TransactionOpenPayload>,
     ) -> impl IntoResponse {
@@ -629,7 +532,7 @@ impl TypeDBService {
 
     async fn transactions_commit(
         _version: ProtocolVersion,
-        State(service): State<Arc<TypeDBService>>,
+        State(service): State<Arc<HTTPTypeDBService>>,
         Accessor(accessor): Accessor,
         path: TransactionPath,
     ) -> impl IntoResponse {
@@ -653,7 +556,7 @@ impl TypeDBService {
 
     async fn transactions_close(
         _version: ProtocolVersion,
-        State(service): State<Arc<TypeDBService>>,
+        State(service): State<Arc<HTTPTypeDBService>>,
         Accessor(accessor): Accessor,
         path: TransactionPath,
     ) -> impl IntoResponse {
@@ -679,7 +582,7 @@ impl TypeDBService {
 
     async fn transactions_rollback(
         _version: ProtocolVersion,
-        State(service): State<Arc<TypeDBService>>,
+        State(service): State<Arc<HTTPTypeDBService>>,
         Accessor(accessor): Accessor,
         path: TransactionPath,
     ) -> impl IntoResponse {
@@ -703,7 +606,7 @@ impl TypeDBService {
 
     async fn transactions_analyse_query(
         _version: ProtocolVersion,
-        State(service): State<Arc<TypeDBService>>,
+        State(service): State<Arc<HTTPTypeDBService>>,
         Accessor(accessor): Accessor,
         path: TransactionPath,
         JsonBody(payload): JsonBody<TransactionQueryPayload>,
@@ -728,7 +631,7 @@ impl TypeDBService {
 
     async fn transactions_query(
         _version: ProtocolVersion,
-        State(service): State<Arc<TypeDBService>>,
+        State(service): State<Arc<HTTPTypeDBService>>,
         Accessor(accessor): Accessor,
         path: TransactionPath,
         JsonBody(payload): JsonBody<TransactionQueryPayload>,
@@ -758,7 +661,7 @@ impl TypeDBService {
 
     async fn query(
         _version: ProtocolVersion,
-        State(service): State<Arc<TypeDBService>>,
+        State(service): State<Arc<HTTPTypeDBService>>,
         Accessor(accessor): Accessor,
         JsonBody(payload): JsonBody<QueryPayload>,
     ) -> impl IntoResponse {

--- a/server/service/http/typedb_service.rs
+++ b/server/service/http/typedb_service.rs
@@ -517,7 +517,7 @@ impl TypeDBService {
 
                 let (mut transaction_profile, update_result) = match service.server_state.user_manager().await {
                     Some(user_manager) => {
-                        match user_manager.update2(&username, &user_update, &credential_update) {
+                        match user_manager.update(&username, &user_update, &credential_update) {
                             (mut transaction_profile, Ok((database, snapshot))) => {
                                 let commit_profile = transaction_profile.commit_profile();
                                 let into_commit_record_result = snapshot

--- a/server/service/http/typedb_service.rs
+++ b/server/service/http/typedb_service.rs
@@ -537,7 +537,7 @@ impl TypeDBService {
                 let username = user_path.username.as_str();
                 let (mut transaction_profile, delete_result) = match service.server_state.user_manager().await {
                     Some(user_manager) => {
-                        match user_manager.delete2(username) {
+                        match user_manager.delete(username) {
                             (Some(mut transaction_profile), Ok((database, snapshot))) => {
                                 let commit_profile = transaction_profile.commit_profile();
                                 let into_commit_record_result = snapshot

--- a/server/service/http/typedb_service.rs
+++ b/server/service/http/typedb_service.rs
@@ -579,9 +579,9 @@ impl TypeDBService {
                                 (transaction_profile, into_commit_record_result
                                     .map(|commit_record| (commit_intent.database_drop_guard, commit_record)))
                             }
-                            (None, Err(error)) =>
+                            (None, Err(typedb_source)) =>
                                 return Err(
-                                    HttpServiceError::State { typedb_source: Arc::new(LocalServerStateError::UserCannotBeDeleted { typedb_source: error }) }
+                                    HttpServiceError::State { typedb_source: Arc::new(LocalServerStateError::UserCannotBeDeleted { typedb_source }) }
                                 ),
                             (None, Ok(_)) => panic!("Unexpected condition"),
                             (Some(_), Err(_)) => panic!("Unexpected condition"),

--- a/server/service/mod.rs
+++ b/server/service/mod.rs
@@ -11,6 +11,7 @@ pub(crate) mod grpc;
 pub mod http;
 mod import_service;
 mod transaction_service;
+pub mod typedb_service;
 
 #[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialOrd, PartialEq, Eq, Hash)]
 #[serde(rename_all = "camelCase")]

--- a/server/service/typedb_service.rs
+++ b/server/service/typedb_service.rs
@@ -1,0 +1,125 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+use std::sync::Arc;
+use storage::snapshot::CommittableSnapshot;
+use user::errors::{UserCreateError, UserDeleteError, UserUpdateError};
+use user::permission_manager::PermissionManager;
+use crate::{
+    authentication::Accessor,
+    error::LocalServerStateError,
+    state::ArcServerState,
+};
+use crate::error::ArcServerStateError;
+use crate::system_init::SYSTEM_DB;
+
+pub struct TypeDBService;
+
+impl TypeDBService {
+    pub async fn create_user(
+        server_state: &ArcServerState,
+        accessor: Accessor,
+        user: system::concepts::User,
+        credential: system::concepts::Credential,
+    ) -> Result<(), ArcServerStateError> {
+        if !PermissionManager::exec_user_create_permitted(accessor.0.as_str()) {
+            return Err(Arc::new(LocalServerStateError::OperationNotPermitted {}));
+        }
+
+        let user_manager = server_state.user_manager().await
+            .ok_or(LocalServerStateError::NotInitialised {})?;
+
+        let (mut transaction_profile, commit_intent_result) = user_manager.create(&user, &credential);
+        
+        let commit_intent = commit_intent_result
+            .map_err(|typedb_source| LocalServerStateError::UserCannotBeCreated { typedb_source })?;
+
+        let commit_profile = transaction_profile.commit_profile();
+        let commit_record = commit_intent.write_snapshot
+            .finalise(commit_profile)
+            .map_err(|_error| LocalServerStateError::UserCannotBeCreated { 
+                typedb_source: UserCreateError::Unexpected { } 
+            })?;
+
+        if let Some(commit_record) = commit_record {
+            let commit_profile = transaction_profile.commit_profile();
+            server_state.database_data_commit(SYSTEM_DB, commit_record, commit_profile).await?;
+        }
+
+        Ok(())
+    }
+
+    pub async fn update_user(
+        server_state: &ArcServerState,
+        accessor: Accessor,
+        username: &str,
+        user_update: Option<system::concepts::User>,
+        credential_update: Option<system::concepts::Credential>,
+    ) -> Result<(), ArcServerStateError> {
+        if !PermissionManager::exec_user_update_permitted(accessor.0.as_str(), username) {
+            return Err(Arc::new(LocalServerStateError::OperationNotPermitted {}));
+        }
+
+        let user_manager = server_state.user_manager().await
+            .ok_or(LocalServerStateError::NotInitialised {})?;
+
+        let (mut transaction_profile, commit_intent_result) = user_manager.update(username, &user_update, &credential_update);
+        
+        let commit_intent = commit_intent_result
+            .map_err(|typedb_source| LocalServerStateError::UserCannotBeUpdated { typedb_source })?;
+
+        let commit_profile = transaction_profile.commit_profile();
+        let commit_record = commit_intent.write_snapshot
+            .finalise(commit_profile)
+            .map_err(|_error| LocalServerStateError::UserCannotBeUpdated { 
+                typedb_source: UserUpdateError::Unexpected { } 
+            })?;
+
+        if let Some(commit_record) = commit_record {
+            let commit_profile = transaction_profile.commit_profile();
+            server_state.database_data_commit(SYSTEM_DB, commit_record, commit_profile).await?;
+        }
+
+        Ok(())
+    }
+
+    pub async fn delete_user(
+        server_state: &ArcServerState,
+        accessor: Accessor,
+        username: &str,
+    ) -> Result<(), ArcServerStateError> {
+        if !PermissionManager::exec_user_delete_allowed(accessor.0.as_str(), username) {
+            return Err(Arc::new(LocalServerStateError::OperationNotPermitted {}));
+        }
+
+        let user_manager = server_state.user_manager().await
+            .ok_or(LocalServerStateError::NotInitialised {})?;
+
+        let (transaction_profile_opt, commit_intent_result) = user_manager.delete(username);
+        
+        let mut transaction_profile = transaction_profile_opt
+            .ok_or(LocalServerStateError::UserCannotBeDeleted { 
+                typedb_source: UserDeleteError::Unexpected { } 
+            })?;
+
+        let commit_intent = commit_intent_result
+            .map_err(|error| LocalServerStateError::UserCannotBeDeleted { typedb_source: error })?;
+
+        let commit_profile = transaction_profile.commit_profile();
+        let commit_record = commit_intent.write_snapshot
+            .finalise(commit_profile)
+            .map_err(|_error| LocalServerStateError::UserCannotBeDeleted { 
+                typedb_source: UserDeleteError::Unexpected { } 
+            })?;
+
+        if let Some(commit_record) = commit_record {
+            let commit_profile = transaction_profile.commit_profile();
+            server_state.database_data_commit(SYSTEM_DB, commit_record, commit_profile).await?;
+        }
+
+        Ok(())
+    }
+}

--- a/server/service/typedb_service.rs
+++ b/server/service/typedb_service.rs
@@ -25,7 +25,7 @@ impl TypeDBService {
         user: system::concepts::User,
         credential: system::concepts::Credential,
     ) -> Result<(), ArcServerStateError> {
-        if !PermissionManager::exec_user_create_permitted(accessor.0.as_str()) {
+        if !PermissionManager::exec_user_create_permitted(accessor.as_str()) {
             return Err(Arc::new(LocalServerStateError::OperationNotPermitted {}));
         }
 
@@ -59,7 +59,7 @@ impl TypeDBService {
         user_update: Option<system::concepts::User>,
         credential_update: Option<system::concepts::Credential>,
     ) -> Result<(), ArcServerStateError> {
-        if !PermissionManager::exec_user_update_permitted(accessor.0.as_str(), username) {
+        if !PermissionManager::exec_user_update_permitted(accessor.as_str(), username) {
             return Err(Arc::new(LocalServerStateError::OperationNotPermitted {}));
         }
 
@@ -91,7 +91,7 @@ impl TypeDBService {
         accessor: Accessor,
         username: &str,
     ) -> Result<(), ArcServerStateError> {
-        if !PermissionManager::exec_user_delete_allowed(accessor.0.as_str(), username) {
+        if !PermissionManager::exec_user_delete_allowed(accessor.as_str(), username) {
             return Err(Arc::new(LocalServerStateError::OperationNotPermitted {}));
         }
 

--- a/server/state.rs
+++ b/server/state.rs
@@ -215,7 +215,6 @@ impl LocalServerState {
 
     pub async fn load(&mut self) {
         let system_database = self.database_manager().await.database_unrestricted(SYSTEM_DB).unwrap();
-        println!("load system db: {:?}", system_database);
         let user_manager = Arc::new(UserManager::new(system_database));
         let credential_verifier = Arc::new(CredentialVerifier::new(user_manager.clone()));
         self.user_manager = Some(user_manager);

--- a/server/state.rs
+++ b/server/state.rs
@@ -449,7 +449,7 @@ impl ServerState for LocalServerState {
     }
 
     async fn users_get(&self, name: &str, accessor: Accessor) -> Result<User, ArcServerStateError> {
-        if !PermissionManager::exec_user_get_permitted(accessor.0.as_str(), name) {
+        if !PermissionManager::exec_user_get_permitted(accessor.as_str(), name) {
             return Err(Arc::new(LocalServerStateError::OperationNotPermitted {}));
         }
 
@@ -466,7 +466,7 @@ impl ServerState for LocalServerState {
     }
 
     async fn users_all(&self, accessor: Accessor) -> Result<Vec<User>, ArcServerStateError> {
-        if !PermissionManager::exec_user_all_permitted(accessor.0.as_str()) {
+        if !PermissionManager::exec_user_all_permitted(accessor.as_str()) {
             return Err(Arc::new(LocalServerStateError::OperationNotPermitted {}));
         }
 

--- a/server/system_init.rs
+++ b/server/system_init.rs
@@ -45,9 +45,9 @@ pub async fn get_system_database_schema_commit_record(db: Arc<Database<WALClient
         );
     });
     let mut commit_profile = transaction_profile.commit_profile();
-    let (_, snapshot) = finalise_result
+    let commit_intent = finalise_result
         .map_err(|error| LocalServerStateError::DatabaseSchemaCommitFailed { typedb_source: error })?;
-    let commit_record_opt = snapshot.finalise(&mut commit_profile)
+    let commit_record_opt = commit_intent.schema_snapshot.finalise(&mut commit_profile)
         .map_err(|error| LocalServerStateError::DatabaseSchemaCommitFailed { typedb_source: SchemaCommitError::SnapshotError { typedb_source: error }})?;
     return Ok((transaction_profile, commit_record_opt));
 }

--- a/server/system_init.rs
+++ b/server/system_init.rs
@@ -65,9 +65,9 @@ pub async fn get_default_user_commit_record(user_manager: &user::user_manager::U
         &Credential::PasswordType { password_hash: PasswordHash::from_password(DEFAULT_USER_PASSWORD) },
     );
     let mut commit_profile = transaction_profile.commit_profile();
-    let (_, snapshot) = finalise_result
+    let commit_intent = finalise_result
         .map_err(|error| LocalServerStateError::UserCannotBeCreated { typedb_source: error })?;
-    let commit_record_opt = snapshot.finalise(&mut commit_profile)
+    let commit_record_opt = commit_intent.write_snapshot.finalise(&mut commit_profile)
         .map_err(|error| LocalServerStateError::DatabaseSchemaCommitFailed { typedb_source: SchemaCommitError::SnapshotError { typedb_source: error }})?;
     return Ok((transaction_profile, commit_record_opt));
 }

--- a/system/util.rs
+++ b/system/util.rs
@@ -13,7 +13,7 @@ pub mod transaction_util {
         transaction::{DatabaseDropGuard, DataCommitError, SchemaCommitError, TransactionRead, TransactionSchema, TransactionWrite},
         Database,
     };
-    use database::transaction::DataCommitIntent;
+    use database::transaction::{DataCommitIntent, SchemaCommitIntent};
     use function::function_manager::FunctionManager;
     use options::TransactionOptions;
     use query::query_manager::QueryManager;
@@ -36,7 +36,7 @@ pub mod transaction_util {
         pub fn schema_transaction<T>(
             &self,
             fn_: impl Fn(&mut SchemaSnapshot<WALClient>, &TypeManager, &ThingManager, &FunctionManager, &QueryManager) -> T,
-        ) -> (TransactionProfile, Result<(DatabaseDropGuard<WALClient>, SchemaSnapshot<WALClient>), SchemaCommitError>) {
+        ) -> (TransactionProfile, Result<SchemaCommitIntent<WALClient>, SchemaCommitError>) {
             let TransactionSchema {
                 snapshot,
                 type_manager,
@@ -62,7 +62,7 @@ pub mod transaction_util {
             let (profile, result) = tx.finalise();
             (profile, result)
         }
-        
+
         pub fn schema_transaction_commit<T>(
             &self,
             fn_: impl Fn(&mut SchemaSnapshot<WALClient>, &TypeManager, &ThingManager, &FunctionManager, &QueryManager) -> T,

--- a/system/util.rs
+++ b/system/util.rs
@@ -13,6 +13,7 @@ pub mod transaction_util {
         transaction::{DatabaseDropGuard, DataCommitError, SchemaCommitError, TransactionRead, TransactionSchema, TransactionWrite},
         Database,
     };
+    use database::transaction::DataCommitIntent;
     use function::function_manager::FunctionManager;
     use options::TransactionOptions;
     use query::query_manager::QueryManager;
@@ -109,7 +110,7 @@ pub mod transaction_util {
                 Arc<Database<WALClient>>,
                 TransactionOptions,
             ) -> (T, Arc<WriteSnapshot<WALClient>>),
-        ) -> (TransactionProfile, Result<(DatabaseDropGuard<WALClient>, WriteSnapshot<WALClient>), DataCommitError>) {
+        ) -> (TransactionProfile, Result<DataCommitIntent<WALClient>, DataCommitError>) {
             let TransactionWrite {
                 snapshot,
                 type_manager,

--- a/user/user_manager.rs
+++ b/user/user_manager.rs
@@ -23,12 +23,11 @@ use crate::errors::{UserCreateError, UserDeleteError, UserGetError, UserUpdateEr
 #[derive(Debug)]
 pub struct UserManager {
     transaction_util: TransactionUtil,
-    system_db: Arc<Database<WALClient>>
 }
 
 impl UserManager {
     pub fn new(system_db: Arc<Database<WALClient>>) -> Self {
-        UserManager { transaction_util: TransactionUtil::new(system_db.clone()), system_db }
+        UserManager { transaction_util: TransactionUtil::new(system_db.clone()) }
     }
 
     pub fn all(&self) -> Vec<User> {

--- a/user/user_manager.rs
+++ b/user/user_manager.rs
@@ -61,7 +61,7 @@ impl UserManager {
         (transaction_profile, create_result)
     }
 
-    pub fn update2(
+    pub fn update(
         &self,
         username: &str,
         user: &Option<User>,
@@ -86,34 +86,6 @@ impl UserManager {
             Err(_query_error) => Err(UserUpdateError::IllegalUsername {}),
         };
         (transaction_profile, update_result)
-    }
-
-    pub fn update(
-        &self,
-        username: &str,
-        user: &Option<User>,
-        credential: &Option<Credential>,
-    ) -> Result<(), UserUpdateError> {
-        let update_result = self
-            .transaction_util
-            .write_transaction_commit(|snapshot, type_mgr, thing_mgr, fn_mgr, query_mgr, _db, _tx_opts| {
-                user_repository::update(
-                    snapshot,
-                    &type_mgr,
-                    thing_mgr.clone(),
-                    &fn_mgr,
-                    &query_mgr,
-                    username,
-                    user,
-                    credential,
-                )
-            })
-            .1;
-        match update_result {
-            Ok(Ok(())) => Ok(()),
-            Ok(Err(_query_error)) => Err(UserUpdateError::IllegalUsername {}),
-            Err(_commit_error) => Err(UserUpdateError::Unexpected {}),
-        }
     }
 
     pub fn delete(

--- a/user/user_manager.rs
+++ b/user/user_manager.rs
@@ -50,7 +50,7 @@ impl UserManager {
     pub fn create(&self, user: &User, credential: &Credential) -> (TransactionProfile, Result<(DatabaseDropGuard<WALClient>, WriteSnapshot<WALClient>), UserCreateError>) {
         let (transaction_profile, create_result) = self
             .transaction_util
-            .write_transaction(|snapshot, type_mgr, thing_mgr, fn_mgr, query_mgr, _dbb, _tx_opts| {
+            .write_transaction(|snapshot, type_mgr, thing_mgr, fn_mgr, query_mgr, _db, _tx_opts| {
                 user_repository::create(snapshot, &type_mgr, thing_mgr.clone(), &fn_mgr, &query_mgr, user, credential)
             });
         let create_result = match create_result {
@@ -68,7 +68,7 @@ impl UserManager {
     ) -> (TransactionProfile, Result<(DatabaseDropGuard<WALClient>, WriteSnapshot<WALClient>), UserUpdateError>) {
         let (transaction_profile, update_result) = self
             .transaction_util
-            .write_transaction(|snapshot, type_mgr, thing_mgr, fn_mgr, query_mgr, _dbb, _tx_opts| {
+            .write_transaction(|snapshot, type_mgr, thing_mgr, fn_mgr, query_mgr, _db, _tx_opts| {
                 user_repository::update(
                     snapshot,
                     &type_mgr,
@@ -110,7 +110,7 @@ impl UserManager {
 
         let (transaction_profile, delete_result) = self
             .transaction_util
-            .write_transaction(|snapshot, type_mgr, thing_mgr, fn_mgr, query_mgr, _dbb, _tx_opts| {
+            .write_transaction(|snapshot, type_mgr, thing_mgr, fn_mgr, query_mgr, _db, _tx_opts| {
                 user_repository::delete(snapshot, &type_mgr, thing_mgr.clone(), &fn_mgr, &query_mgr, username)
             });
         let delete_result = match delete_result {

--- a/user/user_manager.rs
+++ b/user/user_manager.rs
@@ -80,10 +80,9 @@ impl UserManager {
                     credential,
                 )
             });
-        let update_result = match update_result {
-            Ok(tuple) => Ok(tuple),
-            Err(_query_error) => Err(UserUpdateError::IllegalUsername {}),
-        };
+        let update_result = update_result
+            .map(|tuple| tuple)
+            .map_err(|_query_error| UserUpdateError::IllegalUsername {});
         (transaction_profile, update_result)
     }
 
@@ -113,10 +112,10 @@ impl UserManager {
             .write_transaction(|snapshot, type_mgr, thing_mgr, fn_mgr, query_mgr, _db, _tx_opts| {
                 user_repository::delete(snapshot, &type_mgr, thing_mgr.clone(), &fn_mgr, &query_mgr, username)
             });
-        let delete_result = match delete_result {
-            Ok(tuple) => Ok(tuple),
-            Err(_query_error) => Err(UserDeleteError::IllegalUsername {}),
-        };
+
+        let delete_result = delete_result
+            .map(|tuple| tuple)
+            .map_err(|_query_error| UserDeleteError::IllegalUsername {});
 
         (Some(transaction_profile), delete_result)
     }

--- a/user/user_manager.rs
+++ b/user/user_manager.rs
@@ -7,7 +7,7 @@
 use std::sync::Arc;
 
 use database::Database;
-use database::transaction::{DatabaseDropGuard, TransactionWrite};
+use database::transaction::{DataCommitIntent, DatabaseDropGuard, TransactionWrite};
 use resource::constants::server::DEFAULT_USER_NAME;
 use resource::profile::{CommitProfile, TransactionProfile};
 use storage::durability_client::WALClient;
@@ -47,7 +47,7 @@ impl UserManager {
         self.get(username).map(|opt| opt.is_some())
     }
 
-    pub fn create(&self, user: &User, credential: &Credential) -> (TransactionProfile, Result<(DatabaseDropGuard<WALClient>, WriteSnapshot<WALClient>), UserCreateError>) {
+    pub fn create(&self, user: &User, credential: &Credential) -> (TransactionProfile, Result<DataCommitIntent<WALClient>, UserCreateError>) {
         let (transaction_profile, create_result) = self
             .transaction_util
             .write_transaction(|snapshot, type_mgr, thing_mgr, fn_mgr, query_mgr, _db, _tx_opts| {
@@ -65,7 +65,7 @@ impl UserManager {
         username: &str,
         user: &Option<User>,
         credential: &Option<Credential>,
-    ) -> (TransactionProfile, Result<(DatabaseDropGuard<WALClient>, WriteSnapshot<WALClient>), UserUpdateError>) {
+    ) -> (TransactionProfile, Result<DataCommitIntent<WALClient>, UserUpdateError>) {
         let (transaction_profile, update_result) = self
             .transaction_util
             .write_transaction(|snapshot, type_mgr, thing_mgr, fn_mgr, query_mgr, _db, _tx_opts| {
@@ -89,7 +89,7 @@ impl UserManager {
     pub fn delete(
         &self,
         username: &str
-    ) -> (Option<TransactionProfile>, Result<(DatabaseDropGuard<WALClient>, WriteSnapshot<WALClient>), UserDeleteError>) {
+    ) -> (Option<TransactionProfile>, Result<DataCommitIntent<WALClient>, UserDeleteError>) {
         if username == DEFAULT_USER_NAME {
             return (None, Err(UserDeleteError::DefaultUserCannotBeDeleted {}));
         }


### PR DESCRIPTION
## Product change and motivation
Make user update and delete functionality use the supplied `ServerState` object to perform data commit. This architecture change would allow TypeDB Cluster to supply its own `ServerState` implementation which will contain cluster-wide data commit functionality

## Implementation
- Make the `update` and `delete` methods in `UserManager` to return commit record
- Remove user update and delete methods in server state as the data commit will make use of the `database_data_commit` functionality
- Update user update and delete functionality in GRPC and HTTP services to include data commit step