### PR TITLE
SpillOverCache removes key before inserting

### DIFF
--- a/.factory/automation.yml
+++ b/.factory/automation.yml
@@ -67,6 +67,7 @@ build:
       dependencies: [build]
       command: |
         bazel run @typedb_dependencies//tool/bazelinstall:remote_cache_setup.sh
+        bazel test //common/cache:test_crate_cache --test_output=streamed
         bazel test //compiler:test_crate_compiler --test_output=streamed
         bazel test //concept:test_crate_concept --test_output=streamed
         bazel test //database:test_crate_database --test_output=streamed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -702,6 +702,7 @@ dependencies = [
  "resource",
  "rocksdb",
  "serde",
+ "test_utils",
  "tracing",
  "uuid",
 ]

--- a/common/cache/BUILD
+++ b/common/cache/BUILD
@@ -3,7 +3,7 @@
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 load("@typedb_dependencies//tool/checkstyle:rules.bzl", "checkstyle_test")
-load("@rules_rust//rust:defs.bzl", "rust_library")
+load("@rules_rust//rust:defs.bzl", "rust_library", "rust_test")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -21,6 +21,14 @@ rust_library(
         "@crates//:serde",
         "@crates//:tracing",
         "@crates//:uuid",
+    ]
+)
+
+rust_test(
+    name = "test_crate_cache",
+    crate = ":cache",
+    deps = [
+        "//util/test:test_utils",
     ]
 )
 

--- a/common/cache/Cargo.toml
+++ b/common/cache/Cargo.toml
@@ -12,6 +12,13 @@ features = {}
 [lib]
 	path = "cache.rs"
 
+[dev-dependencies]
+
+	[dev-dependencies.test_utils]
+		path = "../../util/test"
+		features = []
+		default-features = false
+
 [dependencies]
 
 	[dependencies.tracing]


### PR DESCRIPTION
## Product change and motivation
Fixes a bug causing in SpillOverCache where a key can be inserted in both the memory backed map, and the disk back mapped.

## Implementation
Call remove before inserting.