### PR TITLE
Fix regression in BDD user management tests

### DIFF
--- a/.factory/automation.yml
+++ b/.factory/automation.yml
@@ -24,17 +24,12 @@ build:
     build:
       image: typedb-ubuntu-22.04
       command: |
-        echo 'build'
-
-#    build:
-#      image: typedb-ubuntu-22.04
-#      command: |
-#        sudo apt update
-#        sudo apt install -y libclang-dev
-#        bazel run @typedb_dependencies//tool/bazelinstall:remote_cache_setup.sh
-#        bazel build //...
-#        bazel run @typedb_dependencies//tool/checkstyle:test-coverage
-#        bazel test $(bazel query 'kind(checkstyle_test, //...)') --test_output=streamed
+        sudo apt update
+        sudo apt install -y libclang-dev
+        bazel run @typedb_dependencies//tool/bazelinstall:remote_cache_setup.sh
+        bazel build //... 
+        bazel run @typedb_dependencies//tool/checkstyle:test-coverage
+        bazel test $(bazel query 'kind(checkstyle_test, //...)') --test_output=streamed
 
 #    build-dependency:
 #      image: typedb-ubuntu-22.04

--- a/.factory/automation.yml
+++ b/.factory/automation.yml
@@ -24,12 +24,17 @@ build:
     build:
       image: typedb-ubuntu-22.04
       command: |
-        sudo apt update
-        sudo apt install -y libclang-dev
-        bazel run @typedb_dependencies//tool/bazelinstall:remote_cache_setup.sh
-        bazel build //... 
-        bazel run @typedb_dependencies//tool/checkstyle:test-coverage
-        bazel test $(bazel query 'kind(checkstyle_test, //...)') --test_output=streamed
+        echo 'build'
+
+#    build:
+#      image: typedb-ubuntu-22.04
+#      command: |
+#        sudo apt update
+#        sudo apt install -y libclang-dev
+#        bazel run @typedb_dependencies//tool/bazelinstall:remote_cache_setup.sh
+#        bazel build //...
+#        bazel run @typedb_dependencies//tool/checkstyle:test-coverage
+#        bazel test $(bazel query 'kind(checkstyle_test, //...)') --test_output=streamed
 
 #    build-dependency:
 #      image: typedb-ubuntu-22.04

--- a/server/service/grpc/transaction_service.rs
+++ b/server/service/grpc/transaction_service.rs
@@ -388,7 +388,7 @@ impl TransactionService {
         let database_name = open_req.database;
         let database = self
             .server_state
-            .databases_get(database_name.as_ref())
+            .databases_get_unrestricted(database_name.as_ref())
             .await
             .map_err(|typedb_source| typedb_source.into_error_message().into_status())?
             .ok_or_else(|| {

--- a/server/service/typedb_service.rs
+++ b/server/service/typedb_service.rs
@@ -34,9 +34,7 @@ impl TypeDBService {
 
         let user_manager = server_state.user_manager().await.ok_or(LocalServerStateError::NotInitialised {})?;
 
-        let create_result = user_manager.create(&user, &credential);
-
-        let (mut transaction_profile, commit_intent) = create_result
+        let (mut transaction_profile, commit_intent) = user_manager.create(&user, &credential)
             .map_err(|(_, typedb_source)| LocalServerStateError::UserCannotBeCreated { typedb_source })?;
 
         let commit_profile = transaction_profile.commit_profile();
@@ -95,13 +93,8 @@ impl TypeDBService {
 
         let user_manager = server_state.user_manager().await.ok_or(LocalServerStateError::NotInitialised {})?;
 
-        let (transaction_profile_opt, commit_intent_result) = user_manager.delete(username);
-
-        let mut transaction_profile = transaction_profile_opt
-            .ok_or(LocalServerStateError::UserCannotBeDeleted { typedb_source: UserDeleteError::Unexpected {} })?;
-
-        let commit_intent = commit_intent_result
-            .map_err(|error| LocalServerStateError::UserCannotBeDeleted { typedb_source: error })?;
+        let (mut transaction_profile, commit_intent) = user_manager.delete(username)
+            .map_err(|(_, typedb_source)| LocalServerStateError::UserCannotBeDeleted { typedb_source })?;
 
         let commit_profile = transaction_profile.commit_profile();
         let commit_record = commit_intent.write_snapshot.finalise(commit_profile).map_err(|_error| {

--- a/server/service/typedb_service.rs
+++ b/server/service/typedb_service.rs
@@ -34,8 +34,11 @@ impl TypeDBService {
 
         let user_manager = server_state.user_manager().await.ok_or(LocalServerStateError::NotInitialised {})?;
 
-        let (mut transaction_profile, commit_intent_result) = user_manager.create(&user, &credential);
-
+        let (transaction_profile_opt, commit_intent_result) = user_manager.create(&user, &credential);
+let mut transaction_profile = transaction_profile_opt
+            .ok_or(LocalServerStateError::UserCannotBeCreated {
+                typedb_source: UserCreateError::Unexpected { }
+            })?;
         let commit_intent = commit_intent_result
             .map_err(|typedb_source| LocalServerStateError::UserCannotBeCreated { typedb_source })?;
 

--- a/server/system_init.rs
+++ b/server/system_init.rs
@@ -29,7 +29,7 @@ pub const SYSTEM_DB: &str = concat!(internal_database_prefix!(), "system");
 pub async fn initialise_system_database(
     server_state: &dyn ServerState,
 ) -> Result<Arc<Database<WALClient>>, ArcServerStateError> {
-    server_state.databases_create(SYSTEM_DB).await?;
+    server_state.databases_create_unrestricted(SYSTEM_DB).await?;
     let db = server_state.database_manager().await.database_unrestricted(SYSTEM_DB).expect("todo");
     initialise_system_database_schema(db.clone(), server_state).await?;
     Ok(db)

--- a/server/system_init.rs
+++ b/server/system_init.rs
@@ -17,6 +17,7 @@ use system::{
     repositories::SCHEMA,
     util::transaction_util::TransactionUtil,
 };
+use user::errors::UserCreateError;
 
 use crate::{
     error::{ArcServerStateError, LocalServerStateError},


### PR DESCRIPTION
## Product change and motivation
This PR fixes a BDD regression issue due to the changes in user and database management.

## Implementation
1. Add validations into the "create user" method in `UserManager`
2. Update control flow such that correct error messages are returned when managing users through the RPC endpoints
3. Make system database initialisation use "unrestricted" variant of the database management methods