### PR TITLE
Add eager cleanup strategy of deleted keys

### DIFF
--- a/.factory/automation.yml
+++ b/.factory/automation.yml
@@ -100,7 +100,8 @@ build:
         bazel test --config=ci $(bazel query 'kind(rust_test, //query/tests/...)') --test_output=streamed
         # TODO: Uncomment!
         # bazel test --config=ci $(bazel query 'kind(rust_test, //storage/tests/...)') --test_output=streamed
-        bazel test --config=ci //storage/tests:test_mvcc //storage/tests:test_snapshot //storage/tests:test_isolation //storage/tests:test_storage --test_output=streamed
+        bazel test --config=ci //storage/tests:test_mvcc //storage/tests:test_snapshot //storage/tests:test_isolation \
+            //storage/tests:test_storage //storage/tests:test_cleanup --test_output=streamed
 
         bazel test --config=ci --config=stress //database/tests:test_statistics_synchronization
 

--- a/common/error/error.rs
+++ b/common/error/error.rs
@@ -285,7 +285,7 @@ macro_rules! typedb_error {
         }
 
         impl ::std::fmt::Debug for $name {
-        fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+            fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
                 ::std::fmt::Debug::fmt(self as &dyn $crate::TypeDBError, f)
             }
         }

--- a/common/options/options.rs
+++ b/common/options/options.rs
@@ -13,7 +13,7 @@ use resource::constants::server::{
 };
 
 #[derive(Debug, Clone)]
-pub enum DatabaseCleanupStrategy {
+pub enum MvccCleanupStrategy {
     Disabled,
     Eager,
 }

--- a/common/options/options.rs
+++ b/common/options/options.rs
@@ -12,6 +12,12 @@ use resource::constants::server::{
     DEFAULT_SCHEMA_LOCK_ACQUIRE_TIMEOUT_MILLIS, DEFAULT_TRANSACTION_PARALLEL, DEFAULT_TRANSACTION_TIMEOUT_MILLIS,
 };
 
+#[derive(Debug, Clone)]
+pub enum DatabaseCleanupStrategy {
+    Disabled,
+    Eager,
+}
+
 #[derive(Debug)]
 pub struct TransactionOptions {
     pub parallel: bool,

--- a/concept/thing/cleanup.rs
+++ b/concept/thing/cleanup.rs
@@ -24,12 +24,12 @@ use storage::{
     keyspace::KeyspaceSet,
 };
 
-type Key = StorageKey<'static, BUFFER_KEY_INLINE>;
+type CleanupRecordKey = StorageKey<'static, BUFFER_KEY_INLINE>;
 
 #[derive(Debug)]
 struct KeyRangeInclusive {
-    start: Key,
-    end: Key,
+    start: CleanupRecordKey,
+    end: CleanupRecordKey,
     fixed_width: bool,
 }
 
@@ -37,14 +37,14 @@ impl KeyRangeInclusive {
     fn merge(self, other: Self) -> Self {
         debug_assert_eq!(self.fixed_width, other.fixed_width);
         Self {
-            start: Key::min(self.start, other.start),
-            end: Key::max(self.end, other.end),
+            start: CleanupRecordKey::min(self.start, other.start),
+            end: CleanupRecordKey::max(self.end, other.end),
             fixed_width: self.fixed_width,
         }
     }
 }
 
-impl From<KeyRangeInclusive> for KeyRange<Key> {
+impl From<KeyRangeInclusive> for KeyRange<CleanupRecordKey> {
     fn from(value: KeyRangeInclusive) -> Self {
         let KeyRangeInclusive { start, end, fixed_width } = value;
         Self::new(RangeStart::Inclusive(start), RangeEnd::EndPrefixInclusive(end), fixed_width)
@@ -53,7 +53,7 @@ impl From<KeyRangeInclusive> for KeyRange<Key> {
 
 #[derive(Debug, Default)]
 pub struct CleanupRecord {
-    intervals: BTreeMap<Key, KeyRangeInclusive>,
+    intervals: BTreeMap<CleanupRecordKey, KeyRangeInclusive>,
 }
 
 impl CleanupRecord {
@@ -65,14 +65,14 @@ impl CleanupRecord {
         Self {
             intervals: KS::iter()
                 .map(|ks| {
-                    let empty_key = || Key::new(ks, Bytes::copy(&[]));
+                    let empty_key = || CleanupRecordKey::new(ks, Bytes::copy(&[]));
                     (empty_key(), KeyRangeInclusive { start: empty_key(), end: empty_key(), fixed_width: false })
                 })
                 .collect(),
         }
     }
 
-    pub fn insert(&mut self, prefix: Key, key: Key, fixed_width_keys: bool) {
+    pub fn insert(&mut self, prefix: CleanupRecordKey, key: CleanupRecordKey, fixed_width_keys: bool) {
         debug_assert!(key.starts_with(&prefix));
         match self.intervals.entry(prefix) {
             Entry::Vacant(vacant_entry) => {
@@ -90,21 +90,23 @@ impl CleanupRecord {
     }
 
     pub fn merge(a: Self, b: Self) -> Self {
-        let intervals = itertools::merge_join_by(a.intervals, b.intervals, |(apfx, _), (bpfx, _)| Key::cmp(apfx, bpfx))
-            .map(|x| match x {
-                EitherOrBoth::Left(kv) | EitherOrBoth::Right(kv) => kv,
-                EitherOrBoth::Both((pfx, range_a), (_pfx, range_b)) => {
-                    debug_assert_eq!(pfx, _pfx);
-                    (pfx, range_a.merge(range_b))
-                }
-            })
-            .collect();
+        let intervals = itertools::merge_join_by(a.intervals, b.intervals, |(apfx, _), (bpfx, _)| {
+            CleanupRecordKey::cmp(apfx, bpfx)
+        })
+        .map(|x| match x {
+            EitherOrBoth::Left(kv) | EitherOrBoth::Right(kv) => kv,
+            EitherOrBoth::Both((pfx, range_a), (_pfx, range_b)) => {
+                debug_assert_eq!(pfx, _pfx);
+                (pfx, range_a.merge(range_b))
+            }
+        })
+        .collect();
         Self { intervals }
     }
 }
 
 impl IntoIterator for CleanupRecord {
-    type Item = (Key, KeyRange<Key>);
+    type Item = (CleanupRecordKey, KeyRange<CleanupRecordKey>);
 
     type IntoIter = IntoIter;
 
@@ -114,11 +116,14 @@ impl IntoIterator for CleanupRecord {
 }
 
 pub struct IntoIter(
-    Map<btree_map::IntoIter<Key, KeyRangeInclusive>, fn((Key, KeyRangeInclusive)) -> (Key, KeyRange<Key>)>,
+    Map<
+        btree_map::IntoIter<CleanupRecordKey, KeyRangeInclusive>,
+        fn((CleanupRecordKey, KeyRangeInclusive)) -> (CleanupRecordKey, KeyRange<CleanupRecordKey>),
+    >,
 );
 
 impl Iterator for IntoIter {
-    type Item = (Key, KeyRange<Key>);
+    type Item = (CleanupRecordKey, KeyRange<CleanupRecordKey>);
 
     fn next(&mut self) -> Option<Self::Item> {
         self.0.next()
@@ -149,7 +154,7 @@ mod serialise {
         ser::SerializeMap,
     };
 
-    use super::{CleanupRecord, Key, KeyRangeInclusive};
+    use super::{CleanupRecord, CleanupRecordKey, KeyRangeInclusive};
 
     impl Serialize for CleanupRecord {
         fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
@@ -172,7 +177,7 @@ mod serialise {
             struct KeyRangeMapVisitor;
 
             impl<'de> Visitor<'de> for KeyRangeMapVisitor {
-                type Value = BTreeMap<Key, KeyRangeInclusive>;
+                type Value = BTreeMap<CleanupRecordKey, KeyRangeInclusive>;
 
                 fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
                     formatter.write_str(type_name::<Self>())
@@ -184,7 +189,7 @@ mod serialise {
                 {
                     let mut intervals = BTreeMap::new();
                     while let Some((prefix, range)) = map.next_entry()? {
-                        intervals.insert(Key::Array(prefix), range);
+                        intervals.insert(CleanupRecordKey::Array(prefix), range);
                     }
                     Ok(intervals)
                 }
@@ -239,8 +244,8 @@ mod serialise {
                     }
 
                     Ok(KeyRangeInclusive {
-                        start: Key::Array(start.ok_or_else(|| de::Error::missing_field("start"))?),
-                        end: Key::Array(end.ok_or_else(|| de::Error::missing_field("end"))?),
+                        start: CleanupRecordKey::Array(start.ok_or_else(|| de::Error::missing_field("start"))?),
+                        end: CleanupRecordKey::Array(end.ok_or_else(|| de::Error::missing_field("end"))?),
                         fixed_width: fixed_width.ok_or_else(|| de::Error::missing_field("fixed_width"))?,
                     })
                 }

--- a/concept/thing/cleanup.rs
+++ b/concept/thing/cleanup.rs
@@ -216,8 +216,8 @@ mod serialise {
                     let mut end = None;
                     let mut fixed_width = None;
 
-                    while let Some(key) = map.next_key()? {
-                        match key {
+                    while let Some(key) = map.next_key::<String>()? {
+                        match key.as_str() {
                             "start" => start = Some(map.next_value()?),
                             "end" => end = Some(map.next_value()?),
                             "fixed_width" => fixed_width = Some(map.next_value()?),

--- a/concept/thing/cleanup.rs
+++ b/concept/thing/cleanup.rs
@@ -12,6 +12,7 @@ use std::{
     iter::Map,
 };
 
+use bytes::Bytes;
 use durability::DurabilityRecordType;
 use itertools::EitherOrBoth;
 use primitive::prefix::Prefix;
@@ -20,6 +21,7 @@ use storage::{
     durability_client::{DurabilityRecord, UnsequencedDurabilityRecord},
     key_range::{KeyRange, RangeEnd, RangeStart},
     key_value::StorageKey,
+    keyspace::KeyspaceSet,
 };
 
 type Key = StorageKey<'static, BUFFER_KEY_INLINE>;
@@ -57,6 +59,17 @@ pub struct CleanupRecord {
 impl CleanupRecord {
     pub fn new() -> Self {
         Self { intervals: BTreeMap::new() }
+    }
+
+    pub fn everything<KS: KeyspaceSet>() -> Self {
+        Self {
+            intervals: KS::iter()
+                .map(|ks| {
+                    let empty_key = || Key::new(ks, Bytes::copy(&[]));
+                    (empty_key(), KeyRangeInclusive { start: empty_key(), end: empty_key(), fixed_width: false })
+                })
+                .collect(),
+        }
     }
 
     pub fn insert(&mut self, prefix: Key, key: Key, fixed_width_keys: bool) {

--- a/concept/thing/cleanup.rs
+++ b/concept/thing/cleanup.rs
@@ -1,0 +1,239 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+use std::{
+    collections::{
+        BTreeMap,
+        btree_map::{self, Entry},
+    },
+    iter::Map,
+};
+
+use durability::DurabilityRecordType;
+use itertools::EitherOrBoth;
+use primitive::prefix::Prefix;
+use resource::constants::snapshot::BUFFER_KEY_INLINE;
+use storage::{
+    durability_client::{DurabilityRecord, UnsequencedDurabilityRecord},
+    key_range::{KeyRange, RangeEnd, RangeStart},
+    key_value::StorageKey,
+};
+
+type Key = StorageKey<'static, BUFFER_KEY_INLINE>;
+
+#[derive(Debug)]
+struct KeyRangeInclusive {
+    start: Key,
+    end: Key,
+    fixed_width: bool,
+}
+
+impl KeyRangeInclusive {
+    fn merge(self, other: Self) -> Self {
+        debug_assert_eq!(self.fixed_width, other.fixed_width);
+        Self {
+            start: Key::min(self.start, other.start),
+            end: Key::max(self.end, other.end),
+            fixed_width: self.fixed_width,
+        }
+    }
+}
+
+impl From<KeyRangeInclusive> for KeyRange<Key> {
+    fn from(value: KeyRangeInclusive) -> Self {
+        let KeyRangeInclusive { start, end, fixed_width } = value;
+        Self::new(RangeStart::Inclusive(start), RangeEnd::EndPrefixInclusive(end), fixed_width)
+    }
+}
+
+#[derive(Debug, Default)]
+pub struct CleanupRecord {
+    intervals: BTreeMap<Key, KeyRangeInclusive>,
+}
+
+impl CleanupRecord {
+    pub fn new() -> Self {
+        Self { intervals: BTreeMap::new() }
+    }
+
+    pub fn insert(&mut self, prefix: Key, key: Key, fixed_width_keys: bool) {
+        debug_assert!(key.starts_with(&prefix));
+        match self.intervals.entry(prefix) {
+            Entry::Vacant(vacant_entry) => {
+                vacant_entry.insert(KeyRangeInclusive { start: key.clone(), end: key, fixed_width: fixed_width_keys });
+            }
+            Entry::Occupied(mut occupied_entry) => {
+                debug_assert_eq!(occupied_entry.get().fixed_width, fixed_width_keys);
+                if key < occupied_entry.get().start {
+                    occupied_entry.get_mut().start = key;
+                } else if key > occupied_entry.get().end {
+                    occupied_entry.get_mut().end = key;
+                }
+            }
+        }
+    }
+
+    pub fn merge(a: Self, b: Self) -> Self {
+        let intervals = itertools::merge_join_by(a.intervals, b.intervals, |(apfx, _), (bpfx, _)| Key::cmp(apfx, bpfx))
+            .map(|x| match x {
+                EitherOrBoth::Left(kv) | EitherOrBoth::Right(kv) => kv,
+                EitherOrBoth::Both((pfx, range_a), (_pfx, range_b)) => {
+                    debug_assert_eq!(pfx, _pfx);
+                    (pfx, range_a.merge(range_b))
+                }
+            })
+            .collect();
+        Self { intervals }
+    }
+}
+
+impl IntoIterator for CleanupRecord {
+    type Item = (Key, KeyRange<Key>);
+
+    type IntoIter = IntoIter;
+
+    fn into_iter(self) -> Self::IntoIter {
+        IntoIter(self.intervals.into_iter().map(|(prefix, range)| (prefix, range.into())))
+    }
+}
+
+pub struct IntoIter(
+    Map<btree_map::IntoIter<Key, KeyRangeInclusive>, fn((Key, KeyRangeInclusive)) -> (Key, KeyRange<Key>)>,
+);
+
+impl Iterator for IntoIter {
+    type Item = (Key, KeyRange<Key>);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.0.next()
+    }
+}
+
+impl DurabilityRecord for CleanupRecord {
+    const RECORD_TYPE: DurabilityRecordType = 11;
+    const RECORD_NAME: &'static str = "";
+
+    fn serialise_into(&self, writer: &mut impl std::io::Write) -> bincode::Result<()> {
+        bincode::serialize_into(writer, self)
+    }
+
+    fn deserialise_from(reader: &mut impl std::io::Read) -> bincode::Result<Self> {
+        bincode::deserialize_from(reader)
+    }
+}
+
+impl UnsequencedDurabilityRecord for CleanupRecord {}
+
+mod serialise {
+    use std::{any::type_name, collections::BTreeMap, fmt};
+
+    use serde::{
+        Deserialize, Serialize,
+        de::{self, Visitor},
+        ser::SerializeMap,
+    };
+
+    use super::{CleanupRecord, Key, KeyRangeInclusive};
+
+    impl Serialize for CleanupRecord {
+        fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            let mut map = serializer.serialize_map(Some(self.intervals.len()))?;
+            for (prefix, range) in &self.intervals {
+                map.serialize_entry(&prefix.clone().into_owned_array(), &range)?;
+            }
+            map.end()
+        }
+    }
+
+    impl<'de> Deserialize<'de> for CleanupRecord {
+        fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            struct KeyRangeMapVisitor;
+
+            impl<'de> Visitor<'de> for KeyRangeMapVisitor {
+                type Value = BTreeMap<Key, KeyRangeInclusive>;
+
+                fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+                    formatter.write_str(type_name::<Self>())
+                }
+
+                fn visit_map<A>(self, mut map: A) -> Result<Self::Value, A::Error>
+                where
+                    A: serde::de::MapAccess<'de>,
+                {
+                    let mut intervals = BTreeMap::new();
+                    while let Some((prefix, range)) = map.next_entry()? {
+                        intervals.insert(Key::Array(prefix), range);
+                    }
+                    Ok(intervals)
+                }
+            }
+
+            Ok(CleanupRecord { intervals: deserializer.deserialize_map(KeyRangeMapVisitor)? })
+        }
+    }
+
+    impl Serialize for KeyRangeInclusive {
+        fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            let mut map = serializer.serialize_map(Some(3))?;
+            map.serialize_entry("start", &self.start.clone().into_owned_array())?;
+            map.serialize_entry("end", &self.end.clone().into_owned_array())?;
+            map.serialize_entry("fixed_width", &self.fixed_width)?;
+            map.end()
+        }
+    }
+
+    impl<'de> Deserialize<'de> for KeyRangeInclusive {
+        fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            struct KeyRangeInclusiveVisitor;
+
+            impl<'de> Visitor<'de> for KeyRangeInclusiveVisitor {
+                type Value = KeyRangeInclusive;
+
+                fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+                    formatter.write_str(type_name::<Self>())
+                }
+
+                fn visit_map<A>(self, mut map: A) -> Result<Self::Value, A::Error>
+                where
+                    A: serde::de::MapAccess<'de>,
+                {
+                    let mut start = None;
+                    let mut end = None;
+                    let mut fixed_width = None;
+
+                    while let Some(key) = map.next_key()? {
+                        match key {
+                            "start" => start = Some(map.next_value()?),
+                            "end" => end = Some(map.next_value()?),
+                            "fixed_width" => fixed_width = Some(map.next_value()?),
+                            field => return Err(de::Error::unknown_field(field, &["start", "end", "fixed_width"])),
+                        }
+                    }
+
+                    Ok(KeyRangeInclusive {
+                        start: Key::Array(start.ok_or_else(|| de::Error::missing_field("start"))?),
+                        end: Key::Array(end.ok_or_else(|| de::Error::missing_field("end"))?),
+                        fixed_width: fixed_width.ok_or_else(|| de::Error::missing_field("fixed_width"))?,
+                    })
+                }
+            }
+
+            deserializer.deserialize_map(KeyRangeInclusiveVisitor)
+        }
+    }
+}

--- a/concept/thing/mod.rs
+++ b/concept/thing/mod.rs
@@ -24,6 +24,7 @@ use crate::{
     type_::TypeAPI,
 };
 
+pub mod cleanup;
 pub mod attribute;
 pub mod entity;
 pub mod has;

--- a/concept/thing/mod.rs
+++ b/concept/thing/mod.rs
@@ -24,8 +24,8 @@ use crate::{
     type_::TypeAPI,
 };
 
-pub mod cleanup;
 pub mod attribute;
+pub mod cleanup;
 pub mod entity;
 pub mod has;
 pub mod object;

--- a/concept/thing/statistics.rs
+++ b/concept/thing/statistics.rs
@@ -242,8 +242,10 @@ impl Statistics {
         commits: &BTreeMap<SequenceNumber, CommittedWrites>,
         storage: &MVCCStorage<D>,
     ) -> Result<i64, MVCCReadError> {
+        type CleanupFn = Box<dyn FnOnce(&mut Statistics)>;
+
         let mut total_delta = 0;
-        let mut deferred_type_cleanups: Vec<Box<dyn FnOnce(&mut Self)>> = Vec::new();
+        let mut deferred_type_cleanups: Vec<CleanupFn> = Vec::new();
 
         for (key, write) in writes.operations.iterate_writes() {
             let delta =
@@ -1004,37 +1006,37 @@ mod serialise {
         map.into_iter().map(|(type_, value)| (type_.into_object_type(), value)).collect()
     }
 
+    impl<'de> Deserialize<'de> for Field {
+        fn deserialize<D>(deserializer: D) -> Result<Field, D::Error>
+        where
+            D: Deserializer<'de>,
+        {
+            struct FieldVisitor;
+
+            impl Visitor<'_> for FieldVisitor {
+                type Value = Field;
+
+                fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+                    formatter.write_str("Unrecognised field")
+                }
+
+                fn visit_str<E>(self, value: &str) -> Result<Field, E>
+                where
+                    E: de::Error,
+                {
+                    Field::from(value).ok_or_else(|| de::Error::unknown_field(value, &Field::NAMES))
+                }
+            }
+
+            deserializer.deserialize_identifier(FieldVisitor)
+        }
+    }
+
     impl<'de> Deserialize<'de> for Statistics {
         fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
         where
             D: Deserializer<'de>,
         {
-            impl<'de> Deserialize<'de> for Field {
-                fn deserialize<D>(deserializer: D) -> Result<Field, D::Error>
-                where
-                    D: Deserializer<'de>,
-                {
-                    struct FieldVisitor;
-
-                    impl Visitor<'_> for FieldVisitor {
-                        type Value = Field;
-
-                        fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-                            formatter.write_str("Unrecognised field")
-                        }
-
-                        fn visit_str<E>(self, value: &str) -> Result<Field, E>
-                        where
-                            E: de::Error,
-                        {
-                            Field::from(value).ok_or_else(|| de::Error::unknown_field(value, &Field::NAMES))
-                        }
-                    }
-
-                    deserializer.deserialize_identifier(FieldVisitor)
-                }
-            }
-
             struct StatisticsVisitor;
 
             impl<'de> Visitor<'de> for StatisticsVisitor {

--- a/concept/thing/thing_manager.rs
+++ b/concept/thing/thing_manager.rs
@@ -1819,11 +1819,11 @@ impl ThingManager {
         self.cleanup_relations(snapshot, storage_counters.clone()).map_err(|err| vec![*err])?;
         self.cleanup_attributes(snapshot, storage_counters.clone()).map_err(|err| vec![*err])?;
 
-        self.create_commit_locks(snapshot)
+        self.finalise_storage_writes(snapshot)
             .map_err(|error| vec![ConceptWriteError::ConceptRead { typedb_source: error }])
     }
 
-    fn create_commit_locks(
+    fn finalise_storage_writes(
         &self,
         snapshot: &mut impl WritableSnapshot,
     ) -> Result<CleanupRecord, Box<ConceptReadError>> {
@@ -1831,88 +1831,39 @@ impl ThingManager {
 
         // TODO: Should not collect here (iterate_writes() already copies)
         for (key, write) in snapshot.iterate_writes().collect_vec() {
-            if ThingEdgeHas::is_has(&key) {
-                let has = ThingEdgeHas::decode(Bytes::Reference(key.bytes()));
-                let object = Object::new(has.from());
-                let attribute = Attribute::new(has.to());
-                let attribute_type = attribute.type_();
-
-                self.add_exclusive_lock_for_unique_constraint(snapshot, &object, attribute)?;
-                self.add_exclusive_lock_for_owns_cardinality_constraint(snapshot, &object, attribute_type)?;
-            } else if ThingEdgeLinks::is_links(&key) {
-                let role_player = ThingEdgeLinks::decode(Bytes::Reference(key.bytes()));
-                let relation = Relation::new(role_player.relation());
-                let player = Object::new(role_player.player());
-                let role_type = RoleType::build_from_type_id(role_player.role_id());
-
-                self.add_exclusive_lock_for_plays_cardinality_constraint(snapshot, &player, role_type)?;
-                self.add_exclusive_lock_for_relates_cardinality_constraint(snapshot, &relation, role_type)?;
-            }
+            self.create_commit_locks(snapshot, &key)?;
 
             if let Write::Delete = write {
-                if let Some(object) = ObjectVertex::try_decode(key.bytes()) {
-                    let prefix = ObjectVertex::build_prefix_type(object.prefix(), object.type_id_(), object.keyspace());
-                    cleanup_record.insert(
-                        prefix.resize_to(),
-                        StorageKey::Array(key).resize_to(),
-                        ObjectVertex::FIXED_WIDTH_ENCODING,
-                    );
-                } else if let Some(attr) = AttributeVertex::try_decode(key.bytes()) {
-                    let prefix = AttributeVertex::build_prefix_type(attr.prefix(), attr.type_id_(), attr.keyspace());
-                    cleanup_record.insert(
-                        prefix.resize_to(),
-                        StorageKey::Array(key).resize_to(),
-                        AttributeVertex::FIXED_WIDTH_ENCODING,
-                    );
-                } else if let Some(has) = ThingEdgeHas::try_decode(key.bytes()) {
-                    let prefix = ThingEdgeHas::prefix_from_type(Object::new(has.from()).type_().vertex());
-                    cleanup_record.insert(
-                        prefix.resize_to(),
-                        StorageKey::Array(key).resize_to(),
-                        ThingEdgeHas::FIXED_WIDTH_ENCODING,
-                    );
-                } else if let Some(reverse_has) = ThingEdgeHasReverse::try_decode(key.bytes()) {
-                    let prefix = ThingEdgeHasReverse::prefix_from_attribute_type(
-                        reverse_has.from().value_type_category(),
-                        reverse_has.from().type_id_(),
-                    );
-                    cleanup_record.insert(
-                        prefix.resize_to(),
-                        StorageKey::Array(key).resize_to(),
-                        ThingEdgeHasReverse::FIXED_WIDTH_ENCODING,
-                    );
-                } else if let Some(links) = ThingEdgeLinks::try_decode(key.bytes()) {
-                    let prefix = if links.is_reverse() {
-                        ThingEdgeLinks::prefix_reverse_from_player_type(
-                            Object::new(links.from()).type_().vertex().prefix(),
-                            links.from().type_id_(),
-                        )
-                    } else {
-                        ThingEdgeLinks::prefix_from_relation_type(links.from().type_id_())
-                    };
-                    cleanup_record.insert(
-                        prefix.resize_to(),
-                        StorageKey::Array(key).resize_to(),
-                        ThingEdgeLinks::FIXED_WIDTH_ENCODING,
-                    );
-                } else if let Some(links_index) = ThingEdgeIndexedRelation::try_decode(key.bytes()) {
-                    let prefix = ThingEdgeIndexedRelation::prefix_relation_type_start_type_parts(
-                        links_index.relation_type_id(),
-                        Object::new(links_index.from()).type_().vertex().prefix(),
-                        links_index.from().type_id_(),
-                    );
-                    cleanup_record.insert(
-                        prefix.resize_to(),
-                        StorageKey::Array(key).resize_to(),
-                        ThingEdgeIndexedRelation::FIXED_WIDTH_ENCODING,
-                    );
-                } else {
-                    debug!("Unhandled delete when constructing compaction record!")
-                }
+                register_delete_in_cleanup_record(&mut cleanup_record, key);
             }
         }
 
         Ok(cleanup_record)
+    }
+
+    fn create_commit_locks(
+        &self,
+        snapshot: &mut impl WritableSnapshot,
+        key: &StorageKeyArray<BUFFER_KEY_INLINE>,
+    ) -> Result<(), Box<ConceptReadError>> {
+        if ThingEdgeHas::is_has(key) {
+            let has = ThingEdgeHas::decode(Bytes::Reference(key.bytes()));
+            let object = Object::new(has.from());
+            let attribute = Attribute::new(has.to());
+            let attribute_type = attribute.type_();
+
+            self.add_exclusive_lock_for_unique_constraint(snapshot, &object, attribute)?;
+            self.add_exclusive_lock_for_owns_cardinality_constraint(snapshot, &object, attribute_type)?;
+        } else if ThingEdgeLinks::is_links(key) {
+            let role_player = ThingEdgeLinks::decode(Bytes::Reference(key.bytes()));
+            let relation = Relation::new(role_player.relation());
+            let player = Object::new(role_player.player());
+            let role_type = RoleType::build_from_type_id(role_player.role_id());
+
+            self.add_exclusive_lock_for_plays_cardinality_constraint(snapshot, &player, role_type)?;
+            self.add_exclusive_lock_for_relates_cardinality_constraint(snapshot, &relation, role_type)?;
+        }
+        Ok(())
     }
 
     fn add_exclusive_lock_for_unique_constraint(
@@ -3071,5 +3022,67 @@ impl ThingManager {
                 unreachable!("Encountered an `insert` while a `put` was expected in the snapshot.")
             }
         }
+    }
+}
+
+fn register_delete_in_cleanup_record(cleanup_record: &mut CleanupRecord, key: StorageKeyArray<BUFFER_KEY_INLINE>) {
+    if let Some(object) = ObjectVertex::try_decode(key.bytes()) {
+        let prefix = ObjectVertex::build_prefix_type(object.prefix(), object.type_id_(), object.keyspace());
+        cleanup_record.insert(
+            prefix.resize_to(),
+            StorageKey::Array(key).resize_to(),
+            ObjectVertex::FIXED_WIDTH_ENCODING,
+        );
+    } else if let Some(attr) = AttributeVertex::try_decode(key.bytes()) {
+        let prefix = AttributeVertex::build_prefix_type(attr.prefix(), attr.type_id_(), attr.keyspace());
+        cleanup_record.insert(
+            prefix.resize_to(),
+            StorageKey::Array(key).resize_to(),
+            AttributeVertex::FIXED_WIDTH_ENCODING,
+        );
+    } else if let Some(has) = ThingEdgeHas::try_decode(key.bytes()) {
+        let prefix = ThingEdgeHas::prefix_from_type(Object::new(has.from()).type_().vertex());
+        cleanup_record.insert(
+            prefix.resize_to(),
+            StorageKey::Array(key).resize_to(),
+            ThingEdgeHas::FIXED_WIDTH_ENCODING,
+        );
+    } else if let Some(reverse_has) = ThingEdgeHasReverse::try_decode(key.bytes()) {
+        let prefix = ThingEdgeHasReverse::prefix_from_attribute_type(
+            reverse_has.from().value_type_category(),
+            reverse_has.from().type_id_(),
+        );
+        cleanup_record.insert(
+            prefix.resize_to(),
+            StorageKey::Array(key).resize_to(),
+            ThingEdgeHasReverse::FIXED_WIDTH_ENCODING,
+        );
+    } else if let Some(links) = ThingEdgeLinks::try_decode(key.bytes()) {
+        let prefix = if links.is_reverse() {
+            ThingEdgeLinks::prefix_reverse_from_player_type(
+                Object::new(links.from()).type_().vertex().prefix(),
+                links.from().type_id_(),
+            )
+        } else {
+            ThingEdgeLinks::prefix_from_relation_type(links.from().type_id_())
+        };
+        cleanup_record.insert(
+            prefix.resize_to(),
+            StorageKey::Array(key).resize_to(),
+            ThingEdgeLinks::FIXED_WIDTH_ENCODING,
+        );
+    } else if let Some(links_index) = ThingEdgeIndexedRelation::try_decode(key.bytes()) {
+        let prefix = ThingEdgeIndexedRelation::prefix_relation_type_start_type_parts(
+            links_index.relation_type_id(),
+            Object::new(links_index.from()).type_().vertex().prefix(),
+            links_index.from().type_id_(),
+        );
+        cleanup_record.insert(
+            prefix.resize_to(),
+            StorageKey::Array(key).resize_to(),
+            ThingEdgeIndexedRelation::FIXED_WIDTH_ENCODING,
+        );
+    } else {
+        debug!("Unhandled delete when constructing compaction record!")
     }
 }

--- a/concept/thing/thing_manager.rs
+++ b/concept/thing/thing_manager.rs
@@ -1865,7 +1865,7 @@ impl ThingManager {
                         AttributeVertex::FIXED_WIDTH_ENCODING,
                     );
                 } else if let Some(has) = ThingEdgeHas::try_decode(key.bytes()) {
-                    let prefix = ThingEdgeHas::prefix_from_type_parts(has.from().prefix(), has.from().type_id_());
+                    let prefix = ThingEdgeHas::prefix_from_type(Object::new(has.from()).type_().vertex());
                     cleanup_record.insert(
                         prefix.resize_to(),
                         StorageKey::Array(key).resize_to(),
@@ -1883,7 +1883,10 @@ impl ThingManager {
                     );
                 } else if let Some(links) = ThingEdgeLinks::try_decode(key.bytes()) {
                     let prefix = if links.is_reverse() {
-                        ThingEdgeLinks::prefix_reverse_from_player_type(links.from().prefix(), links.from().type_id_())
+                        ThingEdgeLinks::prefix_reverse_from_player_type(
+                            Object::new(links.from()).type_().vertex().prefix(),
+                            links.from().type_id_(),
+                        )
                     } else {
                         ThingEdgeLinks::prefix_from_relation_type(links.from().type_id_())
                     };
@@ -1895,7 +1898,7 @@ impl ThingManager {
                 } else if let Some(links_index) = ThingEdgeIndexedRelation::try_decode(key.bytes()) {
                     let prefix = ThingEdgeIndexedRelation::prefix_relation_type_start_type_parts(
                         links_index.relation_type_id(),
-                        links_index.from().prefix(),
+                        Object::new(links_index.from()).type_().vertex().prefix(),
                         links_index.from().type_id_(),
                     );
                     cleanup_record.insert(

--- a/concept/thing/thing_manager.rs
+++ b/concept/thing/thing_manager.rs
@@ -68,6 +68,7 @@ use storage::{
     key_value::{StorageKey, StorageKeyArray, StorageKeyReference},
     snapshot::{ReadableSnapshot, WritableSnapshot, write::Write},
 };
+use tracing::debug;
 
 use crate::{
     ConceptStatus,
@@ -76,6 +77,7 @@ use crate::{
     thing::{
         ThingAPI,
         attribute::{Attribute, AttributeIterator},
+        cleanup::CleanupRecord,
         decode_attribute_ids, decode_role_players, encode_attribute_ids, encode_role_players,
         entity::Entity,
         has::Has,
@@ -1795,7 +1797,7 @@ impl ThingManager {
         &self,
         snapshot: &mut Snapshot,
         storage_counters: StorageCounters,
-    ) -> Result<(), Vec<ConceptWriteError>> {
+    ) -> Result<CleanupRecord, Vec<ConceptWriteError>> {
         let cardinality_change_tracker =
             CardinalityChangeTracker::build(snapshot, self.type_manager(), self, storage_counters.clone())
                 .map_err(|typedb_source| vec![ConceptWriteError::ConceptRead { typedb_source }])?;
@@ -1817,15 +1819,18 @@ impl ThingManager {
         self.cleanup_relations(snapshot, storage_counters.clone()).map_err(|err| vec![*err])?;
         self.cleanup_attributes(snapshot, storage_counters.clone()).map_err(|err| vec![*err])?;
 
-        match self.create_commit_locks(snapshot) {
-            Ok(_) => Ok(()),
-            Err(error) => Err(vec![ConceptWriteError::ConceptRead { typedb_source: error }]),
-        }
+        self.create_commit_locks(snapshot)
+            .map_err(|error| vec![ConceptWriteError::ConceptRead { typedb_source: error }])
     }
 
-    fn create_commit_locks(&self, snapshot: &mut impl WritableSnapshot) -> Result<(), Box<ConceptReadError>> {
+    fn create_commit_locks(
+        &self,
+        snapshot: &mut impl WritableSnapshot,
+    ) -> Result<CleanupRecord, Box<ConceptReadError>> {
+        let mut cleanup_record = CleanupRecord::new();
+
         // TODO: Should not collect here (iterate_writes() already copies)
-        for (key, _write) in snapshot.iterate_writes().collect_vec() {
+        for (key, write) in snapshot.iterate_writes().collect_vec() {
             if ThingEdgeHas::is_has(&key) {
                 let has = ThingEdgeHas::decode(Bytes::Reference(key.bytes()));
                 let object = Object::new(has.from());
@@ -1843,9 +1848,68 @@ impl ThingManager {
                 self.add_exclusive_lock_for_plays_cardinality_constraint(snapshot, &player, role_type)?;
                 self.add_exclusive_lock_for_relates_cardinality_constraint(snapshot, &relation, role_type)?;
             }
+
+            if let Write::Delete = write {
+                if let Some(object) = ObjectVertex::try_decode(key.bytes()) {
+                    let prefix = ObjectVertex::build_prefix_type(object.prefix(), object.type_id_(), object.keyspace());
+                    cleanup_record.insert(
+                        prefix.resize_to(),
+                        StorageKey::Array(key).resize_to(),
+                        ObjectVertex::FIXED_WIDTH_ENCODING,
+                    );
+                } else if let Some(attr) = AttributeVertex::try_decode(key.bytes()) {
+                    let prefix = AttributeVertex::build_prefix_type(attr.prefix(), attr.type_id_(), attr.keyspace());
+                    cleanup_record.insert(
+                        prefix.resize_to(),
+                        StorageKey::Array(key).resize_to(),
+                        AttributeVertex::FIXED_WIDTH_ENCODING,
+                    );
+                } else if let Some(has) = ThingEdgeHas::try_decode(key.bytes()) {
+                    let prefix = ThingEdgeHas::prefix_from_type_parts(has.from().prefix(), has.from().type_id_());
+                    cleanup_record.insert(
+                        prefix.resize_to(),
+                        StorageKey::Array(key).resize_to(),
+                        ThingEdgeHas::FIXED_WIDTH_ENCODING,
+                    );
+                } else if let Some(reverse_has) = ThingEdgeHasReverse::try_decode(key.bytes()) {
+                    let prefix = ThingEdgeHasReverse::prefix_from_attribute_type(
+                        reverse_has.from().value_type_category(),
+                        reverse_has.from().type_id_(),
+                    );
+                    cleanup_record.insert(
+                        prefix.resize_to(),
+                        StorageKey::Array(key).resize_to(),
+                        ThingEdgeHasReverse::FIXED_WIDTH_ENCODING,
+                    );
+                } else if let Some(links) = ThingEdgeLinks::try_decode(key.bytes()) {
+                    let prefix = if links.is_reverse() {
+                        ThingEdgeLinks::prefix_reverse_from_player_type(links.from().prefix(), links.from().type_id_())
+                    } else {
+                        ThingEdgeLinks::prefix_from_relation_type(links.from().type_id_())
+                    };
+                    cleanup_record.insert(
+                        prefix.resize_to(),
+                        StorageKey::Array(key).resize_to(),
+                        ThingEdgeLinks::FIXED_WIDTH_ENCODING,
+                    );
+                } else if let Some(links_index) = ThingEdgeIndexedRelation::try_decode(key.bytes()) {
+                    let prefix = ThingEdgeIndexedRelation::prefix_relation_type_start_type_parts(
+                        links_index.relation_type_id(),
+                        links_index.from().prefix(),
+                        links_index.from().type_id_(),
+                    );
+                    cleanup_record.insert(
+                        prefix.resize_to(),
+                        StorageKey::Array(key).resize_to(),
+                        ThingEdgeIndexedRelation::FIXED_WIDTH_ENCODING,
+                    );
+                } else {
+                    debug!("Unhandled delete when constructing compaction record!")
+                }
+            }
         }
 
-        Ok(())
+        Ok(cleanup_record)
     }
 
     fn add_exclusive_lock_for_unique_constraint(

--- a/database/database.rs
+++ b/database/database.rs
@@ -53,7 +53,7 @@ use storage::{
     sequence_number::SequenceNumber,
     snapshot::snapshot_id::SnapshotId,
 };
-use tracing::{Level, debug, event, trace};
+use tracing::{Level, debug, error, event, trace};
 
 use crate::{
     DatabaseOpenError::FunctionCacheInitialise,
@@ -602,6 +602,22 @@ fn make_update_statistics_fn(
             schema.write().unwrap().thing_statistics = new_statistics;
             debug!("Finished updating statistics for database {}", database_name.as_str());
         }
+    }
+}
+
+fn make_compact_fn(
+    database_name: String,
+    storage: Arc<MVCCStorage<WALClient>>,
+    schema: Arc<RwLock<Schema>>,
+) -> impl Fn() {
+    move || {
+        debug!("Running compaction for database {}", database_name);
+        let start = std::time::Instant::now();
+        if let Err(error) = storage.compact::<EncodingKeyspace>(schema.read().unwrap().thing_statistics.sequence_number)
+        {
+            error!("Compaction failed: {:?}", error);
+        }
+        debug!("Finished compaction for database {} in {:?}", database_name, start.elapsed());
     }
 }
 

--- a/database/database.rs
+++ b/database/database.rs
@@ -5,9 +5,9 @@
  */
 
 use std::{
-    collections::VecDeque,
+    collections::{BTreeMap, VecDeque},
     ffi::OsString,
-    fmt, fs, io,
+    fmt, fs, io, mem,
     path::{Path, PathBuf},
     sync::{
         Arc, Mutex, MutexGuard, RwLock, TryLockError,
@@ -17,7 +17,10 @@ use std::{
 };
 
 use concept::{
-    thing::statistics::{Statistics, StatisticsError},
+    thing::{
+        cleanup::CleanupRecord,
+        statistics::{Statistics, StatisticsError},
+    },
     type_::type_manager::{
         TypeManager,
         type_cache::{TypeCache, TypeCacheCreateError},
@@ -43,8 +46,10 @@ use encoding::{
 use error::typedb_error;
 use fail_point::{UNFINISHED_CHECKPOINT, fail_point};
 use function::{FunctionError, function_cache::FunctionCache};
+use itertools::Itertools;
+use options::DatabaseCleanupStrategy;
 use query::query_cache::QueryCache;
-use resource::constants::database::{CHECKPOINT_INTERVAL, STATISTICS_UPDATE_INTERVAL};
+use resource::constants::database::{CHECKPOINT_INTERVAL, CLEANUP_WAKEUP_INTERVAL, STATISTICS_UPDATE_INTERVAL};
 use storage::{
     MVCCStorage, StorageDeleteError, StorageOpenError, StorageResetError,
     durability_client::{DurabilityClient, DurabilityClientError, WALClient},
@@ -89,9 +94,12 @@ pub struct Database<D> {
 
     pub(super) schema: Arc<RwLock<Schema>>,
     pub(super) query_cache: Arc<QueryCache>,
+    pub(super) _cleanup_queue: Arc<RwLock<BTreeMap<SequenceNumber, CleanupRecord>>>,
+
     schema_write_transaction_exclusivity: Mutex<SchemaWriteTransactionState>,
     _statistics_updater: IntervalRunner,
     _checkpointer: IntervalRunner,
+    _cleanup_worker: IntervalRunner,
 }
 
 impl<D> fmt::Debug for Database<D> {
@@ -247,10 +255,10 @@ impl<D: DurabilityClient> Database<D> {
         &self,
         open_sequence_number: DurabilitySequenceNumber,
         snapshot_id: SnapshotId,
-    ) -> Result<bool, DatabaseOpenError> {
+    ) -> Result<bool, Box<DatabaseOpenError>> {
         self.storage
             .commit_record_exists(open_sequence_number, snapshot_id)
-            .map_err(|typedb_source| DatabaseOpenError::DurabilityClientRead { typedb_source })
+            .map_err(|typedb_source| Box::new(DatabaseOpenError::DurabilityClientRead { typedb_source }))
     }
 }
 
@@ -259,7 +267,8 @@ impl Database<WALClient> {
         path: &Path,
         diagnostics_manager: &DiagnosticsManager,
         rocks_resources: &RocksResources,
-    ) -> Result<Database<WALClient>, DatabaseOpenError> {
+        cleanup_strategy: DatabaseCleanupStrategy,
+    ) -> Result<Database<WALClient>, Box<DatabaseOpenError>> {
         use DatabaseOpenError::InvalidUnicodeName;
 
         let file_name = path.file_name().unwrap();
@@ -267,9 +276,9 @@ impl Database<WALClient> {
         let wal_metrics = diagnostics_manager.wal_metrics(name, DatabaseManager::is_internal_database(name));
 
         if path.exists() {
-            Self::load(path, name, wal_metrics, rocks_resources)
+            Self::load(path, name, wal_metrics, rocks_resources, cleanup_strategy)
         } else {
-            Self::create(path, name, wal_metrics, rocks_resources)
+            Self::create(path, name, wal_metrics, rocks_resources, cleanup_strategy)
         }
     }
 
@@ -278,7 +287,8 @@ impl Database<WALClient> {
         name: impl AsRef<str>,
         wal_metrics: FsyncMetrics,
         rocks_resources: &RocksResources,
-    ) -> Result<Database<WALClient>, DatabaseOpenError> {
+        cleanup_strategy: DatabaseCleanupStrategy,
+    ) -> Result<Database<WALClient>, Box<DatabaseOpenError>> {
         use DatabaseOpenError::{
             DirectoryCreate, Encoding, FunctionCacheInitialise, StorageOpen, TypeCacheInitialise, WALOpen,
         };
@@ -290,6 +300,7 @@ impl Database<WALClient> {
         let wal = WAL::create(path, wal_metrics).map_err(|source| WALOpen { source })?;
         let mut wal_client = WALClient::new(wal);
         wal_client.register_record_type::<Statistics>();
+        wal_client.register_record_type::<CleanupRecord>();
 
         let storage = Arc::new(
             MVCCStorage::create::<EncodingKeyspace>(name, path, wal_client, rocks_resources)
@@ -326,7 +337,12 @@ impl Database<WALClient> {
             schema_txn_lock.clone(),
             query_cache.clone(),
         );
+
         let checkpoint_fn = make_checkpoint_fn(name.to_owned(), path.to_owned(), SequenceNumber::MIN, storage.clone());
+
+        let _cleanup_queue = Arc::<RwLock<BTreeMap<SequenceNumber, CleanupRecord>>>::default();
+        let cleanup_fn =
+            make_cleanup_fn(name.to_owned(), storage.clone(), schema.clone(), _cleanup_queue.clone(), cleanup_strategy);
 
         Ok(Database::<WALClient> {
             name: Arc::<str>::from(name),
@@ -337,9 +353,11 @@ impl Database<WALClient> {
             thing_vertex_generator,
             schema,
             query_cache,
+            _cleanup_queue,
             schema_write_transaction_exclusivity: Mutex::new((false, 0, VecDeque::with_capacity(100))),
             _statistics_updater: IntervalRunner::new(update_statistics, STATISTICS_UPDATE_INTERVAL),
             _checkpointer: IntervalRunner::new(checkpoint_fn, CHECKPOINT_INTERVAL),
+            _cleanup_worker: IntervalRunner::new(cleanup_fn, CLEANUP_WAKEUP_INTERVAL),
         })
     }
 
@@ -348,7 +366,8 @@ impl Database<WALClient> {
         name: impl AsRef<str>,
         wal_metrics: FsyncMetrics,
         rocks_resources: &RocksResources,
-    ) -> Result<Database<WALClient>, DatabaseOpenError> {
+        cleanup_strategy: DatabaseCleanupStrategy,
+    ) -> Result<Database<WALClient>, Box<DatabaseOpenError>> {
         use DatabaseOpenError::{
             CheckpointCreate, CheckpointLoad, DurabilityClientRead, Encoding, NotADatabase, StatisticsInitialise,
             StorageOpen, TypeCacheInitialise, WALOpen,
@@ -366,15 +385,16 @@ impl Database<WALClient> {
         let wal = match WAL::load(path, wal_metrics) {
             Ok(wal) => wal,
             Err(DurabilityServiceError::WAL { source: WALError::LoadDirectoryMissing { .. } }) => {
-                return Err(NotADatabase { name: name.to_owned() });
+                return Err(Box::new(NotADatabase { name: name.to_owned() }));
             }
-            Err(source) => return Err(WALOpen { source }),
+            Err(source) => return Err(Box::new(WALOpen { source })),
         };
 
         let wal_last_sequence_number = wal.previous();
 
         let mut wal_client = WALClient::new(wal);
         wal_client.register_record_type::<Statistics>();
+        wal_client.register_record_type::<CleanupRecord>();
 
         event!(Level::TRACE, "Loading last database '{}' checkpoint", &name);
         let checkpoint = CheckpointReader::open_latest::<EncodingKeyspace>(path)
@@ -428,9 +448,12 @@ impl Database<WALClient> {
 
         let checkpoint_sequence_number = match checkpoint {
             None => SequenceNumber::MIN,
-            Some(checkpoint) => checkpoint
-                .read_sequence_number()
-                .map_err(|err| CheckpointLoad { name: name.to_string(), typedb_source: err })?,
+            Some(checkpoint) => {
+                checkpoint
+                    .read_metadata()
+                    .map_err(|err| CheckpointLoad { name: name.to_string(), typedb_source: err })?
+                    .watermark
+            }
         };
 
         let query_cache = Arc::new(QueryCache::new());
@@ -444,6 +467,16 @@ impl Database<WALClient> {
         let checkpoint_fn =
             make_checkpoint_fn(name.to_owned(), path.to_owned(), checkpoint_sequence_number, storage.clone());
 
+        let _cleanup_queue = Arc::new(RwLock::new(
+            storage
+                .durability()
+                .iter_type_from(storage.earliest_uncleaned())
+                .and_then(Itertools::try_collect)
+                .map_err(|typedb_source| DatabaseOpenError::DurabilityClientRead { typedb_source })?,
+        ));
+        let cleanup_fn =
+            make_cleanup_fn(name.to_owned(), storage.clone(), schema.clone(), _cleanup_queue.clone(), cleanup_strategy);
+
         let database = Database::<WALClient> {
             name: Arc::<str>::from(name),
             path: path.to_owned(),
@@ -453,6 +486,7 @@ impl Database<WALClient> {
             thing_vertex_generator,
             schema,
             query_cache,
+            _cleanup_queue,
             schema_write_transaction_exclusivity: Mutex::new((false, 0, VecDeque::with_capacity(100))),
             _statistics_updater: IntervalRunner::new(update_statistics, STATISTICS_UPDATE_INTERVAL),
             _checkpointer: IntervalRunner::new_with_initial_delay(
@@ -460,6 +494,7 @@ impl Database<WALClient> {
                 CHECKPOINT_INTERVAL,
                 CHECKPOINT_INTERVAL,
             ),
+            _cleanup_worker: IntervalRunner::new(cleanup_fn, CLEANUP_WAKEUP_INTERVAL),
         };
 
         if checkpoint_sequence_number < wal_last_sequence_number {
@@ -480,6 +515,7 @@ impl Database<WALClient> {
         trace!("Deleting database '{}'.", &self.name);
         drop(self._statistics_updater);
         drop(self._checkpointer);
+        drop(self._cleanup_worker);
         drop(Arc::into_inner(self.schema).expect("Cannot get exclusive ownership of inner of Arc<Schema>."));
         drop(Arc::into_inner(self.query_cache).expect("Cannot get exclusive ownership of inner of Arc<QueryCache>."));
         drop(
@@ -503,7 +539,7 @@ impl Database<WALClient> {
         Ok(())
     }
 
-    pub fn reset(&mut self) -> Result<(), DatabaseResetError> {
+    pub fn reset(&mut self) -> Result<(), Box<DatabaseResetError>> {
         use DatabaseResetError::CorruptionPartialResetStorageInUse;
 
         self.reserve_schema_transaction(Duration::from_secs(60).as_millis() as u64)
@@ -511,21 +547,21 @@ impl Database<WALClient> {
         let mut locked_schema = self.schema.write().unwrap();
 
         match Arc::get_mut(&mut self.storage) {
-            None => return Err(DatabaseResetError::StorageInUse {}),
+            None => return Err(Box::new(DatabaseResetError::StorageInUse {})),
             Some(storage) => {
                 storage.reset().map_err(|err| CorruptionPartialResetStorageInUse { typedb_source: err })?
             }
         }
         match Arc::get_mut(&mut self.definition_key_generator) {
-            None => return Err(CorruptionPartialResetKeyGeneratorInUse {}),
+            None => return Err(Box::new(CorruptionPartialResetKeyGeneratorInUse {})),
             Some(definition_key_generator) => definition_key_generator.reset(),
         }
         match Arc::get_mut(&mut self.type_vertex_generator) {
-            None => return Err(CorruptionPartialResetTypeVertexGeneratorInUse {}),
+            None => return Err(Box::new(CorruptionPartialResetTypeVertexGeneratorInUse {})),
             Some(type_vertex_generator) => type_vertex_generator.reset(),
         }
         match Arc::get_mut(&mut self.thing_vertex_generator) {
-            None => return Err(CorruptionPartialResetThingVertexGeneratorInUse {}),
+            None => return Err(Box::new(CorruptionPartialResetThingVertexGeneratorInUse {})),
             Some(thing_vertex_generator) => thing_vertex_generator.reset(),
         }
 
@@ -605,19 +641,48 @@ fn make_update_statistics_fn(
     }
 }
 
-fn make_compact_fn(
+fn make_cleanup_fn(
     database_name: String,
     storage: Arc<MVCCStorage<WALClient>>,
     schema: Arc<RwLock<Schema>>,
+    cleanup_queue: Arc<RwLock<BTreeMap<SequenceNumber, CleanupRecord>>>,
+    cleanup_strategy: DatabaseCleanupStrategy,
 ) -> impl Fn() {
-    move || {
-        debug!("Running compaction for database {}", database_name);
-        let start = std::time::Instant::now();
-        if let Err(error) = storage.compact::<EncodingKeyspace>(schema.read().unwrap().thing_statistics.sequence_number)
-        {
-            error!("Compaction failed: {:?}", error);
-        }
-        debug!("Finished compaction for database {} in {:?}", database_name, start.elapsed());
+    fn make_disabled_cleanup_fn() -> Box<dyn Fn() + Send + Sync> {
+        Box::new(|| ())
+    }
+
+    fn make_eager_cleanup_fn(
+        database_name: String,
+        storage: Arc<MVCCStorage<WALClient>>,
+        schema: Arc<RwLock<Schema>>,
+        cleanup_queue: Arc<RwLock<BTreeMap<SequenceNumber, CleanupRecord>>>,
+    ) -> Box<dyn Fn() + Send + Sync> {
+        Box::new(move || {
+            debug!("Running compaction for database {}", database_name);
+            let start = std::time::Instant::now();
+            let statistics_watermark = schema.read().unwrap().thing_statistics.sequence_number;
+            let earliest_possible_reader = storage.earliest_possible_reader();
+            let watermark = SequenceNumber::min(statistics_watermark, earliest_possible_reader);
+
+            let range = {
+                let mut queue = cleanup_queue.write().unwrap();
+                let tail_including_watermark = queue.split_off(&watermark);
+                mem::replace(&mut *queue, tail_including_watermark)
+            };
+
+            let ranges = range.into_values().fold(CleanupRecord::default(), CleanupRecord::merge);
+
+            if let Err(error) = storage.cleanup_dead_keys::<EncodingKeyspace>(watermark, ranges) {
+                error!("Compaction failed: {:?}", error);
+            }
+            debug!("Finished compaction for database {} in {:?}", database_name, start.elapsed());
+        })
+    }
+
+    match cleanup_strategy {
+        DatabaseCleanupStrategy::Disabled => make_disabled_cleanup_fn(),
+        DatabaseCleanupStrategy::Eager => make_eager_cleanup_fn(database_name, storage, schema, cleanup_queue),
     }
 }
 

--- a/database/database.rs
+++ b/database/database.rs
@@ -649,8 +649,12 @@ fn make_cleanup_fn(
     cleanup_queue: Arc<RwLock<BTreeMap<SequenceNumber, CleanupRecord>>>,
     cleanup_strategy: DatabaseCleanupStrategy,
 ) -> impl Fn() {
-    fn make_disabled_cleanup_fn() -> Box<dyn Fn() + Send + Sync> {
-        Box::new(|| ())
+    fn make_disabled_cleanup_fn(
+        cleanup_queue: Arc<RwLock<BTreeMap<SequenceNumber, CleanupRecord>>>,
+    ) -> Box<dyn Fn() + Send + Sync> {
+        Box::new(move || {
+            cleanup_queue.write().unwrap().clear();
+        })
     }
 
     fn make_eager_cleanup_fn(
@@ -692,7 +696,7 @@ fn make_cleanup_fn(
     }
 
     match cleanup_strategy {
-        DatabaseCleanupStrategy::Disabled => make_disabled_cleanup_fn(),
+        DatabaseCleanupStrategy::Disabled => make_disabled_cleanup_fn(cleanup_queue),
         DatabaseCleanupStrategy::Eager => make_eager_cleanup_fn(database_name, storage, schema, cleanup_queue),
     }
 }

--- a/database/database.rs
+++ b/database/database.rs
@@ -468,13 +468,17 @@ impl Database<WALClient> {
             make_checkpoint_fn(name.to_owned(), path.to_owned(), checkpoint_sequence_number, storage.clone());
 
         let earliest_uncleaned = storage.earliest_uncleaned();
-        let cleanup_queue = Arc::new(RwLock::new(
-            storage
-                .durability()
-                .iter_type_from(earliest_uncleaned)
-                .and_then(Itertools::try_collect)
-                .map_err(|typedb_source| DatabaseOpenError::DurabilityClientRead { typedb_source })?,
-        ));
+        let cleanup_queue = if let DatabaseCleanupStrategy::Disabled = cleanup_strategy {
+            Default::default()
+        } else {
+            Arc::new(RwLock::new(
+                storage
+                    .durability()
+                    .iter_type_from(earliest_uncleaned)
+                    .and_then(Itertools::try_collect)
+                    .map_err(|typedb_source| DatabaseOpenError::DurabilityClientRead { typedb_source })?,
+            ))
+        };
         let cleanup_fn =
             make_cleanup_fn(name.to_owned(), storage.clone(), schema.clone(), cleanup_queue.clone(), cleanup_strategy);
 

--- a/database/database.rs
+++ b/database/database.rs
@@ -673,7 +673,7 @@ fn make_cleanup_fn(
 
             let ranges = range.into_values().fold(CleanupRecord::default(), CleanupRecord::merge);
 
-            if let Err(error) = storage.cleanup_dead_keys::<EncodingKeyspace>(watermark, ranges) {
+            if let Err(error) = storage.cleanup_dead_keys(watermark, ranges) {
                 error!("Compaction failed: {:?}", error);
             }
             debug!("Finished compaction for database {} in {:?}", database_name, start.elapsed());

--- a/database/database.rs
+++ b/database/database.rs
@@ -340,9 +340,9 @@ impl Database<WALClient> {
 
         let checkpoint_fn = make_checkpoint_fn(name.to_owned(), path.to_owned(), SequenceNumber::MIN, storage.clone());
 
-        let _cleanup_queue = Arc::<RwLock<BTreeMap<SequenceNumber, CleanupRecord>>>::default();
+        let cleanup_queue = Arc::<RwLock<BTreeMap<SequenceNumber, CleanupRecord>>>::default();
         let cleanup_fn =
-            make_cleanup_fn(name.to_owned(), storage.clone(), schema.clone(), _cleanup_queue.clone(), cleanup_strategy);
+            make_cleanup_fn(name.to_owned(), storage.clone(), schema.clone(), cleanup_queue.clone(), cleanup_strategy);
 
         Ok(Database::<WALClient> {
             name: Arc::<str>::from(name),
@@ -353,7 +353,7 @@ impl Database<WALClient> {
             thing_vertex_generator,
             schema,
             query_cache,
-            _cleanup_queue,
+            _cleanup_queue: cleanup_queue,
             schema_write_transaction_exclusivity: Mutex::new((false, 0, VecDeque::with_capacity(100))),
             _statistics_updater: IntervalRunner::new(update_statistics, STATISTICS_UPDATE_INTERVAL),
             _checkpointer: IntervalRunner::new(checkpoint_fn, CHECKPOINT_INTERVAL),
@@ -467,15 +467,18 @@ impl Database<WALClient> {
         let checkpoint_fn =
             make_checkpoint_fn(name.to_owned(), path.to_owned(), checkpoint_sequence_number, storage.clone());
 
-        let _cleanup_queue = Arc::new(RwLock::new(
-            storage
-                .durability()
-                .iter_type_from(storage.earliest_uncleaned())
-                .and_then(Itertools::try_collect)
-                .map_err(|typedb_source| DatabaseOpenError::DurabilityClientRead { typedb_source })?,
-        ));
+        let earliest_uncleaned = storage.earliest_uncleaned();
+        let mut cleanup_queue: BTreeMap<_, _> = storage
+            .durability()
+            .iter_type_from(earliest_uncleaned)
+            .and_then(Itertools::try_collect)
+            .map_err(|typedb_source| DatabaseOpenError::DurabilityClientRead { typedb_source })?;
+        if cleanup_queue.first_key_value().is_none_or(|(k, _)| k > &earliest_uncleaned) {
+            cleanup_queue.insert(earliest_uncleaned, CleanupRecord::everything::<EncodingKeyspace>());
+        }
+        let cleanup_queue = Arc::new(RwLock::new(cleanup_queue));
         let cleanup_fn =
-            make_cleanup_fn(name.to_owned(), storage.clone(), schema.clone(), _cleanup_queue.clone(), cleanup_strategy);
+            make_cleanup_fn(name.to_owned(), storage.clone(), schema.clone(), cleanup_queue.clone(), cleanup_strategy);
 
         let database = Database::<WALClient> {
             name: Arc::<str>::from(name),
@@ -486,7 +489,7 @@ impl Database<WALClient> {
             thing_vertex_generator,
             schema,
             query_cache,
-            _cleanup_queue,
+            _cleanup_queue: cleanup_queue,
             schema_write_transaction_exclusivity: Mutex::new((false, 0, VecDeque::with_capacity(100))),
             _statistics_updater: IntervalRunner::new(update_statistics, STATISTICS_UPDATE_INTERVAL),
             _checkpointer: IntervalRunner::new_with_initial_delay(

--- a/database/database.rs
+++ b/database/database.rs
@@ -47,7 +47,7 @@ use error::typedb_error;
 use fail_point::{UNFINISHED_CHECKPOINT, fail_point};
 use function::{FunctionError, function_cache::FunctionCache};
 use itertools::Itertools;
-use options::DatabaseCleanupStrategy;
+use options::MvccCleanupStrategy;
 use query::query_cache::QueryCache;
 use resource::constants::database::{CHECKPOINT_INTERVAL, CLEANUP_WAKEUP_INTERVAL, STATISTICS_UPDATE_INTERVAL};
 use storage::{
@@ -267,7 +267,7 @@ impl Database<WALClient> {
         path: &Path,
         diagnostics_manager: &DiagnosticsManager,
         rocks_resources: &RocksResources,
-        cleanup_strategy: DatabaseCleanupStrategy,
+        cleanup_strategy: MvccCleanupStrategy,
     ) -> Result<Database<WALClient>, Box<DatabaseOpenError>> {
         use DatabaseOpenError::InvalidUnicodeName;
 
@@ -287,7 +287,7 @@ impl Database<WALClient> {
         name: impl AsRef<str>,
         wal_metrics: FsyncMetrics,
         rocks_resources: &RocksResources,
-        cleanup_strategy: DatabaseCleanupStrategy,
+        cleanup_strategy: MvccCleanupStrategy,
     ) -> Result<Database<WALClient>, Box<DatabaseOpenError>> {
         use DatabaseOpenError::{
             DirectoryCreate, Encoding, FunctionCacheInitialise, StorageOpen, TypeCacheInitialise, WALOpen,
@@ -366,7 +366,7 @@ impl Database<WALClient> {
         name: impl AsRef<str>,
         wal_metrics: FsyncMetrics,
         rocks_resources: &RocksResources,
-        cleanup_strategy: DatabaseCleanupStrategy,
+        cleanup_strategy: MvccCleanupStrategy,
     ) -> Result<Database<WALClient>, Box<DatabaseOpenError>> {
         use DatabaseOpenError::{
             CheckpointCreate, CheckpointLoad, DurabilityClientRead, Encoding, NotADatabase, StatisticsInitialise,
@@ -468,7 +468,7 @@ impl Database<WALClient> {
             make_checkpoint_fn(name.to_owned(), path.to_owned(), checkpoint_sequence_number, storage.clone());
 
         let earliest_uncleaned = storage.earliest_uncleaned();
-        let cleanup_queue = if let DatabaseCleanupStrategy::Disabled = cleanup_strategy {
+        let cleanup_queue = if let MvccCleanupStrategy::Disabled = cleanup_strategy {
             Default::default()
         } else {
             Arc::new(RwLock::new(
@@ -651,7 +651,7 @@ fn make_cleanup_fn(
     storage: Arc<MVCCStorage<WALClient>>,
     schema: Arc<RwLock<Schema>>,
     cleanup_queue: Arc<RwLock<BTreeMap<SequenceNumber, CleanupRecord>>>,
-    cleanup_strategy: DatabaseCleanupStrategy,
+    cleanup_strategy: MvccCleanupStrategy,
 ) -> impl Fn() {
     fn make_disabled_cleanup_fn(
         cleanup_queue: Arc<RwLock<BTreeMap<SequenceNumber, CleanupRecord>>>,
@@ -692,7 +692,7 @@ fn make_cleanup_fn(
                 }
             };
 
-            if let Err(error) = storage.cleanup_dead_keys(watermark, ranges) {
+            if let Err(error) = storage.mvcc_cleanup(watermark, ranges) {
                 error!("Cleanup failed: {:?}", error);
             }
             debug!("Finished cleanup for database {} in {:?}", database_name, start.elapsed());
@@ -700,8 +700,8 @@ fn make_cleanup_fn(
     }
 
     match cleanup_strategy {
-        DatabaseCleanupStrategy::Disabled => make_disabled_cleanup_fn(cleanup_queue),
-        DatabaseCleanupStrategy::Eager => make_eager_cleanup_fn(database_name, storage, schema, cleanup_queue),
+        MvccCleanupStrategy::Disabled => make_disabled_cleanup_fn(cleanup_queue),
+        MvccCleanupStrategy::Eager => make_eager_cleanup_fn(database_name, storage, schema, cleanup_queue),
     }
 }
 

--- a/database/database.rs
+++ b/database/database.rs
@@ -58,7 +58,7 @@ use storage::{
     sequence_number::SequenceNumber,
     snapshot::snapshot_id::SnapshotId,
 };
-use tracing::{Level, debug, error, event, trace};
+use tracing::{Level, debug, error, event, info, trace};
 
 use crate::{
     DatabaseOpenError::FunctionCacheInitialise,
@@ -468,15 +468,13 @@ impl Database<WALClient> {
             make_checkpoint_fn(name.to_owned(), path.to_owned(), checkpoint_sequence_number, storage.clone());
 
         let earliest_uncleaned = storage.earliest_uncleaned();
-        let mut cleanup_queue: BTreeMap<_, _> = storage
-            .durability()
-            .iter_type_from(earliest_uncleaned)
-            .and_then(Itertools::try_collect)
-            .map_err(|typedb_source| DatabaseOpenError::DurabilityClientRead { typedb_source })?;
-        if cleanup_queue.first_key_value().is_none_or(|(k, _)| k > &earliest_uncleaned) {
-            cleanup_queue.insert(earliest_uncleaned, CleanupRecord::everything::<EncodingKeyspace>());
-        }
-        let cleanup_queue = Arc::new(RwLock::new(cleanup_queue));
+        let cleanup_queue = Arc::new(RwLock::new(
+            storage
+                .durability()
+                .iter_type_from(earliest_uncleaned)
+                .and_then(Itertools::try_collect)
+                .map_err(|typedb_source| DatabaseOpenError::DurabilityClientRead { typedb_source })?,
+        ));
         let cleanup_fn =
             make_cleanup_fn(name.to_owned(), storage.clone(), schema.clone(), cleanup_queue.clone(), cleanup_strategy);
 
@@ -662,7 +660,7 @@ fn make_cleanup_fn(
         cleanup_queue: Arc<RwLock<BTreeMap<SequenceNumber, CleanupRecord>>>,
     ) -> Box<dyn Fn() + Send + Sync> {
         Box::new(move || {
-            debug!("Running compaction for database {}", database_name);
+            debug!("Running cleanup for database {}", database_name);
             let start = std::time::Instant::now();
             let statistics_watermark = schema.read().unwrap().thing_statistics.sequence_number;
             let earliest_possible_reader = storage.earliest_possible_reader();
@@ -674,12 +672,22 @@ fn make_cleanup_fn(
                 mem::replace(&mut *queue, tail_including_watermark)
             };
 
-            let ranges = range.into_values().fold(CleanupRecord::default(), CleanupRecord::merge);
+            let ranges = {
+                let contains_start = range.contains_key(&storage.earliest_uncleaned());
+                let contains_end = range.contains_key(&watermark.previous());
+                let all_consecutive = range.keys().tuple_windows().all(|(a, &b)| a.next() == b);
+                if contains_start && contains_end && all_consecutive {
+                    range.into_values().fold(CleanupRecord::default(), CleanupRecord::merge)
+                } else {
+                    info!("Missing delta records during cleanup; scanning database for dead keys.");
+                    CleanupRecord::everything::<EncodingKeyspace>()
+                }
+            };
 
             if let Err(error) = storage.cleanup_dead_keys(watermark, ranges) {
-                error!("Compaction failed: {:?}", error);
+                error!("Cleanup failed: {:?}", error);
             }
-            debug!("Finished compaction for database {} in {:?}", database_name, start.elapsed());
+            debug!("Finished cleanup for database {} in {:?}", database_name, start.elapsed());
         })
     }
 

--- a/database/database_manager.rs
+++ b/database/database_manager.rs
@@ -13,7 +13,7 @@ use std::{
 use cache::CACHE_DB_NAME_PREFIX;
 use diagnostics::diagnostics_manager::DiagnosticsManager;
 pub(crate) use durability::sync_directory;
-use options::{DatabaseCleanupStrategy, byte_size::ByteSize};
+use options::{MvccCleanupStrategy, byte_size::ByteSize};
 use resource::{constants::database::INTERNAL_DATABASE_PREFIX, internal_database_prefix};
 use storage::{durability_client::WALClient, keyspace::rocks_resources::RocksResources};
 use tracing::{Level, debug, event, warn};
@@ -42,7 +42,7 @@ pub struct DatabaseManager {
     database_registry: DatabaseRegistry,
     diagnostics_manager: Arc<DiagnosticsManager>,
     rocks_resources: Arc<RocksResources>,
-    cleanup_strategy: DatabaseCleanupStrategy,
+    cleanup_strategy: MvccCleanupStrategy,
 }
 
 impl DatabaseManager {
@@ -54,7 +54,7 @@ impl DatabaseManager {
         rocksdb_cache_size: ByteSize,
         rocksdb_write_buffers_limit: ByteSize,
         import_ownership: ImportOwnership,
-        cleanup_strategy: DatabaseCleanupStrategy,
+        cleanup_strategy: MvccCleanupStrategy,
     ) -> Result<Arc<Self>, Box<DatabaseOpenError>> {
         let data_directory = data_directory.as_ref().to_owned();
         let import_directory = data_directory.join(Self::IMPORT_DIRECTORY_NAME);
@@ -92,7 +92,7 @@ impl DatabaseManager {
         import_directory: &Path,
         diagnostics_manager: &DiagnosticsManager,
         rocks_resources: &RocksResources,
-        cleanup_strategy: DatabaseCleanupStrategy,
+        cleanup_strategy: MvccCleanupStrategy,
     ) -> Result<DatabasesMap, Box<DatabaseOpenError>> {
         let mut databases = DatabasesMap::new();
 
@@ -138,7 +138,7 @@ impl DatabaseManager {
         served_databases: &DatabasesMap,
         diagnostics_manager: &DiagnosticsManager,
         rocks_resources: &RocksResources,
-        cleanup_strategy: DatabaseCleanupStrategy,
+        cleanup_strategy: MvccCleanupStrategy,
     ) -> Result<DatabasesMap, Box<DatabaseOpenError>> {
         match import_ownership {
             ImportOwnership::Exclusive => {
@@ -193,7 +193,7 @@ impl DatabaseManager {
         served_databases: &DatabasesMap,
         diagnostics_manager: &DiagnosticsManager,
         rocks_resources: &RocksResources,
-        cleanup_strategy: DatabaseCleanupStrategy,
+        cleanup_strategy: MvccCleanupStrategy,
     ) -> Result<DatabasesMap, Box<DatabaseOpenError>> {
         let mut recovered = DatabasesMap::new();
         if !directory.exists() {

--- a/database/database_manager.rs
+++ b/database/database_manager.rs
@@ -13,7 +13,7 @@ use std::{
 use cache::CACHE_DB_NAME_PREFIX;
 use diagnostics::diagnostics_manager::DiagnosticsManager;
 pub(crate) use durability::sync_directory;
-use options::byte_size::ByteSize;
+use options::{DatabaseCleanupStrategy, byte_size::ByteSize};
 use resource::{constants::database::INTERNAL_DATABASE_PREFIX, internal_database_prefix};
 use storage::{durability_client::WALClient, keyspace::rocks_resources::RocksResources};
 use tracing::{Level, debug, event, warn};
@@ -42,6 +42,7 @@ pub struct DatabaseManager {
     database_registry: DatabaseRegistry,
     diagnostics_manager: Arc<DiagnosticsManager>,
     rocks_resources: Arc<RocksResources>,
+    cleanup_strategy: DatabaseCleanupStrategy,
 }
 
 impl DatabaseManager {
@@ -53,7 +54,8 @@ impl DatabaseManager {
         rocksdb_cache_size: ByteSize,
         rocksdb_write_buffers_limit: ByteSize,
         import_ownership: ImportOwnership,
-    ) -> Result<Arc<Self>, DatabaseOpenError> {
+        cleanup_strategy: DatabaseCleanupStrategy,
+    ) -> Result<Arc<Self>, Box<DatabaseOpenError>> {
         let data_directory = data_directory.as_ref().to_owned();
         let import_directory = data_directory.join(Self::IMPORT_DIRECTORY_NAME);
         let rocks_resources = Arc::new(RocksResources::new(rocksdb_cache_size, rocksdb_write_buffers_limit));
@@ -62,6 +64,7 @@ impl DatabaseManager {
             &import_directory,
             &diagnostics_manager,
             &rocks_resources,
+            cleanup_strategy.clone(),
         )?;
         let staged_databases = Self::initialise_staged_databases(
             &import_directory,
@@ -69,6 +72,7 @@ impl DatabaseManager {
             &served_databases,
             &diagnostics_manager,
             &rocks_resources,
+            cleanup_strategy.clone(),
         )?;
         let database_registry = DatabaseRegistry::new(served_databases, staged_databases);
 
@@ -79,15 +83,17 @@ impl DatabaseManager {
             database_registry,
             diagnostics_manager,
             rocks_resources,
+            cleanup_strategy,
         }))
     }
 
     fn initialise_served_databases(
-        data_directory: &PathBuf,
+        data_directory: &Path,
         import_directory: &Path,
         diagnostics_manager: &DiagnosticsManager,
         rocks_resources: &RocksResources,
-    ) -> Result<DatabasesMap, DatabaseOpenError> {
+        cleanup_strategy: DatabaseCleanupStrategy,
+    ) -> Result<DatabasesMap, Box<DatabaseOpenError>> {
         let mut databases = DatabasesMap::new();
 
         for entry_path in directory_entries(data_directory)? {
@@ -106,9 +112,14 @@ impl DatabaseManager {
                 continue;
             }
 
-            let database = match Database::<WALClient>::open(&entry_path, diagnostics_manager, rocks_resources) {
+            let database = match Database::<WALClient>::open(
+                &entry_path,
+                diagnostics_manager,
+                rocks_resources,
+                cleanup_strategy.clone(),
+            ) {
                 Ok(database) => database,
-                Err(DatabaseOpenError::NotADatabase { .. }) => {
+                Err(err) if matches!(*err, DatabaseOpenError::NotADatabase { .. }) => {
                     warn!("{entry_path:?} is not a database, skipping");
                     continue;
                 }
@@ -122,24 +133,29 @@ impl DatabaseManager {
     }
 
     fn initialise_staged_databases(
-        import_directory: &PathBuf,
+        import_directory: &Path,
         import_ownership: ImportOwnership,
         served_databases: &DatabasesMap,
         diagnostics_manager: &DiagnosticsManager,
         rocks_resources: &RocksResources,
-    ) -> Result<DatabasesMap, DatabaseOpenError> {
+        cleanup_strategy: DatabaseCleanupStrategy,
+    ) -> Result<DatabasesMap, Box<DatabaseOpenError>> {
         match import_ownership {
             ImportOwnership::Exclusive => {
                 Self::cleanup_import_directory(import_directory)?;
                 Ok(DatabasesMap::new())
             }
-            ImportOwnership::Shared => {
-                Self::recover_staged_databases(import_directory, served_databases, diagnostics_manager, rocks_resources)
-            }
+            ImportOwnership::Shared => Self::recover_staged_databases(
+                import_directory,
+                served_databases,
+                diagnostics_manager,
+                rocks_resources,
+                cleanup_strategy,
+            ),
         }
     }
 
-    fn cleanup_import_directory(directory: &PathBuf) -> Result<(), DatabaseOpenError> {
+    fn cleanup_import_directory(directory: &Path) -> Result<(), Box<DatabaseOpenError>> {
         if !directory.exists() {
             return Ok(());
         }
@@ -173,11 +189,12 @@ impl DatabaseManager {
     }
 
     fn recover_staged_databases(
-        directory: &PathBuf,
+        directory: &Path,
         served_databases: &DatabasesMap,
         diagnostics_manager: &DiagnosticsManager,
         rocks_resources: &RocksResources,
-    ) -> Result<DatabasesMap, DatabaseOpenError> {
+        cleanup_strategy: DatabaseCleanupStrategy,
+    ) -> Result<DatabasesMap, Box<DatabaseOpenError>> {
         let mut recovered = DatabasesMap::new();
         if !directory.exists() {
             return Ok(recovered);
@@ -193,7 +210,12 @@ impl DatabaseManager {
                 Self::remove_import_leftover_best_effort(&entry_path);
                 continue;
             }
-            match Database::<WALClient>::open(&entry_path, diagnostics_manager, rocks_resources) {
+            match Database::<WALClient>::open(
+                &entry_path,
+                diagnostics_manager,
+                rocks_resources,
+                cleanup_strategy.clone(),
+            ) {
                 Ok(database) => {
                     event!(Level::INFO, "Recovered in-progress import of database '{name}' after restart.");
                     recovered.insert(database.name().to_owned(), Arc::new(database));
@@ -221,12 +243,12 @@ impl DatabaseManager {
         }
     }
 
-    pub fn put_database(&self, name: impl AsRef<str>) -> Result<(), DatabaseCreateError> {
+    pub fn put_database(&self, name: impl AsRef<str>) -> Result<(), Box<DatabaseCreateError>> {
         Self::validate_user_database_name(name.as_ref())?;
         self.put_database_unrestricted(name)
     }
 
-    pub fn put_database_unrestricted(&self, name: impl AsRef<str>) -> Result<(), DatabaseCreateError> {
+    pub fn put_database_unrestricted(&self, name: impl AsRef<str>) -> Result<(), Box<DatabaseCreateError>> {
         let name = name.as_ref();
         let mut databases = self.database_registry.write().map_err(|_| DatabaseCreateError::WriteAccessDenied {})?;
         self.ensure_not_staged(&databases.staged, name)?;
@@ -284,7 +306,7 @@ impl DatabaseManager {
             .collect()
     }
 
-    pub fn prepare_for_writes(&self) -> Result<(), DatabaseOpenError> {
+    pub fn prepare_for_writes(&self) -> Result<(), Box<DatabaseOpenError>> {
         for (name, database) in self.database_registry.read().served.iter() {
             database
                 .prepare_for_writes()
@@ -293,11 +315,14 @@ impl DatabaseManager {
         Ok(())
     }
 
-    pub fn prepare_imported_database(&self, name: String) -> Result<Arc<Database<WALClient>>, DatabaseCreateError> {
+    pub fn prepare_imported_database(
+        &self,
+        name: String,
+    ) -> Result<Arc<Database<WALClient>>, Box<DatabaseCreateError>> {
         Self::validate_user_database_name(&name)?;
         let mut databases = self.database_registry.write().map_err(|_| DatabaseCreateError::WriteAccessDenied {})?;
         if self.exists_served(&databases.served, &name) {
-            return Err(DatabaseCreateError::AlreadyExists { name });
+            return Err(Box::new(DatabaseCreateError::AlreadyExists { name }));
         }
         self.evict_staged_leftover(&mut databases.staged, &name)?;
 
@@ -309,19 +334,19 @@ impl DatabaseManager {
         Ok(database)
     }
 
-    pub fn finalise_imported_database(&self, name: &str) -> Result<(), DatabaseCreateError> {
+    pub fn finalise_imported_database(&self, name: &str) -> Result<(), Box<DatabaseCreateError>> {
         let mut databases = self.database_registry.write().map_err(|_| DatabaseCreateError::WriteAccessDenied {})?;
         let database = match Self::take_database(&mut databases.staged, name) {
             Ok(Some(database)) => database,
-            Ok(None) => return Err(DatabaseCreateError::IsNotBeingImported { name: name.to_string() }),
-            Err(_) => return Err(DatabaseCreateError::ImportedDatabaseInUse { name: name.to_string() }),
+            Ok(None) => return Err(Box::new(DatabaseCreateError::IsNotBeingImported { name: name.to_string() })),
+            Err(_) => return Err(Box::new(DatabaseCreateError::ImportedDatabaseInUse { name: name.to_string() })),
         };
         if self.exists_served(&databases.served, name) {
             database.delete().map_err(|typedb_source| DatabaseCreateError::AlreadyExistsAndCleanupBlocked {
                 name: name.to_string(),
                 typedb_source,
             })?;
-            return Err(DatabaseCreateError::AlreadyExists { name: name.to_string() });
+            return Err(Box::new(DatabaseCreateError::AlreadyExists { name: name.to_string() }));
         }
         self.serve_staged_database(&mut databases, name, database)
     }
@@ -387,9 +412,14 @@ impl DatabaseManager {
         }
     }
 
-    fn open_served_database(&self, name: &str) -> Result<Database<WALClient>, DatabaseCreateError> {
-        Database::<WALClient>::open(&self.served_database_path(name), &self.diagnostics_manager, &self.rocks_resources)
-            .map_err(|typedb_source| DatabaseCreateError::DatabaseOpen { typedb_source })
+    fn open_served_database(&self, name: &str) -> Result<Database<WALClient>, Box<DatabaseCreateError>> {
+        Database::<WALClient>::open(
+            &self.served_database_path(name),
+            &self.diagnostics_manager,
+            &self.rocks_resources,
+            self.cleanup_strategy.clone(),
+        )
+        .map_err(|typedb_source| Box::new(DatabaseCreateError::DatabaseOpen { typedb_source: *typedb_source }))
     }
 
     fn exists_served(&self, served: &DatabasesMap, name: &str) -> bool {
@@ -407,7 +437,7 @@ impl DatabaseManager {
         databases: &mut Databases,
         name: &str,
         database: Database<WALClient>,
-    ) -> Result<(), DatabaseCreateError> {
+    ) -> Result<(), Box<DatabaseCreateError>> {
         let staged_path = database.path.clone();
         drop(database);
         self.move_directory_to_data(name, &staged_path)?;
@@ -420,49 +450,55 @@ impl DatabaseManager {
         Ok(())
     }
 
-    fn move_directory_to_data(&self, name: &str, directory: &Path) -> Result<(), DatabaseCreateError> {
+    fn move_directory_to_data(&self, name: &str, directory: &Path) -> Result<(), Box<DatabaseCreateError>> {
         let directory_name =
             directory.file_name().ok_or_else(|| DatabaseCreateError::DatabaseMove { name: name.to_string() })?;
 
         let target_path = self.data_directory.join(directory_name);
-        fs::rename(directory, &target_path)
-            .map_err(|source| DatabaseCreateError::DirectoryWrite { name: name.to_string(), source: Arc::new(source) })
+        fs::rename(directory, &target_path).map_err(|source| {
+            Box::new(DatabaseCreateError::DirectoryWrite { name: name.to_string(), source: Arc::new(source) })
+        })
     }
 
-    fn ensure_not_staged(&self, staged: &DatabasesMap, name: &str) -> Result<(), DatabaseCreateError> {
+    fn ensure_not_staged(&self, staged: &DatabasesMap, name: &str) -> Result<(), Box<DatabaseCreateError>> {
         if staged.contains_key(name) {
-            return Err(DatabaseCreateError::IsBeingImported { name: name.to_string() });
+            return Err(Box::new(DatabaseCreateError::IsBeingImported { name: name.to_string() }));
         }
         if !self.staged_database_exists(name) {
             return Ok(());
         }
         match self.import_ownership {
-            ImportOwnership::Shared => Err(DatabaseCreateError::IsBeingImported { name: name.to_string() }),
+            ImportOwnership::Shared => Err(Box::new(DatabaseCreateError::IsBeingImported { name: name.to_string() })),
             ImportOwnership::Exclusive => self.remove_staged_directory(name).map_err(|source| {
-                DatabaseCreateError::DirectoryWrite { name: name.to_string(), source: Arc::new(source) }
+                Box::new(DatabaseCreateError::DirectoryWrite { name: name.to_string(), source: Arc::new(source) })
             }),
         }
     }
 
-    fn evict_staged_leftover(&self, staged: &mut DatabasesMap, name: &str) -> Result<(), DatabaseCreateError> {
+    fn evict_staged_leftover(&self, staged: &mut DatabasesMap, name: &str) -> Result<(), Box<DatabaseCreateError>> {
         match Self::take_database(staged, name) {
-            Ok(Some(leftover)) => leftover.delete().map_err(|typedb_source| DatabaseCreateError::ImportCleanupFailed {
-                name: name.to_string(),
-                typedb_source,
+            Ok(Some(leftover)) => leftover.delete().map_err(|typedb_source| {
+                Box::new(DatabaseCreateError::ImportCleanupFailed { name: name.to_string(), typedb_source })
             }),
-            Ok(None) if self.staged_database_exists(name) => {
-                fs::remove_dir_all(self.staged_database_path(name)).map_err(|source| {
-                    DatabaseCreateError::DirectoryWrite { name: name.to_string(), source: Arc::new(source) }
-                })
-            }
+            Ok(None) if self.staged_database_exists(name) => fs::remove_dir_all(self.staged_database_path(name))
+                .map_err(|source| {
+                    Box::new({
+                        DatabaseCreateError::DirectoryWrite { name: name.to_string(), source: Arc::new(source) }
+                    })
+                }),
             Ok(None) => Ok(()),
-            Err(_) => Err(DatabaseCreateError::ImportedDatabaseInUse { name: name.to_string() }),
+            Err(_) => Err(Box::new(DatabaseCreateError::ImportedDatabaseInUse { name: name.to_string() })),
         }
     }
 
-    fn open_staged_database(&self, name: &str) -> Result<Database<WALClient>, DatabaseCreateError> {
-        Database::<WALClient>::open(&self.staged_database_path(name), &self.diagnostics_manager, &self.rocks_resources)
-            .map_err(|typedb_source| DatabaseCreateError::DatabaseOpen { typedb_source })
+    fn open_staged_database(&self, name: &str) -> Result<Database<WALClient>, Box<DatabaseCreateError>> {
+        Database::<WALClient>::open(
+            &self.staged_database_path(name),
+            &self.diagnostics_manager,
+            &self.rocks_resources,
+            self.cleanup_strategy.clone(),
+        )
+        .map_err(|typedb_source| Box::new(DatabaseCreateError::DatabaseOpen { typedb_source: *typedb_source }))
     }
 
     fn served_database_path(&self, name: &str) -> PathBuf {
@@ -490,16 +526,16 @@ impl DatabaseManager {
         sync_directory(&self.import_directory)
     }
 
-    fn validate_user_database_name(name: &str) -> Result<(), DatabaseCreateError> {
+    fn validate_user_database_name(name: &str) -> Result<(), Box<DatabaseCreateError>> {
         if Self::is_internal_database(name) {
-            return Err(DatabaseCreateError::InternalDatabaseCreationProhibited {});
+            return Err(Box::new(DatabaseCreateError::InternalDatabaseCreationProhibited {}));
         }
         Self::validate_database_name(name)
     }
 
-    fn validate_database_name(name: &str) -> Result<(), DatabaseCreateError> {
+    fn validate_database_name(name: &str) -> Result<(), Box<DatabaseCreateError>> {
         if !typeql::common::identifier::is_valid_label(name) {
-            return Err(DatabaseCreateError::InvalidName { name: name.to_string() });
+            return Err(Box::new(DatabaseCreateError::InvalidName { name: name.to_string() }));
         }
         Ok(())
     }
@@ -509,16 +545,15 @@ pub(crate) fn file_name_lossy(path: &Path) -> String {
     path.file_name().unwrap_or("".as_ref()).to_string_lossy().to_string()
 }
 
-pub(crate) fn directory_entries(directory: &Path) -> Result<Vec<PathBuf>, DatabaseOpenError> {
+pub(crate) fn directory_entries(directory: &Path) -> Result<Vec<PathBuf>, Box<DatabaseOpenError>> {
     let entries = fs::read_dir(directory).map_err(|error| DatabaseOpenError::DirectoryRead {
         name: file_name_lossy(directory),
         source: Arc::new(error),
     })?;
     entries
         .map(|entry| {
-            entry.map(|entry| entry.path()).map_err(|error| DatabaseOpenError::DirectoryRead {
-                name: file_name_lossy(directory),
-                source: Arc::new(error),
+            entry.map(|entry| entry.path()).map_err(|error| {
+                Box::new(DatabaseOpenError::DirectoryRead { name: file_name_lossy(directory), source: Arc::new(error) })
             })
         })
         .collect()

--- a/database/tests/database.rs
+++ b/database/tests/database.rs
@@ -8,7 +8,7 @@ use std::sync::Arc;
 
 use database::{Database, database_manager::DatabaseManager};
 use diagnostics::diagnostics_manager::DiagnosticsManager;
-use options::{DatabaseCleanupStrategy, byte_size::ByteSize};
+use options::{MvccCleanupStrategy, byte_size::ByteSize};
 use storage::durability_client::WALClient;
 use test_utils::{create_tmp_dir, create_tmp_storage_dir, init_logging};
 use test_utils_storage::create_rocks_resources;
@@ -23,7 +23,7 @@ fn create_delete_database() {
         &database_path.join("create_delete"),
         &diagnostics_manager,
         &resources,
-        DatabaseCleanupStrategy::Disabled,
+        MvccCleanupStrategy::Disabled,
     );
     assert!(db_result.is_ok(), "{:?}", db_result.unwrap_err());
     let db = db_result.unwrap();
@@ -41,7 +41,7 @@ fn prepare_for_writes_iterates_every_loaded_database() {
         ByteSize::mb(64),
         ByteSize::mb(64),
         database::database_manager::ImportOwnership::Exclusive,
-        DatabaseCleanupStrategy::Disabled,
+        MvccCleanupStrategy::Disabled,
     )
     .expect("DatabaseManager::new");
     for name in ["alpha", "beta", "gamma"] {

--- a/database/tests/database.rs
+++ b/database/tests/database.rs
@@ -8,7 +8,7 @@ use std::sync::Arc;
 
 use database::{Database, database_manager::DatabaseManager};
 use diagnostics::diagnostics_manager::DiagnosticsManager;
-use options::byte_size::ByteSize;
+use options::{DatabaseCleanupStrategy, byte_size::ByteSize};
 use storage::durability_client::WALClient;
 use test_utils::{create_tmp_dir, create_tmp_storage_dir, init_logging};
 use test_utils_storage::create_rocks_resources;
@@ -19,7 +19,12 @@ fn create_delete_database() {
     let database_path = create_tmp_storage_dir();
     let diagnostics_manager = Arc::new(DiagnosticsManager::new_disabled());
     let resources = create_rocks_resources();
-    let db_result = Database::<WALClient>::open(&database_path.join("create_delete"), &diagnostics_manager, &resources);
+    let db_result = Database::<WALClient>::open(
+        &database_path.join("create_delete"),
+        &diagnostics_manager,
+        &resources,
+        DatabaseCleanupStrategy::Disabled,
+    );
     assert!(db_result.is_ok(), "{:?}", db_result.unwrap_err());
     let db = db_result.unwrap();
     let delete_result = db.delete();
@@ -36,6 +41,7 @@ fn prepare_for_writes_iterates_every_loaded_database() {
         ByteSize::mb(64),
         ByteSize::mb(64),
         database::database_manager::ImportOwnership::Exclusive,
+        DatabaseCleanupStrategy::Disabled,
     )
     .expect("DatabaseManager::new");
     for name in ["alpha", "beta", "gamma"] {

--- a/database/tests/import.rs
+++ b/database/tests/import.rs
@@ -12,7 +12,7 @@ use database::{
     database_manager::{DatabaseManager, ImportOwnership},
 };
 use diagnostics::diagnostics_manager::DiagnosticsManager;
-use options::{DatabaseCleanupStrategy, byte_size::ByteSize};
+use options::{MvccCleanupStrategy, byte_size::ByteSize};
 use test_utils::{TempDir, create_tmp_dir, init_logging};
 
 fn manager(data_dir: &TempDir, import_ownership: ImportOwnership) -> Arc<DatabaseManager> {
@@ -23,7 +23,7 @@ fn manager(data_dir: &TempDir, import_ownership: ImportOwnership) -> Arc<Databas
         ByteSize::mb(64),
         ByteSize::mb(64),
         import_ownership,
-        DatabaseCleanupStrategy::Disabled,
+        MvccCleanupStrategy::Disabled,
     )
     .expect("DatabaseManager::new")
 }

--- a/database/tests/import.rs
+++ b/database/tests/import.rs
@@ -12,13 +12,20 @@ use database::{
     database_manager::{DatabaseManager, ImportOwnership},
 };
 use diagnostics::diagnostics_manager::DiagnosticsManager;
-use options::byte_size::ByteSize;
+use options::{DatabaseCleanupStrategy, byte_size::ByteSize};
 use test_utils::{TempDir, create_tmp_dir, init_logging};
 
 fn manager(data_dir: &TempDir, import_ownership: ImportOwnership) -> Arc<DatabaseManager> {
     let diagnostics = Arc::new(DiagnosticsManager::new_disabled());
-    DatabaseManager::new(data_dir.as_ref(), diagnostics, ByteSize::mb(64), ByteSize::mb(64), import_ownership)
-        .expect("DatabaseManager::new")
+    DatabaseManager::new(
+        data_dir.as_ref(),
+        diagnostics,
+        ByteSize::mb(64),
+        ByteSize::mb(64),
+        import_ownership,
+        DatabaseCleanupStrategy::Disabled,
+    )
+    .expect("DatabaseManager::new")
 }
 
 fn import_path(data_dir: &TempDir, name: &str) -> std::path::PathBuf {
@@ -45,12 +52,18 @@ fn import_lifecycle_publishes_and_is_idempotent() {
     let dbm = manager(&data_dir, ImportOwnership::Shared);
 
     let staging = dbm.prepare_imported_database("typedb".to_string()).expect("prepare");
-    assert!(matches!(dbm.finalise_imported_database("typedb"), Err(DatabaseCreateError::ImportedDatabaseInUse { .. })));
+    assert!(matches!(
+        *dbm.finalise_imported_database("typedb").unwrap_err(),
+        DatabaseCreateError::ImportedDatabaseInUse { .. }
+    ));
     drop(staging);
     dbm.finalise_imported_database("typedb").expect("finalise");
     assert!(dbm.database("typedb").is_some());
     assert!(!import_path(&data_dir, "typedb").exists());
-    assert!(matches!(dbm.finalise_imported_database("typedb"), Err(DatabaseCreateError::IsNotBeingImported { .. })));
+    assert!(matches!(
+        *dbm.finalise_imported_database("typedb").unwrap_err(),
+        DatabaseCreateError::IsNotBeingImported { .. }
+    ));
 }
 
 #[test]
@@ -78,10 +91,10 @@ fn prepare_replaces_unheld_leftover_but_rejects_held_staging() {
 
     let staging = dbm.prepare_imported_database("fresh".to_string()).expect("first prepare");
     assert!(matches!(
-        dbm.prepare_imported_database("fresh".to_string()),
-        Err(DatabaseCreateError::ImportedDatabaseInUse { .. })
+        *dbm.prepare_imported_database("fresh".to_string()).unwrap_err(),
+        DatabaseCreateError::ImportedDatabaseInUse { .. }
     ));
-    assert!(matches!(dbm.put_database("fresh"), Err(DatabaseCreateError::IsBeingImported { .. })));
+    assert!(matches!(*dbm.put_database("fresh").unwrap_err(), DatabaseCreateError::IsBeingImported { .. }));
     drop(staging);
     dbm.prepare_imported_database("fresh".to_string()).expect("prepare must replace the unheld leftover");
 }
@@ -94,8 +107,8 @@ fn prepare_rejects_existing_database_and_invalid_names() {
 
     dbm.put_database("existing").expect("create");
     assert!(matches!(
-        dbm.prepare_imported_database("existing".to_string()),
-        Err(DatabaseCreateError::AlreadyExists { .. })
+        *dbm.prepare_imported_database("existing".to_string()).unwrap_err(),
+        DatabaseCreateError::AlreadyExists { .. }
     ));
     assert!(dbm.prepare_imported_database("_internal".to_string()).is_err());
     assert!(dbm.prepare_imported_database("not a name".to_string()).is_err());
@@ -128,7 +141,7 @@ fn dead_leftovers_are_replaced_by_create_prepare_and_cancel() {
 
     // A live (registered) import blocks creation.
     let staging = dbm.prepare_imported_database("blocked".to_string()).expect("prepare");
-    assert!(matches!(dbm.put_database("blocked"), Err(DatabaseCreateError::IsBeingImported { .. })));
+    assert!(matches!(*dbm.put_database("blocked").unwrap_err(), DatabaseCreateError::IsBeingImported { .. }));
     drop(staging);
     dbm.discard_imported_database("blocked").expect("cancel");
 
@@ -136,7 +149,7 @@ fn dead_leftovers_are_replaced_by_create_prepare_and_cancel() {
     // Under Resume it keeps the name reserved for create — only the import operations that decide
     // the name's fate (a fresh prepare, a cancel) replace or remove it.
     fs::create_dir_all(import_path(&data_dir, "created-over")).unwrap();
-    assert!(matches!(dbm.put_database("created-over"), Err(DatabaseCreateError::IsBeingImported { .. })));
+    assert!(matches!(*dbm.put_database("created-over").unwrap_err(), DatabaseCreateError::IsBeingImported { .. }));
     assert!(import_path(&data_dir, "created-over").exists());
 
     fs::create_dir_all(import_path(&data_dir, "prepared-over")).unwrap();
@@ -197,10 +210,10 @@ fn resume_recovery_restores_staging_and_discards_junk() {
     // The unopenable staging is kept: it reserves the name against creation — surviving further
     // restarts — until a cancel or a fresh prepare of the import concludes it.
     assert!(import_path(&data_dir, "corrupt").exists());
-    assert!(matches!(dbm.put_database("corrupt"), Err(DatabaseCreateError::IsBeingImported { .. })));
+    assert!(matches!(*dbm.put_database("corrupt").unwrap_err(), DatabaseCreateError::IsBeingImported { .. }));
     drop(dbm);
     let dbm = manager(&data_dir, ImportOwnership::Shared);
-    assert!(matches!(dbm.put_database("corrupt"), Err(DatabaseCreateError::IsBeingImported { .. })));
+    assert!(matches!(*dbm.put_database("corrupt").unwrap_err(), DatabaseCreateError::IsBeingImported { .. }));
     assert!(dbm.discard_imported_database("corrupt").is_err());
     assert!(!import_path(&data_dir, "corrupt").exists());
     dbm.put_database("corrupt").expect("create after the cancel released the name");
@@ -237,7 +250,10 @@ fn staged_leftover_of_a_published_database_is_discarded_on_recovery() {
     assert!(dbm.database("typedb").is_some(), "the published database must survive");
     assert_eq!(dbm.imported_database_names(), Vec::<String>::new());
     assert!(!import_path(&data_dir, "typedb").exists(), "the staging copy must be discarded on recovery");
-    assert!(matches!(dbm.finalise_imported_database("typedb"), Err(DatabaseCreateError::IsNotBeingImported { .. })));
+    assert!(matches!(
+        *dbm.finalise_imported_database("typedb").unwrap_err(),
+        DatabaseCreateError::IsNotBeingImported { .. }
+    ));
     dbm.put_database("typedb").expect("a served database with a healed leftover is an ordinary database");
     assert!(dbm.database("typedb").is_some());
 }
@@ -273,7 +289,7 @@ fn recovered_staging_still_hides_and_blocks_its_name() {
     let dbm = manager(&data_dir, ImportOwnership::Shared);
     assert!(dbm.database("typedb").is_none());
     assert!(dbm.database_names().is_empty());
-    assert!(matches!(dbm.put_database("typedb"), Err(DatabaseCreateError::IsBeingImported { .. })));
+    assert!(matches!(*dbm.put_database("typedb").unwrap_err(), DatabaseCreateError::IsBeingImported { .. }));
 }
 
 #[test]

--- a/database/tests/statistics_synchronization.rs
+++ b/database/tests/statistics_synchronization.rs
@@ -14,7 +14,7 @@ use database::{
 };
 use diagnostics::diagnostics_manager::DiagnosticsManager;
 use executor::ExecutionInterrupt;
-use options::{DatabaseCleanupStrategy, QueryOptions, TransactionOptions, byte_size::ByteSize};
+use options::{MvccCleanupStrategy, QueryOptions, TransactionOptions, byte_size::ByteSize};
 use query::given_rows::GivenRowsSimple;
 use storage::durability_client::WALClient;
 use test_utils::{create_tmp_storage_dir, init_logging};
@@ -48,7 +48,7 @@ fn statistics_synchronization_under_concurrent_load() {
             ByteSize::mb(64),
             ByteSize::mb(64),
             database::database_manager::ImportOwnership::Exclusive,
-            DatabaseCleanupStrategy::Disabled,
+            MvccCleanupStrategy::Disabled,
         )
         .unwrap();
         dbm.put_database(DB_NAME).unwrap();
@@ -85,7 +85,7 @@ fn statistics_synchronization_under_concurrent_load() {
         ByteSize::mb(64),
         ByteSize::mb(64),
         database::database_manager::ImportOwnership::Exclusive,
-        DatabaseCleanupStrategy::Disabled,
+        MvccCleanupStrategy::Disabled,
     )
     .unwrap();
     let database = dbm.database(DB_NAME).unwrap();

--- a/database/tests/statistics_synchronization.rs
+++ b/database/tests/statistics_synchronization.rs
@@ -14,7 +14,7 @@ use database::{
 };
 use diagnostics::diagnostics_manager::DiagnosticsManager;
 use executor::ExecutionInterrupt;
-use options::{QueryOptions, TransactionOptions, byte_size::ByteSize};
+use options::{DatabaseCleanupStrategy, QueryOptions, TransactionOptions, byte_size::ByteSize};
 use query::given_rows::GivenRowsSimple;
 use storage::durability_client::WALClient;
 use test_utils::{create_tmp_storage_dir, init_logging};
@@ -48,6 +48,7 @@ fn statistics_synchronization_under_concurrent_load() {
             ByteSize::mb(64),
             ByteSize::mb(64),
             database::database_manager::ImportOwnership::Exclusive,
+            DatabaseCleanupStrategy::Disabled,
         )
         .unwrap();
         dbm.put_database(DB_NAME).unwrap();
@@ -84,6 +85,7 @@ fn statistics_synchronization_under_concurrent_load() {
         ByteSize::mb(64),
         ByteSize::mb(64),
         database::database_manager::ImportOwnership::Exclusive,
+        DatabaseCleanupStrategy::Disabled,
     )
     .unwrap();
     let database = dbm.database(DB_NAME).unwrap();

--- a/database/tests/test_transaction_isolation.rs
+++ b/database/tests/test_transaction_isolation.rs
@@ -15,7 +15,7 @@ use database::{
 use diagnostics::diagnostics_manager::DiagnosticsManager;
 use encoding::graph::thing::vertex_attribute::StringAttributeID;
 use executor::ExecutionInterrupt;
-use options::{QueryOptions, TransactionOptions, byte_size::ByteSize};
+use options::{DatabaseCleanupStrategy, QueryOptions, TransactionOptions, byte_size::ByteSize};
 use query::given_rows::GivenRowsSimple;
 use storage::{
     StorageCommitError, durability_client::WALClient, isolation_manager::IsolationConflict, snapshot::SnapshotError,
@@ -33,6 +33,7 @@ fn create_reset_database() -> (TempDir, Arc<Database<WALClient>>) {
         ByteSize::mb(64),
         ByteSize::mb(64),
         database::database_manager::ImportOwnership::Exclusive,
+        DatabaseCleanupStrategy::Disabled,
     )
     .unwrap();
     dbm.put_database(DB_NAME).unwrap();

--- a/database/tests/test_transaction_isolation.rs
+++ b/database/tests/test_transaction_isolation.rs
@@ -15,7 +15,7 @@ use database::{
 use diagnostics::diagnostics_manager::DiagnosticsManager;
 use encoding::graph::thing::vertex_attribute::StringAttributeID;
 use executor::ExecutionInterrupt;
-use options::{DatabaseCleanupStrategy, QueryOptions, TransactionOptions, byte_size::ByteSize};
+use options::{MvccCleanupStrategy, QueryOptions, TransactionOptions, byte_size::ByteSize};
 use query::given_rows::GivenRowsSimple;
 use storage::{
     StorageCommitError, durability_client::WALClient, isolation_manager::IsolationConflict, snapshot::SnapshotError,
@@ -33,7 +33,7 @@ fn create_reset_database() -> (TempDir, Arc<Database<WALClient>>) {
         ByteSize::mb(64),
         ByteSize::mb(64),
         database::database_manager::ImportOwnership::Exclusive,
-        DatabaseCleanupStrategy::Disabled,
+        MvccCleanupStrategy::Disabled,
     )
     .unwrap();
     dbm.put_database(DB_NAME).unwrap();

--- a/database/tests/transaction.rs
+++ b/database/tests/transaction.rs
@@ -45,6 +45,7 @@ fn create_database(databases_path: &TempDir) -> Arc<Database<WALClient>> {
         ByteSize::mb(64),
         ByteSize::mb(64),
         database::database_manager::ImportOwnership::Exclusive,
+        options::DatabaseCleanupStrategy::Disabled,
     )
     .expect("Expected database manager");
     database_manager.put_database(DB_NAME).expect("Expected database creation");

--- a/database/tests/transaction.rs
+++ b/database/tests/transaction.rs
@@ -45,7 +45,7 @@ fn create_database(databases_path: &TempDir) -> Arc<Database<WALClient>> {
         ByteSize::mb(64),
         ByteSize::mb(64),
         database::database_manager::ImportOwnership::Exclusive,
-        options::DatabaseCleanupStrategy::Disabled,
+        options::MvccCleanupStrategy::Disabled,
     )
     .expect("Expected database manager");
     database_manager.put_database(DB_NAME).expect("Expected database creation");

--- a/database/transaction.rs
+++ b/database/transaction.rs
@@ -18,6 +18,7 @@ use concept::{
     },
 };
 use durability::DurabilitySequenceNumber;
+use encoding::{EncodingKeyspace, layout::prefix::Prefix};
 use error::typedb_error;
 use function::{FunctionError, function_cache::FunctionCache, function_manager::FunctionManager};
 use options::TransactionOptions;
@@ -25,6 +26,7 @@ use query::query_manager::QueryManager;
 use resource::profile::{CommitProfile, TransactionProfile};
 use storage::{
     durability_client::{DurabilityClient, DurabilityClientError},
+    keyspace::KeyspaceSet,
     snapshot::{
         CommittableSnapshot, ReadSnapshot, ReadableSnapshot, SchemaSnapshot, SnapshotError, WritableSnapshot,
         WriteSnapshot, snapshot_id::SnapshotId,
@@ -187,7 +189,7 @@ impl<D: DurabilityClient> TransactionWrite<D> {
             Ok(snapshot) => snapshot,
         };
 
-        let cleanup_ranges = match self.thing_manager.finalise(&mut snapshot, commit_profile.storage_counters()) {
+        let cleanup_record = match self.thing_manager.finalise(&mut snapshot, commit_profile.storage_counters()) {
             Ok(compaction) => compaction,
             Err(errs) => {
                 // TODO: send all the errors, not just the first,
@@ -197,7 +199,7 @@ impl<D: DurabilityClient> TransactionWrite<D> {
             }
         };
         commit_profile.things_finalised();
-        (profile, Ok(DataCommitIntent { database_drop_guard: self.database, write_snapshot: snapshot, cleanup_ranges }))
+        (profile, Ok(DataCommitIntent { database_drop_guard: self.database, write_snapshot: snapshot, cleanup_record }))
     }
 
     pub fn rollback(&mut self) {
@@ -298,7 +300,7 @@ impl<D: DurabilityClient> TransactionSchema<D> {
         };
         commit_profile.types_validated();
 
-        let cleanup_ranges = match self.thing_manager.finalise(&mut snapshot, commit_profile.storage_counters()) {
+        let cleanup_record = match self.thing_manager.finalise(&mut snapshot, commit_profile.storage_counters()) {
             Ok(compaction) => compaction,
             Err(errs) => {
                 // TODO: send all the errors, not just the first,
@@ -319,7 +321,7 @@ impl<D: DurabilityClient> TransactionSchema<D> {
         let _type_manager = Arc::into_inner(self.type_manager).expect("Failed to unwrap Arc<TypeManager>");
         (
             profile,
-            Ok(SchemaCommitIntent { database_drop_guard: self.database, schema_snapshot: snapshot, cleanup_ranges }),
+            Ok(SchemaCommitIntent { database_drop_guard: self.database, schema_snapshot: snapshot, cleanup_record }),
         )
     }
 
@@ -394,12 +396,12 @@ macro_rules! with_transaction_parts {
 pub struct DataCommitIntent<D> {
     database_drop_guard: DatabaseDropGuard<D>,
     write_snapshot: WriteSnapshot<D>,
-    cleanup_ranges: CleanupRecord,
+    cleanup_record: CleanupRecord,
 }
 
 impl<D: DurabilityClient> DataCommitIntent<D> {
-    pub fn new(database: Arc<Database<D>>, write_snapshot: WriteSnapshot<D>, cleanup_ranges: CleanupRecord) -> Self {
-        Self { database_drop_guard: DatabaseDropGuard::new(database), write_snapshot, cleanup_ranges }
+    pub fn new(database: Arc<Database<D>>, write_snapshot: WriteSnapshot<D>, cleanup_record: CleanupRecord) -> Self {
+        Self { database_drop_guard: DatabaseDropGuard::new(database), write_snapshot, cleanup_record }
     }
 }
 
@@ -424,9 +426,9 @@ impl<D: DurabilityClient> CommitIntent for DataCommitIntent<D> {
             database
                 .storage
                 .durability()
-                .unsequenced_write(&self.cleanup_ranges)
+                .unsequenced_write(&self.cleanup_record)
                 .map_err(|typedb_source| DataCommitError::DurabilityError { typedb_source })?;
-            database._cleanup_queue.write().unwrap().insert(sequence_number, self.cleanup_ranges);
+            database._cleanup_queue.write().unwrap().insert(sequence_number, self.cleanup_record);
         }
         Ok(())
     }
@@ -435,12 +437,12 @@ impl<D: DurabilityClient> CommitIntent for DataCommitIntent<D> {
 pub struct SchemaCommitIntent<D> {
     database_drop_guard: DatabaseDropGuard<D>,
     schema_snapshot: SchemaSnapshot<D>,
-    cleanup_ranges: CleanupRecord,
+    cleanup_record: CleanupRecord,
 }
 
 impl<D: DurabilityClient> SchemaCommitIntent<D> {
-    pub fn new(database: Arc<Database<D>>, schema_snapshot: SchemaSnapshot<D>, cleanup_ranges: CleanupRecord) -> Self {
-        Self { database_drop_guard: DatabaseDropGuard::new(database), schema_snapshot, cleanup_ranges }
+    pub fn new(database: Arc<Database<D>>, schema_snapshot: SchemaSnapshot<D>, cleanup_record: CleanupRecord) -> Self {
+        Self { database_drop_guard: DatabaseDropGuard::new(database), schema_snapshot, cleanup_record }
     }
 }
 
@@ -486,9 +488,9 @@ impl<D: DurabilityClient> CommitIntent for SchemaCommitIntent<D> {
             database
                 .storage
                 .durability()
-                .unsequenced_write(&self.cleanup_ranges)
+                .unsequenced_write(&self.cleanup_record)
                 .map_err(|typedb_source| SchemaCommitError::DurabilityError { typedb_source })?;
-            database._cleanup_queue.write().unwrap().insert(sequence_number, self.cleanup_ranges);
+            database._cleanup_queue.write().unwrap().insert(sequence_number, self.cleanup_record);
 
             // replace schema cache
             let type_cache = match TypeCache::new(database.storage.clone(), sequence_number) {

--- a/database/transaction.rs
+++ b/database/transaction.rs
@@ -11,7 +11,7 @@ use std::{
 
 use concept::{
     error::ConceptWriteError,
-    thing::{statistics::StatisticsError, thing_manager::ThingManager},
+    thing::{cleanup::CleanupRecord, statistics::StatisticsError, thing_manager::ThingManager},
     type_::type_manager::{
         TypeManager,
         type_cache::{TypeCache, TypeCacheCreateError},
@@ -24,8 +24,7 @@ use options::TransactionOptions;
 use query::query_manager::QueryManager;
 use resource::profile::{CommitProfile, TransactionProfile};
 use storage::{
-    durability_client::DurabilityClient,
-    record::CommitRecord,
+    durability_client::{DurabilityClient, DurabilityClientError},
     snapshot::{
         CommittableSnapshot, ReadSnapshot, ReadableSnapshot, SchemaSnapshot, SnapshotError, WritableSnapshot,
         WriteSnapshot, snapshot_id::SnapshotId,
@@ -98,7 +97,7 @@ impl<D: DurabilityClient> TransactionRead<D> {
     }
 
     pub fn snapshot(&self) -> &ReadSnapshot<D> {
-        &*self.snapshot
+        &self.snapshot
     }
 
     pub fn close(self) {
@@ -188,14 +187,17 @@ impl<D: DurabilityClient> TransactionWrite<D> {
             Ok(snapshot) => snapshot,
         };
 
-        if let Err(errs) = self.thing_manager.finalise(&mut snapshot, commit_profile.storage_counters()) {
-            // TODO: send all the errors, not just the first,
-            // when we can print the stacktraces of multiple errors, not just a single one
-            let error = errs.into_iter().next().unwrap();
-            return (profile, Err(DataCommitError::ConceptWriteErrorsFirst { typedb_source: Box::new(error) }));
+        let cleanup_ranges = match self.thing_manager.finalise(&mut snapshot, commit_profile.storage_counters()) {
+            Ok(compaction) => compaction,
+            Err(errs) => {
+                // TODO: send all the errors, not just the first,
+                // when we can print the stacktraces of multiple errors, not just a single one
+                let error = errs.into_iter().next().unwrap();
+                return (profile, Err(DataCommitError::ConceptWriteErrorsFirst { typedb_source: Box::new(error) }));
+            }
         };
         commit_profile.things_finalised();
-        (profile, Ok(DataCommitIntent { database_drop_guard: self.database, write_snapshot: snapshot }))
+        (profile, Ok(DataCommitIntent { database_drop_guard: self.database, write_snapshot: snapshot, cleanup_ranges }))
     }
 
     pub fn rollback(&mut self) {
@@ -296,13 +298,14 @@ impl<D: DurabilityClient> TransactionSchema<D> {
         };
         commit_profile.types_validated();
 
-        if let Err(errs) = self.thing_manager.finalise(&mut snapshot, commit_profile.storage_counters()) {
-            // TODO: send all the errors, not just the first,
-            // when we can print the stacktraces of multiple errors, not just a single one
-            return (
-                profile,
-                Err(ConceptWriteErrorsFirst { typedb_source: Box::new(errs.into_iter().next().unwrap()) }),
-            );
+        let cleanup_ranges = match self.thing_manager.finalise(&mut snapshot, commit_profile.storage_counters()) {
+            Ok(compaction) => compaction,
+            Err(errs) => {
+                // TODO: send all the errors, not just the first,
+                // when we can print the stacktraces of multiple errors, not just a single one
+                let error = errs.into_iter().next().unwrap();
+                return (profile, Err(ConceptWriteErrorsFirst { typedb_source: Box::new(error) }));
+            }
         };
         commit_profile.things_finalised();
         drop(self.thing_manager);
@@ -314,7 +317,10 @@ impl<D: DurabilityClient> TransactionSchema<D> {
         commit_profile.functions_finalised();
 
         let _type_manager = Arc::into_inner(self.type_manager).expect("Failed to unwrap Arc<TypeManager>");
-        (profile, Ok(SchemaCommitIntent { database_drop_guard: self.database, schema_snapshot: snapshot }))
+        (
+            profile,
+            Ok(SchemaCommitIntent { database_drop_guard: self.database, schema_snapshot: snapshot, cleanup_ranges }),
+        )
     }
 
     pub fn rollback(&mut self) {
@@ -388,23 +394,12 @@ macro_rules! with_transaction_parts {
 pub struct DataCommitIntent<D> {
     database_drop_guard: DatabaseDropGuard<D>,
     write_snapshot: WriteSnapshot<D>,
+    cleanup_ranges: CleanupRecord,
 }
 
 impl<D: DurabilityClient> DataCommitIntent<D> {
-    pub fn new(database: Arc<Database<D>>, write_snapshot: WriteSnapshot<D>) -> Self {
-        Self { database_drop_guard: DatabaseDropGuard::new(database), write_snapshot }
-    }
-
-    pub fn from_commit_record(database: Arc<Database<D>>, commit_record: CommitRecord) -> Self {
-        let snapshot = WriteSnapshot::new_with_commit_record(database.storage.clone(), commit_record);
-        Self::new(database, snapshot)
-    }
-
-    pub fn into_commit_record(
-        self,
-    ) -> (DatabaseDropGuard<D>, storage::isolation_manager::ReaderDropGuard, CommitRecord) {
-        let (reader_guard, commit_record) = self.write_snapshot.into_commit_record();
-        (self.database_drop_guard, reader_guard, commit_record)
+    pub fn new(database: Arc<Database<D>>, write_snapshot: WriteSnapshot<D>, cleanup_ranges: CleanupRecord) -> Self {
+        Self { database_drop_guard: DatabaseDropGuard::new(database), write_snapshot, cleanup_ranges }
     }
 }
 
@@ -420,33 +415,32 @@ impl<D: DurabilityClient> CommitIntent for DataCommitIntent<D> {
     }
 
     fn commit(self, commit_profile: &mut CommitProfile) -> Result<(), DataCommitError> {
-        self.write_snapshot
-            .commit(commit_profile)
-            .map(|_| ())
-            .map_err(|typedb_source| DataCommitError::SnapshotError { typedb_source })
+        let sequence_number = match self.write_snapshot.commit(commit_profile) {
+            Ok(sequence_number) => sequence_number,
+            Err(typedb_source) => return Err(DataCommitError::SnapshotError { typedb_source }),
+        };
+        if let Some(sequence_number) = sequence_number {
+            let database = &self.database_drop_guard;
+            database
+                .storage
+                .durability()
+                .unsequenced_write(&self.cleanup_ranges)
+                .map_err(|typedb_source| DataCommitError::DurabilityError { typedb_source })?;
+            database._cleanup_queue.write().unwrap().insert(sequence_number, self.cleanup_ranges);
+        }
+        Ok(())
     }
 }
 
 pub struct SchemaCommitIntent<D> {
     database_drop_guard: DatabaseDropGuard<D>,
     schema_snapshot: SchemaSnapshot<D>,
+    cleanup_ranges: CleanupRecord,
 }
 
 impl<D: DurabilityClient> SchemaCommitIntent<D> {
-    pub fn new(database: Arc<Database<D>>, schema_snapshot: SchemaSnapshot<D>) -> Self {
-        Self { database_drop_guard: DatabaseDropGuard::new(database), schema_snapshot }
-    }
-
-    pub fn from_commit_record(database: Arc<Database<D>>, commit_record: CommitRecord) -> Self {
-        let snapshot = SchemaSnapshot::new_with_commit_record(database.storage.clone(), commit_record);
-        Self::new(database, snapshot)
-    }
-
-    pub fn into_commit_record(
-        self,
-    ) -> (DatabaseDropGuard<D>, storage::isolation_manager::ReaderDropGuard, CommitRecord) {
-        let (reader_guard, commit_record) = self.schema_snapshot.into_commit_record();
-        (self.database_drop_guard, reader_guard, commit_record)
+    pub fn new(database: Arc<Database<D>>, schema_snapshot: SchemaSnapshot<D>, cleanup_ranges: CleanupRecord) -> Self {
+        Self { database_drop_guard: DatabaseDropGuard::new(database), schema_snapshot, cleanup_ranges }
     }
 }
 
@@ -489,6 +483,13 @@ impl<D: DurabilityClient> CommitIntent for SchemaCommitIntent<D> {
         };
 
         if let Some(sequence_number) = sequence_number {
+            database
+                .storage
+                .durability()
+                .unsequenced_write(&self.cleanup_ranges)
+                .map_err(|typedb_source| SchemaCommitError::DurabilityError { typedb_source })?;
+            database._cleanup_queue.write().unwrap().insert(sequence_number, self.cleanup_ranges);
+
             // replace schema cache
             let type_cache = match TypeCache::new(database.storage.clone(), sequence_number) {
                 Ok(type_cache) => type_cache,
@@ -573,6 +574,7 @@ typedb_error! {
         ConceptWriteErrors(2, "Data commit error.", write_errors: Vec<ConceptWriteError>),
         ConceptWriteErrorsFirst(3, "Data commit error.", typedb_source: Box<ConceptWriteError>),
         SnapshotError(4, "Snapshot error.", typedb_source: SnapshotError),
+        DurabilityError(5, "Durability error.", typedb_source: DurabilityClientError),
     }
 }
 
@@ -585,6 +587,7 @@ typedb_error! {
         StatisticsError(4, "Statistics error.", typedb_source: StatisticsError),
         FunctionError(5, "Function error.", typedb_source: FunctionError),
         SnapshotError(6, "Snapshot error.", typedb_source: SnapshotError),
+        DurabilityError(7, "Durability error.", typedb_source: DurabilityClientError),
     }
 }
 

--- a/database/transaction.rs
+++ b/database/transaction.rs
@@ -18,7 +18,6 @@ use concept::{
     },
 };
 use durability::DurabilitySequenceNumber;
-use encoding::{EncodingKeyspace, layout::prefix::Prefix};
 use error::typedb_error;
 use function::{FunctionError, function_cache::FunctionCache, function_manager::FunctionManager};
 use options::TransactionOptions;
@@ -26,7 +25,6 @@ use query::query_manager::QueryManager;
 use resource::profile::{CommitProfile, TransactionProfile};
 use storage::{
     durability_client::{DurabilityClient, DurabilityClientError},
-    keyspace::KeyspaceSet,
     snapshot::{
         CommittableSnapshot, ReadSnapshot, ReadableSnapshot, SchemaSnapshot, SnapshotError, WritableSnapshot,
         WriteSnapshot, snapshot_id::SnapshotId,

--- a/encoding/encoding.rs
+++ b/encoding/encoding.rs
@@ -6,6 +6,7 @@
 
 #![deny(elided_lifetimes_in_paths)]
 #![deny(unused_must_use)]
+#![allow(clippy::collapsible_if, reason = "false positive central")]
 
 use std::ffi::c_int;
 

--- a/encoding/graph/thing/edge.rs
+++ b/encoding/graph/thing/edge.rs
@@ -67,6 +67,15 @@ impl ThingEdgeHas {
         Self { owner, attribute }
     }
 
+    pub fn try_decode(bytes: &[u8]) -> Option<Self> {
+        if bytes[Self::INDEX_PREFIX] != Self::PREFIX.prefix_id().byte {
+            return None;
+        }
+        let owner = ObjectVertex::try_decode(bytes.get(Self::range_from())?)?;
+        let attribute = AttributeVertex::try_decode(bytes.get(Self::range_from().end..)?)?;
+        Some(Self { owner, attribute })
+    }
+
     pub fn prefix_from_type(type_: TypeVertex) -> StorageKey<'static, { ThingEdgeHas::LENGTH_PREFIX_FROM_TYPE }> {
         let mut bytes = ByteArray::zeros(Self::LENGTH_PREFIX_FROM_TYPE);
         bytes[Self::INDEX_PREFIX] = Self::PREFIX.prefix_id().byte;
@@ -236,10 +245,28 @@ impl ThingEdgeHasReverse {
                 bytes[Self::INDEX_FROM_VALUE_PREFIX]
             ]));
         debug_assert_eq!(bytes.len() - attribute_len, 1 + ObjectVertex::LENGTH);
-        let len = bytes.len();
-        let attribute = AttributeVertex::decode(&bytes[1..attribute_len + 1]);
-        let owner = ObjectVertex::decode(&bytes[attribute_len + 1..len]);
+        let attribute = AttributeVertex::decode(&bytes[1..][..attribute_len]);
+        let owner = ObjectVertex::decode(&bytes[attribute_len + 1..]);
         Self { owner, attribute }
+    }
+
+    pub fn try_decode(bytes: &[u8]) -> Option<Self> {
+        if *bytes.get(Self::INDEX_PREFIX)? != Self::PREFIX.prefix_id().byte {
+            return None;
+        }
+
+        let attribute_len = AttributeVertex::RANGE_TYPE_ID.end
+            + AttributeID::value_type_encoding_length(ValueTypeCategory::from_bytes([
+                *bytes.get(Self::INDEX_FROM_VALUE_PREFIX)?
+            ]));
+
+        if bytes.len() - attribute_len != 1 + ObjectVertex::LENGTH {
+            return None;
+        }
+
+        let attribute = AttributeVertex::try_decode(bytes.get(1..)?.get(..attribute_len)?)?;
+        let owner = ObjectVertex::try_decode(bytes.get(attribute_len + 1..)?)?;
+        Some(Self { owner, attribute })
     }
 
     pub fn prefix_from_prefix_short(
@@ -508,20 +535,27 @@ impl ThingEdgeLinks {
 
     pub fn decode(bytes: Bytes<'_, BUFFER_KEY_INLINE>) -> Self {
         debug_assert_eq!(bytes.length(), Self::LENGTH);
+        let from = ObjectVertex::decode(&bytes[Self::RANGE_FROM]);
+        let to = ObjectVertex::decode(&bytes[Self::RANGE_TO]);
+        let role_id = TypeID::decode(bytes[Self::RANGE_ROLE_ID].try_into().unwrap());
         match Prefix::from_prefix_id(PrefixID::new(bytes[Self::INDEX_PREFIX])).expect("Unrecognized prefix byte") {
-            Self::PREFIX => {
-                let relation = ObjectVertex::decode(&bytes[Self::RANGE_FROM]);
-                let player = ObjectVertex::decode(&bytes[Self::RANGE_TO]);
-                let role_id = TypeID::decode(bytes[Self::RANGE_ROLE_ID].try_into().unwrap());
-                Self { relation, player, role_id, is_reverse: false }
-            }
-            Self::PREFIX_REVERSE => {
-                let player = ObjectVertex::decode(&bytes[Self::RANGE_FROM]);
-                let relation = ObjectVertex::decode(&bytes[Self::RANGE_TO]);
-                let role_id = TypeID::decode(bytes[Self::RANGE_ROLE_ID].try_into().unwrap());
-                Self { relation, player, role_id, is_reverse: true }
-            }
+            Self::PREFIX => Self { relation: from, player: to, role_id, is_reverse: false },
+            Self::PREFIX_REVERSE => Self { relation: to, player: from, role_id, is_reverse: true },
             _ => panic!(),
+        }
+    }
+
+    pub fn try_decode(bytes: &[u8]) -> Option<Self> {
+        if bytes.len() != Self::LENGTH {
+            return None;
+        }
+        let from = ObjectVertex::try_decode(bytes.get(Self::RANGE_FROM)?)?;
+        let to = ObjectVertex::try_decode(bytes.get(Self::RANGE_TO)?)?;
+        let role_id = TypeID::try_decode(bytes.get(Self::RANGE_ROLE_ID)?)?;
+        match Prefix::from_prefix_id(PrefixID::new(bytes[Self::INDEX_PREFIX]))? {
+            Self::PREFIX => Some(Self { relation: from, player: to, role_id, is_reverse: false }),
+            Self::PREFIX_REVERSE => Some(Self { relation: to, player: from, role_id, is_reverse: true }),
+            _ => None,
         }
     }
 
@@ -599,7 +633,7 @@ impl ThingEdgeLinks {
     pub fn prefix_reverse_from_player_type(
         player_type_prefix: Prefix,
         player_type_id: TypeID,
-    ) -> StorageKey<'static, { ThingEdgeLinks::LENGTH_PREFIX_FROM }> {
+    ) -> StorageKey<'static, { ThingEdgeLinks::LENGTH_PREFIX_FROM_TYPE }> {
         let mut bytes = ByteArray::zeros(Self::LENGTH_PREFIX_FROM_TYPE);
         bytes[Self::INDEX_PREFIX] = Self::PREFIX_REVERSE.prefix_id().byte;
         ObjectVertex::write_prefix_type(
@@ -842,6 +876,29 @@ impl ThingEdgeIndexedRelation {
         Self::new_from_relation_parts(player_from, player_to, relation_type_id, relation_id, role_id_from, role_id_to)
     }
 
+    pub fn try_decode(bytes: &[u8]) -> Option<Self> {
+        if *bytes.get(Self::INDEX_PREFIX)? != Self::PREFIX.prefix_id().byte {
+            return None;
+        }
+
+        let player_from = ObjectVertex::try_decode(bytes.get(Self::RANGE_START)?)?;
+        let player_to = ObjectVertex::try_decode(bytes.get(Self::RANGE_END)?)?;
+        let role_id_from = TypeID::try_decode(bytes.get(Self::RANGE_START_ROLE_TYPE_ID)?)?;
+        let role_id_to = TypeID::try_decode(bytes.get(Self::RANGE_END_ROLE_TYPE_ID)?)?;
+
+        let relation_type_id = TypeID::try_decode(bytes.get(Self::RANGE_RELATION_TYPE_ID)?)?;
+        let relation_id = ObjectID::try_decode(bytes.get(Self::RANGE_RELATION_ID)?)?;
+
+        Some(Self::new_from_relation_parts(
+            player_from,
+            player_to,
+            relation_type_id,
+            relation_id,
+            role_id_from,
+            role_id_to,
+        ))
+    }
+
     pub fn prefix_relation_type(
         relation_id: TypeID,
     ) -> StorageKey<'static, { ThingEdgeIndexedRelation::LENGTH_PREFIX_REL_TYPE_ID }> {
@@ -862,6 +919,17 @@ impl ThingEdgeIndexedRelation {
         let start_type_id = start_instance_type.type_id_();
         ObjectVertex::write_prefix_type(&mut bytes[Self::RANGE_START_TYPE], start_type_prefix, start_type_id);
         StorageKey::new_owned(Self::KEYSPACE, bytes)
+    }
+
+    pub fn prefix_relation_type_start_type_parts(
+        relation_id: TypeID,
+        start_instance_type_prefix: Prefix,
+        start_instance_type_id: TypeID,
+    ) -> StorageKey<'static, { ThingEdgeIndexedRelation::LENGTH_PREFIX_REL_TYPE_ID_START_TYPE }> {
+        Self::prefix_relation_type_start_type(
+            relation_id,
+            TypeVertex::new(start_instance_type_prefix.prefix_id(), start_instance_type_id),
+        )
     }
 
     pub fn prefix_start(

--- a/encoding/graph/thing/vertex_generator.rs
+++ b/encoding/graph/thing/vertex_generator.rs
@@ -131,6 +131,7 @@ impl ThingVertexGenerator {
                 }
             }
         }
+
         for type_id in relation_types {
             let mut max_object_id =
                 ObjectVertex::build_relation(TypeID::new(type_id), ObjectID::new(u64::MAX)).to_bytes().into_array();
@@ -149,6 +150,7 @@ impl ThingVertexGenerator {
                 }
             }
         }
+
         Ok(())
     }
 

--- a/encoding/graph/thing/vertex_object.rs
+++ b/encoding/graph/thing/vertex_object.rs
@@ -159,6 +159,10 @@ impl ObjectID {
         ObjectID { value: u64::from_be_bytes(bytes) }
     }
 
+    pub fn try_decode(bytes: &[u8]) -> Option<Self> {
+        Some(ObjectID { value: u64::from_be_bytes(bytes.try_into().ok()?) })
+    }
+
     pub fn to_bytes(self) -> [u8; ObjectID::LENGTH] {
         self.value.to_be_bytes()
     }

--- a/encoding/graph/type_/vertex.rs
+++ b/encoding/graph/type_/vertex.rs
@@ -108,7 +108,7 @@ pub type TypeIDUInt = u16;
 impl TypeID {
     pub const MIN: Self = Self::new(TypeIDUInt::MIN);
     pub const MAX: Self = Self::new(TypeIDUInt::MAX);
-    pub(crate) const LENGTH: usize = std::mem::size_of::<TypeIDUInt>();
+    pub(crate) const LENGTH: usize = size_of::<TypeIDUInt>();
 
     pub const fn new(id: TypeIDUInt) -> Self {
         Self { value: id }
@@ -116,6 +116,10 @@ impl TypeID {
 
     pub fn decode(bytes: [u8; TypeID::LENGTH]) -> TypeID {
         TypeID { value: TypeIDUInt::from_be_bytes(bytes) }
+    }
+
+    pub fn try_decode(bytes: &[u8]) -> Option<TypeID> {
+        Some(TypeID { value: TypeIDUInt::from_be_bytes(bytes.try_into().ok()?) })
     }
 
     pub fn as_u16(&self) -> u16 {

--- a/resource/constants.rs
+++ b/resource/constants.rs
@@ -124,6 +124,8 @@ pub mod database {
     pub const STATISTICS_UPDATE_INTERVAL: Duration = Duration::from_millis(50);
     pub const CHECKPOINT_INTERVAL: Duration = Duration::from_secs(60);
 
+    pub const CLEANUP_WAKEUP_INTERVAL: Duration = Duration::from_secs(60);
+
     #[macro_export]
     macro_rules! internal_database_prefix {
         () => {

--- a/server/config.yml
+++ b/server/config.yml
@@ -27,6 +27,8 @@ storage:
     rocksdb:
         cache-size: 1gb
         write-buffers-limit: 512mb
+    compaction:
+        strategy: eager
 
 logging:
     directory: "logs"

--- a/server/config.yml
+++ b/server/config.yml
@@ -28,7 +28,7 @@ storage:
         cache-size: 1gb
         write-buffers-limit: 512mb
     cleanup:
-        strategy: eager
+        strategy: disabled
 
 logging:
     directory: "logs"

--- a/server/config.yml
+++ b/server/config.yml
@@ -27,9 +27,10 @@ storage:
     rocksdb:
         cache-size: 1gb
         write-buffers-limit: 512mb
-    cleanup:
-        enabled: false
-        strategy: eager
+    mvcc:
+        cleanup:
+            enabled: false
+            strategy: eager
 
 logging:
     directory: "logs"

--- a/server/config.yml
+++ b/server/config.yml
@@ -28,7 +28,8 @@ storage:
         cache-size: 1gb
         write-buffers-limit: 512mb
     cleanup:
-        strategy: disabled
+        enabled: false
+        strategy: eager
 
 logging:
     directory: "logs"

--- a/server/config.yml
+++ b/server/config.yml
@@ -27,7 +27,7 @@ storage:
     rocksdb:
         cache-size: 1gb
         write-buffers-limit: 512mb
-    compaction:
+    cleanup:
         strategy: eager
 
 logging:

--- a/server/error.rs
+++ b/server/error.rs
@@ -255,12 +255,14 @@ impl ServerStateError for LocalServerStateError {
                     TypeCacheCreateError::SnapshotIterate { .. } => System,
                 },
                 SchemaCommitError::StatisticsError { .. } => System,
+                SchemaCommitError::DurabilityError { .. } => System,
             },
             Self::DatabaseDataCommitFailed { typedb_source } => match typedb_source {
                 DataCommitError::ConceptWriteErrors { write_errors, .. } => concept_writes_origin(write_errors.iter()),
                 DataCommitError::ConceptWriteErrorsFirst { typedb_source, .. } => concept_write_origin(typedb_source),
                 DataCommitError::SnapshotError { typedb_source, .. } => snapshot_commit_origin(typedb_source),
                 DataCommitError::SnapshotInUse { .. } => Internal,
+                DataCommitError::DurabilityError { .. } => System,
             },
             Self::DatabaseImport { typedb_source } => match typedb_source {
                 DatabaseImportServiceError::ConceptDecode { .. }

--- a/server/parameters/config.rs
+++ b/server/parameters/config.rs
@@ -126,6 +126,8 @@ pub struct StorageConfig {
     pub data_directory: PathBuf,
     #[serde(default)]
     pub rocksdb: RocksDbConfig,
+    #[serde(default)]
+    pub compaction: CompactionConfig,
 }
 
 #[derive(Clone, Debug, Deserialize)]
@@ -149,6 +151,15 @@ const fn default_rocksdb_cache_size() -> ByteSize {
 
 const fn default_rocksdb_write_buffers_limit() -> ByteSize {
     ByteSize::mb(512)
+}
+
+#[derive(Default, Clone, Debug, Deserialize)]
+#[serde(tag = "strategy")]
+#[serde(rename_all = "kebab-case")]
+pub enum CompactionConfig {
+    #[default]
+    Disabled,
+    Eager,
 }
 
 #[derive(Clone, Debug, Deserialize)]

--- a/server/parameters/config.rs
+++ b/server/parameters/config.rs
@@ -127,7 +127,7 @@ pub struct StorageConfig {
     #[serde(default)]
     pub rocksdb: RocksDbConfig,
     #[serde(default)]
-    pub compaction: CompactionConfig,
+    pub cleanup: CleanupConfig,
 }
 
 #[derive(Clone, Debug, Deserialize)]
@@ -156,7 +156,7 @@ const fn default_rocksdb_write_buffers_limit() -> ByteSize {
 #[derive(Default, Clone, Debug, Deserialize)]
 #[serde(tag = "strategy")]
 #[serde(rename_all = "kebab-case")]
-pub enum CompactionConfig {
+pub enum CleanupConfig {
     #[default]
     Disabled,
     Eager,

--- a/server/parameters/config.rs
+++ b/server/parameters/config.rs
@@ -126,6 +126,12 @@ pub struct StorageConfig {
     pub data_directory: PathBuf,
     #[serde(default)]
     pub rocksdb: RocksDbConfig,
+    pub mvcc: MvccConfig,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub struct MvccConfig {
     #[serde(default)]
     pub cleanup: OptionEnabled<CleanupConfig>,
 }

--- a/server/parameters/config.rs
+++ b/server/parameters/config.rs
@@ -12,7 +12,7 @@ use std::{
     time::Duration,
 };
 
-use options::{DatabaseCleanupStrategy, byte_size::ByteSize};
+use options::{MvccCleanupStrategy, byte_size::ByteSize};
 use resource::constants::server::{DEFAULT_AUTHENTICATION_TOKEN_EXPIRATION, MONITORING_DEFAULT_PORT};
 use serde::Deserialize;
 use serde_with::{DurationSeconds, serde_as};
@@ -187,7 +187,7 @@ pub enum CleanupConfig {
     Eager,
 }
 
-impl From<CleanupConfig> for DatabaseCleanupStrategy {
+impl From<CleanupConfig> for MvccCleanupStrategy {
     fn from(value: CleanupConfig) -> Self {
         match value {
             CleanupConfig::Eager => Self::Eager,

--- a/server/parameters/config.rs
+++ b/server/parameters/config.rs
@@ -127,7 +127,7 @@ pub struct StorageConfig {
     #[serde(default)]
     pub rocksdb: RocksDbConfig,
     #[serde(default)]
-    pub cleanup: CleanupConfig,
+    pub cleanup: OptionEnabled<CleanupConfig>,
 }
 
 #[derive(Clone, Debug, Deserialize)]
@@ -153,19 +153,43 @@ const fn default_rocksdb_write_buffers_limit() -> ByteSize {
     ByteSize::mb(512)
 }
 
-#[derive(Default, Clone, Debug, Deserialize)]
+#[derive(Clone, Debug, Deserialize)]
+#[serde(tag = "enabled")]
+#[serde(rename_all = "kebab-case")]
+pub struct OptionEnabled<T> {
+    enabled: bool,
+    #[serde(flatten)]
+    #[serde(default = "None")]
+    inner: Option<T>,
+}
+
+impl<T> OptionEnabled<T> {
+    pub fn map<U>(self, f: fn(T) -> U) -> OptionEnabled<U> {
+        let Self { enabled, inner } = self;
+        OptionEnabled { enabled, inner: inner.map(f) }
+    }
+
+    pub fn unwrap_or(self, default: T) -> T {
+        self.inner.filter(|_| self.enabled).unwrap_or(default)
+    }
+}
+
+impl<T> Default for OptionEnabled<T> {
+    fn default() -> Self {
+        Self { enabled: false, inner: None }
+    }
+}
+
+#[derive(Clone, Debug, Deserialize)]
 #[serde(tag = "strategy")]
 #[serde(rename_all = "kebab-case")]
 pub enum CleanupConfig {
-    #[default]
-    Disabled,
     Eager,
 }
 
 impl From<CleanupConfig> for DatabaseCleanupStrategy {
     fn from(value: CleanupConfig) -> Self {
         match value {
-            CleanupConfig::Disabled => Self::Disabled,
             CleanupConfig::Eager => Self::Eager,
         }
     }

--- a/server/parameters/config.rs
+++ b/server/parameters/config.rs
@@ -126,10 +126,11 @@ pub struct StorageConfig {
     pub data_directory: PathBuf,
     #[serde(default)]
     pub rocksdb: RocksDbConfig,
+    #[serde(default)]
     pub mvcc: MvccConfig,
 }
 
-#[derive(Clone, Debug, Deserialize)]
+#[derive(Clone, Debug, Default, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub struct MvccConfig {
     #[serde(default)]

--- a/server/parameters/config.rs
+++ b/server/parameters/config.rs
@@ -12,7 +12,7 @@ use std::{
     time::Duration,
 };
 
-use options::byte_size::ByteSize;
+use options::{DatabaseCleanupStrategy, byte_size::ByteSize};
 use resource::constants::server::{DEFAULT_AUTHENTICATION_TOKEN_EXPIRATION, MONITORING_DEFAULT_PORT};
 use serde::Deserialize;
 use serde_with::{DurationSeconds, serde_as};
@@ -160,6 +160,15 @@ pub enum CleanupConfig {
     #[default]
     Disabled,
     Eager,
+}
+
+impl From<CleanupConfig> for DatabaseCleanupStrategy {
+    fn from(value: CleanupConfig) -> Self {
+        match value {
+            CleanupConfig::Disabled => Self::Disabled,
+            CleanupConfig::Eager => Self::Eager,
+        }
+    }
 }
 
 #[derive(Clone, Debug, Deserialize)]

--- a/server/state/database_operator.rs
+++ b/server/state/database_operator.rs
@@ -95,7 +95,7 @@ pub trait DatabaseOperator: Debug + Send + Sync {
 
     async fn delete(&self, name: &str) -> Result<(), ArcServerStateError>;
 
-    async fn prepare_for_writes(&self) -> Result<(), DatabaseOpenError>;
+    async fn prepare_for_writes(&self) -> Result<(), Box<DatabaseOpenError>>;
 }
 
 #[derive(Debug)]
@@ -143,7 +143,7 @@ impl DatabaseImportHandler for LocalDatabaseImportHandler {
         let name = staged_database.name().to_owned();
         drop(staged_database);
         database_manager.finalise_imported_database(&name).map_err(|typedb_source| {
-            Arc::new(LocalServerStateError::DatabaseImportFinaliseFailed { typedb_source }) as _
+            Arc::new(LocalServerStateError::DatabaseImportFinaliseFailed { typedb_source: *typedb_source }) as _
         })
     }
 }
@@ -209,7 +209,7 @@ impl LocalDatabaseOperator {
 
     pub fn prepare_imported_database(&self, name: String) -> Result<Arc<Database<WALClient>>, ArcServerStateError> {
         self.database_manager.prepare_imported_database(name).map_err(|typedb_source| {
-            arc_server_state_err(LocalServerStateError::DatabaseImportPrepareFailed { typedb_source })
+            arc_server_state_err(LocalServerStateError::DatabaseImportPrepareFailed { typedb_source: *typedb_source })
         })
     }
 
@@ -227,12 +227,14 @@ impl LocalDatabaseOperator {
 
     pub fn finalise_imported_database(&self, name: &str) -> Result<(), ArcServerStateError> {
         self.database_manager.finalise_imported_database(name).map_err(|typedb_source| {
-            arc_server_state_err(LocalServerStateError::DatabaseImportFinaliseFailed { typedb_source })
+            arc_server_state_err(LocalServerStateError::DatabaseImportFinaliseFailed { typedb_source: *typedb_source })
         })
     }
 }
 
-pub fn get_database_schema<D: DurabilityClient>(database: Arc<Database<D>>) -> Result<String, LocalServerStateError> {
+pub fn get_database_schema<D: DurabilityClient>(
+    database: Arc<Database<D>>,
+) -> Result<String, Box<LocalServerStateError>> {
     let transaction = TransactionRead::open(database, options::TransactionOptions::default())
         .map_err(|typedb_source| LocalServerStateError::FailedToOpenPrerequisiteTransaction { typedb_source })?;
     let schema = get_transaction_schema(&transaction)
@@ -242,7 +244,7 @@ pub fn get_database_schema<D: DurabilityClient>(database: Arc<Database<D>>) -> R
 
 pub fn get_database_type_schema<D: DurabilityClient>(
     database: Arc<Database<D>>,
-) -> Result<String, LocalServerStateError> {
+) -> Result<String, Box<LocalServerStateError>> {
     let transaction = TransactionRead::open(database, options::TransactionOptions::default())
         .map_err(|typedb_source| LocalServerStateError::FailedToOpenPrerequisiteTransaction { typedb_source })?;
     let type_schema = get_transaction_type_schema(&transaction)
@@ -252,20 +254,20 @@ pub fn get_database_type_schema<D: DurabilityClient>(
 
 pub fn get_functions_syntax<D: DurabilityClient>(
     transaction: &TransactionRead<D>,
-) -> Result<String, LocalServerStateError> {
+) -> Result<String, Box<LocalServerStateError>> {
     transaction
         .function_manager
         .get_functions_syntax(transaction.snapshot())
-        .map_err(|typedb_source| LocalServerStateError::FunctionReadError { typedb_source })
+        .map_err(|typedb_source| Box::new(LocalServerStateError::FunctionReadError { typedb_source }))
 }
 
 pub fn get_types_syntax<D: DurabilityClient>(
     transaction: &TransactionRead<D>,
-) -> Result<String, LocalServerStateError> {
+) -> Result<String, Box<LocalServerStateError>> {
     transaction
         .type_manager
         .get_types_syntax(transaction.snapshot())
-        .map_err(|typedb_source| LocalServerStateError::ConceptReadError { typedb_source })
+        .map_err(|typedb_source| Box::new(LocalServerStateError::ConceptReadError { typedb_source }))
 }
 
 #[async_trait]
@@ -289,13 +291,13 @@ impl DatabaseOperator for LocalDatabaseOperator {
     async fn create(&self, name: &str) -> Result<(), ArcServerStateError> {
         self.database_manager
             .put_database(name)
-            .map_err(|err| arc_server_state_err(LocalServerStateError::DatabaseCannotBeCreated { typedb_source: err }))
+            .map_err(|err| arc_server_state_err(LocalServerStateError::DatabaseCannotBeCreated { typedb_source: *err }))
     }
 
     async fn create_unrestricted(&self, name: &str) -> Result<(), ArcServerStateError> {
         self.database_manager
             .put_database_unrestricted(name)
-            .map_err(|err| arc_server_state_err(LocalServerStateError::DatabaseCannotBeCreated { typedb_source: err }))
+            .map_err(|err| arc_server_state_err(LocalServerStateError::DatabaseCannotBeCreated { typedb_source: *err }))
     }
 
     async fn spawn_import_service(
@@ -336,7 +338,7 @@ impl DatabaseOperator for LocalDatabaseOperator {
 
     async fn schema(&self, name: &str) -> Result<String, ArcServerStateError> {
         match self.database_manager.database(name) {
-            Some(db) => get_database_schema(db),
+            Some(db) => get_database_schema(db).map_err(|boxed| *boxed),
             None => Err(LocalServerStateError::DatabaseNotFound { name: name.to_string() }),
         }
         .map_err(arc_server_state_err)
@@ -347,7 +349,7 @@ impl DatabaseOperator for LocalDatabaseOperator {
             None => Err(Arc::new(LocalServerStateError::DatabaseNotFound { name: name.to_string() })),
             Some(database) => match get_database_type_schema(database) {
                 Ok(type_schema) => Ok(type_schema),
-                Err(err) => Err(Arc::new(err)),
+                Err(err) => Err(Arc::new(*err)),
             },
         }
     }
@@ -393,8 +395,8 @@ impl DatabaseOperator for LocalDatabaseOperator {
         let Some(database) = self.get_unrestricted(name).await? else {
             return Err(Arc::new(LocalServerStateError::DatabaseNotFound { name: name.to_string() }));
         };
-        database.commit_record_exists(open_sequence_number, snapshot_id).map_err(|typedb_source| {
-            arc_server_state_err(LocalServerStateError::DatabaseCommitRecordExistsFailed { typedb_source })
+        database.commit_record_exists(open_sequence_number, snapshot_id).map_err(|err| {
+            arc_server_state_err(LocalServerStateError::DatabaseCommitRecordExistsFailed { typedb_source: *err })
         })
     }
 
@@ -404,7 +406,7 @@ impl DatabaseOperator for LocalDatabaseOperator {
             .map_err(|err| arc_server_state_err(LocalServerStateError::DatabaseCannotBeDeleted { typedb_source: err }))
     }
 
-    async fn prepare_for_writes(&self) -> Result<(), DatabaseOpenError> {
+    async fn prepare_for_writes(&self) -> Result<(), Box<DatabaseOpenError>> {
         let database_manager = self.database_manager.clone();
         tokio::task::spawn_blocking(move || database_manager.prepare_for_writes())
             .await

--- a/server/state/mod.rs
+++ b/server/state/mod.rs
@@ -14,7 +14,7 @@ use std::{collections::HashSet, net::SocketAddr, path::PathBuf, sync::Arc};
 use concurrency::{IntervalRunner, TokioTaskSpawner};
 use database::database_manager::{DatabaseManager, ImportOwnership};
 use diagnostics::{Diagnostics, diagnostics_manager::DiagnosticsManager};
-use options::DatabaseCleanupStrategy;
+use options::MvccCleanupStrategy;
 use resource::{constants::server::DATABASE_METRICS_UPDATE_INTERVAL, distribution_info::DistributionInfo};
 use tokio::{net::lookup_host, sync::watch::Receiver};
 
@@ -94,7 +94,7 @@ impl ServerState {
             config.storage.rocksdb.cache_size,
             config.storage.rocksdb.write_buffers_limit,
             import_ownership,
-            config.storage.cleanup.clone().map(Into::into).unwrap_or(DatabaseCleanupStrategy::Disabled),
+            config.storage.cleanup.clone().map(Into::into).unwrap_or(MvccCleanupStrategy::Disabled),
         )
         .map_err(|typedb_source| ServerOpenError::DatabaseOpen { typedb_source: *typedb_source })?;
         let database_diagnostics_updater = IntervalRunner::new(

--- a/server/state/mod.rs
+++ b/server/state/mod.rs
@@ -93,8 +93,9 @@ impl ServerState {
             config.storage.rocksdb.cache_size,
             config.storage.rocksdb.write_buffers_limit,
             import_ownership,
+            config.storage.cleanup.clone().into(),
         )
-        .map_err(|typedb_source| ServerOpenError::DatabaseOpen { typedb_source })?;
+        .map_err(|typedb_source| ServerOpenError::DatabaseOpen { typedb_source: *typedb_source })?;
         let database_diagnostics_updater = IntervalRunner::new(
             {
                 let diagnostics_manager = diagnostics_manager.clone();

--- a/server/state/mod.rs
+++ b/server/state/mod.rs
@@ -94,7 +94,7 @@ impl ServerState {
             config.storage.rocksdb.cache_size,
             config.storage.rocksdb.write_buffers_limit,
             import_ownership,
-            config.storage.cleanup.clone().map(Into::into).unwrap_or(MvccCleanupStrategy::Disabled),
+            config.storage.mvcc.cleanup.clone().map(Into::into).unwrap_or(MvccCleanupStrategy::Disabled),
         )
         .map_err(|typedb_source| ServerOpenError::DatabaseOpen { typedb_source: *typedb_source })?;
         let database_diagnostics_updater = IntervalRunner::new(

--- a/server/state/mod.rs
+++ b/server/state/mod.rs
@@ -14,6 +14,7 @@ use std::{collections::HashSet, net::SocketAddr, path::PathBuf, sync::Arc};
 use concurrency::{IntervalRunner, TokioTaskSpawner};
 use database::database_manager::{DatabaseManager, ImportOwnership};
 use diagnostics::{Diagnostics, diagnostics_manager::DiagnosticsManager};
+use options::DatabaseCleanupStrategy;
 use resource::{constants::server::DATABASE_METRICS_UPDATE_INTERVAL, distribution_info::DistributionInfo};
 use tokio::{net::lookup_host, sync::watch::Receiver};
 
@@ -93,7 +94,7 @@ impl ServerState {
             config.storage.rocksdb.cache_size,
             config.storage.rocksdb.write_buffers_limit,
             import_ownership,
-            config.storage.cleanup.clone().into(),
+            config.storage.cleanup.clone().map(Into::into).unwrap_or(DatabaseCleanupStrategy::Disabled),
         )
         .map_err(|typedb_source| ServerOpenError::DatabaseOpen { typedb_source: *typedb_source })?;
         let database_diagnostics_updater = IntervalRunner::new(

--- a/storage/Cargo.toml
+++ b/storage/Cargo.toml
@@ -123,3 +123,7 @@ features = {}
 	path = "tests/test_storage.rs"
 	name = "test_storage"
 
+[[test]]
+	path = "tests/test_cleanup.rs"
+	name = "test_cleanup"
+

--- a/storage/isolation_manager.rs
+++ b/storage/isolation_manager.rs
@@ -232,6 +232,10 @@ impl IsolationManager {
         self.timeline.watermark()
     }
 
+    pub(crate) fn earliest_reader(&self) -> Option<SequenceNumber> {
+        self.timeline.earliest_reader()
+    }
+
     pub fn reset(&mut self) {
         self.timeline = Timeline::new(self.initial_sequence_number);
     }
@@ -419,6 +423,15 @@ impl Timeline {
 
     fn watermark(&self) -> SequenceNumber {
         SequenceNumber::from(self.watermark.load(Ordering::SeqCst))
+    }
+
+    fn earliest_reader(&self) -> Option<SequenceNumber> {
+        for window in &*self.windows.read().unwrap() {
+            if window.readers.load(Ordering::Relaxed) > 0 {
+                return Some(window.start());
+            }
+        }
+        None
     }
 
     fn record_reader(&self, sequence_number: SequenceNumber) -> ReaderDropGuard {

--- a/storage/key_range.rs
+++ b/storage/key_range.rs
@@ -58,8 +58,8 @@ impl<T: Prefix> KeyRange<T> {
         prefix_mapper: impl Fn(&'a T) -> V,
         fixed_width_mapper: impl Fn(bool) -> bool,
     ) -> KeyRange<V> {
-        let start = (&self.start).map(&prefix_mapper);
-        let end = (&self.end).map(&prefix_mapper);
+        let start = self.start.map(&prefix_mapper);
+        let end = self.end.map(&prefix_mapper);
         let fixed_width = fixed_width_mapper(self.fixed_width_keys);
         match fixed_width {
             true => KeyRange::new_fixed_width(start, end),
@@ -69,12 +69,8 @@ impl<T: Prefix> KeyRange<T> {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum RangeStart<T>
-where
-    T: Ord + Debug,
-{
+pub enum RangeStart<T: Ord> {
     Inclusive(T),
-    ExcludeFirstWithPrefix(T),
     ExcludePrefix(T),
 }
 
@@ -85,14 +81,13 @@ where
     pub fn map<'a: 'b, 'b, U: Ord + Debug + 'b>(&'a self, mapper: impl FnOnce(&'a T) -> U) -> RangeStart<U> {
         match self {
             Self::Inclusive(end) => RangeStart::Inclusive(mapper(end)),
-            Self::ExcludeFirstWithPrefix(end) => RangeStart::ExcludeFirstWithPrefix(mapper(end)),
             Self::ExcludePrefix(end) => RangeStart::ExcludePrefix(mapper(end)),
         }
     }
 
     pub fn get_value(&self) -> &T {
         match self {
-            Self::Inclusive(value) | Self::ExcludeFirstWithPrefix(value) | Self::ExcludePrefix(value) => value,
+            Self::Inclusive(value) | Self::ExcludePrefix(value) => value,
         }
     }
     //

--- a/storage/keyspace/iterator.rs
+++ b/storage/keyspace/iterator.rs
@@ -38,7 +38,6 @@ impl KeyspaceRangeIterator {
     ) -> Self {
         let start_prefix = match range.start() {
             RangeStart::Inclusive(bytes) => Bytes::Reference(bytes.as_ref()),
-            RangeStart::ExcludeFirstWithPrefix(bytes) => Bytes::Reference(bytes.as_ref()),
             RangeStart::ExcludePrefix(bytes) => {
                 let mut cloned = bytes.to_array();
                 cloned.increment().unwrap();
@@ -51,9 +50,6 @@ impl KeyspaceRangeIterator {
             iterpool.get_iterator_unprefixed(keyspace)
         };
         let mut iterator = DBIterator::new_from(raw_iterator, start_prefix.as_ref(), storage_counters);
-        if matches!(range.start(), RangeStart::ExcludeFirstWithPrefix(_)) {
-            Self::may_skip_start(&mut iterator, range.start().get_value());
-        }
 
         let continue_condition = match range.end() {
             RangeEnd::WithinStartAsPrefix => {
@@ -81,13 +77,13 @@ impl KeyspaceRangeIterator {
                         // if the key is shorter than the end, and the end starts with the key, then it must be OK
                         //  example: A will be included when searching up to and including AA
                         // otherwise, the key is longer and we check the corresponding ranges
-                        end_inclusive.starts_with(key) || &key[0..end_inclusive.len()] <= &**end_inclusive
+                        end_inclusive.starts_with(key) || key[0..end_inclusive.len()] <= **end_inclusive
                     }
                     ContinueCondition::EndPrefixExclusive(end_exclusive) => {
                         // if the key is shorter than the end, and the end starts with the key, then it must be OK
                         //  example: A will be included when searching up to but not including AA
                         // otherwise, the key is longer and we check the corresponding ranges
-                        end_exclusive.starts_with(key) || &key[0..end_exclusive.len()] < &**end_exclusive
+                        end_exclusive.starts_with(key) || key[0..end_exclusive.len()] < **end_exclusive
                     }
                     ContinueCondition::Always => true,
                 }
@@ -100,9 +96,7 @@ impl KeyspaceRangeIterator {
         keyspace: &Keyspace,
         range: &KeyRange<Bytes<'_, INLINE_BYTES>>,
     ) -> bool {
-        let Some(prefix_length) = keyspace.prefix_length() else {
-            return false;
-        };
+        let Some(prefix_length) = keyspace.prefix_length() else { return false };
         let start = range.start().get_value();
         if start.length() < prefix_length {
             return false;

--- a/storage/keyspace/keyspace.rs
+++ b/storage/keyspace/keyspace.rs
@@ -116,6 +116,10 @@ impl Keyspaces {
         &self.keyspaces[keyspace_index.0 as usize]
     }
 
+    pub(crate) fn iter(&self) -> impl Iterator<Item = &Keyspace> {
+        self.keyspaces.iter()
+    }
+
     pub(crate) fn write(&self, write_batches: WriteBatches) -> Result<(), KeyspaceError> {
         for (index, write_batch) in write_batches.into_iter() {
             debug_assert!(index < KEYSPACE_MAXIMUM_COUNT);

--- a/storage/recovery/checkpoint.rs
+++ b/storage/recovery/checkpoint.rs
@@ -37,10 +37,16 @@ const CHECKPOINT_DIR_NAME: &str = "checkpoint";
 const STORAGE_METADATA_FILE_NAME: &str = "STORAGE_METADATA";
 const TEMP_FILE_EXTENSION: &str = "tmp";
 
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy)]
 pub struct StorageMetadata {
     pub watermark: SequenceNumber,
-    pub cleanup_sequence_number: Option<SequenceNumber>,
+    cleanup_sequence_number: Option<SequenceNumber>,
+}
+
+impl StorageMetadata {
+    pub fn new(watermark: SequenceNumber, cleanup_sequence_number: SequenceNumber) -> Self {
+        Self { watermark, cleanup_sequence_number: Some(cleanup_sequence_number) }
+    }
 }
 
 impl FromStr for StorageMetadata {
@@ -317,12 +323,7 @@ impl CheckpointWriter {
         Ok(Self { checkpoint_directory, temporary_directory })
     }
 
-    pub fn add_storage(
-        &self,
-        keyspaces: &Keyspaces,
-        watermark: SequenceNumber,
-        cleanup_sequence_number: SequenceNumber,
-    ) -> Result<(), CheckpointCreateError> {
+    pub fn add_storage(&self, keyspaces: &Keyspaces, metadata: StorageMetadata) -> Result<(), CheckpointCreateError> {
         use CheckpointCreateError::{KeyspaceCheckpoint, MetadataWrite};
 
         keyspaces
@@ -332,13 +333,8 @@ impl CheckpointWriter {
         fail_point!(CHECKPOINT_METADATA_WRITE_FAIL);
 
         let metadata_file_path = self.temporary_directory.join(STORAGE_METADATA_FILE_NAME);
-        write_file(
-            &metadata_file_path,
-            StorageMetadata { watermark, cleanup_sequence_number: Some(cleanup_sequence_number) }
-                .to_string()
-                .as_bytes(),
-        )
-        .map_err(|e| MetadataWrite { file_path: metadata_file_path, source: Arc::new(e) })?;
+        write_file(&metadata_file_path, metadata.to_string().as_bytes())
+            .map_err(|e| MetadataWrite { file_path: metadata_file_path, source: Arc::new(e) })?;
 
         Ok(())
     }

--- a/storage/recovery/checkpoint.rs
+++ b/storage/recovery/checkpoint.rs
@@ -9,11 +9,14 @@ use std::{
     fmt,
     fs::{self, File},
     io::{self, Read, Write},
+    num::ParseIntError,
     path::{Path, PathBuf},
+    str::FromStr,
     sync::Arc,
 };
 
 use chrono::{DateTime, Utc};
+use durability::DurabilitySequenceNumber;
 use error::typedb_error;
 use fail_point::{
     CHECKPOINT_CLEANUP_FAIL, CHECKPOINT_CLEANUP_PARTIAL_FAIL, CHECKPOINT_DIR_CREATE_FAIL, CHECKPOINT_FILE_EMPTY,
@@ -33,6 +36,83 @@ use crate::{
 const CHECKPOINT_DIR_NAME: &str = "checkpoint";
 const STORAGE_METADATA_FILE_NAME: &str = "STORAGE_METADATA";
 const TEMP_FILE_EXTENSION: &str = "tmp";
+
+#[derive(Debug)]
+pub struct StorageMetadata {
+    pub watermark: SequenceNumber,
+    pub cleanup_sequence_number: Option<SequenceNumber>,
+}
+
+impl FromStr for StorageMetadata {
+    type Err = StorageMetadataParseError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        if !s.contains('=') {
+            // fallback to the legacy single number format
+            return Ok(Self { watermark: DurabilitySequenceNumber::new(s.parse()?), cleanup_sequence_number: None });
+        }
+
+        let mut sequence_number = None;
+        let mut cleanup_sequence_number = None;
+        for line in s.lines() {
+            if line.trim().is_empty() {
+                continue;
+            }
+            let (key, value) =
+                line.split_once('=').ok_or(StorageMetadataParseError::InvalidFormat { line: line.to_owned() })?;
+            let key = key.trim();
+            let value = value.trim();
+            match key {
+                "watermark" => sequence_number = Some(DurabilitySequenceNumber::new(value.parse()?)),
+                "cleanup" => cleanup_sequence_number = Some(DurabilitySequenceNumber::new(value.parse()?)),
+                _ => (), // ignore any extra fields
+            }
+        }
+        let sequence_number =
+            sequence_number.ok_or(StorageMetadataParseError::MissingField { field_name: "sequence_number" })?;
+        Ok(Self { watermark: sequence_number, cleanup_sequence_number })
+    }
+}
+
+impl fmt::Display for StorageMetadata {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        writeln!(f, "watermark={}", self.watermark.number())?;
+        if let Some(cleanup) = self.cleanup_sequence_number {
+            writeln!(f, "cleanup={}", cleanup.number())?;
+        }
+        Ok(())
+    }
+}
+
+pub enum StorageMetadataParseError {
+    InvalidFormat { line: String },
+    MissingField { field_name: &'static str },
+    ParseInt(ParseIntError),
+}
+
+impl fmt::Display for StorageMetadataParseError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::InvalidFormat { line } => {
+                write!(f, "Could not parse metadata line: {line:?}, expected 'key = value'.")
+            }
+            Self::MissingField { field_name } => write!(f, "Missing mandatory field '{field_name}' in the metadata."),
+            Self::ParseInt(parse_int_error) => write!(f, "Failed to parse integer: {parse_int_error}"),
+        }
+    }
+}
+
+impl fmt::Debug for StorageMetadataParseError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Display::fmt(self, f)
+    }
+}
+
+impl From<ParseIntError> for StorageMetadataParseError {
+    fn from(value: ParseIntError) -> Self {
+        Self::ParseInt(value)
+    }
+}
 
 /// A checkpoint is a directory, which contains at least the storage checkpointing data: keyspaces + the watermark.
 /// The watermark represents a sequence number that is guaranteed to be in all the keyspaces, and after which we may
@@ -78,7 +158,7 @@ impl CheckpointReader {
         keyspaces_dir: &Path,
         durability_client: &Durability,
         rocks_resources: &RocksResources,
-    ) -> Result<(Keyspaces, SequenceNumber), CheckpointLoadError> {
+    ) -> Result<(Keyspaces, SequenceNumber, SequenceNumber), CheckpointLoadError> {
         use CheckpointLoadError::{CheckpointRestore, CommitRecoveryFailed, KeyspaceOpen};
 
         for keyspace in KS::iter() {
@@ -94,32 +174,30 @@ impl CheckpointReader {
 
         trace!("Finished recovering keyspaces, recovering missing commits");
 
-        let checkpoint_sequence_number = self.read_sequence_number()?;
-        if checkpoint_sequence_number > durability_client.previous() {
+        let metadata = self.read_metadata()?;
+        if metadata.watermark > durability_client.previous() {
             panic!(
                 "The checkpoint is ahead of the durability service! The durability logs may have been corrupted. Aborting."
             );
         }
 
-        let recovery_start = checkpoint_sequence_number + 1;
+        let recovery_start = metadata.watermark + 1;
         let recovered_commits = load_commit_data_from(recovery_start, durability_client)
             .map_err(|err| CommitRecoveryFailed { typedb_source: err })?;
         let next_sequence_number = recovered_commits.keys().max().copied().unwrap_or(recovery_start - 1) + 1;
         trace!("Applying missing commits");
         apply_recovered(database_name, recovered_commits, durability_client, &keyspaces)
             .map_err(|err| CommitRecoveryFailed { typedb_source: err })?;
-        Ok((keyspaces, next_sequence_number))
+        Ok((keyspaces, next_sequence_number, metadata.cleanup_sequence_number.unwrap_or(SequenceNumber::MIN)))
     }
 
-    pub fn read_sequence_number(&self) -> Result<SequenceNumber, CheckpointLoadError> {
+    pub fn read_metadata(&self) -> Result<StorageMetadata, CheckpointLoadError> {
         use CheckpointLoadError::MetadataRead;
 
         let metadata_file_path = self.directory.join(STORAGE_METADATA_FILE_NAME);
         let metadata = fs::read_to_string(metadata_file_path)
             .map_err(|error| MetadataRead { dir: self.directory.clone(), source: Arc::new(error) })?;
-        Ok(SequenceNumber::new(
-            metadata.parse().expect("Could not read METADATA file (could try to restore from previous checkpoint)"),
-        ))
+        Ok(metadata.parse().expect("Could not read METADATA file (could try to restore from previous checkpoint)"))
     }
 
     fn is_complete<KS: KeyspaceSet>(&self) -> io::Result<bool> {
@@ -239,7 +317,12 @@ impl CheckpointWriter {
         Ok(Self { checkpoint_directory, temporary_directory })
     }
 
-    pub fn add_storage(&self, keyspaces: &Keyspaces, watermark: SequenceNumber) -> Result<(), CheckpointCreateError> {
+    pub fn add_storage(
+        &self,
+        keyspaces: &Keyspaces,
+        watermark: SequenceNumber,
+        cleanup_sequence_number: SequenceNumber,
+    ) -> Result<(), CheckpointCreateError> {
         use CheckpointCreateError::{KeyspaceCheckpoint, MetadataWrite};
 
         keyspaces
@@ -249,8 +332,13 @@ impl CheckpointWriter {
         fail_point!(CHECKPOINT_METADATA_WRITE_FAIL);
 
         let metadata_file_path = self.temporary_directory.join(STORAGE_METADATA_FILE_NAME);
-        write_file(&metadata_file_path, watermark.number().to_string().as_bytes())
-            .map_err(|e| MetadataWrite { file_path: metadata_file_path, source: Arc::new(e) })?;
+        write_file(
+            &metadata_file_path,
+            StorageMetadata { watermark, cleanup_sequence_number: Some(cleanup_sequence_number) }
+                .to_string()
+                .as_bytes(),
+        )
+        .map_err(|e| MetadataWrite { file_path: metadata_file_path, source: Arc::new(e) })?;
 
         Ok(())
     }

--- a/storage/snapshot/buffer.rs
+++ b/storage/snapshot/buffer.rs
@@ -238,7 +238,6 @@ pub(crate) fn range_start_as_bound<const INLINE: usize>(
 ) -> Bound<Bytes<'_, INLINE>> {
     match range_start {
         RangeStart::Inclusive(bytes) => Bound::Included(bytes),
-        RangeStart::ExcludeFirstWithPrefix(bytes) => Bound::Excluded(bytes),
         RangeStart::ExcludePrefix(bytes) => {
             let mut cloned = bytes.clone().into_array();
             cloned.increment().unwrap();

--- a/storage/snapshot/snapshot.rs
+++ b/storage/snapshot/snapshot.rs
@@ -228,6 +228,7 @@ pub struct ReadSnapshot<D> {
     id: SnapshotId,
     iterator_pool: IteratorPool, // Must be declared & dropped before storage
     storage: Arc<MVCCStorage<D>>,
+    reader_guard: ReaderDropGuard,
 }
 
 impl<D: fmt::Debug> fmt::Debug for ReadSnapshot<D> {
@@ -238,8 +239,15 @@ impl<D: fmt::Debug> fmt::Debug for ReadSnapshot<D> {
 
 impl<D> ReadSnapshot<D> {
     pub(crate) fn new(storage: Arc<MVCCStorage<D>>, open_sequence_number: SequenceNumber) -> Self {
+        let reader_guard = storage.isolation_manager.opened_for_read(open_sequence_number);
         // Note: for serialisability, we would need to register the open transaction to the IsolationManager
-        ReadSnapshot { open_sequence_number, id: SnapshotId::new(), iterator_pool: IteratorPool::new(), storage }
+        ReadSnapshot {
+            open_sequence_number,
+            id: SnapshotId::new(),
+            iterator_pool: IteratorPool::new(),
+            storage,
+            reader_guard,
+        }
     }
 }
 

--- a/storage/storage.rs
+++ b/storage/storage.rs
@@ -36,6 +36,7 @@ use resource::{
     constants::{snapshot::BUFFER_VALUE_INLINE, storage::WATERMARK_WAIT_INTERVAL_MICROSECONDS},
     profile::{CommitProfile, StorageCounters},
 };
+use rocksdb::WriteBatch;
 use tracing::trace;
 
 use crate::{
@@ -43,7 +44,7 @@ use crate::{
     error::{MVCCStorageError, MVCCStorageErrorKind},
     isolation_manager::{IsolationManager, ValidatedCommit},
     iterator::MVCCRangeIterator,
-    key_range::KeyRange,
+    key_range::{KeyRange, RangeStart},
     key_value::{StorageKey, StorageKeyReference},
     keyspace::{
         IteratorPool, Keyspace, KeyspaceError, KeyspaceId, KeyspaceOpenError, KeyspaceSet, Keyspaces,
@@ -81,6 +82,7 @@ pub struct MVCCStorage<Durability> {
     durability_client: Durability,
     isolation_manager: IsolationManager,
     highest_committed_snapshot: AtomicU64,
+    earliest_uncompacted: AtomicU64,
 }
 
 impl<Durability> MVCCStorage<Durability> {
@@ -117,6 +119,7 @@ impl<Durability> MVCCStorage<Durability> {
             keyspaces,
             isolation_manager,
             highest_committed_snapshot: AtomicU64::new(next_sequence_number.number() - 1),
+            earliest_uncompacted: AtomicU64::new(0),
         })
     }
 
@@ -180,6 +183,7 @@ impl<Durability> MVCCStorage<Durability> {
             keyspaces,
             isolation_manager,
             highest_committed_snapshot: AtomicU64::new(next_sequence_number.number() - 1),
+            earliest_uncompacted: AtomicU64::new(0),
         })
     }
 
@@ -388,8 +392,7 @@ impl<Durability> MVCCStorage<Durability> {
     where
         Durability: DurabilityClient,
     {
-        let mut iter = self.durability_client.iter_sequenced_type_from::<CommitRecord>(open_sequence_number)?;
-        while let Some(entry) = iter.next() {
+        for entry in self.durability_client.iter_sequenced_type_from::<CommitRecord>(open_sequence_number)? {
             let (_, iter_record) = entry?;
             if iter_record.snapshot_id() == snapshot_id && iter_record.open_sequence_number() == open_sequence_number {
                 return Ok(true);
@@ -580,6 +583,55 @@ impl<Durability> MVCCStorage<Durability> {
         Ok(())
     }
 
+    fn compaction_watermark(&self, limit: SequenceNumber) -> SequenceNumber {
+        let seq = SequenceNumber::min(limit, self.isolation_manager.watermark());
+        if let Some(earliest_reader) = self.isolation_manager.earliest_reader() {
+            SequenceNumber::min(seq, earliest_reader)
+        } else {
+            seq
+        }
+    }
+
+    pub fn compact<KS: KeyspaceSet>(&self, limit: SequenceNumber) -> Result<(), StorageCompactError> {
+        let watermark = self.compaction_watermark(limit);
+        if self.earliest_uncompacted.load(Ordering::Relaxed) >= watermark.number() {
+            return Ok(());
+        }
+
+        for ks in KS::iter() {
+            let keyspace = self.get_keyspace(ks.id());
+            let mut it = keyspace.iterate_range(
+                &IteratorPool::new(),
+                &KeyRange::new(
+                    RangeStart::Inclusive(Bytes::<0>::reference(&[])),
+                    key_range::RangeEnd::Unbounded,
+                    false,
+                ),
+                StorageCounters::DISABLED,
+            );
+            let mut batch = WriteBatch::default();
+            let mut last_seen = None;
+            while let Some(raw) = it.next() {
+                let (k, _) =
+                    raw.map_err(|err| StorageCompactError::Keyspace { name: self.name.clone(), source: err })?;
+                let mvcc_key = MVCCKey::wrap_slice(k);
+
+                if mvcc_key.sequence_number() < watermark
+                    && (matches!(mvcc_key.operation(), StorageOperation::Delete)
+                        || last_seen.as_deref() == Some(mvcc_key.key()))
+                {
+                    batch.delete(k);
+                }
+                last_seen = Some(Bytes::<MVCC_KEY_INLINE_SIZE>::copy(mvcc_key.key()));
+            }
+            keyspace
+                .write(batch)
+                .map_err(|err| StorageCompactError::Keyspace { name: self.name.clone(), source: err })?;
+        }
+        self.earliest_uncompacted.store(watermark.number(), Ordering::Relaxed);
+        Ok(())
+    }
+
     pub fn estimate_size_in_bytes(&self) -> Result<u64, StorageOpenError> {
         self.keyspaces.estimate_size_in_bytes().map_err(|source| StorageOpenError::Keyspace { source })
     }
@@ -617,6 +669,13 @@ typedb_error! {
         MVCCRead(4, "Commit in database '{name}' failed due to failed read from MVCC storage layer.", name: Arc<str>, source: MVCCReadError),
         Keyspace(5, "Commit in database '{name}' failed due to a storage keyspace error.", name: Arc<str>, source: Arc<KeyspaceError>),
         Durability(6, "Commit in database '{name}' failed due to error in durability client.", name: Arc<str>, typedb_source: DurabilityClientError),
+    }
+}
+
+typedb_error! {
+    pub StorageCompactError(component = "Storage commit", prefix = "STP") {
+        Internal(1, "Compaction in database '{name}' failed with internal error.", name: Arc<str>, source: Arc<dyn Error + Send + Sync + 'static>),
+        Keyspace(2, "Compaction in database '{name}' failed due to a storage keyspace error.", name: Arc<str>, source: KeyspaceError),
     }
 }
 

--- a/storage/storage.rs
+++ b/storage/storage.rs
@@ -610,7 +610,7 @@ impl<Durability> MVCCStorage<Durability> {
         ranges: impl IntoIterator<
             Item = (StorageKey<'static, BUFFER_KEY_INLINE>, KeyRange<StorageKey<'static, BUFFER_KEY_INLINE>>),
         >,
-    ) -> Result<(), StorageCompactError> {
+    ) -> Result<(), StorageCleanupError> {
         let cleanup_until = SequenceNumber::min(cleanup_until, self.earliest_possible_reader());
 
         if self.earliest_uncleaned.load(Ordering::Relaxed) >= cleanup_until.number() {
@@ -635,7 +635,7 @@ impl<Durability> MVCCStorage<Durability> {
             let mut last_seen = None;
             while let Some(raw) = it.next() {
                 let (k, _) =
-                    raw.map_err(|err| StorageCompactError::Keyspace { name: self.name.clone(), source: err })?;
+                    raw.map_err(|err| StorageCleanupError::Keyspace { name: self.name.clone(), source: err })?;
                 let mvcc_key = MVCCKey::wrap_slice(k);
 
                 let overwritten =
@@ -653,7 +653,7 @@ impl<Durability> MVCCStorage<Durability> {
         for (keyspace_id, batch) in batches {
             self.get_keyspace(keyspace_id)
                 .write(batch)
-                .map_err(|err| StorageCompactError::Keyspace { name: self.name.clone(), source: err })?;
+                .map_err(|err| StorageCleanupError::Keyspace { name: self.name.clone(), source: err })?;
         }
 
         self.earliest_uncleaned.store(cleanup_until.number(), Ordering::Relaxed);
@@ -701,9 +701,9 @@ typedb_error! {
 }
 
 typedb_error! {
-    pub StorageCompactError(component = "Storage commit", prefix = "STP") {
-        Internal(1, "Compaction in database '{name}' failed with internal error.", name: Arc<str>, source: Arc<dyn Error + Send + Sync + 'static>),
-        Keyspace(2, "Compaction in database '{name}' failed due to a storage keyspace error.", name: Arc<str>, source: KeyspaceError),
+    pub StorageCleanupError(component = "Storage cleanup", prefix = "STP") {
+        Internal(1, "Cleanup in database '{name}' failed with internal error.", name: Arc<str>, source: Arc<dyn Error + Send + Sync + 'static>),
+        Keyspace(2, "Cleanup in database '{name}' failed due to a storage keyspace error.", name: Arc<str>, source: KeyspaceError),
     }
 }
 

--- a/storage/storage.rs
+++ b/storage/storage.rs
@@ -611,6 +611,8 @@ impl<Durability> MVCCStorage<Durability> {
             Item = (StorageKey<'static, BUFFER_KEY_INLINE>, KeyRange<StorageKey<'static, BUFFER_KEY_INLINE>>),
         >,
     ) -> Result<(), StorageCompactError> {
+        let cleanup_until = SequenceNumber::min(cleanup_until, self.earliest_possible_reader());
+
         if self.earliest_uncleaned.load(Ordering::Relaxed) >= cleanup_until.number() {
             return Ok(());
         }

--- a/storage/storage.rs
+++ b/storage/storage.rs
@@ -9,6 +9,8 @@
 #![allow(clippy::module_inception)]
 
 use std::{
+    collections::BTreeMap,
+    convert::identity,
     error::Error,
     fs, io,
     path::{Path, PathBuf},
@@ -33,7 +35,10 @@ use keyspace::KeyspaceDeleteError;
 use lending_iterator::LendingIterator;
 use logger::{error, result::ResultExt};
 use resource::{
-    constants::{snapshot::BUFFER_VALUE_INLINE, storage::WATERMARK_WAIT_INTERVAL_MICROSECONDS},
+    constants::{
+        snapshot::{BUFFER_KEY_INLINE, BUFFER_VALUE_INLINE},
+        storage::WATERMARK_WAIT_INTERVAL_MICROSECONDS,
+    },
     profile::{CommitProfile, StorageCounters},
 };
 use rocksdb::WriteBatch;
@@ -44,7 +49,7 @@ use crate::{
     error::{MVCCStorageError, MVCCStorageErrorKind},
     isolation_manager::{IsolationManager, ValidatedCommit},
     iterator::MVCCRangeIterator,
-    key_range::{KeyRange, RangeStart},
+    key_range::KeyRange,
     key_value::{StorageKey, StorageKeyReference},
     keyspace::{
         IteratorPool, Keyspace, KeyspaceError, KeyspaceId, KeyspaceOpenError, KeyspaceSet, Keyspaces,
@@ -82,7 +87,7 @@ pub struct MVCCStorage<Durability> {
     durability_client: Durability,
     isolation_manager: IsolationManager,
     highest_committed_snapshot: AtomicU64,
-    earliest_uncompacted: AtomicU64,
+    earliest_uncleaned: AtomicU64,
 }
 
 impl<Durability> MVCCStorage<Durability> {
@@ -119,7 +124,7 @@ impl<Durability> MVCCStorage<Durability> {
             keyspaces,
             isolation_manager,
             highest_committed_snapshot: AtomicU64::new(next_sequence_number.number() - 1),
-            earliest_uncompacted: AtomicU64::new(0),
+            earliest_uncleaned: AtomicU64::new(0),
         })
     }
 
@@ -149,16 +154,15 @@ impl<Durability> MVCCStorage<Durability> {
         let storage_dir = path.join(Self::STORAGE_DIR_NAME);
 
         Self::register_durability_record_types(&mut durability_client);
-        let (keyspaces, next_sequence_number) = if let Some(checkpoint) = checkpoint {
+        let (keyspaces, next_sequence_number, earliest_uncleaned) = if let Some(checkpoint) = checkpoint {
             checkpoint
                 .recover_storage::<KS, _>(name, &storage_dir, &durability_client, rocks_resources)
                 .map_err(|error| RecoverFromCheckpoint { name: name.to_owned(), typedb_source: error })?
         } else {
-            match fs::remove_dir_all(&storage_dir) {
-                Err(err) if err.kind() != io::ErrorKind::NotFound => {
-                    return Err(StorageDirectoryRecreate { name: name.to_owned(), source: Arc::new(err) });
-                }
-                _ => (),
+            if let Err(err) = fs::remove_dir_all(&storage_dir)
+                && err.kind() != io::ErrorKind::NotFound
+            {
+                return Err(StorageDirectoryRecreate { name: name.to_owned(), source: Arc::new(err) });
             }
             fail_point!(STORAGE_MISSING_STORAGE_DIR);
             fs::create_dir_all(&storage_dir)
@@ -172,7 +176,7 @@ impl<Durability> MVCCStorage<Durability> {
             apply_recovered(name, commits, &durability_client, &keyspaces)
                 .map_err(|err| RecoverFromDurability { name: name.to_owned(), typedb_source: err })?;
             trace!("Finished applying commits from WAL.");
-            (keyspaces, next_sequence_number)
+            (keyspaces, next_sequence_number, SequenceNumber::MIN)
         };
 
         let isolation_manager = IsolationManager::new(next_sequence_number);
@@ -183,7 +187,7 @@ impl<Durability> MVCCStorage<Durability> {
             keyspaces,
             isolation_manager,
             highest_committed_snapshot: AtomicU64::new(next_sequence_number.number() - 1),
-            earliest_uncompacted: AtomicU64::new(0),
+            earliest_uncleaned: AtomicU64::new(earliest_uncleaned.number()),
         })
     }
 
@@ -418,7 +422,11 @@ impl<Durability> MVCCStorage<Durability> {
     }
 
     pub fn checkpoint(&self, checkpoint: &CheckpointWriter) -> Result<(), CheckpointCreateError> {
-        checkpoint.add_storage(&self.keyspaces, self.snapshot_watermark())
+        checkpoint.add_storage(
+            &self.keyspaces,
+            self.snapshot_watermark(),
+            SequenceNumber::new(self.earliest_uncleaned.load(Ordering::Relaxed)),
+        )
     }
 
     pub fn delete_storage(self) -> Result<(), StorageDeleteError>
@@ -583,40 +591,51 @@ impl<Durability> MVCCStorage<Durability> {
         Ok(())
     }
 
-    fn compaction_watermark(&self, limit: SequenceNumber) -> SequenceNumber {
-        let seq = SequenceNumber::min(limit, self.isolation_manager.watermark());
+    pub fn earliest_possible_reader(&self) -> SequenceNumber {
+        let watermark = self.isolation_manager.watermark();
         if let Some(earliest_reader) = self.isolation_manager.earliest_reader() {
-            SequenceNumber::min(seq, earliest_reader)
+            SequenceNumber::min(watermark, earliest_reader)
         } else {
-            seq
+            watermark
         }
     }
 
-    pub fn compact<KS: KeyspaceSet>(&self, limit: SequenceNumber) -> Result<(), StorageCompactError> {
-        let watermark = self.compaction_watermark(limit);
-        if self.earliest_uncompacted.load(Ordering::Relaxed) >= watermark.number() {
+    pub fn earliest_uncleaned(&self) -> SequenceNumber {
+        SequenceNumber::new(self.earliest_uncleaned.load(Ordering::Relaxed))
+    }
+
+    pub fn cleanup_dead_keys<KS: KeyspaceSet>(
+        &self,
+        cleanup_until: SequenceNumber,
+        ranges: impl IntoIterator<
+            Item = (StorageKey<'static, BUFFER_KEY_INLINE>, KeyRange<StorageKey<'static, BUFFER_KEY_INLINE>>),
+        >,
+    ) -> Result<(), StorageCompactError> {
+        if self.earliest_uncleaned.load(Ordering::Relaxed) >= cleanup_until.number() {
             return Ok(());
         }
 
-        for ks in KS::iter() {
-            let keyspace = self.get_keyspace(ks.id());
-            let mut it = keyspace.iterate_range(
+        let mut batches = BTreeMap::from_iter(KS::iter().map(|keyspace| (keyspace.id(), WriteBatch::default())));
+
+        for (prefix, range) in ranges {
+            let keyspace_id = prefix.keyspace_id();
+            let batch = batches.get_mut(&keyspace_id).unwrap_or_else(|| {
+                panic!("Keyspace ID {keyspace_id} not found in write batches during cleanup! Keyspace mismatch?")
+            });
+
+            let mut it = self.get_keyspace(keyspace_id).iterate_range(
                 &IteratorPool::new(),
-                &KeyRange::new(
-                    RangeStart::Inclusive(Bytes::<0>::reference(&[])),
-                    key_range::RangeEnd::Unbounded,
-                    false,
-                ),
+                &range.map(StorageKey::as_bytes, identity),
                 StorageCounters::DISABLED,
             );
-            let mut batch = WriteBatch::default();
+
             let mut last_seen = None;
             while let Some(raw) = it.next() {
                 let (k, _) =
                     raw.map_err(|err| StorageCompactError::Keyspace { name: self.name.clone(), source: err })?;
                 let mvcc_key = MVCCKey::wrap_slice(k);
 
-                if mvcc_key.sequence_number() < watermark
+                if mvcc_key.sequence_number() < cleanup_until
                     && (matches!(mvcc_key.operation(), StorageOperation::Delete)
                         || last_seen.as_deref() == Some(mvcc_key.key()))
                 {
@@ -624,11 +643,15 @@ impl<Durability> MVCCStorage<Durability> {
                 }
                 last_seen = Some(Bytes::<MVCC_KEY_INLINE_SIZE>::copy(mvcc_key.key()));
             }
-            keyspace
+        }
+
+        for (keyspace_id, batch) in batches {
+            self.get_keyspace(keyspace_id)
                 .write(batch)
                 .map_err(|err| StorageCompactError::Keyspace { name: self.name.clone(), source: err })?;
         }
-        self.earliest_uncompacted.store(watermark.number(), Ordering::Relaxed);
+
+        self.earliest_uncleaned.store(cleanup_until.number(), Ordering::Relaxed);
         Ok(())
     }
 

--- a/storage/storage.rs
+++ b/storage/storage.rs
@@ -57,7 +57,7 @@ use crate::{
     },
     record::{CommitRecord, LegacyCommitRecordV1, StatusRecord},
     recovery::{
-        checkpoint::{CheckpointCreateError, CheckpointLoadError, CheckpointReader, CheckpointWriter},
+        checkpoint::{CheckpointCreateError, CheckpointLoadError, CheckpointReader, CheckpointWriter, StorageMetadata},
         commit_recovery::{StorageRecoveryError, apply_recovered, load_commit_data_from},
     },
     sequence_number::SequenceNumber,
@@ -421,12 +421,15 @@ impl<Durability> MVCCStorage<Durability> {
         self.keyspaces.get(keyspace_id)
     }
 
-    pub fn checkpoint(&self, checkpoint: &CheckpointWriter) -> Result<(), CheckpointCreateError> {
-        checkpoint.add_storage(
-            &self.keyspaces,
+    fn metadata(&self) -> StorageMetadata {
+        StorageMetadata::new(
             self.snapshot_watermark(),
             SequenceNumber::new(self.earliest_uncleaned.load(Ordering::Relaxed)),
         )
+    }
+
+    pub fn checkpoint(&self, checkpoint: &CheckpointWriter) -> Result<(), CheckpointCreateError> {
+        checkpoint.add_storage(&self.keyspaces, self.metadata())
     }
 
     pub fn delete_storage(self) -> Result<(), StorageDeleteError>

--- a/storage/storage.rs
+++ b/storage/storage.rs
@@ -604,7 +604,7 @@ impl<Durability> MVCCStorage<Durability> {
         SequenceNumber::new(self.earliest_uncleaned.load(Ordering::Relaxed))
     }
 
-    pub fn cleanup_dead_keys<KS: KeyspaceSet>(
+    pub fn cleanup_dead_keys(
         &self,
         cleanup_until: SequenceNumber,
         ranges: impl IntoIterator<
@@ -615,7 +615,8 @@ impl<Durability> MVCCStorage<Durability> {
             return Ok(());
         }
 
-        let mut batches = BTreeMap::from_iter(KS::iter().map(|keyspace| (keyspace.id(), WriteBatch::default())));
+        let mut batches =
+            BTreeMap::from_iter(self.keyspaces.iter().map(|keyspace| (keyspace.id(), WriteBatch::default())));
 
         for (prefix, range) in ranges {
             let keyspace_id = prefix.keyspace_id();

--- a/storage/storage.rs
+++ b/storage/storage.rs
@@ -635,10 +635,12 @@ impl<Durability> MVCCStorage<Durability> {
                     raw.map_err(|err| StorageCompactError::Keyspace { name: self.name.clone(), source: err })?;
                 let mvcc_key = MVCCKey::wrap_slice(k);
 
-                if mvcc_key.sequence_number() < cleanup_until
-                    && (matches!(mvcc_key.operation(), StorageOperation::Delete)
-                        || last_seen.as_deref() == Some(mvcc_key.key()))
-                {
+                let overwritten =
+                    mvcc_key.sequence_number() < cleanup_until && last_seen.as_deref() == Some(mvcc_key.key());
+                let deleted = mvcc_key.sequence_number() <= cleanup_until
+                    && matches!(mvcc_key.operation(), StorageOperation::Delete);
+
+                if overwritten || deleted {
                     batch.delete(k);
                 }
                 last_seen = Some(Bytes::<MVCC_KEY_INLINE_SIZE>::copy(mvcc_key.key()));

--- a/storage/storage.rs
+++ b/storage/storage.rs
@@ -607,7 +607,7 @@ impl<Durability> MVCCStorage<Durability> {
         SequenceNumber::new(self.earliest_uncleaned.load(Ordering::Relaxed))
     }
 
-    pub fn cleanup_dead_keys(
+    pub fn mvcc_cleanup(
         &self,
         cleanup_until: SequenceNumber,
         ranges: impl IntoIterator<

--- a/storage/tests/BUILD
+++ b/storage/tests/BUILD
@@ -135,6 +135,28 @@ rust_test(
     ]
 )
 
+rust_test(
+    name = "test_cleanup",
+    crate_root = "test_cleanup.rs",
+    srcs = glob([
+        "test_cleanup.rs",
+    ]),
+    deps = [
+        "//common/bytes",
+        "//common/lending_iterator",
+        "//common/logger",
+        "//common/primitive",
+        "//diagnostics",
+        "//durability",
+        "//resource",
+        "//storage",
+        "//util/test:test_utils",
+        ":test_utils_storage",
+
+        "@crates//:tracing",
+    ]
+)
+
 rustfmt_test(
     name = "rustfmt_test",
     targets = [

--- a/storage/tests/test_cleanup.rs
+++ b/storage/tests/test_cleanup.rs
@@ -128,10 +128,10 @@ fn concurrent_reader_cleanup_test() {
 }
 
 fn get_key(
-    key_1: StorageKeyArray<BUFFER_KEY_INLINE>,
+    key: StorageKeyArray<BUFFER_KEY_INLINE>,
     snapshot: &ReadSnapshot<WALClient>,
 ) -> Option<ByteArray<BUFFER_KEY_INLINE>> {
-    snapshot.get::<BUFFER_KEY_INLINE>(StorageKey::Array(key_1).as_reference(), StorageCounters::DISABLED).unwrap()
+    snapshot.get::<BUFFER_KEY_INLINE>(StorageKey::Array(key).as_reference(), StorageCounters::DISABLED).unwrap()
 }
 
 fn count_keys(storage: &MVCCStorage<WALClient>) -> usize {

--- a/storage/tests/test_cleanup.rs
+++ b/storage/tests/test_cleanup.rs
@@ -1,0 +1,125 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+#![allow(const_item_mutation, reason = "`&mut CommitProfile::DISABLED` is a dummy")]
+
+use std::sync::Arc;
+
+use bytes::{Bytes, byte_array::ByteArray, util::HexBytesFormatter};
+use diagnostics::metrics::FsyncMetrics;
+use durability::wal::WAL;
+use itertools::Itertools;
+use lending_iterator::LendingIterator;
+use logger::result::ResultExt;
+use resource::{
+    constants::snapshot::{BUFFER_KEY_INLINE, BUFFER_VALUE_INLINE},
+    profile::{CommitProfile, StorageCounters},
+};
+use storage::{
+    StorageOpenError,
+    key_range::{KeyRange, RangeEnd, RangeStart},
+    key_value::{StorageKey, StorageKeyArray, StorageKeyReference},
+    keyspace::{IteratorPool, KeyspaceOpenError, KeyspaceSet, KeyspaceValidationError},
+    snapshot::{CommittableSnapshot, PreloadedRangesSnapshot, ReadableSnapshot, WritableSnapshot},
+};
+use test_utils::{create_tmp_storage_dir, init_logging};
+use test_utils_storage::{checkpoint_storage, create_storage, load_storage, test_keyspace_set};
+
+use self::TestKeyspaceSet::{Keyspace, Keyspace2};
+
+test_keyspace_set! {
+    Keyspace => 0: "keyspace",
+    Keyspace2 => 1: "keyspace2",
+}
+
+#[test]
+fn cleanup_test() {
+    init_logging();
+    let storage_path = create_tmp_storage_dir();
+    let storage = create_storage::<TestKeyspaceSet>(&storage_path).unwrap();
+
+    let key_1 = StorageKeyArray::<BUFFER_KEY_INLINE>::from((Keyspace, [0x0, 0x0, 0x1]));
+    let key_2 = StorageKeyArray::<BUFFER_KEY_INLINE>::from((Keyspace, [0x1, 0x0, 0x10]));
+    let key_3 = StorageKeyArray::<BUFFER_KEY_INLINE>::from((Keyspace, [0x1, 0x0, 0xff]));
+    let key_4 = StorageKeyArray::<BUFFER_KEY_INLINE>::from((Keyspace, [0x2, 0x0, 0xff]));
+
+    let mut snapshot = storage.clone().open_snapshot_write();
+    snapshot.put(key_1.clone());
+    snapshot.put(key_2.clone());
+    snapshot.put(key_3.clone());
+    snapshot.put(key_4.clone());
+    snapshot.commit(&mut CommitProfile::DISABLED).unwrap_or_log();
+
+    assert_eq!(
+        storage
+            .iterate_keyspace_range(
+                &IteratorPool::default(),
+                KeyRange::new_unbounded(RangeStart::Inclusive(StorageKey::Array(key_1.clone()))),
+                StorageCounters::DISABLED
+            )
+            .count(),
+        4
+    );
+
+    let mut snapshot = storage.clone().open_snapshot_write();
+    snapshot.delete(key_1.clone());
+    snapshot.delete(key_2.clone());
+    let seq = snapshot.commit(&mut CommitProfile::DISABLED).unwrap_or_log().unwrap();
+
+    assert_eq!(
+        storage
+            .iterate_keyspace_range(
+                &IteratorPool::default(),
+                KeyRange::new_unbounded(RangeStart::Inclusive(StorageKey::Array(key_1.clone()))),
+                StorageCounters::DISABLED
+            )
+            .count(),
+        6
+    );
+
+    storage
+        .cleanup_dead_keys(
+            seq,
+            [(
+                StorageKey::new(Keyspace, Bytes::copy(&[])),
+                KeyRange::new_unbounded(RangeStart::Inclusive(StorageKey::Array(key_1.clone()))),
+            )],
+        )
+        .unwrap_or_log();
+
+    assert_eq!(
+        storage
+            .iterate_keyspace_range(
+                &IteratorPool::default(),
+                KeyRange::new_unbounded(RangeStart::Inclusive(StorageKey::Array(key_1.clone()))),
+                StorageCounters::DISABLED
+            )
+            .count(),
+        2
+    );
+
+    let snapshot = storage.open_snapshot_read();
+    assert_eq!(
+        snapshot.get::<BUFFER_KEY_INLINE>(StorageKey::Array(key_1).as_reference(), StorageCounters::DISABLED).unwrap(),
+        None
+    );
+    assert_eq!(
+        snapshot.get::<BUFFER_KEY_INLINE>(StorageKey::Array(key_2).as_reference(), StorageCounters::DISABLED).unwrap(),
+        None
+    );
+    assert!(
+        snapshot
+            .get::<BUFFER_KEY_INLINE>(StorageKey::Array(key_3).as_reference(), StorageCounters::DISABLED)
+            .unwrap()
+            .is_some()
+    );
+    assert!(
+        snapshot
+            .get::<BUFFER_KEY_INLINE>(StorageKey::Array(key_4).as_reference(), StorageCounters::DISABLED)
+            .unwrap()
+            .is_some()
+    );
+}

--- a/storage/tests/test_cleanup.rs
+++ b/storage/tests/test_cleanup.rs
@@ -6,27 +6,21 @@
 
 #![allow(const_item_mutation, reason = "`&mut CommitProfile::DISABLED` is a dummy")]
 
-use std::sync::Arc;
-
-use bytes::{Bytes, byte_array::ByteArray, util::HexBytesFormatter};
-use diagnostics::metrics::FsyncMetrics;
-use durability::wal::WAL;
-use itertools::Itertools;
+use bytes::Bytes;
 use lending_iterator::LendingIterator;
 use logger::result::ResultExt;
 use resource::{
-    constants::snapshot::{BUFFER_KEY_INLINE, BUFFER_VALUE_INLINE},
+    constants::snapshot::BUFFER_KEY_INLINE,
     profile::{CommitProfile, StorageCounters},
 };
 use storage::{
-    StorageOpenError,
-    key_range::{KeyRange, RangeEnd, RangeStart},
-    key_value::{StorageKey, StorageKeyArray, StorageKeyReference},
-    keyspace::{IteratorPool, KeyspaceOpenError, KeyspaceSet, KeyspaceValidationError},
-    snapshot::{CommittableSnapshot, PreloadedRangesSnapshot, ReadableSnapshot, WritableSnapshot},
+    key_range::{KeyRange, RangeStart},
+    key_value::{StorageKey, StorageKeyArray},
+    keyspace::IteratorPool,
+    snapshot::{CommittableSnapshot, ReadableSnapshot, WritableSnapshot},
 };
 use test_utils::{create_tmp_storage_dir, init_logging};
-use test_utils_storage::{checkpoint_storage, create_storage, load_storage, test_keyspace_set};
+use test_utils_storage::{create_storage, test_keyspace_set};
 
 use self::TestKeyspaceSet::{Keyspace, Keyspace2};
 

--- a/storage/tests/test_cleanup.rs
+++ b/storage/tests/test_cleanup.rs
@@ -6,8 +6,6 @@
 
 #![allow(const_item_mutation, reason = "`&mut CommitProfile::DISABLED` is a dummy")]
 
-use std::sync::Arc;
-
 use bytes::{Bytes, byte_array::ByteArray};
 use lending_iterator::LendingIterator;
 use logger::result::ResultExt;

--- a/storage/tests/test_cleanup.rs
+++ b/storage/tests/test_cleanup.rs
@@ -58,7 +58,7 @@ fn cleanup_test() {
     assert_eq!(count_keys(&storage), 6);
 
     storage
-        .cleanup_dead_keys(
+        .mvcc_cleanup(
             seq,
             [(
                 StorageKey::new(Keyspace, Bytes::copy(&[])),
@@ -108,7 +108,7 @@ fn concurrent_reader_cleanup_test() {
     assert_eq!(count_keys(&storage), 6);
 
     storage
-        .cleanup_dead_keys(
+        .mvcc_cleanup(
             seq,
             [(
                 StorageKey::new(Keyspace, Bytes::copy(&[])),

--- a/storage/tests/test_cleanup.rs
+++ b/storage/tests/test_cleanup.rs
@@ -6,7 +6,9 @@
 
 #![allow(const_item_mutation, reason = "`&mut CommitProfile::DISABLED` is a dummy")]
 
-use bytes::Bytes;
+use std::sync::Arc;
+
+use bytes::{Bytes, byte_array::ByteArray};
 use lending_iterator::LendingIterator;
 use logger::result::ResultExt;
 use resource::{
@@ -14,19 +16,20 @@ use resource::{
     profile::{CommitProfile, StorageCounters},
 };
 use storage::{
+    MVCCStorage,
+    durability_client::WALClient,
     key_range::{KeyRange, RangeStart},
     key_value::{StorageKey, StorageKeyArray},
     keyspace::IteratorPool,
-    snapshot::{CommittableSnapshot, ReadableSnapshot, WritableSnapshot},
+    snapshot::{CommittableSnapshot, ReadSnapshot, ReadableSnapshot, WritableSnapshot},
 };
 use test_utils::{create_tmp_storage_dir, init_logging};
 use test_utils_storage::{create_storage, test_keyspace_set};
 
-use self::TestKeyspaceSet::{Keyspace, Keyspace2};
+use self::TestKeyspaceSet::Keyspace;
 
 test_keyspace_set! {
     Keyspace => 0: "keyspace",
-    Keyspace2 => 1: "keyspace2",
 }
 
 #[test]
@@ -47,32 +50,14 @@ fn cleanup_test() {
     snapshot.put(key_4.clone());
     snapshot.commit(&mut CommitProfile::DISABLED).unwrap_or_log();
 
-    assert_eq!(
-        storage
-            .iterate_keyspace_range(
-                &IteratorPool::default(),
-                KeyRange::new_unbounded(RangeStart::Inclusive(StorageKey::Array(key_1.clone()))),
-                StorageCounters::DISABLED
-            )
-            .count(),
-        4
-    );
+    assert_eq!(count_keys(&storage), 4);
 
     let mut snapshot = storage.clone().open_snapshot_write();
     snapshot.delete(key_1.clone());
     snapshot.delete(key_2.clone());
     let seq = snapshot.commit(&mut CommitProfile::DISABLED).unwrap_or_log().unwrap();
 
-    assert_eq!(
-        storage
-            .iterate_keyspace_range(
-                &IteratorPool::default(),
-                KeyRange::new_unbounded(RangeStart::Inclusive(StorageKey::Array(key_1.clone()))),
-                StorageCounters::DISABLED
-            )
-            .count(),
-        6
-    );
+    assert_eq!(count_keys(&storage), 6);
 
     storage
         .cleanup_dead_keys(
@@ -84,36 +69,80 @@ fn cleanup_test() {
         )
         .unwrap_or_log();
 
-    assert_eq!(
-        storage
-            .iterate_keyspace_range(
-                &IteratorPool::default(),
-                KeyRange::new_unbounded(RangeStart::Inclusive(StorageKey::Array(key_1.clone()))),
-                StorageCounters::DISABLED
-            )
-            .count(),
-        2
-    );
+    assert_eq!(count_keys(&storage), 2);
 
     let snapshot = storage.open_snapshot_read();
-    assert_eq!(
-        snapshot.get::<BUFFER_KEY_INLINE>(StorageKey::Array(key_1).as_reference(), StorageCounters::DISABLED).unwrap(),
-        None
-    );
-    assert_eq!(
-        snapshot.get::<BUFFER_KEY_INLINE>(StorageKey::Array(key_2).as_reference(), StorageCounters::DISABLED).unwrap(),
-        None
-    );
-    assert!(
-        snapshot
-            .get::<BUFFER_KEY_INLINE>(StorageKey::Array(key_3).as_reference(), StorageCounters::DISABLED)
-            .unwrap()
-            .is_some()
-    );
-    assert!(
-        snapshot
-            .get::<BUFFER_KEY_INLINE>(StorageKey::Array(key_4).as_reference(), StorageCounters::DISABLED)
-            .unwrap()
-            .is_some()
-    );
+    assert_eq!(get_key(key_1, &snapshot), None);
+    assert_eq!(get_key(key_2, &snapshot), None);
+    assert!(get_key(key_3, &snapshot).is_some());
+    assert!(get_key(key_4, &snapshot).is_some());
+}
+
+#[test]
+fn concurrent_reader_cleanup_test() {
+    init_logging();
+    let storage_path = create_tmp_storage_dir();
+    let storage = create_storage::<TestKeyspaceSet>(&storage_path).unwrap();
+
+    let key_1 = StorageKeyArray::<BUFFER_KEY_INLINE>::from((Keyspace, [0x0, 0x0, 0x1]));
+    let key_2 = StorageKeyArray::<BUFFER_KEY_INLINE>::from((Keyspace, [0x1, 0x0, 0x10]));
+    let key_3 = StorageKeyArray::<BUFFER_KEY_INLINE>::from((Keyspace, [0x1, 0x0, 0xff]));
+    let key_4 = StorageKeyArray::<BUFFER_KEY_INLINE>::from((Keyspace, [0x2, 0x0, 0xff]));
+
+    let mut snapshot = storage.clone().open_snapshot_write();
+    snapshot.put(key_1.clone());
+    snapshot.put(key_2.clone());
+    snapshot.put(key_3.clone());
+    snapshot.put(key_4.clone());
+    snapshot.commit(&mut CommitProfile::DISABLED).unwrap_or_log();
+
+    assert_eq!(count_keys(&storage), 4);
+
+    let snapshot = storage.clone().open_snapshot_read();
+
+    let seq = {
+        let mut snapshot = storage.clone().open_snapshot_write();
+        snapshot.delete(key_1.clone());
+        snapshot.delete(key_2.clone());
+        snapshot.commit(&mut CommitProfile::DISABLED).unwrap_or_log().unwrap()
+    };
+
+    assert_eq!(count_keys(&storage), 6);
+
+    storage
+        .cleanup_dead_keys(
+            seq,
+            [(
+                StorageKey::new(Keyspace, Bytes::copy(&[])),
+                KeyRange::new_unbounded(RangeStart::Inclusive(StorageKey::Array(key_1.clone()))),
+            )],
+        )
+        .unwrap_or_log();
+
+    assert_eq!(count_keys(&storage), 6);
+
+    assert!(get_key(key_1, &snapshot).is_some());
+    assert!(get_key(key_2, &snapshot).is_some());
+    assert!(get_key(key_3, &snapshot).is_some());
+    assert!(get_key(key_4, &snapshot).is_some());
+}
+
+fn get_key(
+    key_1: StorageKeyArray<BUFFER_KEY_INLINE>,
+    snapshot: &ReadSnapshot<WALClient>,
+) -> Option<ByteArray<BUFFER_KEY_INLINE>> {
+    snapshot.get::<BUFFER_KEY_INLINE>(StorageKey::Array(key_1).as_reference(), StorageCounters::DISABLED).unwrap()
+}
+
+fn count_keys(storage: &MVCCStorage<WALClient>) -> usize {
+    storage
+        .iterate_keyspace_range(
+            &IteratorPool::default(),
+            KeyRange::new_unbounded(RangeStart::Inclusive(StorageKey::Array(StorageKeyArray::new(
+                Keyspace,
+                ByteArray::<BUFFER_KEY_INLINE>::empty(),
+            )))),
+            StorageCounters::DISABLED,
+        )
+        .count()
 }

--- a/storage/tests/test_snapshot.rs
+++ b/storage/tests/test_snapshot.rs
@@ -5,6 +5,7 @@
  */
 
 #![deny(unused_must_use)]
+#![allow(const_item_mutation, reason = "`&mut CommitProfile::DISABLED` is a dummy")]
 
 use bytes::byte_array::ByteArray;
 use lending_iterator::LendingIterator;

--- a/tests/behaviour/steps/connection/transaction.rs
+++ b/tests/behaviour/steps/connection/transaction.rs
@@ -128,7 +128,9 @@ pub async fn transaction_commits(context: &mut Context, may_error: params::MayEr
                     DataCommitError::ConceptWriteErrorsFirst { typedb_source } => {
                         may_error.check_concept_write_without_read_errors::<()>(&Err(typedb_source));
                     }
-                    DataCommitError::SnapshotInUse { .. } | DataCommitError::SnapshotError { .. } => {
+                    DataCommitError::SnapshotInUse { .. }
+                    | DataCommitError::SnapshotError { .. }
+                    | DataCommitError::DurabilityError { .. } => {
                         panic!("Unexpected write commit error: {:?}", error);
                     }
                 }
@@ -151,7 +153,8 @@ pub async fn transaction_commits(context: &mut Context, may_error: params::MayEr
                     SchemaCommitError::FunctionError { .. } => {}
                     SchemaCommitError::TypeCacheUpdateError { .. }
                     | SchemaCommitError::StatisticsError { .. }
-                    | SchemaCommitError::SnapshotError { .. } => {
+                    | SchemaCommitError::SnapshotError { .. }
+                    | SchemaCommitError::DurabilityError { .. } => {
                         panic!("Unexpected schema commit error: {:?}", error);
                     }
                 }

--- a/tests/benchmarks/concurrent_ops/bench_concurrency.rs
+++ b/tests/benchmarks/concurrent_ops/bench_concurrency.rs
@@ -25,7 +25,7 @@ use database::{
 };
 use diagnostics::diagnostics_manager::DiagnosticsManager;
 use executor::{ExecutionInterrupt, pipeline::stage::StageIterator};
-use options::{QueryOptions, TransactionOptions, byte_size::ByteSize};
+use options::{DatabaseCleanupStrategy, QueryOptions, TransactionOptions, byte_size::ByteSize};
 use query::given_rows::GivenRowsSimple;
 use rand_core::RngCore;
 use storage::durability_client::WALClient;
@@ -147,6 +147,7 @@ fn create_database(schema: &str) -> (TempDir, Arc<Database<WALClient>>) {
         ByteSize::mb(64),
         ByteSize::mb(64),
         ImportOwnership::Exclusive,
+        DatabaseCleanupStrategy::Disabled,
     )
     .unwrap();
     dbm.put_database(DB_NAME).unwrap();

--- a/tests/benchmarks/concurrent_ops/bench_concurrency.rs
+++ b/tests/benchmarks/concurrent_ops/bench_concurrency.rs
@@ -25,7 +25,7 @@ use database::{
 };
 use diagnostics::diagnostics_manager::DiagnosticsManager;
 use executor::{ExecutionInterrupt, pipeline::stage::StageIterator};
-use options::{DatabaseCleanupStrategy, QueryOptions, TransactionOptions, byte_size::ByteSize};
+use options::{MvccCleanupStrategy, QueryOptions, TransactionOptions, byte_size::ByteSize};
 use query::given_rows::GivenRowsSimple;
 use rand_core::RngCore;
 use storage::durability_client::WALClient;
@@ -147,7 +147,7 @@ fn create_database(schema: &str) -> (TempDir, Arc<Database<WALClient>>) {
         ByteSize::mb(64),
         ByteSize::mb(64),
         ImportOwnership::Exclusive,
-        DatabaseCleanupStrategy::Disabled,
+        MvccCleanupStrategy::Disabled,
     )
     .unwrap();
     dbm.put_database(DB_NAME).unwrap();

--- a/tests/benchmarks/iam/bench_iam.rs
+++ b/tests/benchmarks/iam/bench_iam.rs
@@ -13,7 +13,7 @@ use database::{
 };
 use diagnostics::diagnostics_manager::DiagnosticsManager;
 use executor::{ExecutionInterrupt, batch::Batch, pipeline::stage::StageIterator};
-use options::{DatabaseCleanupStrategy, TransactionOptions, byte_size::ByteSize};
+use options::{MvccCleanupStrategy, TransactionOptions, byte_size::ByteSize};
 use query::given_rows::GivenRowsSimple;
 use storage::durability_client::WALClient;
 use test_utils::create_tmp_storage_dir;
@@ -119,7 +119,7 @@ fn setup() -> Arc<Database<WALClient>> {
             ByteSize::mb(64),
             ByteSize::mb(64),
             ImportOwnership::Exclusive,
-            DatabaseCleanupStrategy::Disabled,
+            MvccCleanupStrategy::Disabled,
         )
         .unwrap();
         dbm.put_database(DB_NAME).unwrap();
@@ -138,7 +138,7 @@ fn setup() -> Arc<Database<WALClient>> {
         ByteSize::mb(64),
         ByteSize::mb(64),
         ImportOwnership::Exclusive,
-        DatabaseCleanupStrategy::Disabled,
+        MvccCleanupStrategy::Disabled,
     )
     .unwrap();
     dbm.put_database(DB_NAME).unwrap();

--- a/tests/benchmarks/iam/bench_iam.rs
+++ b/tests/benchmarks/iam/bench_iam.rs
@@ -13,7 +13,7 @@ use database::{
 };
 use diagnostics::diagnostics_manager::DiagnosticsManager;
 use executor::{ExecutionInterrupt, batch::Batch, pipeline::stage::StageIterator};
-use options::{TransactionOptions, byte_size::ByteSize};
+use options::{DatabaseCleanupStrategy, TransactionOptions, byte_size::ByteSize};
 use query::given_rows::GivenRowsSimple;
 use storage::durability_client::WALClient;
 use test_utils::create_tmp_storage_dir;
@@ -119,6 +119,7 @@ fn setup() -> Arc<Database<WALClient>> {
             ByteSize::mb(64),
             ByteSize::mb(64),
             ImportOwnership::Exclusive,
+            DatabaseCleanupStrategy::Disabled,
         )
         .unwrap();
         dbm.put_database(DB_NAME).unwrap();
@@ -137,6 +138,7 @@ fn setup() -> Arc<Database<WALClient>> {
         ByteSize::mb(64),
         ByteSize::mb(64),
         ImportOwnership::Exclusive,
+        DatabaseCleanupStrategy::Disabled,
     )
     .unwrap();
     dbm.put_database(DB_NAME).unwrap();


### PR DESCRIPTION
## Product change and motivation

We implement an `eager` cleanup strategy, disabled by default, that scans the backing storage for inaccessible data (keys marked as deleted or shadowed by later writes) and deletes them for good.

## Implementation

In a database with significant churn, the MVCC iterator is forced to sift through all the deleted and old invisible keys when producing keys within a given prefix. For instance, an entity iterator within a type has to consider and discard all entities that have been deleted. If the database use has been delete-heavy, a significant proportion of the keys may be "dead", i.e. tombstones or MVCC-invisible. This increases the work required to find the next visible key.

This PR introduces an optional "brute force" solution in deleting the invisible keys in RocksDB as soon as no existing or future transaction is able to read them. A future PR will take the churn into account during the construction of the query plan in the compiler, and attempt to avoid full scans in types with significant churn.