### PR TITLE
Thread a QueryContext through the query lifecycle

### DIFF
--- a/compiler/annotation/pipeline.rs
+++ b/compiler/annotation/pipeline.rs
@@ -46,9 +46,8 @@ use crate::{
         },
         fetch::{AnnotatedFetch, annotate_fetch},
         function::{
-            AnnotatedFunctionSignatures, AnnotatedFunctionSignaturesImpl, AnnotatedPreambleFunctions,
-            AnnotatedSchemaFunctions, FunctionParameterAnnotation, annotate_preamble_functions,
-            get_annotations_from_labels_vec,
+            AnnotatedFunctionSignaturesImpl, AnnotatedPreambleFunctions, AnnotatedSchemaFunctions,
+            FunctionParameterAnnotation, annotate_preamble_functions, get_annotations_from_labels_vec,
         },
         match_inference::infer_types_for_block,
         type_annotations::{BlockAnnotations, ConstraintTypeAnnotations, TypeAnnotations},
@@ -118,14 +117,18 @@ pub fn annotate_preamble_and_pipeline(
     schema_function_annotations: Arc<AnnotatedSchemaFunctions>,
     variable_registry: &mut VariableRegistry,
     parameters: &ParameterRegistry,
-    translated_preamble: Vec<Function>,
-    translated_given: Option<TranslatedGiven>,
-    translated_stages: Vec<TranslatedStage>,
-    translated_fetch: Option<FetchObject>,
+    translated_preamble: Arc<Vec<Function>>,
+    translated_given: Arc<Option<TranslatedGiven>>,
+    translated_stages: Arc<Vec<TranslatedStage>>,
+    translated_fetch: Arc<Option<FetchObject>>,
 ) -> Result<AnnotatedPipeline, AnnotationError> {
-    let annotated_preamble =
-        annotate_preamble_functions(translated_preamble, snapshot, type_manager, schema_function_annotations.clone())
-            .map_err(|typedb_source| AnnotationError::PreambleTypeInference { typedb_source })?;
+    let annotated_preamble = annotate_preamble_functions(
+        translated_preamble.as_ref().clone(),
+        snapshot,
+        type_manager,
+        schema_function_annotations.clone(),
+    )
+    .map_err(|typedb_source| AnnotationError::PreambleTypeInference { typedb_source })?;
     let combined_signature_annotations =
         AnnotatedFunctionSignaturesImpl::new(&schema_function_annotations, &annotated_preamble);
     let mut ctx = PipelineAnnotationContext::new(
@@ -135,7 +138,7 @@ pub fn annotate_preamble_and_pipeline(
         variable_registry,
         parameters,
     );
-    let annotated_given = annotate_given_stage(&mut ctx, translated_given)?;
+    let annotated_given = annotate_given_stage(&mut ctx, translated_given.as_ref())?;
     let input_annotations = if let Some(given) = &annotated_given {
         RunningVariableAnnotations::from_iterator(
             given.variables.iter().copied().zip(given.expected_types.iter().cloned()),
@@ -143,16 +146,24 @@ pub fn annotate_preamble_and_pipeline(
     } else {
         RunningVariableAnnotations::empty()
     };
-    let (annotated_stages, output_annotations) =
-        annotate_pipeline_stages(&mut ctx, translated_stages, input_annotations, None, PipelineOrigin::Query)?;
-    let annotated_fetch =
-        translated_fetch.map(|fetch| annotate_fetch(&mut ctx, fetch, &output_annotations)).transpose()?;
+    let (annotated_stages, output_annotations) = annotate_pipeline_stages(
+        &mut ctx,
+        translated_stages.as_ref().clone(),
+        input_annotations,
+        None,
+        PipelineOrigin::Query,
+    )?;
+    let annotated_fetch = translated_fetch
+        .as_ref()
+        .clone()
+        .map(|fetch| annotate_fetch(&mut ctx, fetch, &output_annotations))
+        .transpose()?;
     Ok(AnnotatedPipeline { annotated_given, annotated_stages, annotated_fetch, annotated_preamble })
 }
 
 fn annotate_given_stage(
     ctx: &mut PipelineAnnotationContext<'_, impl ReadableSnapshot>,
-    translated_given: Option<TranslatedGiven>,
+    translated_given: &Option<TranslatedGiven>,
 ) -> Result<Option<AnnotatedGiven>, AnnotationError> {
     let Some(TranslatedGiven { variables, labels, .. }) = translated_given else {
         return Ok(None);
@@ -174,7 +185,7 @@ fn annotate_given_stage(
             }
         })
         .collect();
-    Ok(Some(AnnotatedGiven { variables, expected_types, optionality }))
+    Ok(Some(AnnotatedGiven { variables: variables.clone(), expected_types, optionality }))
 }
 
 pub(crate) fn annotate_pipeline_stages(

--- a/compiler/annotation/pipeline.rs
+++ b/compiler/annotation/pipeline.rs
@@ -46,9 +46,8 @@ use crate::{
         },
         fetch::{AnnotatedFetch, annotate_fetch},
         function::{
-            AnnotatedFunctionSignatures, AnnotatedFunctionSignaturesImpl, AnnotatedPreambleFunctions,
-            AnnotatedSchemaFunctions, FunctionParameterAnnotation, annotate_preamble_functions,
-            get_annotations_from_labels_vec,
+            AnnotatedFunctionSignaturesImpl, AnnotatedPreambleFunctions, AnnotatedSchemaFunctions,
+            FunctionParameterAnnotation, annotate_preamble_functions, get_annotations_from_labels_vec,
         },
         inference::match_inference::infer_types_for_block,
         type_annotations::{BlockAnnotations, ConstraintTypeAnnotations, TypeAnnotations},
@@ -118,14 +117,18 @@ pub fn annotate_preamble_and_pipeline(
     schema_function_annotations: Arc<AnnotatedSchemaFunctions>,
     variable_registry: &mut VariableRegistry,
     parameters: &ParameterRegistry,
-    translated_preamble: Vec<Function>,
-    translated_given: Option<TranslatedGiven>,
-    translated_stages: Vec<TranslatedStage>,
-    translated_fetch: Option<FetchObject>,
+    translated_preamble: Arc<Vec<Function>>,
+    translated_given: Arc<Option<TranslatedGiven>>,
+    translated_stages: Arc<Vec<TranslatedStage>>,
+    translated_fetch: Arc<Option<FetchObject>>,
 ) -> Result<AnnotatedPipeline, AnnotationError> {
-    let annotated_preamble =
-        annotate_preamble_functions(translated_preamble, snapshot, type_manager, schema_function_annotations.clone())
-            .map_err(|typedb_source| AnnotationError::PreambleTypeInference { typedb_source })?;
+    let annotated_preamble = annotate_preamble_functions(
+        translated_preamble.as_ref().clone(),
+        snapshot,
+        type_manager,
+        schema_function_annotations.clone(),
+    )
+    .map_err(|typedb_source| AnnotationError::PreambleTypeInference { typedb_source })?;
     let combined_signature_annotations =
         AnnotatedFunctionSignaturesImpl::new(&schema_function_annotations, &annotated_preamble);
     let mut ctx = PipelineAnnotationContext::new(
@@ -135,7 +138,7 @@ pub fn annotate_preamble_and_pipeline(
         variable_registry,
         parameters,
     );
-    let annotated_given = annotate_given_stage(&mut ctx, translated_given)?;
+    let annotated_given = annotate_given_stage(&mut ctx, translated_given.as_ref())?;
     let input_annotations = if let Some(given) = &annotated_given {
         RunningVariableAnnotations::from_iterator(
             given.variables.iter().copied().zip(given.expected_types.iter().cloned()),
@@ -143,16 +146,24 @@ pub fn annotate_preamble_and_pipeline(
     } else {
         RunningVariableAnnotations::empty()
     };
-    let (annotated_stages, output_annotations) =
-        annotate_pipeline_stages(&mut ctx, translated_stages, input_annotations, None, PipelineOrigin::Query)?;
-    let annotated_fetch =
-        translated_fetch.map(|fetch| annotate_fetch(&mut ctx, fetch, &output_annotations)).transpose()?;
+    let (annotated_stages, output_annotations) = annotate_pipeline_stages(
+        &mut ctx,
+        translated_stages.as_ref().clone(),
+        input_annotations,
+        None,
+        PipelineOrigin::Query,
+    )?;
+    let annotated_fetch = translated_fetch
+        .as_ref()
+        .clone()
+        .map(|fetch| annotate_fetch(&mut ctx, fetch, &output_annotations))
+        .transpose()?;
     Ok(AnnotatedPipeline { annotated_given, annotated_stages, annotated_fetch, annotated_preamble })
 }
 
 fn annotate_given_stage(
     ctx: &mut PipelineAnnotationContext<'_, impl ReadableSnapshot>,
-    translated_given: Option<TranslatedGiven>,
+    translated_given: &Option<TranslatedGiven>,
 ) -> Result<Option<AnnotatedGiven>, AnnotationError> {
     let Some(TranslatedGiven { variables, labels, .. }) = translated_given else {
         return Ok(None);
@@ -174,7 +185,7 @@ fn annotate_given_stage(
             }
         })
         .collect();
-    Ok(Some(AnnotatedGiven { variables, expected_types, optionality }))
+    Ok(Some(AnnotatedGiven { variables: variables.clone(), expected_types, optionality }))
 }
 
 pub(crate) fn annotate_pipeline_stages(

--- a/compiler/executable/pipeline.rs
+++ b/compiler/executable/pipeline.rs
@@ -19,7 +19,6 @@ use ir::{
     },
     pipeline::{VariableRegistry, function_signature::FunctionID, reduce::AssignedReduction},
 };
-use itertools::Itertools;
 
 use crate::{
     VariablePosition,

--- a/concept/type_/type_manager.rs
+++ b/concept/type_/type_manager.rs
@@ -29,7 +29,6 @@ use resource::{
     profile::StorageCounters,
 };
 use storage::{
-    durability_client::DurabilityClient,
     keyspace::KeyspaceSet,
     snapshot::{PreloadedRangesSnapshot, ReadableSnapshot, WritableSnapshot, iterator::SnapshotIteratorError},
 };

--- a/concept/type_/type_manager/type_cache/type_cache.rs
+++ b/concept/type_/type_manager/type_cache/type_cache.rs
@@ -15,7 +15,7 @@ use encoding::{
 };
 use error::typedb_error;
 use storage::{
-    MVCCStorage, durability_client::DurabilityClient, keyspace::KeyspaceSet, sequence_number::SequenceNumber,
+    MVCCStorage, durability_client::DurabilityClient, sequence_number::SequenceNumber,
     snapshot::iterator::SnapshotIteratorError,
 };
 

--- a/concept/type_/type_manager/validation/commit_time_validation.rs
+++ b/concept/type_/type_manager/validation/commit_time_validation.rs
@@ -8,7 +8,7 @@ use std::collections::{HashMap, HashSet};
 
 use encoding::graph::definition::r#struct::StructDefinition;
 use itertools::Itertools;
-use storage::{keyspace::KeyspaceSet, snapshot::ReadableSnapshot};
+use storage::snapshot::ReadableSnapshot;
 
 use crate::{
     error::ConceptReadError,

--- a/database/migration/database_importer.rs
+++ b/database/migration/database_importer.rs
@@ -41,10 +41,10 @@ use concept::{
 use encoding::value::{label::Label, value::Value};
 use error::{TypeDBError, typedb_error};
 use options::TransactionOptions;
-use query::error::QueryError;
+use query::{error::QueryError, query_manager::ParsedSchemaQuery};
 use resource::{
     constants::{common::SECONDS_IN_DAY, snapshot::BUFFER_KEY_INLINE},
-    profile::StorageCounters,
+    profile::{QueryProfile, StorageCounters},
 };
 use storage::{
     durability_client::WALClient,
@@ -550,10 +550,10 @@ impl DatabaseImporter {
             typeql::query::QueryStructure::Schema(schema_query) => match &schema_query {
                 SchemaQuery::Define(_) => {
                     let transaction = Self::open_schema_transaction(self.database()?)?;
-                    let (transaction, query_result) =
-                        spawn_blocking(move || execute_schema_query(transaction, schema_query, schema))
-                            .await
-                            .expect("Expected schema query execution finishing");
+                    let parsed = ParsedSchemaQuery::new(schema_query, Arc::new(schema), QueryProfile::new(false));
+                    let (transaction, query_result) = spawn_blocking(move || execute_schema_query(transaction, parsed))
+                        .await
+                        .expect("Expected schema query execution finishing");
                     query_result.map_err(|typedb_source| DatabaseImportError::SchemaQueryFailed { typedb_source })?;
                     Self::commit_schema_transaction(transaction)
                         .await

--- a/database/migration/database_importer.rs
+++ b/database/migration/database_importer.rs
@@ -43,10 +43,10 @@ use concept::{
 use encoding::value::{label::Label, value::Value};
 use error::{TypeDBError, typedb_error};
 use options::TransactionOptions;
-use query::error::QueryError;
+use query::{error::QueryError, query_manager::ParsedSchemaQuery};
 use resource::{
     constants::{common::SECONDS_IN_DAY, snapshot::BUFFER_KEY_INLINE},
-    profile::StorageCounters,
+    profile::{QueryProfile, StorageCounters},
 };
 use storage::{
     durability_client::WALClient,
@@ -561,10 +561,10 @@ impl DatabaseImporter {
             typeql::query::QueryStructure::Schema(schema_query) => match &schema_query {
                 SchemaQuery::Define(_) => {
                     let transaction = Self::open_schema_transaction(self.database()?)?;
-                    let (transaction, query_result) =
-                        spawn_blocking(move || execute_schema_query(transaction, schema_query, schema))
-                            .await
-                            .expect("Expected schema query execution finishing");
+                    let parsed = ParsedSchemaQuery::new(schema_query, Arc::new(schema), QueryProfile::new(false));
+                    let (transaction, query_result) = spawn_blocking(move || execute_schema_query(transaction, parsed))
+                        .await
+                        .expect("Expected schema query execution finishing");
                     query_result.map_err(|typedb_source| DatabaseImportError::SchemaQueryFailed { typedb_source })?;
                     Self::commit_schema_transaction(transaction)
                         .await

--- a/database/query.rs
+++ b/database/query.rs
@@ -17,10 +17,13 @@ use function::function_manager::FunctionManager;
 use ir::pipeline::ParameterRegistry;
 use itertools::{Either, Itertools};
 use options::QueryOptions;
-use query::{error::QueryError, given_rows::GivenRows, query_manager::QueryManager};
+use query::{
+    error::QueryError,
+    given_rows::GivenRows,
+    query_manager::{ParsedPipeline, ParsedSchemaQuery, QueryManager},
+};
 use storage::{durability_client::WALClient, snapshot::WritableSnapshot};
 use tracing::{Level, event};
-use typeql::query::{Pipeline, SchemaQuery};
 
 use crate::{
     transaction::{TransactionSchema, TransactionWrite},
@@ -50,21 +53,13 @@ impl WriteQueryAnswer {
 
 pub fn execute_schema_query(
     transaction: TransactionSchema<WALClient>,
-    query: SchemaQuery,
-    source_query: String,
+    parsed: ParsedSchemaQuery,
 ) -> (TransactionSchema<WALClient>, Result<(), Box<QueryError>>) {
     with_transaction_parts!(
         TransactionSchema,
         transaction,
         |inner_snapshot, type_manager, thing_manager, function_manager, query_manager| {
-            query_manager.execute_schema(
-                &mut inner_snapshot,
-                &type_manager,
-                &thing_manager,
-                &function_manager,
-                &query,
-                &source_query,
-            )
+            query_manager.execute_schema(&mut inner_snapshot, &type_manager, &thing_manager, &function_manager, parsed)
         }
     )
 }
@@ -72,9 +67,8 @@ pub fn execute_schema_query(
 pub fn execute_write_query_in_schema(
     transaction: TransactionSchema<WALClient>,
     query_options: QueryOptions,
-    query_pipeline: Arc<Pipeline>,
+    parsed: ParsedPipeline,
     given_rows: Option<impl GivenRows>,
-    source_query: String,
     interrupt: ExecutionInterrupt,
 ) -> (TransactionSchema<WALClient>, WriteQueryResult) {
     let TransactionSchema {
@@ -95,9 +89,8 @@ pub fn execute_write_query_in_schema(
         function_manager.clone(),
         &query_manager,
         query_options,
-        query_pipeline,
+        parsed,
         given_rows,
-        &source_query,
         interrupt,
     );
 
@@ -118,9 +111,8 @@ pub fn execute_write_query_in_schema(
 pub fn execute_write_query_in_write(
     transaction: TransactionWrite<WALClient>,
     query_options: QueryOptions,
-    query_pipeline: Arc<Pipeline>,
+    parsed: ParsedPipeline,
     given_rows: Option<impl GivenRows>,
-    source_query: String,
     interrupt: ExecutionInterrupt,
 ) -> (TransactionWrite<WALClient>, WriteQueryResult) {
     let TransactionWrite {
@@ -141,9 +133,8 @@ pub fn execute_write_query_in_write(
         function_manager.clone(),
         &query_manager,
         query_options,
-        query_pipeline,
+        parsed,
         given_rows,
-        &source_query,
         interrupt,
     );
 
@@ -168,9 +159,8 @@ pub(crate) fn execute_write_query_in<Snapshot: WritableSnapshot + 'static>(
     function_manager: Arc<FunctionManager>,
     query_manager: &QueryManager,
     query_options: QueryOptions,
-    query_pipeline: Arc<Pipeline>,
+    parsed: ParsedPipeline,
     given_rows: Option<impl GivenRows>,
-    source_query: &str,
     interrupt: ExecutionInterrupt,
 ) -> (Snapshot, WriteQueryResult) {
     let start_time = Instant::now();
@@ -179,25 +169,23 @@ pub(crate) fn execute_write_query_in<Snapshot: WritableSnapshot + 'static>(
         type_manager,
         thing_manager,
         function_manager,
-        &query_pipeline,
+        parsed,
         given_rows,
-        source_query,
     );
     let pipeline = match result {
         Ok(pipeline) => pipeline,
         Err((snapshot, err)) => return (snapshot, Err(err)),
     };
 
+    let query_context = pipeline.query_context().clone();
     if pipeline.has_fetch() {
-        let (iterator, parameters, snapshot, query_profile) = match pipeline.into_documents_iterator(interrupt) {
-            Ok((iterator, ExecutionContext { snapshot, profile, parameters, .. })) => {
-                (iterator, parameters, snapshot, profile)
-            }
+        let (iterator, snapshot) = match pipeline.into_documents_iterator(interrupt) {
+            Ok((iterator, ExecutionContext { snapshot, .. })) => (iterator, snapshot),
             Err((err, ExecutionContext { snapshot, .. })) => {
                 return (
                     Arc::into_inner(snapshot).unwrap(),
                     Err(Box::new(QueryError::WritePipelineExecution {
-                        source_query: source_query.to_string(),
+                        source_query: query_context.source_query.as_ref().to_owned(),
                         typedb_source: err,
                     })),
                 );
@@ -205,19 +193,21 @@ pub(crate) fn execute_write_query_in<Snapshot: WritableSnapshot + 'static>(
         };
 
         let result = match iterator.collect::<Result<Vec<_>, _>>() {
-            Ok(documents) => Ok(WriteQueryAnswer::new_documents(query_options, (parameters, documents))),
+            Ok(documents) => {
+                Ok(WriteQueryAnswer::new_documents(query_options, (query_context.parameters.clone(), documents)))
+            }
             Err(err) => Err(Box::new(QueryError::WritePipelineExecution {
-                source_query: source_query.to_string(),
+                source_query: query_context.source_query.as_ref().to_owned(),
                 typedb_source: err,
             })),
         };
-        if query_profile.is_enabled() {
+        if query_context.profile.is_enabled() {
             let micros = Instant::now().duration_since(start_time).as_micros();
             event!(
                 Level::INFO,
                 "Write query done (excluding network request time) in {} micros.\n{}",
                 micros,
-                query_profile
+                query_context.profile,
             );
         }
         (Arc::into_inner(snapshot).unwrap(), result)
@@ -225,13 +215,13 @@ pub(crate) fn execute_write_query_in<Snapshot: WritableSnapshot + 'static>(
         let named_outputs = pipeline.rows_positions().unwrap();
         let pipeline_structure = pipeline.pipeline_structure().cloned();
         let query_output_descriptor: StreamQueryOutputDescriptor = named_outputs.clone().into_iter().sorted().collect();
-        let (iterator, snapshot, query_profile) = match pipeline.into_rows_iterator(interrupt) {
-            Ok((iterator, ExecutionContext { snapshot, profile, .. })) => (iterator, snapshot, profile),
+        let (iterator, snapshot) = match pipeline.into_rows_iterator(interrupt) {
+            Ok((iterator, ExecutionContext { snapshot, .. })) => (iterator, snapshot),
             Err((err, ExecutionContext { snapshot, .. })) => {
                 return (
                     Arc::into_inner(snapshot).unwrap(),
                     Err(Box::new(QueryError::WritePipelineExecution {
-                        source_query: source_query.to_string(),
+                        source_query: query_context.source_query.as_ref().to_owned(),
                         typedb_source: err,
                     })),
                 );
@@ -246,19 +236,19 @@ pub(crate) fn execute_write_query_in<Snapshot: WritableSnapshot + 'static>(
             Err(err) => (
                 Arc::into_inner(snapshot).unwrap(),
                 Err(Box::new(QueryError::WritePipelineExecution {
-                    source_query: source_query.to_string(),
+                    source_query: query_context.source_query.as_ref().to_owned(),
                     typedb_source: err,
                 })),
             ),
         };
 
-        if query_profile.is_enabled() {
+        if query_context.profile.is_enabled() {
             let micros = Instant::now().duration_since(start_time).as_micros();
             event!(
                 Level::INFO,
                 "Write query done (excluding network request time) in {} micros.\n{}",
                 micros,
-                query_profile
+                query_context.profile
             );
         }
         result

--- a/database/tests/BUILD
+++ b/database/tests/BUILD
@@ -38,6 +38,7 @@ rust_test(
         "//database",
         "//diagnostics",
         "//encoding",
+        "//resource",
         "//storage",
         "//util/test:test_utils",
 
@@ -58,6 +59,7 @@ rust_test(
         "//diagnostics",
         "//executor",
         "//query",
+        "//resource",
         "//storage",
         "//util/test:test_utils",
 
@@ -77,6 +79,7 @@ rust_test(
         "//encoding",
         "//executor",
         "//query",
+        "//resource",
         "//storage",
         "//util/test:test_utils",
 

--- a/database/tests/statistics_synchronization.rs
+++ b/database/tests/statistics_synchronization.rs
@@ -15,7 +15,11 @@ use database::{
 use diagnostics::diagnostics_manager::DiagnosticsManager;
 use executor::ExecutionInterrupt;
 use options::{QueryOptions, TransactionOptions, byte_size::ByteSize};
-use query::given_rows::GivenRowsSimple;
+use query::{
+    given_rows::GivenRowsSimple,
+    query_manager::{ParsedPipeline, ParsedSchemaQuery},
+};
+use resource::profile::QueryProfile;
 use storage::durability_client::WALClient;
 use test_utils::{create_tmp_storage_dir, init_logging};
 
@@ -54,7 +58,8 @@ fn statistics_synchronization_under_concurrent_load() {
 
         let schema_query = typeql::parse_query(SCHEMA).unwrap().into_structure().into_schema();
         let tx = TransactionSchema::open(database.clone(), TransactionOptions::default()).unwrap();
-        let (tx, result) = execute_schema_query(tx, schema_query, SCHEMA.to_string());
+        let parsed = ParsedSchemaQuery::new(schema_query, Arc::new(SCHEMA.to_string()), QueryProfile::new(false));
+        let (tx, result) = execute_schema_query(tx, parsed);
         result.unwrap();
         let (mut profile, intent) = tx.finalise();
         intent.unwrap().commit(profile.commit_profile()).unwrap();
@@ -102,9 +107,8 @@ fn run_insert_batch(database: &Arc<Database<WALClient>>, batch_id: usize) {
         let (returned_tx, result) = execute_write_query_in_write(
             tx,
             QueryOptions::default_grpc(),
-            Arc::new(pipeline),
+            ParsedPipeline::new(Arc::new(pipeline), Arc::new(query_str), QueryProfile::new(false)),
             None::<GivenRowsSimple>,
-            query_str,
             ExecutionInterrupt::new_uninterruptible(),
         );
         result.unwrap();

--- a/database/tests/test_transaction_isolation.rs
+++ b/database/tests/test_transaction_isolation.rs
@@ -16,7 +16,11 @@ use diagnostics::diagnostics_manager::DiagnosticsManager;
 use encoding::graph::thing::vertex_attribute::StringAttributeID;
 use executor::ExecutionInterrupt;
 use options::{QueryOptions, TransactionOptions, byte_size::ByteSize};
-use query::given_rows::GivenRowsSimple;
+use query::{
+    given_rows::GivenRowsSimple,
+    query_manager::{ParsedPipeline, ParsedSchemaQuery},
+};
+use resource::profile::QueryProfile;
 use storage::{
     StorageCommitError, durability_client::WALClient, isolation_manager::IsolationConflict, snapshot::SnapshotError,
 };
@@ -40,9 +44,10 @@ fn create_reset_database() -> (TempDir, Arc<Database<WALClient>>) {
 }
 
 fn commit_schema(database: Arc<Database<WALClient>>, schema: &str) {
-    let parsed = typeql::parse_query(schema).unwrap().into_structure().into_schema();
+    let schema_query = typeql::parse_query(schema).unwrap().into_structure().into_schema();
     let tx = TransactionSchema::open(database, TransactionOptions::default()).unwrap();
-    let (tx, result) = execute_schema_query(tx, parsed, schema.to_string());
+    let parsed = ParsedSchemaQuery::new(schema_query, Arc::new(schema.to_string()), QueryProfile::new(false));
+    let (tx, result) = execute_schema_query(tx, parsed);
     result.unwrap();
     let (mut profile, intent) = tx.finalise();
     intent.unwrap().commit(profile.commit_profile()).unwrap();
@@ -64,9 +69,8 @@ fn run_write(tx: TransactionWrite<WALClient>, query: &str) -> TransactionWrite<W
     let (tx, result) = execute_write_query_in_write(
         tx,
         QueryOptions::default_grpc(),
-        Arc::new(pipeline),
+        ParsedPipeline::new(Arc::new(pipeline), Arc::new(query.to_string()), QueryProfile::new(false)),
         None::<GivenRowsSimple>,
-        query.to_string(),
         ExecutionInterrupt::new_uninterruptible(),
     );
     result.unwrap_or_else(|err| panic!("write query failed: {query:?}: {err:?}"));

--- a/diagnostics/reports/mod.rs
+++ b/diagnostics/reports/mod.rs
@@ -4,14 +4,10 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-use std::{
-    collections::HashMap,
-    hash::{Hash, Hasher},
-    sync::Arc,
-};
+use std::{collections::HashMap, sync::Arc};
 
 use chrono::{DateTime, Utc};
-use serde::{Serialize, Serializer, ser::SerializeStruct};
+use serde::{Serialize, Serializer};
 use serde_json::{Map, Value, to_value};
 
 use crate::{

--- a/durability/wal.rs
+++ b/durability/wal.rs
@@ -754,7 +754,6 @@ impl Drop for FsyncThread {
 
 #[cfg(test)]
 mod test {
-    use std::sync::Arc;
 
     use assert as assert_true;
     use diagnostics::metrics::FsyncMetrics;

--- a/executor/benches/bench_instructions.rs
+++ b/executor/benches/bench_instructions.rs
@@ -247,7 +247,7 @@ fn build_has_ir(multi_attribute_type: bool) -> (Block, BenchVars, PipelineTransl
 
 fn build_has_unbound_executor(
     storage: &Arc<MVCCStorage<WALClient>>,
-) -> (HasExecutor, ExecutionContext<storage::snapshot::ReadSnapshot<WALClient>>) {
+) -> (HasExecutor, ExecutionContext<storage::snapshot::ReadSnapshot<WALClient>>, ParameterRegistry) {
     let (type_manager, thing_manager) = load_managers(storage.clone(), Some(storage.snapshot_watermark()));
     let (entry, vars, mut translation_context, value_parameters) = build_has_ir(false);
 
@@ -270,14 +270,14 @@ fn build_has_unbound_executor(
     // sort_by = person → BinaryIterateMode::Unbound
     let executor =
         HasExecutor::new(has_instruction, vars.variable_modes, vars.person, &snapshot, &thing_manager).unwrap();
-    let context = ExecutionContext::new(Arc::new(snapshot), thing_manager, Arc::default(), Arc::default());
-    (executor, context)
+    let context = ExecutionContext::new(Arc::new(snapshot), thing_manager, Arc::default());
+    (executor, context, value_parameters)
 }
 
 fn build_has_reverse_unbound_executor(
     storage: &Arc<MVCCStorage<WALClient>>,
     multi_attribute_type: bool,
-) -> (HasReverseExecutor, ExecutionContext<storage::snapshot::ReadSnapshot<WALClient>>) {
+) -> (HasReverseExecutor, ExecutionContext<storage::snapshot::ReadSnapshot<WALClient>>, ParameterRegistry) {
     let (type_manager, thing_manager) = load_managers(storage.clone(), Some(storage.snapshot_watermark()));
     let (entry, vars, mut translation_context, value_parameters) = build_has_ir(multi_attribute_type);
 
@@ -307,8 +307,8 @@ fn build_has_reverse_unbound_executor(
         &thing_manager,
     )
     .unwrap();
-    let context = ExecutionContext::new(Arc::new(snapshot), thing_manager, Arc::default(), Arc::default());
-    (executor, context)
+    let context = ExecutionContext::new(Arc::new(snapshot), thing_manager, Arc::default());
+    (executor, context, value_parameters)
 }
 
 struct LinksBenchVars {
@@ -351,7 +351,7 @@ fn build_links_ir() -> (Block, LinksBenchVars, PipelineTranslationContext, Param
 
 fn build_links_unbound_executor(
     storage: &Arc<MVCCStorage<WALClient>>,
-) -> (LinksExecutor, ExecutionContext<storage::snapshot::ReadSnapshot<WALClient>>) {
+) -> (LinksExecutor, ExecutionContext<storage::snapshot::ReadSnapshot<WALClient>>, ParameterRegistry) {
     let (type_manager, thing_manager) = load_managers(storage.clone(), Some(storage.snapshot_watermark()));
     let (entry, vars, mut translation_context, value_parameters) = build_links_ir();
 
@@ -373,8 +373,8 @@ fn build_links_unbound_executor(
     let links_instruction = LinksInstruction::new(links, Inputs::None([]), &entry_annotations).map(&vars.mapping);
     let executor =
         LinksExecutor::new(links_instruction, vars.variable_modes, vars.membership, &snapshot, &thing_manager).unwrap();
-    let context = ExecutionContext::new(Arc::new(snapshot), thing_manager, Arc::default(), Arc::default());
-    (executor, context)
+    let context = ExecutionContext::new(Arc::new(snapshot), thing_manager, Arc::default());
+    (executor, context, value_parameters)
 }
 
 fn assert_count(mut iter: TupleIterator, expected_count: usize) {
@@ -402,10 +402,12 @@ fn criterion_benchmark(c: &mut Criterion) {
     setup_has_data(&storage);
     setup_links_data(&storage);
 
-    let (has_exec, has_ctx) = build_has_unbound_executor(&storage);
-    let (has_reverse_single_exec, has_reverse_single_ctx) = build_has_reverse_unbound_executor(&storage, false);
-    let (has_reverse_multi_exec, has_reverse_multi_ctx) = build_has_reverse_unbound_executor(&storage, true);
-    let (links_exec, links_ctx) = build_links_unbound_executor(&storage);
+    let (has_exec, has_ctx, has_params) = build_has_unbound_executor(&storage);
+    let (has_reverse_single_exec, has_reverse_single_ctx, has_reverse_single_params) =
+        build_has_reverse_unbound_executor(&storage, false);
+    let (has_reverse_multi_exec, has_reverse_multi_ctx, has_reverse_multi_params) =
+        build_has_reverse_unbound_executor(&storage, true);
+    let (links_exec, links_ctx, links_params) = build_links_unbound_executor(&storage);
     let count_single = NUM_PERSONS * AGES_PER_PERSON;
     let count_multi = NUM_PERSONS * (AGES_PER_PERSON + NAMES_PER_PERSON);
     let count_links = NUM_MEMBERSHIPS * 2;
@@ -414,7 +416,9 @@ fn criterion_benchmark(c: &mut Criterion) {
     group.sampling_mode(SamplingMode::Linear);
     group.bench_function("single_type", |b| {
         b.iter(|| {
-            let iter = has_exec.get_iterator(&has_ctx, MaybeOwnedRow::empty(), StorageCounters::DISABLED).unwrap();
+            let iter = has_exec
+                .get_iterator(&has_ctx, &has_params, MaybeOwnedRow::empty(), StorageCounters::DISABLED)
+                .unwrap();
             assert_count(iter, count_single);
         })
     });
@@ -425,7 +429,12 @@ fn criterion_benchmark(c: &mut Criterion) {
     group.bench_function("single_type", |b| {
         b.iter(|| {
             let iter = has_reverse_single_exec
-                .get_iterator(&has_reverse_single_ctx, MaybeOwnedRow::empty(), StorageCounters::DISABLED)
+                .get_iterator(
+                    &has_reverse_single_ctx,
+                    &has_reverse_single_params,
+                    MaybeOwnedRow::empty(),
+                    StorageCounters::DISABLED,
+                )
                 .unwrap();
             assert_count(iter, count_single);
         })
@@ -433,7 +442,12 @@ fn criterion_benchmark(c: &mut Criterion) {
     group.bench_function("multi_type", |b| {
         b.iter(|| {
             let iter = has_reverse_multi_exec
-                .get_iterator(&has_reverse_multi_ctx, MaybeOwnedRow::empty(), StorageCounters::DISABLED)
+                .get_iterator(
+                    &has_reverse_multi_ctx,
+                    &has_reverse_multi_params,
+                    MaybeOwnedRow::empty(),
+                    StorageCounters::DISABLED,
+                )
                 .unwrap();
             assert_count(iter, count_multi);
         })
@@ -444,7 +458,9 @@ fn criterion_benchmark(c: &mut Criterion) {
     group.sampling_mode(SamplingMode::Linear);
     group.bench_function("single_type", |b| {
         b.iter(|| {
-            let iter = links_exec.get_iterator(&links_ctx, MaybeOwnedRow::empty(), StorageCounters::DISABLED).unwrap();
+            let iter = links_exec
+                .get_iterator(&links_ctx, &links_params, MaybeOwnedRow::empty(), StorageCounters::DISABLED)
+                .unwrap();
             assert_count(iter, count_links);
         })
     });

--- a/executor/benches/bench_instructions.rs
+++ b/executor/benches/bench_instructions.rs
@@ -248,7 +248,7 @@ fn build_has_ir(multi_attribute_type: bool) -> (Block, BenchVars, PipelineTransl
 
 fn build_has_unbound_executor(
     storage: &Arc<MVCCStorage<WALClient>>,
-) -> (HasExecutor, ExecutionContext<storage::snapshot::ReadSnapshot<WALClient>>) {
+) -> (HasExecutor, ExecutionContext<storage::snapshot::ReadSnapshot<WALClient>>, ParameterRegistry) {
     let (type_manager, thing_manager) = load_managers(storage.clone(), Some(storage.snapshot_watermark()));
     let (entry, vars, mut translation_context, value_parameters) = build_has_ir(false);
 
@@ -271,14 +271,14 @@ fn build_has_unbound_executor(
     // sort_by = person → BinaryIterateMode::Unbound
     let executor =
         HasExecutor::new(has_instruction, vars.variable_modes, vars.person, &snapshot, &thing_manager).unwrap();
-    let context = ExecutionContext::new(Arc::new(snapshot), thing_manager, Arc::default(), Arc::default());
-    (executor, context)
+    let context = ExecutionContext::new(Arc::new(snapshot), thing_manager, Arc::default());
+    (executor, context, value_parameters)
 }
 
 fn build_has_reverse_unbound_executor(
     storage: &Arc<MVCCStorage<WALClient>>,
     multi_attribute_type: bool,
-) -> (HasReverseExecutor, ExecutionContext<storage::snapshot::ReadSnapshot<WALClient>>) {
+) -> (HasReverseExecutor, ExecutionContext<storage::snapshot::ReadSnapshot<WALClient>>, ParameterRegistry) {
     let (type_manager, thing_manager) = load_managers(storage.clone(), Some(storage.snapshot_watermark()));
     let (entry, vars, mut translation_context, value_parameters) = build_has_ir(multi_attribute_type);
 
@@ -308,8 +308,8 @@ fn build_has_reverse_unbound_executor(
         &thing_manager,
     )
     .unwrap();
-    let context = ExecutionContext::new(Arc::new(snapshot), thing_manager, Arc::default(), Arc::default());
-    (executor, context)
+    let context = ExecutionContext::new(Arc::new(snapshot), thing_manager, Arc::default());
+    (executor, context, value_parameters)
 }
 
 struct LinksBenchVars {
@@ -352,7 +352,7 @@ fn build_links_ir() -> (Block, LinksBenchVars, PipelineTranslationContext, Param
 
 fn build_links_unbound_executor(
     storage: &Arc<MVCCStorage<WALClient>>,
-) -> (LinksExecutor, ExecutionContext<storage::snapshot::ReadSnapshot<WALClient>>) {
+) -> (LinksExecutor, ExecutionContext<storage::snapshot::ReadSnapshot<WALClient>>, ParameterRegistry) {
     let (type_manager, thing_manager) = load_managers(storage.clone(), Some(storage.snapshot_watermark()));
     let (entry, vars, mut translation_context, value_parameters) = build_links_ir();
 
@@ -374,8 +374,8 @@ fn build_links_unbound_executor(
     let links_instruction = LinksInstruction::new(links, Inputs::None([]), &entry_annotations).map(&vars.mapping);
     let executor =
         LinksExecutor::new(links_instruction, vars.variable_modes, vars.membership, &snapshot, &thing_manager).unwrap();
-    let context = ExecutionContext::new(Arc::new(snapshot), thing_manager, Arc::default(), Arc::default());
-    (executor, context)
+    let context = ExecutionContext::new(Arc::new(snapshot), thing_manager, Arc::default());
+    (executor, context, value_parameters)
 }
 
 fn assert_count(mut iter: TupleIterator, expected_count: usize) {
@@ -403,10 +403,12 @@ fn criterion_benchmark(c: &mut Criterion) {
     setup_has_data(&storage);
     setup_links_data(&storage);
 
-    let (has_exec, has_ctx) = build_has_unbound_executor(&storage);
-    let (has_reverse_single_exec, has_reverse_single_ctx) = build_has_reverse_unbound_executor(&storage, false);
-    let (has_reverse_multi_exec, has_reverse_multi_ctx) = build_has_reverse_unbound_executor(&storage, true);
-    let (links_exec, links_ctx) = build_links_unbound_executor(&storage);
+    let (has_exec, has_ctx, has_params) = build_has_unbound_executor(&storage);
+    let (has_reverse_single_exec, has_reverse_single_ctx, has_reverse_single_params) =
+        build_has_reverse_unbound_executor(&storage, false);
+    let (has_reverse_multi_exec, has_reverse_multi_ctx, has_reverse_multi_params) =
+        build_has_reverse_unbound_executor(&storage, true);
+    let (links_exec, links_ctx, links_params) = build_links_unbound_executor(&storage);
     let count_single = NUM_PERSONS * AGES_PER_PERSON;
     let count_multi = NUM_PERSONS * (AGES_PER_PERSON + NAMES_PER_PERSON);
     let count_links = NUM_MEMBERSHIPS * 2;
@@ -415,7 +417,9 @@ fn criterion_benchmark(c: &mut Criterion) {
     group.sampling_mode(SamplingMode::Linear);
     group.bench_function("single_type", |b| {
         b.iter(|| {
-            let iter = has_exec.get_iterator(&has_ctx, MaybeOwnedRow::empty(), StorageCounters::DISABLED).unwrap();
+            let iter = has_exec
+                .get_iterator(&has_ctx, &has_params, MaybeOwnedRow::empty(), StorageCounters::DISABLED)
+                .unwrap();
             assert_count(iter, count_single);
         })
     });
@@ -426,7 +430,12 @@ fn criterion_benchmark(c: &mut Criterion) {
     group.bench_function("single_type", |b| {
         b.iter(|| {
             let iter = has_reverse_single_exec
-                .get_iterator(&has_reverse_single_ctx, MaybeOwnedRow::empty(), StorageCounters::DISABLED)
+                .get_iterator(
+                    &has_reverse_single_ctx,
+                    &has_reverse_single_params,
+                    MaybeOwnedRow::empty(),
+                    StorageCounters::DISABLED,
+                )
                 .unwrap();
             assert_count(iter, count_single);
         })
@@ -434,7 +443,12 @@ fn criterion_benchmark(c: &mut Criterion) {
     group.bench_function("multi_type", |b| {
         b.iter(|| {
             let iter = has_reverse_multi_exec
-                .get_iterator(&has_reverse_multi_ctx, MaybeOwnedRow::empty(), StorageCounters::DISABLED)
+                .get_iterator(
+                    &has_reverse_multi_ctx,
+                    &has_reverse_multi_params,
+                    MaybeOwnedRow::empty(),
+                    StorageCounters::DISABLED,
+                )
                 .unwrap();
             assert_count(iter, count_multi);
         })
@@ -445,7 +459,9 @@ fn criterion_benchmark(c: &mut Criterion) {
     group.sampling_mode(SamplingMode::Linear);
     group.bench_function("single_type", |b| {
         b.iter(|| {
-            let iter = links_exec.get_iterator(&links_ctx, MaybeOwnedRow::empty(), StorageCounters::DISABLED).unwrap();
+            let iter = links_exec
+                .get_iterator(&links_ctx, &links_params, MaybeOwnedRow::empty(), StorageCounters::DISABLED)
+                .unwrap();
             assert_count(iter, count_links);
         })
     });

--- a/executor/instruction/checker.rs
+++ b/executor/instruction/checker.rs
@@ -70,7 +70,8 @@ impl<T> Checker<T> {
 
     pub(crate) fn value_range_for(
         &self,
-        context: &ExecutionContext<impl ReadableSnapshot + 'static>,
+        execution_context: &ExecutionContext<impl ReadableSnapshot + 'static>,
+        parameters: &ParameterRegistry,
         row: Option<MaybeOwnedRow<'_>>,
         target_variable: ExecutorVariable,
         storage_counters: StorageCounters,
@@ -104,10 +105,10 @@ impl<T> Checker<T> {
             match check {
                 CheckInstruction::Comparison { lhs, rhs, comparator } => {
                     if lhs.as_variable() == Some(target_variable) {
-                        let rhs_variable_value = get_vertex_value(rhs, row.as_ref(), &context.parameters);
+                        let rhs_variable_value = get_vertex_value(rhs, row.as_ref(), parameters);
                         let rhs_value = Self::read_value(
-                            context.snapshot.as_ref(),
-                            &context.thing_manager,
+                            execution_context.snapshot.as_ref(),
+                            &execution_context.thing_manager,
                             &rhs_variable_value,
                             storage_counters.clone(),
                         )?;
@@ -128,10 +129,10 @@ impl<T> Checker<T> {
                         debug_assert!(
                             rhs.as_variable().expect("RHS of comparison must be a variable") == target_variable
                         );
-                        let lhs_variable_value = get_vertex_value(lhs, row.as_ref(), &context.parameters);
+                        let lhs_variable_value = get_vertex_value(lhs, row.as_ref(), parameters);
                         let lhs_value = Self::read_value(
-                            context.snapshot.as_ref(),
-                            &context.thing_manager,
+                            execution_context.snapshot.as_ref(),
+                            &execution_context.thing_manager,
                             &lhs_variable_value,
                             storage_counters.clone(),
                         )?;
@@ -153,10 +154,10 @@ impl<T> Checker<T> {
                 CheckInstruction::Is { lhs, rhs } => {
                     if *lhs == target_variable {
                         let rhs_as_vertex = CheckVertex::Variable(*rhs);
-                        let rhs_variable_value = get_vertex_value(&rhs_as_vertex, row.as_ref(), &context.parameters);
+                        let rhs_variable_value = get_vertex_value(&rhs_as_vertex, row.as_ref(), parameters);
                         let rhs_value = Self::read_value(
-                            context.snapshot.as_ref(),
-                            &context.thing_manager,
+                            execution_context.snapshot.as_ref(),
+                            &execution_context.thing_manager,
                             &rhs_variable_value,
                             storage_counters.clone(),
                         )?;
@@ -166,10 +167,10 @@ impl<T> Checker<T> {
                         }
                     } else {
                         let lhs_as_vertex = CheckVertex::Variable(*lhs);
-                        let lhs_variable_value = get_vertex_value(&lhs_as_vertex, row.as_ref(), &context.parameters);
+                        let lhs_variable_value = get_vertex_value(&lhs_as_vertex, row.as_ref(), parameters);
                         let lhs_value = Self::read_value(
-                            context.snapshot.as_ref(),
-                            &context.thing_manager,
+                            execution_context.snapshot.as_ref(),
+                            &execution_context.thing_manager,
                             &lhs_variable_value,
                             storage_counters.clone(),
                         )?;
@@ -210,11 +211,11 @@ impl<T> Checker<T> {
         &self,
         vertex: &CheckVertex<ExecutorVariable>,
         row: &MaybeOwnedRow<'_>,
-        context: &ExecutionContext<impl ReadableSnapshot + 'static>,
+        parameters: &ParameterRegistry,
     ) -> Box<dyn for<'a> Fn(&'a T) -> VariableValue<'a>> {
         match vertex.as_variable().and_then(|v| self.extractors.get(&v)) {
             None => {
-                let value = get_vertex_value(vertex, Some(row), &context.parameters);
+                let value = get_vertex_value(vertex, Some(row), parameters);
                 let owned_value = value.into_owned();
                 Box::new(move |_| owned_value.clone())
             }
@@ -224,44 +225,59 @@ impl<T> Checker<T> {
 
     pub(crate) fn filter(
         &self,
-        context: &ExecutionContext<impl ReadableSnapshot + 'static>,
+        execution_context: &ExecutionContext<impl ReadableSnapshot + 'static>,
+        parameters: &ParameterRegistry,
         row: &MaybeOwnedRow<'_>,
         source: T,
         storage_counters: StorageCounters,
     ) -> Result<bool, Box<ConceptReadError>> {
         for check in &self.checks {
             let passes = match check {
-                CheckInstruction::Iid { var, iid } => self.filter_iid(context, row, *var, &source, iid),
+                CheckInstruction::Iid { var, iid } => self.filter_iid(parameters, row, *var, &source, iid),
                 CheckInstruction::TypeList { type_var, types } => {
-                    self.filter_type_list(context, row, *type_var, &source, types)
+                    self.filter_type_list(parameters, row, *type_var, &source, types)
                 }
                 CheckInstruction::ThingTypeList { thing_var, types } => {
-                    self.filter_thing_type_list(context, row, *thing_var, &source, types)
+                    self.filter_thing_type_list(parameters, row, *thing_var, &source, types)
                 }
                 CheckInstruction::Sub { sub_kind, subtype, supertype } => {
-                    self.filter_sub(context, row, *sub_kind, &source, subtype, supertype)?
+                    self.filter_sub(execution_context, parameters, row, *sub_kind, &source, subtype, supertype)?
                 }
                 CheckInstruction::Owns { owner, attribute } => {
-                    self.filter_owns(context, row, &source, owner, attribute)?
+                    self.filter_owns(execution_context, parameters, row, &source, owner, attribute)?
                 }
                 CheckInstruction::Relates { relation, role_type } => {
-                    self.filter_relates(context, row, &source, relation, role_type)?
+                    self.filter_relates(execution_context, parameters, row, &source, relation, role_type)?
                 }
                 CheckInstruction::Plays { player, role_type } => {
-                    self.filter_plays(context, row, &source, player, role_type)?
+                    self.filter_plays(execution_context, parameters, row, &source, player, role_type)?
                 }
                 CheckInstruction::Isa { isa_kind, type_, thing } => {
-                    self.filter_isa(context, row, &source, *isa_kind, type_, thing)?
+                    self.filter_isa(execution_context, parameters, row, &source, *isa_kind, type_, thing)?
                 }
-                CheckInstruction::Has { owner, attribute } => {
-                    self.filter_has(context, row, &source, owner, attribute, storage_counters.clone())?
-                }
-                CheckInstruction::Links { relation, player, role } => {
-                    self.filter_links(context, row, &source, relation, player, role, storage_counters.clone())?
-                }
+                CheckInstruction::Has { owner, attribute } => self.filter_has(
+                    execution_context,
+                    parameters,
+                    row,
+                    &source,
+                    owner,
+                    attribute,
+                    storage_counters.clone(),
+                )?,
+                CheckInstruction::Links { relation, player, role } => self.filter_links(
+                    execution_context,
+                    parameters,
+                    row,
+                    &source,
+                    relation,
+                    player,
+                    role,
+                    storage_counters.clone(),
+                )?,
                 CheckInstruction::IndexedRelation { start_player, end_player, relation, start_role, end_role } => self
                     .filter_indexed_relation(
-                        context,
+                        execution_context,
+                        parameters,
                         row,
                         &source,
                         start_player,
@@ -275,9 +291,16 @@ impl<T> Checker<T> {
                 CheckInstruction::LinksDeduplication { role1, player1, role2, player2 } => {
                     self.filter_links_dedup(row, &source, *role1, *player1, *role2, *player2)
                 }
-                CheckInstruction::Comparison { lhs, rhs, comparator } => {
-                    self.filter_comparison(context, row, &source, lhs, rhs, *comparator, storage_counters.clone())?
-                }
+                CheckInstruction::Comparison { lhs, rhs, comparator } => self.filter_comparison(
+                    execution_context,
+                    parameters,
+                    row,
+                    &source,
+                    lhs,
+                    rhs,
+                    *comparator,
+                    storage_counters.clone(),
+                )?,
                 CheckInstruction::NotNone { variables } => Self::filter_not_none(row, variables),
                 CheckInstruction::Unsatisfiable => false,
             };
@@ -290,7 +313,8 @@ impl<T> Checker<T> {
 
     pub(crate) fn filter_fn_for_row(
         &self,
-        context: &ExecutionContext<impl ReadableSnapshot + 'static>,
+        execution_context: &ExecutionContext<impl ReadableSnapshot + 'static>,
+        parameters: &ParameterRegistry,
         row: &MaybeOwnedRow<'_>,
         storage_counters: StorageCounters,
     ) -> Box<FilterFn<T>> {
@@ -299,33 +323,44 @@ impl<T> Checker<T> {
 
         for check in &self.checks {
             let filter = match check {
-                CheckInstruction::Iid { var, iid } => self.filter_iid_fn(context, row, *var, iid),
+                CheckInstruction::Iid { var, iid } => self.filter_iid_fn(parameters, row, *var, iid),
                 &CheckInstruction::TypeList { type_var, ref types } => {
-                    self.filter_type_list_fn(context, row, type_var, types)
+                    self.filter_type_list_fn(parameters, row, type_var, types)
                 }
                 &CheckInstruction::ThingTypeList { thing_var, ref types } => {
-                    self.filter_thing_type_list_fn(context, row, thing_var, types)
+                    self.filter_thing_type_list_fn(parameters, row, thing_var, types)
                 }
                 &CheckInstruction::Sub { sub_kind, ref subtype, ref supertype } => {
-                    self.filter_sub_fn(context, row, sub_kind, subtype, supertype)
+                    self.filter_sub_fn(execution_context, parameters, row, sub_kind, subtype, supertype)
                 }
-                CheckInstruction::Owns { owner, attribute } => self.filter_owns_fn(context, row, owner, attribute),
+                CheckInstruction::Owns { owner, attribute } => {
+                    self.filter_owns_fn(execution_context, parameters, row, owner, attribute)
+                }
                 CheckInstruction::Relates { relation, role_type } => {
-                    self.filter_relates_fn(context, row, relation, role_type)
+                    self.filter_relates_fn(execution_context, parameters, row, relation, role_type)
                 }
-                CheckInstruction::Plays { player, role_type } => self.filter_plays_fn(context, row, player, role_type),
+                CheckInstruction::Plays { player, role_type } => {
+                    self.filter_plays_fn(execution_context, parameters, row, player, role_type)
+                }
                 &CheckInstruction::Isa { isa_kind, ref type_, ref thing } => {
-                    self.filter_isa_fn(context, row, isa_kind, type_, thing)
+                    self.filter_isa_fn(execution_context, parameters, row, isa_kind, type_, thing)
                 }
                 CheckInstruction::Has { owner, attribute } => {
-                    self.filter_has_fn(context, row, owner, attribute, storage_counters.clone())
+                    self.filter_has_fn(execution_context, parameters, row, owner, attribute, storage_counters.clone())
                 }
-                CheckInstruction::Links { relation, player, role } => {
-                    self.filter_links_fn(context, row, relation, player, role, storage_counters.clone())
-                }
+                CheckInstruction::Links { relation, player, role } => self.filter_links_fn(
+                    execution_context,
+                    parameters,
+                    row,
+                    relation,
+                    player,
+                    role,
+                    storage_counters.clone(),
+                ),
                 CheckInstruction::IndexedRelation { start_player, end_player, relation, start_role, end_role } => self
                     .filter_indexed_relation_fn(
-                        context,
+                        execution_context,
+                        parameters,
                         row,
                         start_player,
                         end_player,
@@ -339,12 +374,18 @@ impl<T> Checker<T> {
                 }
                 CheckInstruction::NotNone { variables } => {
                     todo!()
-                    // self.filter_not(context, row, check)
+                    // self.filter_not(execution_context,  parameters, row, check)
                 }
                 &CheckInstruction::Is { lhs, rhs } => self.filter_is_fn(row, lhs, rhs),
-                CheckInstruction::Comparison { lhs, rhs, comparator } => {
-                    self.filter_comparison_fn(context, row, lhs, rhs, *comparator, storage_counters.clone())
-                }
+                CheckInstruction::Comparison { lhs, rhs, comparator } => self.filter_comparison_fn(
+                    execution_context,
+                    parameters,
+                    row,
+                    lhs,
+                    rhs,
+                    *comparator,
+                    storage_counters.clone(),
+                ),
                 CheckInstruction::Unsatisfiable => Box::new(|_: &T| Ok(false)),
             };
             filters.push(filter);
@@ -363,19 +404,19 @@ impl<T> Checker<T> {
 
     fn filter_iid_fn(
         &self,
-        context: &ExecutionContext<impl ReadableSnapshot + 'static>,
+        parameters: &ParameterRegistry,
         row: &MaybeOwnedRow<'_>,
         var: ExecutorVariable,
         iid: &ir::pattern::ParameterID,
     ) -> Box<dyn Fn(&T) -> Result<bool, Box<ConceptReadError>>> {
-        let var = self.make_extractor(&CheckVertex::Variable(var), row, context);
-        let iid = context.parameters().iid(iid).unwrap().clone();
+        let var = self.make_extractor(&CheckVertex::Variable(var), row, parameters);
+        let iid = parameters.iid(iid).unwrap().clone();
         Box::new(move |value: &T| Ok(Self::check_iid(&iid, var(value))))
     }
 
     fn filter_iid(
         &self,
-        context: &ExecutionContext<impl ReadableSnapshot + 'static>,
+        parameters: &ParameterRegistry,
         row: &MaybeOwnedRow<'_>,
         var: ExecutorVariable,
         source: &T,
@@ -383,9 +424,9 @@ impl<T> Checker<T> {
     ) -> bool {
         let extracted = match self.extractors.get(&var) {
             Some(function) => function(source),
-            None => get_vertex_value(&CheckVertex::Variable(var), Some(row), &context.parameters),
+            None => get_vertex_value(&CheckVertex::Variable(var), Some(row), parameters),
         };
-        let iid = context.parameters().iid(iid).unwrap();
+        let iid = parameters.iid(iid).unwrap();
         Self::check_iid(iid, extracted)
     }
 
@@ -405,19 +446,19 @@ impl<T> Checker<T> {
 
     fn filter_type_list_fn(
         &self,
-        context: &ExecutionContext<impl ReadableSnapshot + 'static>,
+        parameters: &ParameterRegistry,
         row: &MaybeOwnedRow<'_>,
         type_var: ExecutorVariable,
         types: &std::sync::Arc<std::collections::BTreeSet<Type>>,
     ) -> Box<dyn Fn(&T) -> Result<bool, Box<ConceptReadError>>> {
-        let type_ = self.make_extractor(&CheckVertex::Variable(type_var), row, context);
+        let type_ = self.make_extractor(&CheckVertex::Variable(type_var), row, parameters);
         let types = types.clone();
         Box::new(move |value: &T| Ok(types.contains(&unwrap_or_result_false!(type_(value) => Type))))
     }
 
     fn filter_type_list(
         &self,
-        context: &ExecutionContext<impl ReadableSnapshot + 'static>,
+        parameters: &ParameterRegistry,
         row: &MaybeOwnedRow<'_>,
         type_var: ExecutorVariable,
         source: &T,
@@ -425,26 +466,26 @@ impl<T> Checker<T> {
     ) -> bool {
         let extracted = match self.extractors.get(&type_var) {
             Some(function) => function(source),
-            None => get_vertex_value(&CheckVertex::Variable(type_var), Some(row), &context.parameters),
+            None => get_vertex_value(&CheckVertex::Variable(type_var), Some(row), parameters),
         };
         types.contains(&unwrap_or_return_false!(extracted => Type))
     }
 
     fn filter_thing_type_list_fn(
         &self,
-        context: &ExecutionContext<impl ReadableSnapshot + 'static>,
+        parameters: &ParameterRegistry,
         row: &MaybeOwnedRow<'_>,
         thing_var: ExecutorVariable,
         types: &std::sync::Arc<std::collections::BTreeSet<Type>>,
     ) -> Box<dyn Fn(&T) -> Result<bool, Box<ConceptReadError>>> {
-        let thing = self.make_extractor(&CheckVertex::Variable(thing_var), row, context);
+        let thing = self.make_extractor(&CheckVertex::Variable(thing_var), row, parameters);
         let types = types.clone();
         Box::new(move |value: &T| Ok(types.contains(&unwrap_or_result_false!(thing(value) => Thing).type_())))
     }
 
     fn filter_thing_type_list(
         &self,
-        context: &ExecutionContext<impl ReadableSnapshot + 'static>,
+        parameters: &ParameterRegistry,
         row: &MaybeOwnedRow<'_>,
         thing_var: ExecutorVariable,
         source: &T,
@@ -452,23 +493,24 @@ impl<T> Checker<T> {
     ) -> bool {
         let extracted = match self.extractors.get(&thing_var) {
             Some(function) => function(source),
-            None => get_vertex_value(&CheckVertex::Variable(thing_var), Some(row), &context.parameters),
+            None => get_vertex_value(&CheckVertex::Variable(thing_var), Some(row), parameters),
         };
         types.contains(&unwrap_or_return_false!(extracted => Thing).type_())
     }
 
     fn filter_sub_fn(
         &self,
-        context: &ExecutionContext<impl ReadableSnapshot + 'static>,
+        execution_context: &ExecutionContext<impl ReadableSnapshot + 'static>,
+        parameters: &ParameterRegistry,
         row: &MaybeOwnedRow<'_>,
         sub_kind: SubKind,
         subtype: &CheckVertex<ExecutorVariable>,
         supertype: &CheckVertex<ExecutorVariable>,
     ) -> Box<dyn Fn(&T) -> Result<bool, Box<ConceptReadError>>> {
-        let snapshot = context.snapshot.clone();
-        let thing_manager = context.thing_manager.clone();
-        let subtype = self.make_extractor(subtype, row, context);
-        let supertype = self.make_extractor(supertype, row, context);
+        let snapshot = execution_context.snapshot.clone();
+        let thing_manager = execution_context.thing_manager.clone();
+        let subtype = self.make_extractor(subtype, row, parameters);
+        let supertype = self.make_extractor(supertype, row, parameters);
         Box::new(move |source: &T| {
             let subtype = unwrap_or_result_false!(subtype(source) => Type);
             let supertype = unwrap_or_result_false!(supertype(source) => Type);
@@ -478,7 +520,8 @@ impl<T> Checker<T> {
 
     fn filter_sub(
         &self,
-        context: &ExecutionContext<impl ReadableSnapshot + 'static>,
+        execution_context: &ExecutionContext<impl ReadableSnapshot + 'static>,
+        parameters: &ParameterRegistry,
         row: &MaybeOwnedRow<'_>,
         sub_kind: SubKind,
         source: &T,
@@ -487,15 +530,15 @@ impl<T> Checker<T> {
     ) -> Result<bool, Box<ConceptReadError>> {
         let subtype = match subtype.as_variable().and_then(|var| self.extractors.get(&var)) {
             Some(function) => function(source),
-            None => get_vertex_value(subtype, Some(row), &context.parameters),
+            None => get_vertex_value(subtype, Some(row), parameters),
         };
         let supertype = match supertype.as_variable().and_then(|var| self.extractors.get(&var)) {
             Some(function) => function(source),
-            None => get_vertex_value(supertype, Some(row), &context.parameters),
+            None => get_vertex_value(supertype, Some(row), parameters),
         };
         Self::check_sub(
-            context.snapshot.as_ref(),
-            context.thing_manager.as_ref(),
+            execution_context.snapshot.as_ref(),
+            execution_context.thing_manager.as_ref(),
             sub_kind,
             unwrap_or_result_false!(subtype => Type),
             unwrap_or_result_false!(supertype => Type),
@@ -517,15 +560,16 @@ impl<T> Checker<T> {
 
     fn filter_owns_fn(
         &self,
-        context: &ExecutionContext<impl ReadableSnapshot + 'static>,
+        execution_context: &ExecutionContext<impl ReadableSnapshot + 'static>,
+        parameters: &ParameterRegistry,
         row: &MaybeOwnedRow<'_>,
         owner: &CheckVertex<ExecutorVariable>,
         attribute: &CheckVertex<ExecutorVariable>,
     ) -> Box<dyn Fn(&T) -> Result<bool, Box<ConceptReadError>>> {
-        let snapshot = context.snapshot.clone();
-        let thing_manager = context.thing_manager.clone();
-        let owner = self.make_extractor(owner, row, context);
-        let attribute = self.make_extractor(attribute, row, context);
+        let snapshot = execution_context.snapshot.clone();
+        let thing_manager = execution_context.thing_manager.clone();
+        let owner = self.make_extractor(owner, row, parameters);
+        let attribute = self.make_extractor(attribute, row, parameters);
         Box::new(move |value: &T| {
             let owner = unwrap_or_result_false!(owner(value) => Type).as_object_type();
             let attribute = unwrap_or_result_false!(attribute(value) => Type).as_attribute_type();
@@ -535,7 +579,8 @@ impl<T> Checker<T> {
 
     fn filter_owns(
         &self,
-        context: &ExecutionContext<impl ReadableSnapshot + 'static>,
+        execution_context: &ExecutionContext<impl ReadableSnapshot + 'static>,
+        parameters: &ParameterRegistry,
         row: &MaybeOwnedRow<'_>,
         source: &T,
         owner: &CheckVertex<ExecutorVariable>,
@@ -543,30 +588,35 @@ impl<T> Checker<T> {
     ) -> Result<bool, Box<ConceptReadError>> {
         let owner = match owner.as_variable().and_then(|var| self.extractors.get(&var)) {
             Some(&function) => function(source),
-            None => get_vertex_value(owner, Some(row), &context.parameters),
+            None => get_vertex_value(owner, Some(row), parameters),
         };
         let attribute = match attribute.as_variable().and_then(|var| self.extractors.get(&var)) {
             Some(&function) => function(source),
-            None => get_vertex_value(attribute, Some(row), &context.parameters),
+            None => get_vertex_value(attribute, Some(row), parameters),
         };
         let owner = unwrap_or_result_false!(owner => Type).as_object_type();
         let attribute = unwrap_or_result_false!(attribute => Type).as_attribute_type();
         owner
-            .get_owns_attribute(context.snapshot.as_ref(), context.thing_manager.clone().type_manager(), attribute)
+            .get_owns_attribute(
+                execution_context.snapshot.as_ref(),
+                execution_context.thing_manager.clone().type_manager(),
+                attribute,
+            )
             .map(|owns| owns.is_some())
     }
 
     fn filter_relates_fn(
         &self,
-        context: &ExecutionContext<impl ReadableSnapshot + 'static>,
+        execution_context: &ExecutionContext<impl ReadableSnapshot + 'static>,
+        parameters: &ParameterRegistry,
         row: &MaybeOwnedRow<'_>,
         relation: &CheckVertex<ExecutorVariable>,
         role_type: &CheckVertex<ExecutorVariable>,
     ) -> Box<dyn Fn(&T) -> Result<bool, Box<ConceptReadError>>> {
-        let snapshot = context.snapshot.clone();
-        let thing_manager = context.thing_manager.clone();
-        let relation = self.make_extractor(relation, row, context);
-        let role_type = self.make_extractor(role_type, row, context);
+        let snapshot = execution_context.snapshot.clone();
+        let thing_manager = execution_context.thing_manager.clone();
+        let relation = self.make_extractor(relation, row, parameters);
+        let role_type = self.make_extractor(role_type, row, parameters);
         Box::new(move |value: &T| {
             let relation_type = unwrap_or_result_false!(relation(value) => Type).as_relation_type();
             let role_type = unwrap_or_result_false!(role_type(value) => Type).as_role_type();
@@ -578,7 +628,8 @@ impl<T> Checker<T> {
 
     fn filter_relates(
         &self,
-        context: &ExecutionContext<impl ReadableSnapshot + 'static>,
+        execution_context: &ExecutionContext<impl ReadableSnapshot + 'static>,
+        parameters: &ParameterRegistry,
         row: &MaybeOwnedRow<'_>,
         source: &T,
         relation: &CheckVertex<ExecutorVariable>,
@@ -586,30 +637,35 @@ impl<T> Checker<T> {
     ) -> Result<bool, Box<ConceptReadError>> {
         let relation = match relation.as_variable().and_then(|var| self.extractors.get(&var)) {
             Some(function) => function(source),
-            None => get_vertex_value(relation, Some(row), &context.parameters),
+            None => get_vertex_value(relation, Some(row), parameters),
         };
         let role_type = match role_type.as_variable().and_then(|var| self.extractors.get(&var)) {
             Some(function) => function(source),
-            None => get_vertex_value(role_type, Some(row), &context.parameters),
+            None => get_vertex_value(role_type, Some(row), parameters),
         };
         let relation_type = unwrap_or_result_false!(relation => Type).as_relation_type();
         let role_type = unwrap_or_result_false!(role_type => Type).as_role_type();
         relation_type
-            .get_relates_role(context.snapshot.as_ref(), context.thing_manager.type_manager(), role_type)
+            .get_relates_role(
+                execution_context.snapshot.as_ref(),
+                execution_context.thing_manager.type_manager(),
+                role_type,
+            )
             .map(|relates| relates.is_some())
     }
 
     fn filter_plays_fn(
         &self,
-        context: &ExecutionContext<impl ReadableSnapshot + 'static>,
+        execution_context: &ExecutionContext<impl ReadableSnapshot + 'static>,
+        parameters: &ParameterRegistry,
         row: &MaybeOwnedRow<'_>,
         player: &CheckVertex<ExecutorVariable>,
         role_type: &CheckVertex<ExecutorVariable>,
     ) -> Box<dyn Fn(&T) -> Result<bool, Box<ConceptReadError>>> {
-        let snapshot = context.snapshot.clone();
-        let thing_manager = context.thing_manager.clone();
-        let player = self.make_extractor(player, row, context);
-        let role_type = self.make_extractor(role_type, row, context);
+        let snapshot = execution_context.snapshot.clone();
+        let thing_manager = execution_context.thing_manager.clone();
+        let player = self.make_extractor(player, row, parameters);
+        let role_type = self.make_extractor(role_type, row, parameters);
         Box::new({
             move |value: &T| {
                 let object_type = unwrap_or_result_false!(player(value) => Type).as_object_type();
@@ -623,7 +679,8 @@ impl<T> Checker<T> {
 
     fn filter_plays(
         &self,
-        context: &ExecutionContext<impl ReadableSnapshot + 'static>,
+        execution_context: &ExecutionContext<impl ReadableSnapshot + 'static>,
+        parameters: &ParameterRegistry,
         row: &MaybeOwnedRow<'_>,
         source: &T,
         player: &CheckVertex<ExecutorVariable>,
@@ -631,31 +688,36 @@ impl<T> Checker<T> {
     ) -> Result<bool, Box<ConceptReadError>> {
         let player = match player.as_variable().and_then(|var| self.extractors.get(&var)) {
             Some(function) => function(source),
-            None => get_vertex_value(player, Some(row), &context.parameters),
+            None => get_vertex_value(player, Some(row), parameters),
         };
         let role_type = match role_type.as_variable().and_then(|var| self.extractors.get(&var)) {
             Some(&function) => function(source),
-            None => get_vertex_value(role_type, Some(row), &context.parameters),
+            None => get_vertex_value(role_type, Some(row), parameters),
         };
         let object_type = unwrap_or_result_false!(player => Type).as_object_type();
         let role_type = unwrap_or_result_false!(role_type => Type).as_role_type();
         object_type
-            .get_plays_role(context.snapshot.as_ref(), context.thing_manager.type_manager(), role_type)
+            .get_plays_role(
+                execution_context.snapshot.as_ref(),
+                execution_context.thing_manager.type_manager(),
+                role_type,
+            )
             .map(|plays| plays.is_some())
     }
 
     fn filter_isa_fn(
         &self,
-        context: &ExecutionContext<impl ReadableSnapshot + 'static>,
+        execution_context: &ExecutionContext<impl ReadableSnapshot + 'static>,
+        parameters: &ParameterRegistry,
         row: &MaybeOwnedRow<'_>,
         isa_kind: IsaKind,
         type_: &CheckVertex<ExecutorVariable>,
         thing: &CheckVertex<ExecutorVariable>,
     ) -> Box<dyn Fn(&T) -> Result<bool, Box<ConceptReadError>>> {
-        let snapshot = context.snapshot.clone();
-        let thing_manager = context.thing_manager.clone();
-        let thing = self.make_extractor(thing, row, context);
-        let type_ = self.make_extractor(type_, row, context);
+        let snapshot = execution_context.snapshot.clone();
+        let thing_manager = execution_context.thing_manager.clone();
+        let thing = self.make_extractor(thing, row, parameters);
+        let type_ = self.make_extractor(type_, row, parameters);
         Box::new({
             move |value: &T| {
                 let actual = unwrap_or_result_false!(thing(value) => Thing).type_();
@@ -671,7 +733,8 @@ impl<T> Checker<T> {
 
     fn filter_isa(
         &self,
-        context: &ExecutionContext<impl ReadableSnapshot + 'static>,
+        execution_context: &ExecutionContext<impl ReadableSnapshot + 'static>,
+        parameters: &ParameterRegistry,
         row: &MaybeOwnedRow<'_>,
         source: &T,
         isa_kind: IsaKind,
@@ -680,33 +743,38 @@ impl<T> Checker<T> {
     ) -> Result<bool, Box<ConceptReadError>> {
         let thing = match thing.as_variable().and_then(|var| self.extractors.get(&var)) {
             Some(function) => function(source),
-            None => get_vertex_value(thing, Some(row), &context.parameters),
+            None => get_vertex_value(thing, Some(row), parameters),
         };
         let type_ = match type_.as_variable().and_then(|var| self.extractors.get(&var)) {
             Some(function) => function(source),
-            None => get_vertex_value(type_, Some(row), &context.parameters),
+            None => get_vertex_value(type_, Some(row), parameters),
         };
         let actual = unwrap_or_result_false!(thing => Thing).type_();
         let expected = unwrap_or_result_false!(type_ => Type);
         if isa_kind == IsaKind::Exact {
             Ok(actual == expected)
         } else {
-            actual.is_transitive_subtype_of(expected, context.snapshot.as_ref(), context.thing_manager.type_manager())
+            actual.is_transitive_subtype_of(
+                expected,
+                execution_context.snapshot.as_ref(),
+                execution_context.thing_manager.type_manager(),
+            )
         }
     }
 
     fn filter_has_fn(
         &self,
-        context: &ExecutionContext<impl ReadableSnapshot + 'static>,
+        execution_context: &ExecutionContext<impl ReadableSnapshot + 'static>,
+        parameters: &ParameterRegistry,
         row: &MaybeOwnedRow<'_>,
         owner: &CheckVertex<ExecutorVariable>,
         attribute: &CheckVertex<ExecutorVariable>,
         storage_counters: StorageCounters,
     ) -> Box<dyn Fn(&T) -> Result<bool, Box<ConceptReadError>>> {
-        let snapshot = context.snapshot.clone();
-        let thing_manager = context.thing_manager.clone();
-        let owner = self.make_extractor(owner, row, context);
-        let attribute = self.make_extractor(attribute, row, context);
+        let snapshot = execution_context.snapshot.clone();
+        let thing_manager = execution_context.thing_manager.clone();
+        let owner = self.make_extractor(owner, row, parameters);
+        let attribute = self.make_extractor(attribute, row, parameters);
         Box::new({
             move |value: &T| {
                 let owner = unwrap_or_result_false!(owner(value) => Thing).as_object();
@@ -719,7 +787,8 @@ impl<T> Checker<T> {
 
     fn filter_has(
         &self,
-        context: &ExecutionContext<impl ReadableSnapshot + 'static>,
+        execution_context: &ExecutionContext<impl ReadableSnapshot + 'static>,
+        parameters: &ParameterRegistry,
         row: &MaybeOwnedRow<'_>,
         source: &T,
         owner: &CheckVertex<ExecutorVariable>,
@@ -728,17 +797,17 @@ impl<T> Checker<T> {
     ) -> Result<bool, Box<ConceptReadError>> {
         let owner = match owner.as_variable().and_then(|var| self.extractors.get(&var)) {
             Some(function) => function(source),
-            None => get_vertex_value(owner, Some(row), &context.parameters),
+            None => get_vertex_value(owner, Some(row), parameters),
         };
         let attribute = match attribute.as_variable().and_then(|var| self.extractors.get(&var)) {
             Some(function) => function(source),
-            None => get_vertex_value(attribute, Some(row), &context.parameters),
+            None => get_vertex_value(attribute, Some(row), parameters),
         };
         let owner = unwrap_or_result_false!(&owner => Thing).as_object();
         let attribute = unwrap_or_result_false!(&attribute => Thing).as_attribute();
         owner.has_attribute(
-            context.snapshot.as_ref(),
-            context.thing_manager.as_ref(),
+            execution_context.snapshot.as_ref(),
+            execution_context.thing_manager.as_ref(),
             attribute,
             storage_counters.clone(),
         )
@@ -746,18 +815,19 @@ impl<T> Checker<T> {
 
     fn filter_links_fn(
         &self,
-        context: &ExecutionContext<impl ReadableSnapshot + 'static>,
+        execution_context: &ExecutionContext<impl ReadableSnapshot + 'static>,
+        parameters: &ParameterRegistry,
         row: &MaybeOwnedRow<'_>,
         relation: &CheckVertex<ExecutorVariable>,
         player: &CheckVertex<ExecutorVariable>,
         role: &CheckVertex<ExecutorVariable>,
         storage_counters: StorageCounters,
     ) -> Box<dyn Fn(&T) -> Result<bool, Box<ConceptReadError>>> {
-        let snapshot = context.snapshot.clone();
-        let thing_manager = context.thing_manager.clone();
-        let relation = self.make_extractor(relation, row, context);
-        let player = self.make_extractor(player, row, context);
-        let role = self.make_extractor(role, row, context);
+        let snapshot = execution_context.snapshot.clone();
+        let thing_manager = execution_context.thing_manager.clone();
+        let relation = self.make_extractor(relation, row, parameters);
+        let player = self.make_extractor(player, row, parameters);
+        let role = self.make_extractor(role, row, parameters);
         Box::new({
             move |value: &T| {
                 let relation = unwrap_or_result_false!(relation(value) => Thing).as_relation();
@@ -770,7 +840,8 @@ impl<T> Checker<T> {
 
     fn filter_links(
         &self,
-        context: &ExecutionContext<impl ReadableSnapshot + 'static>,
+        execution_context: &ExecutionContext<impl ReadableSnapshot + 'static>,
+        parameters: &ParameterRegistry,
         row: &MaybeOwnedRow<'_>,
         source: &T,
         relation: &CheckVertex<ExecutorVariable>,
@@ -780,22 +851,22 @@ impl<T> Checker<T> {
     ) -> Result<bool, Box<ConceptReadError>> {
         let relation = match relation.as_variable().and_then(|var| self.extractors.get(&var)) {
             Some(function) => function(source),
-            None => get_vertex_value(relation, Some(row), &context.parameters),
+            None => get_vertex_value(relation, Some(row), parameters),
         };
         let player = match player.as_variable().and_then(|var| self.extractors.get(&var)) {
             Some(function) => function(source),
-            None => get_vertex_value(player, Some(row), &context.parameters),
+            None => get_vertex_value(player, Some(row), parameters),
         };
         let role = match role.as_variable().and_then(|var| self.extractors.get(&var)) {
             Some(function) => function(source),
-            None => get_vertex_value(role, Some(row), &context.parameters),
+            None => get_vertex_value(role, Some(row), parameters),
         };
         let relation = unwrap_or_result_false!(relation => Thing).as_relation();
         let player = unwrap_or_result_false!(player => Thing).as_object();
         let role = unwrap_or_result_false!(role => Type).as_role_type();
         relation.has_role_player(
-            context.snapshot.as_ref(),
-            context.thing_manager.as_ref(),
+            execution_context.snapshot.as_ref(),
+            execution_context.thing_manager.as_ref(),
             player,
             role,
             storage_counters.clone(),
@@ -804,7 +875,8 @@ impl<T> Checker<T> {
 
     fn filter_indexed_relation_fn(
         &self,
-        context: &ExecutionContext<impl ReadableSnapshot + 'static>,
+        execution_context: &ExecutionContext<impl ReadableSnapshot + 'static>,
+        parameters: &ParameterRegistry,
         row: &MaybeOwnedRow<'_>,
         start_player: &CheckVertex<ExecutorVariable>,
         end_player: &CheckVertex<ExecutorVariable>,
@@ -813,13 +885,13 @@ impl<T> Checker<T> {
         end_role: &CheckVertex<ExecutorVariable>,
         storage_counters: StorageCounters,
     ) -> Box<dyn Fn(&T) -> Result<bool, Box<ConceptReadError>>> {
-        let snapshot = context.snapshot.clone();
-        let thing_manager = context.thing_manager.clone();
-        let start_player_extractor = self.make_extractor(start_player, row, context);
-        let end_player_extractor = self.make_extractor(end_player, row, context);
-        let relation_extractor = self.make_extractor(relation, row, context);
-        let start_role_extractor = self.make_extractor(start_role, row, context);
-        let end_role_extractor = self.make_extractor(end_role, row, context);
+        let snapshot = execution_context.snapshot.clone();
+        let thing_manager = execution_context.thing_manager.clone();
+        let start_player_extractor = self.make_extractor(start_player, row, parameters);
+        let end_player_extractor = self.make_extractor(end_player, row, parameters);
+        let relation_extractor = self.make_extractor(relation, row, parameters);
+        let start_role_extractor = self.make_extractor(start_role, row, parameters);
+        let end_role_extractor = self.make_extractor(end_role, row, parameters);
         Box::new({
             move |value: &T| {
                 let object = unwrap_or_result_false!(start_player_extractor(value) => Thing).as_object();
@@ -842,7 +914,8 @@ impl<T> Checker<T> {
 
     fn filter_indexed_relation(
         &self,
-        context: &ExecutionContext<impl ReadableSnapshot + 'static>,
+        execution_context: &ExecutionContext<impl ReadableSnapshot + 'static>,
+        parameters: &ParameterRegistry,
         row: &MaybeOwnedRow<'_>,
         source: &T,
         start_player: &CheckVertex<ExecutorVariable>,
@@ -854,23 +927,23 @@ impl<T> Checker<T> {
     ) -> Result<bool, Box<ConceptReadError>> {
         let start_player_extractor = match start_player.as_variable().and_then(|var| self.extractors.get(&var)) {
             Some(function) => function(source),
-            None => get_vertex_value(start_player, Some(row), &context.parameters),
+            None => get_vertex_value(start_player, Some(row), parameters),
         };
         let end_player_extractor = match end_player.as_variable().and_then(|var| self.extractors.get(&var)) {
             Some(function) => function(source),
-            None => get_vertex_value(end_player, Some(row), &context.parameters),
+            None => get_vertex_value(end_player, Some(row), parameters),
         };
         let relation_extractor = match relation.as_variable().and_then(|var| self.extractors.get(&var)) {
             Some(function) => function(source),
-            None => get_vertex_value(relation, Some(row), &context.parameters),
+            None => get_vertex_value(relation, Some(row), parameters),
         };
         let start_role_extractor = match start_role.as_variable().and_then(|var| self.extractors.get(&var)) {
             Some(function) => function(source),
-            None => get_vertex_value(start_role, Some(row), &context.parameters),
+            None => get_vertex_value(start_role, Some(row), parameters),
         };
         let end_role_extractor = match end_role.as_variable().and_then(|var| self.extractors.get(&var)) {
             Some(function) => function(source),
-            None => get_vertex_value(end_role, Some(row), &context.parameters),
+            None => get_vertex_value(end_role, Some(row), parameters),
         };
         let object = unwrap_or_result_false!(start_player_extractor => Thing).as_object();
         let end_player = unwrap_or_result_false!(end_player_extractor => Thing).as_object();
@@ -878,8 +951,8 @@ impl<T> Checker<T> {
         let start_role = unwrap_or_result_false!(start_role_extractor => Type).as_role_type();
         let end_role = unwrap_or_result_false!(end_role_extractor => Type).as_role_type();
         object.has_indexed_relation_player(
-            context.snapshot.as_ref(),
-            context.thing_manager.as_ref(),
+            execution_context.snapshot.as_ref(),
+            execution_context.thing_manager.as_ref(),
             end_player,
             relation,
             start_role,
@@ -1045,17 +1118,18 @@ impl<T> Checker<T> {
 
     fn filter_comparison_fn(
         &self,
-        context: &ExecutionContext<impl ReadableSnapshot + 'static>,
+        execution_context: &ExecutionContext<impl ReadableSnapshot + 'static>,
+        parameters: &ParameterRegistry,
         row: &MaybeOwnedRow<'_>,
         lhs: &CheckVertex<ExecutorVariable>,
         rhs: &CheckVertex<ExecutorVariable>,
         comparator: Comparator,
         storage_counters: StorageCounters,
     ) -> Box<dyn Fn(&T) -> Result<bool, Box<ConceptReadError>>> {
-        let lhs = self.make_extractor(lhs, row, context);
-        let rhs = self.make_extractor(rhs, row, context);
-        let snapshot = context.snapshot.clone();
-        let thing_manager = context.thing_manager.clone();
+        let lhs = self.make_extractor(lhs, row, parameters);
+        let rhs = self.make_extractor(rhs, row, parameters);
+        let snapshot = execution_context.snapshot.clone();
+        let thing_manager = execution_context.thing_manager.clone();
         Box::new(move |value: &T| {
             // NOTE: Empty <op> Empty never matches
             let lhs = match lhs(value) {
@@ -1086,7 +1160,8 @@ impl<T> Checker<T> {
 
     fn filter_comparison(
         &self,
-        context: &ExecutionContext<impl ReadableSnapshot + 'static>,
+        execution_context: &ExecutionContext<impl ReadableSnapshot + 'static>,
+        parameters: &ParameterRegistry,
         row: &MaybeOwnedRow<'_>,
         source: &T,
         lhs: &CheckVertex<ExecutorVariable>,
@@ -1096,28 +1171,30 @@ impl<T> Checker<T> {
     ) -> Result<bool, Box<ConceptReadError>> {
         let lhs = match lhs.as_variable().and_then(|var| self.extractors.get(&var)) {
             Some(function) => function(source),
-            None => get_vertex_value(lhs, Some(row), &context.parameters),
+            None => get_vertex_value(lhs, Some(row), parameters),
         };
         let rhs = match rhs {
             &CheckVertex::Variable(ExecutorVariable::RowPosition(pos)) => row.get(pos).as_reference(),
             &CheckVertex::Variable(_) => unreachable!(),
-            CheckVertex::Parameter(param) => {
-                VariableValue::Value(context.parameters().value_unchecked(param).as_reference())
-            }
+            CheckVertex::Parameter(param) => VariableValue::Value(parameters.value_unchecked(param).as_reference()),
             CheckVertex::Type(_) => unreachable!(),
         };
         let rhs = match &rhs {
-            VariableValue::Thing(Thing::Attribute(attr)) => {
-                attr.get_value(context.snapshot.as_ref(), context.thing_manager.as_ref(), storage_counters.clone())?
-            }
+            VariableValue::Thing(Thing::Attribute(attr)) => attr.get_value(
+                execution_context.snapshot.as_ref(),
+                execution_context.thing_manager.as_ref(),
+                storage_counters.clone(),
+            )?,
             VariableValue::Value(value) => value.as_reference(),
             VariableValue::ThingList(_) | VariableValue::ValueList(_) => unimplemented_feature!(Lists),
             VariableValue::None | VariableValue::Type(_) | VariableValue::Thing(_) => unreachable!(),
         };
         let lhs = match &lhs {
-            VariableValue::Thing(Thing::Attribute(attr)) => {
-                attr.get_value(context.snapshot.as_ref(), context.thing_manager.as_ref(), storage_counters.clone())?
-            }
+            VariableValue::Thing(Thing::Attribute(attr)) => attr.get_value(
+                execution_context.snapshot.as_ref(),
+                execution_context.thing_manager.as_ref(),
+                storage_counters.clone(),
+            )?,
             VariableValue::Value(value) => value.as_reference(),
             VariableValue::ThingList(_) | VariableValue::ValueList(_) => unimplemented_feature!(Lists),
             VariableValue::None | VariableValue::Type(_) | VariableValue::Thing(_) => unreachable!(),

--- a/executor/instruction/has_executor.rs
+++ b/executor/instruction/has_executor.rs
@@ -26,6 +26,7 @@ use concept::{
     type_::{TypeAPI, attribute_type::AttributeType, object_type::ObjectType},
 };
 use encoding::value::{value::Value, value_type::ValueTypeCategory};
+use ir::pipeline::ParameterRegistry;
 use itertools::Itertools;
 use lending_iterator::{LendingIterator, kmerge::KMergeBy};
 use primitive::Bounds;
@@ -171,12 +172,13 @@ impl HasExecutor {
 
     pub fn get_iterator(
         &self,
-        context: &ExecutionContext<impl ReadableSnapshot + 'static>,
+        execution_context: &ExecutionContext<impl ReadableSnapshot + 'static>,
+        parameters: &ParameterRegistry,
         row: MaybeOwnedRow<'_>,
         storage_counters: StorageCounters,
     ) -> Result<TupleIterator, Box<ConceptReadError>> {
         let filter = self.filter_fn.clone();
-        let check = self.checker.filter_fn_for_row(context, &row, storage_counters.clone());
+        let check = self.checker.filter_fn_for_row(execution_context, parameters, &row, storage_counters.clone());
         let filter_for_row: Arc<HasFilterMapFn> = Arc::new(move |item| match filter(&item) {
             Ok(true) => match check(&item) {
                 Ok(true) | Err(_) => Some(item),
@@ -186,14 +188,15 @@ impl HasExecutor {
             Err(_) => Some(item),
         });
         let value_range = self.checker.value_range_for(
-            context,
+            execution_context,
+            parameters,
             Some(row.as_reference()),
             self.has.attribute().as_variable().unwrap(),
             storage_counters.clone(),
         )?;
 
-        let snapshot = &**context.snapshot();
-        let thing_manager = context.thing_manager();
+        let snapshot = &**execution_context.snapshot();
+        let thing_manager = execution_context.thing_manager();
 
         match self.iterate_mode {
             BinaryIterateMode::Unbound => {

--- a/executor/instruction/has_reverse_executor.rs
+++ b/executor/instruction/has_reverse_executor.rs
@@ -19,6 +19,7 @@ use concept::{
     type_::{attribute_type::AttributeType, object_type::ObjectType},
 };
 use encoding::value::value::Value;
+use ir::pipeline::ParameterRegistry;
 use itertools::Itertools;
 use lending_iterator::kmerge::KMergeBy;
 use primitive::Bounds;
@@ -130,24 +131,26 @@ impl HasReverseExecutor {
 
     pub fn get_iterator(
         &self,
-        context: &ExecutionContext<impl ReadableSnapshot + 'static>,
+        execution_context: &ExecutionContext<impl ReadableSnapshot + 'static>,
+        parameters: &ParameterRegistry,
         row: MaybeOwnedRow<'_>,
         storage_counters: StorageCounters,
     ) -> Result<TupleIterator, Box<ConceptReadError>> {
         if self.iterate_mode.is_unbound_inverted() && self.attribute_cache.get().is_none() {
             // one-off initialisation of the cache of constants as we require the Parameters
             let value_range = self.checker.value_range_for(
-                context,
+                execution_context,
+                parameters,
                 None,
                 self.has.attribute().as_variable().unwrap(),
                 storage_counters.clone(),
             )?;
             let mut cache = Vec::new();
             for type_ in self.attribute_owner_types.keys() {
-                let instances: Vec<Attribute> = context
+                let instances: Vec<Attribute> = execution_context
                     .thing_manager
                     .get_attributes_in_range(
-                        context.snapshot.as_ref(),
+                        execution_context.snapshot.as_ref(),
                         type_.as_attribute_type(),
                         &value_range,
                         storage_counters.clone(),
@@ -163,7 +166,7 @@ impl HasReverseExecutor {
         }
 
         let filter = self.filter_fn.clone();
-        let check = self.checker.filter_fn_for_row(context, &row, storage_counters.clone());
+        let check = self.checker.filter_fn_for_row(execution_context, parameters, &row, storage_counters.clone());
         let filter_for_row: Arc<HasFilterMapFn> = Arc::new(move |item| match filter(&item) {
             Ok(true) => match check(&item) {
                 Ok(true) | Err(_) => Some(item),
@@ -173,13 +176,14 @@ impl HasReverseExecutor {
             Err(_) => Some(item),
         });
 
-        let snapshot = &**context.snapshot();
-        let thing_manager = context.thing_manager();
+        let snapshot = &**execution_context.snapshot();
+        let thing_manager = execution_context.thing_manager();
 
         match self.iterate_mode {
             BinaryIterateMode::Unbound => {
                 let range = self.checker.value_range_for(
-                    context,
+                    execution_context,
+                    parameters,
                     Some(row.as_reference()),
                     self.has.attribute().as_variable().unwrap(),
                     storage_counters.clone(),

--- a/executor/instruction/iid_executor.rs
+++ b/executor/instruction/iid_executor.rs
@@ -13,7 +13,7 @@ use concept::{
     thing::{ThingAPI, attribute::Attribute, object::Object},
 };
 use encoding::graph::thing::{ThingVertex, vertex_attribute::AttributeVertex, vertex_object::ObjectVertex};
-use ir::pattern::constraint::Iid;
+use ir::{pattern::constraint::Iid, pipeline::ParameterRegistry};
 use lending_iterator::AsLendingIterator;
 use resource::profile::StorageCounters;
 use storage::snapshot::ReadableSnapshot;
@@ -87,12 +87,13 @@ impl IidExecutor {
 
     pub(crate) fn get_iterator(
         &self,
-        context: &ExecutionContext<impl ReadableSnapshot + 'static>,
+        execution_context: &ExecutionContext<impl ReadableSnapshot + 'static>,
+        parameters: &ParameterRegistry,
         row: MaybeOwnedRow<'_>,
         storage_counters: StorageCounters,
     ) -> Result<TupleIterator, Box<ConceptReadError>> {
         let filter = self.filter_fn.clone();
-        let check = self.checker.filter_fn_for_row(context, &row, storage_counters.clone());
+        let check = self.checker.filter_fn_for_row(execution_context, parameters, &row, storage_counters.clone());
         let filter_for_row: Box<IidFilterMapFn> = Box::new(move |item| match filter(&item) {
             Ok(true) => match check(&item) {
                 Ok(true) | Err(_) => Some(item),
@@ -102,11 +103,11 @@ impl IidExecutor {
             Err(_) => Some(item),
         });
 
-        let snapshot = &**context.snapshot();
-        let thing_manager = context.thing_manager();
+        let snapshot = &**execution_context.snapshot();
+        let thing_manager = execution_context.thing_manager();
 
         let iid_parameter = self.iid.iid().as_parameter().unwrap();
-        let bytes = context.parameters().iid(iid_parameter).unwrap();
+        let bytes = parameters.iid(iid_parameter).unwrap();
 
         let instance = if let Some(object) = ObjectVertex::try_decode(bytes) {
             let object = Object::new(object);

--- a/executor/instruction/indexed_relation_executor.rs
+++ b/executor/instruction/indexed_relation_executor.rs
@@ -32,6 +32,7 @@ use encoding::graph::{
     thing::vertex_object::{ObjectID, ObjectVertex},
     type_::vertex::{TypeID, TypeVertexEncoding},
 };
+use ir::pipeline::ParameterRegistry;
 use itertools::Itertools;
 use lending_iterator::{LendingIterator, kmerge::KMergeBy};
 use primitive::Bounds;
@@ -238,12 +239,13 @@ impl IndexedRelationExecutor {
 
     pub(crate) fn get_iterator(
         &self,
-        context: &ExecutionContext<impl ReadableSnapshot + 'static>,
+        execution_context: &ExecutionContext<impl ReadableSnapshot + 'static>,
+        parameters: &ParameterRegistry,
         row: MaybeOwnedRow<'_>,
         storage_counters: StorageCounters,
     ) -> Result<TupleIterator, Box<ConceptReadError>> {
         let filter = self.filter_fn.clone();
-        let check = self.checker.filter_fn_for_row(context, &row, storage_counters.clone());
+        let check = self.checker.filter_fn_for_row(execution_context, parameters, &row, storage_counters.clone());
 
         let (relation, start_role, end_role) = self.may_get_relation_and_roles(row.as_reference());
 
@@ -261,8 +263,8 @@ impl IndexedRelationExecutor {
             Err(_) => Some(item),
         });
 
-        let snapshot = &**context.snapshot();
-        let thing_manager = context.thing_manager();
+        let snapshot = &**execution_context.snapshot();
+        let thing_manager = execution_context.thing_manager();
 
         match self.iterate_mode {
             IndexedRelationIterateMode::Unbound => {

--- a/executor/instruction/is_executor.rs
+++ b/executor/instruction/is_executor.rs
@@ -12,7 +12,7 @@ use compiler::{
     executable::match_::instructions::{Inputs, IsInstruction},
 };
 use concept::error::ConceptReadError;
-use ir::pattern::constraint::Is;
+use ir::{pattern::constraint::Is, pipeline::ParameterRegistry};
 use lending_iterator::AsLendingIterator;
 use resource::profile::StorageCounters;
 use storage::snapshot::ReadableSnapshot;
@@ -84,11 +84,12 @@ impl IsExecutor {
 
     pub(crate) fn get_iterator(
         &self,
-        context: &ExecutionContext<impl ReadableSnapshot + 'static>,
+        execution_context: &ExecutionContext<impl ReadableSnapshot + 'static>,
+        parameters: &ParameterRegistry,
         row: MaybeOwnedRow<'_>,
         storage_counters: StorageCounters,
     ) -> Result<TupleIterator, Box<ConceptReadError>> {
-        let check = self.checker.filter_fn_for_row(context, &row, storage_counters);
+        let check = self.checker.filter_fn_for_row(execution_context, parameters, &row, storage_counters);
         let filter_for_row: Box<IsFilterMapFn> = Box::new(move |item| match check(&item) {
             Ok(true) | Err(_) => Some(item),
             Ok(false) => None,

--- a/executor/instruction/isa_executor.rs
+++ b/executor/instruction/isa_executor.rs
@@ -19,9 +19,12 @@ use concept::{
     },
 };
 use encoding::value::value::Value;
-use ir::pattern::{
-    Vertex,
-    constraint::{Isa, IsaKind},
+use ir::{
+    pattern::{
+        Vertex,
+        constraint::{Isa, IsaKind},
+    },
+    pipeline::ParameterRegistry,
 };
 use itertools::Itertools;
 use lending_iterator::{AsLendingIterator, LendingIterator};
@@ -112,22 +115,29 @@ impl IsaExecutor {
 
     pub(crate) fn get_iterator(
         &self,
-        context: &ExecutionContext<impl ReadableSnapshot + 'static>,
+        execution_context: &ExecutionContext<impl ReadableSnapshot + 'static>,
+        parameters: &ParameterRegistry,
         row: MaybeOwnedRow<'_>,
         storage_counters: StorageCounters,
     ) -> Result<TupleIterator, Box<ConceptReadError>> {
-        let check = self.checker.filter_fn_for_row(context, &row, storage_counters.clone());
+        let check = self.checker.filter_fn_for_row(execution_context, parameters, &row, storage_counters.clone());
         let filter_for_row: Box<IsaFilterMapFn> = Box::new(move |item| match check(&item) {
             Ok(true) | Err(_) => Some(item),
             Ok(false) => None,
         });
 
-        let snapshot = &**context.snapshot();
-        let thing_manager = context.thing_manager();
+        let snapshot = &**execution_context.snapshot();
+        let thing_manager = execution_context.thing_manager();
         match self.iterate_mode {
             BinaryIterateMode::Unbound => {
                 let instances_range = if let Vertex::Variable(thing_variable) = self.isa.thing() {
-                    self.checker.value_range_for(context, Some(row), *thing_variable, storage_counters.clone())?
+                    self.checker.value_range_for(
+                        execution_context,
+                        parameters,
+                        Some(row),
+                        *thing_variable,
+                        storage_counters.clone(),
+                    )?
                 } else {
                     (Bound::Unbounded, Bound::Unbounded)
                 };

--- a/executor/instruction/isa_reverse_executor.rs
+++ b/executor/instruction/isa_reverse_executor.rs
@@ -18,7 +18,10 @@ use concept::{
     },
 };
 use encoding::value::value::Value;
-use ir::pattern::constraint::{Isa, IsaKind};
+use ir::{
+    pattern::constraint::{Isa, IsaKind},
+    pipeline::ParameterRegistry,
+};
 use itertools::Itertools;
 use lending_iterator::LendingIterator;
 use resource::profile::StorageCounters;
@@ -86,25 +89,27 @@ impl IsaReverseExecutor {
 
     pub(crate) fn get_iterator(
         &self,
-        context: &ExecutionContext<impl ReadableSnapshot + 'static>,
+        execution_context: &ExecutionContext<impl ReadableSnapshot + 'static>,
+        parameters: &ParameterRegistry,
         row: MaybeOwnedRow<'_>,
         storage_counters: StorageCounters,
     ) -> Result<TupleIterator, Box<ConceptReadError>> {
-        let check = self.checker.filter_fn_for_row(context, &row, storage_counters.clone());
+        let check = self.checker.filter_fn_for_row(execution_context, parameters, &row, storage_counters.clone());
         let filter_for_row: Box<IsaFilterMapFn> = Box::new(move |item| match check(&item) {
             Ok(true) | Err(_) => Some(item),
             Ok(false) => None,
         });
 
         let range = self.checker.value_range_for(
-            context,
+            execution_context,
+            parameters,
             Some(row.as_reference()),
             self.isa.thing().as_variable().unwrap(),
             storage_counters.clone(),
         )?;
 
-        let snapshot = &**context.snapshot();
-        let thing_manager = context.thing_manager();
+        let snapshot = &**execution_context.snapshot();
+        let thing_manager = execution_context.thing_manager();
         match self.iterate_mode {
             BinaryIterateMode::Unbound => {
                 let thing_iter = instances_of_types_chained(

--- a/executor/instruction/links_executor.rs
+++ b/executor/instruction/links_executor.rs
@@ -23,6 +23,7 @@ use concept::{
     },
     type_::{object_type::ObjectType, relation_type::RelationType, role_type::RoleType},
 };
+use ir::pipeline::ParameterRegistry;
 use itertools::Itertools;
 use lending_iterator::{LendingIterator, kmerge::KMergeBy};
 use primitive::Bounds;
@@ -168,12 +169,13 @@ impl LinksExecutor {
 
     pub fn get_iterator(
         &self,
-        context: &ExecutionContext<impl ReadableSnapshot + 'static>,
+        execution_context: &ExecutionContext<impl ReadableSnapshot + 'static>,
+        parameters: &ParameterRegistry,
         row: MaybeOwnedRow<'_>,
         storage_counters: StorageCounters,
     ) -> Result<TupleIterator, Box<ConceptReadError>> {
         let filter = self.filter_fn.clone();
-        let check = self.checker.filter_fn_for_row(context, &row, storage_counters.clone());
+        let check = self.checker.filter_fn_for_row(execution_context, parameters, &row, storage_counters.clone());
 
         let existing_role = may_get_role(self.links.role_type().as_variable().unwrap(), row.as_reference());
         let filter_for_row: Arc<LinksFilterMapFn> = Arc::new(move |item| match filter(&item) {
@@ -189,8 +191,8 @@ impl LinksExecutor {
             Err(_) => Some(item),
         });
 
-        let snapshot = &**context.snapshot();
-        let thing_manager = context.thing_manager();
+        let snapshot = &**execution_context.snapshot();
+        let thing_manager = execution_context.thing_manager();
 
         match self.iterate_mode {
             LinksIterateMode::Unbound => {

--- a/executor/instruction/links_reverse_executor.rs
+++ b/executor/instruction/links_reverse_executor.rs
@@ -23,6 +23,7 @@ use concept::{
     },
     type_::{object_type::ObjectType, relation_type::RelationType},
 };
+use ir::pipeline::ParameterRegistry;
 use itertools::Itertools;
 use lending_iterator::kmerge::KMergeBy;
 use primitive::Bounds;
@@ -160,12 +161,13 @@ impl LinksReverseExecutor {
 
     pub(crate) fn get_iterator(
         &self,
-        context: &ExecutionContext<impl ReadableSnapshot + 'static>,
+        execution_context: &ExecutionContext<impl ReadableSnapshot + 'static>,
+        parameters: &ParameterRegistry,
         row: MaybeOwnedRow<'_>,
         storage_counters: StorageCounters,
     ) -> Result<TupleIterator, Box<ConceptReadError>> {
         let filter = self.filter_fn.clone();
-        let check = self.checker.filter_fn_for_row(context, &row, storage_counters.clone());
+        let check = self.checker.filter_fn_for_row(execution_context, parameters, &row, storage_counters.clone());
 
         let existing_role = may_get_role(self.links.role_type().as_variable().unwrap(), row.as_reference());
         let filter_for_row: Arc<LinksFilterMapFn> = Arc::new(move |item| match filter(&item) {
@@ -181,8 +183,8 @@ impl LinksReverseExecutor {
             Err(_) => Some(item),
         });
 
-        let snapshot = &**context.snapshot();
-        let thing_manager = context.thing_manager();
+        let snapshot = &**execution_context.snapshot();
+        let thing_manager = execution_context.thing_manager();
 
         match self.iterate_mode {
             LinksIterateMode::Unbound => {

--- a/executor/instruction/mod.rs
+++ b/executor/instruction/mod.rs
@@ -13,7 +13,7 @@ use compiler::{
     executable::match_::instructions::{ConstraintInstruction, VariableMode, VariableModes},
 };
 use concept::{error::ConceptReadError, thing::thing_manager::ThingManager};
-use ir::pattern::Vertex;
+use ir::{pattern::Vertex, pipeline::ParameterRegistry};
 use itertools::Itertools;
 use resource::profile::StorageCounters;
 use storage::snapshot::ReadableSnapshot;
@@ -151,29 +151,34 @@ impl InstructionExecutor {
 
     pub(crate) fn get_iterator(
         &self,
-        context: &ExecutionContext<impl ReadableSnapshot + 'static>,
+        execution_context: &ExecutionContext<impl ReadableSnapshot + 'static>,
+        parameters: &ParameterRegistry,
         row: MaybeOwnedRow<'_>,
         storage_counters: StorageCounters,
     ) -> Result<TupleIterator, Box<ConceptReadError>> {
         match self {
-            Self::Is(executor) => executor.get_iterator(context, row, storage_counters),
-            Self::Iid(executor) => executor.get_iterator(context, row, storage_counters),
-            Self::TypeList(executor) => executor.get_iterator(context, row, storage_counters),
-            Self::Sub(executor) => executor.get_iterator(context, row, storage_counters),
-            Self::SubReverse(executor) => executor.get_iterator(context, row, storage_counters),
-            Self::Owns(executor) => executor.get_iterator(context, row, storage_counters),
-            Self::OwnsReverse(executor) => executor.get_iterator(context, row, storage_counters),
-            Self::Relates(executor) => executor.get_iterator(context, row, storage_counters),
-            Self::RelatesReverse(executor) => executor.get_iterator(context, row, storage_counters),
-            Self::Plays(executor) => executor.get_iterator(context, row, storage_counters),
-            Self::PlaysReverse(executor) => executor.get_iterator(context, row, storage_counters),
-            Self::Isa(executor) => executor.get_iterator(context, row, storage_counters),
-            Self::IsaReverse(executor) => executor.get_iterator(context, row, storage_counters),
-            Self::Has(executor) => executor.get_iterator(context, row, storage_counters),
-            Self::HasReverse(executor) => executor.get_iterator(context, row, storage_counters),
-            Self::Links(executor) => executor.get_iterator(context, row, storage_counters),
-            Self::LinksReverse(executor) => executor.get_iterator(context, row, storage_counters),
-            Self::IndexedRelation(executor) => executor.get_iterator(context, row, storage_counters),
+            Self::Is(executor) => executor.get_iterator(execution_context, parameters, row, storage_counters),
+            Self::Iid(executor) => executor.get_iterator(execution_context, parameters, row, storage_counters),
+            Self::TypeList(executor) => executor.get_iterator(execution_context, parameters, row, storage_counters),
+            Self::Sub(executor) => executor.get_iterator(execution_context, parameters, row, storage_counters),
+            Self::SubReverse(executor) => executor.get_iterator(execution_context, parameters, row, storage_counters),
+            Self::Owns(executor) => executor.get_iterator(execution_context, parameters, row, storage_counters),
+            Self::OwnsReverse(executor) => executor.get_iterator(execution_context, parameters, row, storage_counters),
+            Self::Relates(executor) => executor.get_iterator(execution_context, parameters, row, storage_counters),
+            Self::RelatesReverse(executor) => {
+                executor.get_iterator(execution_context, parameters, row, storage_counters)
+            }
+            Self::Plays(executor) => executor.get_iterator(execution_context, parameters, row, storage_counters),
+            Self::PlaysReverse(executor) => executor.get_iterator(execution_context, parameters, row, storage_counters),
+            Self::Isa(executor) => executor.get_iterator(execution_context, parameters, row, storage_counters),
+            Self::IsaReverse(executor) => executor.get_iterator(execution_context, parameters, row, storage_counters),
+            Self::Has(executor) => executor.get_iterator(execution_context, parameters, row, storage_counters),
+            Self::HasReverse(executor) => executor.get_iterator(execution_context, parameters, row, storage_counters),
+            Self::Links(executor) => executor.get_iterator(execution_context, parameters, row, storage_counters),
+            Self::LinksReverse(executor) => executor.get_iterator(execution_context, parameters, row, storage_counters),
+            Self::IndexedRelation(executor) => {
+                executor.get_iterator(execution_context, parameters, row, storage_counters)
+            }
         }
     }
 

--- a/executor/instruction/owns_executor.rs
+++ b/executor/instruction/owns_executor.rs
@@ -19,6 +19,7 @@ use concept::{
         ObjectTypeAPI, OwnerAPI, attribute_type::AttributeType, object_type::ObjectType, type_manager::TypeManager,
     },
 };
+use ir::pipeline::ParameterRegistry;
 use itertools::Itertools;
 use lending_iterator::AsLendingIterator;
 use resource::profile::StorageCounters;
@@ -127,12 +128,13 @@ impl OwnsExecutor {
 
     pub(crate) fn get_iterator(
         &self,
-        context: &ExecutionContext<impl ReadableSnapshot + 'static>,
+        execution_context: &ExecutionContext<impl ReadableSnapshot + 'static>,
+        parameters: &ParameterRegistry,
         row: MaybeOwnedRow<'_>,
         storage_counters: StorageCounters,
     ) -> Result<TupleIterator, Box<ConceptReadError>> {
         let filter = self.filter_fn.clone();
-        let check = self.checker.filter_fn_for_row(context, &row, storage_counters.clone());
+        let check = self.checker.filter_fn_for_row(execution_context, parameters, &row, storage_counters.clone());
         let filter_for_row: Box<OwnsFilterMapFn> = Box::new(move |item| match filter(&item) {
             Ok(true) => match check(&item) {
                 Ok(true) | Err(_) => Some(item),
@@ -142,11 +144,11 @@ impl OwnsExecutor {
             Err(_) => Some(item),
         });
 
-        let snapshot = &**context.snapshot();
+        let snapshot = &**execution_context.snapshot();
 
         match self.iterate_mode {
             BinaryIterateMode::Unbound => {
-                let type_manager = context.type_manager();
+                let type_manager = execution_context.type_manager();
                 let owns: Vec<_> = self
                     .owner_attribute_types
                     .keys()
@@ -171,7 +173,7 @@ impl OwnsExecutor {
 
             BinaryIterateMode::BoundFrom => {
                 let owner = type_from_row_or_annotations(self.owns.owner(), row, self.owner_attribute_types.keys());
-                let type_manager = context.type_manager();
+                let type_manager = execution_context.type_manager();
                 let owns = self.get_owns_for_owner(snapshot, type_manager, owner)?;
 
                 let iterator = owns.into_iter().sorted_by_key(|(owner, attribute)| (*attribute, *owner)).map(Ok as _);

--- a/executor/instruction/owns_reverse_executor.rs
+++ b/executor/instruction/owns_reverse_executor.rs
@@ -17,6 +17,7 @@ use concept::{
     error::ConceptReadError,
     type_::{attribute_type::AttributeType, object_type::ObjectType},
 };
+use ir::pipeline::ParameterRegistry;
 use itertools::Itertools;
 use lending_iterator::AsLendingIterator;
 use resource::profile::StorageCounters;
@@ -118,12 +119,13 @@ impl OwnsReverseExecutor {
 
     pub(crate) fn get_iterator(
         &self,
-        context: &ExecutionContext<impl ReadableSnapshot + 'static>,
+        execution_context: &ExecutionContext<impl ReadableSnapshot + 'static>,
+        parameters: &ParameterRegistry,
         row: MaybeOwnedRow<'_>,
         storage_counters: StorageCounters,
     ) -> Result<TupleIterator, Box<ConceptReadError>> {
         let filter = self.filter_fn.clone();
-        let check = self.checker.filter_fn_for_row(context, &row, storage_counters);
+        let check = self.checker.filter_fn_for_row(execution_context, parameters, &row, storage_counters);
         let filter_for_row: Box<OwnsFilterMapFn> = Box::new(move |item| match filter(&item) {
             Ok(true) => match check(&item) {
                 Ok(true) | Err(_) => Some(item),
@@ -133,11 +135,11 @@ impl OwnsReverseExecutor {
             Err(_) => Some(item),
         });
 
-        let snapshot = &**context.snapshot();
+        let snapshot = &**execution_context.snapshot();
 
         match self.iterate_mode {
             BinaryIterateMode::Unbound => {
-                let type_manager = context.type_manager();
+                let type_manager = execution_context.type_manager();
                 let owns: Vec<_> = self
                     .attribute_owner_types
                     .keys()
@@ -169,7 +171,7 @@ impl OwnsReverseExecutor {
                 let attribute_type =
                     type_from_row_or_annotations(self.owns.attribute(), row, self.attribute_owner_types.keys())
                         .as_attribute_type();
-                let type_manager = context.type_manager();
+                let type_manager = execution_context.type_manager();
                 let owns = attribute_type
                     .get_owner_types(snapshot, type_manager)?
                     .to_owned()

--- a/executor/instruction/plays_executor.rs
+++ b/executor/instruction/plays_executor.rs
@@ -17,6 +17,7 @@ use concept::{
     error::ConceptReadError,
     type_::{ObjectTypeAPI, PlayerAPI, object_type::ObjectType, role_type::RoleType, type_manager::TypeManager},
 };
+use ir::pipeline::ParameterRegistry;
 use itertools::Itertools;
 use lending_iterator::AsLendingIterator;
 use resource::profile::StorageCounters;
@@ -124,12 +125,13 @@ impl PlaysExecutor {
 
     pub(crate) fn get_iterator(
         &self,
-        context: &ExecutionContext<impl ReadableSnapshot + 'static>,
+        execution_context: &ExecutionContext<impl ReadableSnapshot + 'static>,
+        parameters: &ParameterRegistry,
         row: MaybeOwnedRow<'_>,
         storage_counters: StorageCounters,
     ) -> Result<TupleIterator, Box<ConceptReadError>> {
         let filter = self.filter_fn.clone();
-        let check = self.checker.filter_fn_for_row(context, &row, storage_counters);
+        let check = self.checker.filter_fn_for_row(execution_context, parameters, &row, storage_counters);
         let filter_for_row: Box<PlaysFilterMapFn> = Box::new(move |item| match filter(&item) {
             Ok(true) => match check(&item) {
                 Ok(true) | Err(_) => Some(item),
@@ -139,11 +141,11 @@ impl PlaysExecutor {
             Err(_) => Some(item),
         });
 
-        let snapshot = &**context.snapshot();
+        let snapshot = &**execution_context.snapshot();
 
         match self.iterate_mode {
             BinaryIterateMode::Unbound => {
-                let type_manager = context.type_manager();
+                let type_manager = execution_context.type_manager();
                 let plays: Vec<_> = self
                     .player_role_types
                     .keys()
@@ -168,7 +170,7 @@ impl PlaysExecutor {
 
             BinaryIterateMode::BoundFrom => {
                 let player = type_from_row_or_annotations(self.plays.player(), row, self.player_role_types.keys());
-                let type_manager = context.type_manager();
+                let type_manager = execution_context.type_manager();
                 let plays = self.get_plays_for_player(snapshot, type_manager, player)?;
 
                 let iterator = plays.into_iter().sorted_by_key(|&(player, role)| (role, player)).map(Ok as _);

--- a/executor/instruction/plays_reverse_executor.rs
+++ b/executor/instruction/plays_reverse_executor.rs
@@ -17,6 +17,7 @@ use concept::{
     error::ConceptReadError,
     type_::{object_type::ObjectType, role_type::RoleType},
 };
+use ir::pipeline::ParameterRegistry;
 use itertools::Itertools;
 use lending_iterator::AsLendingIterator;
 use resource::profile::StorageCounters;
@@ -119,12 +120,13 @@ impl PlaysReverseExecutor {
 
     pub(crate) fn get_iterator(
         &self,
-        context: &ExecutionContext<impl ReadableSnapshot + 'static>,
+        execution_context: &ExecutionContext<impl ReadableSnapshot + 'static>,
+        parameters: &ParameterRegistry,
         row: MaybeOwnedRow<'_>,
         storage_counters: StorageCounters,
     ) -> Result<TupleIterator, Box<ConceptReadError>> {
         let filter = self.filter_fn.clone();
-        let check = self.checker.filter_fn_for_row(context, &row, storage_counters);
+        let check = self.checker.filter_fn_for_row(execution_context, parameters, &row, storage_counters);
         let filter_for_row: Box<PlaysFilterMapFn> = Box::new(move |item| match filter(&item) {
             Ok(true) => match check(&item) {
                 Ok(true) | Err(_) => Some(item),
@@ -134,11 +136,11 @@ impl PlaysReverseExecutor {
             Err(_) => Some(item),
         });
 
-        let snapshot = &**context.snapshot();
+        let snapshot = &**execution_context.snapshot();
 
         match self.iterate_mode {
             BinaryIterateMode::Unbound => {
-                let type_manager = context.type_manager();
+                let type_manager = execution_context.type_manager();
                 let plays: Vec<_> = self
                     .role_player_types
                     .keys()
@@ -170,7 +172,7 @@ impl PlaysReverseExecutor {
                 let role_type =
                     type_from_row_or_annotations(self.plays.role_type(), row, self.role_player_types.keys())
                         .as_role_type();
-                let type_manager = context.type_manager();
+                let type_manager = execution_context.type_manager();
                 let plays = role_type
                     .get_player_types(snapshot, type_manager)?
                     .to_owned()

--- a/executor/instruction/relates_executor.rs
+++ b/executor/instruction/relates_executor.rs
@@ -17,6 +17,7 @@ use concept::{
     error::ConceptReadError,
     type_::{relation_type::RelationType, role_type::RoleType, type_manager::TypeManager},
 };
+use ir::pipeline::ParameterRegistry;
 use itertools::Itertools;
 use lending_iterator::AsLendingIterator;
 use resource::profile::StorageCounters;
@@ -125,12 +126,13 @@ impl RelatesExecutor {
 
     pub(crate) fn get_iterator(
         &self,
-        context: &ExecutionContext<impl ReadableSnapshot + 'static>,
+        execution_context: &ExecutionContext<impl ReadableSnapshot + 'static>,
+        parameters: &ParameterRegistry,
         row: MaybeOwnedRow<'_>,
         storage_counters: StorageCounters,
     ) -> Result<TupleIterator, Box<ConceptReadError>> {
         let filter = self.filter_fn.clone();
-        let check = self.checker.filter_fn_for_row(context, &row, storage_counters);
+        let check = self.checker.filter_fn_for_row(execution_context, parameters, &row, storage_counters);
         let filter_for_row: Box<RelatesFilterMapFn> = Box::new(move |item| match filter(&item) {
             Ok(true) => match check(&item) {
                 Ok(true) | Err(_) => Some(item),
@@ -140,11 +142,11 @@ impl RelatesExecutor {
             Err(_) => Some(item),
         });
 
-        let snapshot = &**context.snapshot();
+        let snapshot = &**execution_context.snapshot();
 
         match self.iterate_mode {
             BinaryIterateMode::Unbound => {
-                let type_manager = context.type_manager();
+                let type_manager = execution_context.type_manager();
                 let relates: Vec<_> = self
                     .relation_role_types
                     .keys()
@@ -170,7 +172,7 @@ impl RelatesExecutor {
             BinaryIterateMode::BoundFrom => {
                 let relation =
                     type_from_row_or_annotations(self.relates.relation(), row, self.relation_role_types.keys());
-                let type_manager = context.type_manager();
+                let type_manager = execution_context.type_manager();
                 let relates = self.get_relates_for_relation(snapshot, type_manager, relation)?;
 
                 let iterator =

--- a/executor/instruction/relates_reverse_executor.rs
+++ b/executor/instruction/relates_reverse_executor.rs
@@ -17,6 +17,7 @@ use concept::{
     error::ConceptReadError,
     type_::{relation_type::RelationType, role_type::RoleType},
 };
+use ir::pipeline::ParameterRegistry;
 use itertools::Itertools;
 use lending_iterator::AsLendingIterator;
 use resource::profile::StorageCounters;
@@ -118,12 +119,13 @@ impl RelatesReverseExecutor {
 
     pub(crate) fn get_iterator(
         &self,
-        context: &ExecutionContext<impl ReadableSnapshot + 'static>,
+        execution_context: &ExecutionContext<impl ReadableSnapshot + 'static>,
+        parameters: &ParameterRegistry,
         row: MaybeOwnedRow<'_>,
         storage_counters: StorageCounters,
     ) -> Result<TupleIterator, Box<ConceptReadError>> {
         let filter = self.filter_fn.clone();
-        let check = self.checker.filter_fn_for_row(context, &row, storage_counters);
+        let check = self.checker.filter_fn_for_row(execution_context, parameters, &row, storage_counters);
         let filter_for_row: Box<RelatesFilterMapFn> = Box::new(move |item| match filter(&item) {
             Ok(true) => match check(&item) {
                 Ok(true) | Err(_) => Some(item),
@@ -133,11 +135,11 @@ impl RelatesReverseExecutor {
             Err(_) => Some(item),
         });
 
-        let snapshot = &**context.snapshot();
+        let snapshot = &**execution_context.snapshot();
 
         match self.iterate_mode {
             BinaryIterateMode::Unbound => {
-                let type_manager = context.type_manager();
+                let type_manager = execution_context.type_manager();
                 let relates: Vec<_> = self
                     .role_relation_types
                     .keys()
@@ -170,7 +172,7 @@ impl RelatesReverseExecutor {
                     type_from_row_or_annotations(self.relates.role_type(), row, self.role_relation_types.keys())
                         .as_role_type();
                 let relates = role_type
-                    .get_relation_types(snapshot, context.type_manager())?
+                    .get_relation_types(snapshot, execution_context.type_manager())?
                     .to_owned()
                     .into_keys()
                     .map(|relation_type| (relation_type, role_type));

--- a/executor/instruction/sub_executor.rs
+++ b/executor/instruction/sub_executor.rs
@@ -14,6 +14,7 @@ use std::{
 use answer::{Type, variable_value::VariableValue};
 use compiler::{ExecutorVariable, executable::match_::instructions::type_::SubInstruction};
 use concept::error::ConceptReadError;
+use ir::pipeline::ParameterRegistry;
 use itertools::Itertools;
 use lending_iterator::AsLendingIterator;
 use resource::profile::StorageCounters;
@@ -111,12 +112,13 @@ impl SubExecutor {
 
     pub(crate) fn get_iterator(
         &self,
-        context: &ExecutionContext<impl ReadableSnapshot + 'static>,
+        execution_context: &ExecutionContext<impl ReadableSnapshot + 'static>,
+        parameters: &ParameterRegistry,
         row: MaybeOwnedRow<'_>,
         storage_counters: StorageCounters,
     ) -> Result<TupleIterator, Box<ConceptReadError>> {
         let filter = self.filter_fn.clone();
-        let check = self.checker.filter_fn_for_row(context, &row, storage_counters);
+        let check = self.checker.filter_fn_for_row(execution_context, parameters, &row, storage_counters);
         let filter_for_row: Box<SubFilterMapFn> = Box::new(move |item| match filter(&item) {
             Ok(true) => match check(&item) {
                 Ok(true) | Err(_) => Some(item),

--- a/executor/instruction/sub_reverse_executor.rs
+++ b/executor/instruction/sub_reverse_executor.rs
@@ -14,6 +14,7 @@ use std::{
 use answer::Type;
 use compiler::{ExecutorVariable, executable::match_::instructions::type_::SubReverseInstruction};
 use concept::error::ConceptReadError;
+use ir::pipeline::ParameterRegistry;
 use itertools::Itertools;
 use lending_iterator::AsLendingIterator;
 use resource::profile::StorageCounters;
@@ -104,12 +105,13 @@ impl SubReverseExecutor {
 
     pub(crate) fn get_iterator(
         &self,
-        context: &ExecutionContext<impl ReadableSnapshot + 'static>,
+        execution_context: &ExecutionContext<impl ReadableSnapshot + 'static>,
+        parameters: &ParameterRegistry,
         row: MaybeOwnedRow<'_>,
         storage_counters: StorageCounters,
     ) -> Result<TupleIterator, Box<ConceptReadError>> {
         let filter = self.filter_fn.clone();
-        let check = self.checker.filter_fn_for_row(context, &row, storage_counters);
+        let check = self.checker.filter_fn_for_row(execution_context, parameters, &row, storage_counters);
         let filter_for_row: Box<SubFilterMapFn> = Box::new(move |item| match filter(&item) {
             Ok(true) => match check(&item) {
                 Ok(true) | Err(_) => Some(item),

--- a/executor/instruction/type_list_executor.rs
+++ b/executor/instruction/type_list_executor.rs
@@ -9,6 +9,7 @@ use std::{collections::HashMap, fmt, iter, vec};
 use answer::{Type, variable_value::VariableValue};
 use compiler::{ExecutorVariable, executable::match_::instructions::type_::TypeListInstruction};
 use concept::error::ConceptReadError;
+use ir::pipeline::ParameterRegistry;
 use itertools::Itertools;
 use lending_iterator::AsLendingIterator;
 use resource::profile::StorageCounters;
@@ -66,11 +67,12 @@ impl TypeListExecutor {
 
     pub(crate) fn get_iterator(
         &self,
-        context: &ExecutionContext<impl ReadableSnapshot + 'static>,
+        execution_context: &ExecutionContext<impl ReadableSnapshot + 'static>,
+        parameters: &ParameterRegistry,
         row: MaybeOwnedRow<'_>,
         storage_counters: StorageCounters,
     ) -> Result<TupleIterator, Box<ConceptReadError>> {
-        let check = self.checker.filter_fn_for_row(context, &row, storage_counters);
+        let check = self.checker.filter_fn_for_row(execution_context, parameters, &row, storage_counters);
         let filter_for_row: Box<TypeFilterMapFn> = Box::new(move |item| match check(&item) {
             Ok(true) | Err(_) => Some(item),
             Ok(false) => None,

--- a/executor/match_executor.rs
+++ b/executor/match_executor.rs
@@ -9,7 +9,8 @@ use std::sync::Arc;
 use compiler::executable::{
     function::ExecutableFunctionRegistry, match_::planner::conjunction_executable::ConjunctionExecutable,
 };
-use concept::{error::ConceptReadError, thing::thing_manager::ThingManager};
+use concept::error::ConceptReadError;
+use ir::pipeline::QueryContext;
 use lending_iterator::{AsLendingIterator, LendingIterator, adaptors::FlatMap};
 use resource::profile::QueryProfile;
 use storage::snapshot::ReadableSnapshot;
@@ -34,61 +35,66 @@ pub struct MatchExecutor {
 impl MatchExecutor {
     pub fn new(
         conjunction_executable: &ConjunctionExecutable,
-        snapshot: &Arc<impl ReadableSnapshot + 'static>,
-        thing_manager: &Arc<ThingManager>,
+        execution_context: &ExecutionContext<impl ReadableSnapshot>,
         input: MaybeOwnedRow<'_>,
         function_registry: Arc<ExecutableFunctionRegistry>,
-        profile: &QueryProfile,
+        profile: &Arc<QueryProfile>,
     ) -> Result<Self, Box<ConceptReadError>> {
         let stage_profile = profile.profile_stage(|| String::from("Match"), conjunction_executable.executable_id());
         Ok(Self {
             entry: create_pattern_executor_for_conjunction(
-                snapshot,
-                thing_manager,
+                execution_context,
                 &function_registry,
                 conjunction_executable,
                 stage_profile,
             )?,
-            tabled_functions: TabledFunctions::new(function_registry),
+            tabled_functions: TabledFunctions::new(function_registry, profile.clone()),
             input: Some(input.into_owned()),
         })
     }
 
     pub fn into_iterator<Snapshot: ReadableSnapshot + 'static>(
         self,
-        context: ExecutionContext<Snapshot>,
+        execution_context: ExecutionContext<Snapshot>,
+        query_context: Arc<QueryContext>,
         interrupt: ExecutionInterrupt,
     ) -> PatternIterator<Snapshot> {
         PatternIterator::new(
-            AsLendingIterator::new(BatchIterator::new(self, context, interrupt)).flat_map(FixedBatchRowIterator::new),
+            AsLendingIterator::new(BatchIterator::new(self, execution_context, query_context, interrupt))
+                .flat_map(FixedBatchRowIterator::new),
         )
     }
 
     pub(super) fn compute_next_batch(
         &mut self,
-        context: &ExecutionContext<impl ReadableSnapshot + 'static>,
+        execution_context: &ExecutionContext<impl ReadableSnapshot + 'static>,
+        query_context: &QueryContext,
         interrupt: &mut ExecutionInterrupt,
     ) -> Result<Option<FixedBatch>, Box<ReadExecutionError>> {
         if let Some(input) = self.input.take() {
             self.entry.prepare(FixedBatch::from(input.into_owned()));
         }
-        self.entry.compute_next_batch(context, interrupt, &mut self.tabled_functions).map_err(|err| Box::new(err))
+        self.entry
+            .compute_next_batch(execution_context, &query_context.parameters, interrupt, &mut self.tabled_functions)
+            .map_err(|err| Box::new(err))
     }
 }
 
 pub(crate) struct BatchIterator<Snapshot> {
     executor: MatchExecutor,
-    context: ExecutionContext<Snapshot>,
+    execution_context: ExecutionContext<Snapshot>,
+    query_context: Arc<QueryContext>,
     interrupt: ExecutionInterrupt,
 }
 
 impl<Snapshot> BatchIterator<Snapshot> {
     pub(crate) fn new(
         executor: MatchExecutor,
-        context: ExecutionContext<Snapshot>,
+        execution_context: ExecutionContext<Snapshot>,
+        query_context: Arc<QueryContext>,
         interrupt: ExecutionInterrupt,
     ) -> Self {
-        Self { executor, context, interrupt }
+        Self { executor, execution_context, query_context, interrupt }
     }
 }
 
@@ -96,7 +102,7 @@ impl<Snapshot: ReadableSnapshot + 'static> Iterator for BatchIterator<Snapshot> 
     type Item = Result<FixedBatch, Box<ReadExecutionError>>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        let batch = self.executor.compute_next_batch(&self.context, &mut self.interrupt);
+        let batch = self.executor.compute_next_batch(&self.execution_context, &self.query_context, &mut self.interrupt);
         batch.transpose()
     }
 }

--- a/executor/pipeline/delete.rs
+++ b/executor/pipeline/delete.rs
@@ -10,7 +10,7 @@ use compiler::executable::delete::{
     instructions::ConnectionInstruction,
 };
 use concept::thing::thing_manager::ThingManager;
-use ir::pipeline::ParameterRegistry;
+use ir::pipeline::{ParameterRegistry, QueryContext};
 use resource::{
     constants::traversal::CHECK_INTERRUPT_FREQUENCY_ROWS,
     profile::{PatternProfile, StepProfile},
@@ -49,7 +49,8 @@ where
     fn into_iterator(
         self,
         input_iterator: Self::InputIterator,
-        mut context: ExecutionContext<Snapshot>,
+        mut execution_context: ExecutionContext<Snapshot>,
+        query_context: Arc<QueryContext>,
         mut interrupt: ExecutionInterrupt,
     ) -> Result<
         (Self::OutputIterator, ExecutionContext<Snapshot>),
@@ -58,17 +59,17 @@ where
         // accumulate once, then we will operate in-place
         let mut batch = match input_iterator.collect_owned() {
             Ok(batch) => batch,
-            Err(err) => return Err((err, context)),
+            Err(err) => return Err((err, execution_context)),
         };
 
         // TODO: all write stages will have the same block below: we could merge them
-        let profile = context.profile.profile_stage(|| String::from("Delete"), self.executable.executable_id);
+        let profile = query_context.profile.profile_stage(|| String::from("Delete"), self.executable.executable_id);
         let pattern_profile = profile.create_or_get_pattern(|| String::from("Delete"));
         let (connection_profiles, optional_connection_profiles, concept_profiles) =
             build_step_profiles(&self.executable, &pattern_profile);
 
         // once the previous iterator is complete, this must be the exclusive owner of Arc's, so unwrap:
-        let snapshot = Arc::get_mut(&mut context.snapshot).unwrap();
+        let snapshot = Arc::get_mut(&mut execution_context.snapshot).unwrap();
         // First delete connections
         for index in 0..batch.len() {
             let mut row = batch.get_row_mut(index);
@@ -77,11 +78,11 @@ where
                 &self.executable.connection_instructions,
                 &connection_profiles,
                 snapshot,
-                &context.thing_manager,
-                &context.parameters,
+                &execution_context.thing_manager,
+                &query_context.parameters,
                 &mut row,
             ) {
-                return Err((Box::new(PipelineExecutionError::WriteError { typedb_source }), context));
+                return Err((Box::new(PipelineExecutionError::WriteError { typedb_source }), execution_context));
             }
 
             for (i, optional) in self.executable.optional_deletes.iter().enumerate() {
@@ -89,17 +90,17 @@ where
                     optional,
                     &optional_connection_profiles[i],
                     snapshot,
-                    &context.thing_manager,
-                    &context.parameters,
+                    &execution_context.thing_manager,
+                    &query_context.parameters,
                     &mut row,
                 ) {
-                    return Err((Box::new(PipelineExecutionError::WriteError { typedb_source }), context));
+                    return Err((Box::new(PipelineExecutionError::WriteError { typedb_source }), execution_context));
                 }
             }
 
             if index % CHECK_INTERRUPT_FREQUENCY_ROWS == 0 {
                 if let Some(interrupt) = interrupt.check() {
-                    return Err((Box::new(PipelineExecutionError::Interrupted { interrupt }), context));
+                    return Err((Box::new(PipelineExecutionError::Interrupted { interrupt }), execution_context));
                 }
             }
         }
@@ -111,21 +112,21 @@ where
                 &self.executable,
                 &concept_profiles,
                 snapshot,
-                &context.thing_manager,
-                &context.parameters,
+                &execution_context.thing_manager,
+                &query_context.parameters,
                 &mut row,
             ) {
-                return Err((Box::new(PipelineExecutionError::WriteError { typedb_source }), context));
+                return Err((Box::new(PipelineExecutionError::WriteError { typedb_source }), execution_context));
             }
 
             if index % CHECK_INTERRUPT_FREQUENCY_ROWS == 0 {
                 if let Some(interrupt) = interrupt.check() {
-                    return Err((Box::new(PipelineExecutionError::Interrupted { interrupt }), context));
+                    return Err((Box::new(PipelineExecutionError::Interrupted { interrupt }), execution_context));
                 }
             }
         }
 
-        Ok((WrittenRowsIterator::new(batch), context))
+        Ok((WrittenRowsIterator::new(batch), execution_context))
     }
 }
 

--- a/executor/pipeline/fetch.rs
+++ b/executor/pipeline/fetch.rs
@@ -24,10 +24,9 @@ use concept::{
 };
 use encoding::value::label::Label;
 use error::{typedb_error, unimplemented_feature};
-use function::function_manager::FunctionManager;
-use ir::{pattern::ParameterID, pipeline::ParameterRegistry};
+use ir::{pattern::ParameterID, pipeline::QueryContext};
 use lending_iterator::LendingIterator;
-use resource::profile::{QueryProfile, StepProfile, StorageCounters};
+use resource::profile::{StepProfile, StorageCounters};
 use storage::snapshot::ReadableSnapshot;
 
 use crate::{
@@ -71,130 +70,97 @@ impl<Snapshot: ReadableSnapshot + 'static> FetchStageExecutor<Snapshot> {
     pub(crate) fn into_iterator<PreviousStage: StageAPI<Snapshot>>(
         self,
         previous_iterator: PreviousStage::OutputIterator,
-        context: ExecutionContext<Snapshot>,
+        execution_context: ExecutionContext<Snapshot>,
+        query_context: Arc<QueryContext>,
         interrupt: ExecutionInterrupt,
     ) -> (impl Iterator<Item = Result<ConceptDocument, Box<PipelineExecutionError>>>, ExecutionContext<Snapshot>) {
-        let ExecutionContext { snapshot, thing_manager, function_manager, parameters, profile } = context.clone();
         let executable = self.executable;
         let functions = self.functions;
-        let stage_profile = profile.profile_stage(|| String::from("Fetch"), executable.executable_id);
+        let stage_profile = query_context.profile.profile_stage(|| String::from("Fetch"), executable.executable_id);
         let pattern_profile = stage_profile.create_or_get_pattern(|| String::from("Fetch pattern"));
         let step = pattern_profile.extend_or_get_step(0, || String::from("Root fetch"));
         let documents_iterator = previous_iterator
-            .map_static(move |row_result| match row_result {
-                Ok(row) => execute_fetch(
-                    &executable,
-                    snapshot.clone(),
-                    thing_manager.clone(),
-                    function_manager.clone(),
-                    parameters.clone(),
-                    functions.clone(),
-                    profile.clone(),
-                    &step,
-                    row.as_reference(),
-                    interrupt.clone(),
-                )
-                .map_err(|err| Box::new(PipelineExecutionError::FetchError { typedb_source: err })),
-                Err(err) => Err(err.clone()),
+            .map_static({
+                let cloned_context = execution_context.clone();
+                move |row_result| match row_result {
+                    Ok(row) => execute_fetch(
+                        &cloned_context,
+                        query_context.clone(),
+                        &executable,
+                        functions.clone(),
+                        &step,
+                        row.as_reference(),
+                        interrupt.clone(),
+                    )
+                    .map_err(|err| Box::new(PipelineExecutionError::FetchError { typedb_source: err })),
+                    Err(err) => Err(err.clone()),
+                }
             })
             .into_iter();
-        (documents_iterator, context)
+        (documents_iterator, execution_context)
     }
 }
 
 fn execute_fetch(
+    execution_context: &ExecutionContext<impl ReadableSnapshot + 'static>,
+    query_context: Arc<QueryContext>,
     fetch: &ExecutableFetch,
-    snapshot: Arc<impl ReadableSnapshot + 'static>,
-    thing_manager: Arc<ThingManager>,
-    function_manager: Arc<FunctionManager>,
-    parameters: Arc<ParameterRegistry>,
     functions: Arc<ExecutableFunctionRegistry>,
-    query_profile: Arc<QueryProfile>,
     step: &StepProfile,
     row: MaybeOwnedRow<'_>,
     interrupt: ExecutionInterrupt,
 ) -> Result<ConceptDocument, FetchExecutionError> {
     let measurement = step.start_measurement();
-    let node = execute_object(
-        &fetch.object_instruction,
-        snapshot,
-        thing_manager,
-        function_manager,
-        parameters,
-        functions,
-        query_profile,
-        row,
-        interrupt,
-    )?;
+    let node = execute_object(execution_context, query_context, &fetch.object_instruction, functions, row, interrupt)?;
     measurement.end(step, 1, 1);
     Ok(ConceptDocument { root: node })
 }
 
 fn execute_fetch_some(
+    execution_context: &ExecutionContext<impl ReadableSnapshot + 'static>,
+    query_context: Arc<QueryContext>,
     fetch_some: &FetchSomeInstruction,
-    snapshot: Arc<impl ReadableSnapshot + 'static>,
-    thing_manager: Arc<ThingManager>,
-    function_manager: Arc<FunctionManager>,
-    parameters: Arc<ParameterRegistry>,
     functions_registry: Arc<ExecutableFunctionRegistry>,
-    query_profile: Arc<QueryProfile>,
     row: MaybeOwnedRow<'_>,
     interrupt: ExecutionInterrupt,
 ) -> Result<DocumentNode, FetchExecutionError> {
     match fetch_some {
         FetchSomeInstruction::SingleVar(position) => variable_value_to_document(row.get(*position).as_reference()),
         FetchSomeInstruction::SingleAttribute(position, attribute_type) => {
-            execute_single_attribute(snapshot, thing_manager, row, position, attribute_type)
+            execute_single_attribute(execution_context, row, position, attribute_type)
         }
         FetchSomeInstruction::SingleFunction(function, variable_positions) => execute_single_function(
-            snapshot,
-            thing_manager,
-            function_manager,
-            parameters,
+            execution_context,
+            &query_context,
             functions_registry,
-            query_profile,
             row,
             interrupt,
             variable_positions,
             function,
         ),
         FetchSomeInstruction::Label(ty) => Ok(DocumentNode::Leaf(DocumentLeaf::Concept(Concept::Type(*ty)))),
-        FetchSomeInstruction::Object(object) => execute_object(
-            object,
-            snapshot,
-            thing_manager,
-            function_manager,
-            parameters,
-            functions_registry,
-            query_profile,
-            row,
-            interrupt,
-        ),
+        FetchSomeInstruction::Object(object) => {
+            execute_object(execution_context, query_context, object, functions_registry, row, interrupt)
+        }
         FetchSomeInstruction::ListFunction(function, variable_positions) => execute_list_function(
-            snapshot,
-            thing_manager,
-            function_manager,
-            parameters,
+            execution_context,
+            &query_context,
             functions_registry,
-            query_profile,
             row,
             interrupt,
             variable_positions,
             function,
         ),
         FetchSomeInstruction::ListSubFetch(subfetch) => execute_list_subfetch(
-            snapshot,
-            thing_manager,
-            function_manager,
-            parameters,
+            execution_context,
+            query_context.clone(),
             functions_registry,
-            query_profile,
             row,
             interrupt,
             subfetch,
         ),
         FetchSomeInstruction::ListAttributesAsList(position, attribute_type) => {
-            execute_list_attributes_as_list(snapshot, thing_manager, row, position, attribute_type)
+            execute_list_attributes_as_list(execution_context, row, position, attribute_type)
         }
         FetchSomeInstruction::ListAttributesFromList(_, _) => {
             Err(FetchExecutionError::Unimplemented { description: "List attributes are not available yet." })
@@ -203,8 +169,7 @@ fn execute_fetch_some(
 }
 
 fn execute_single_attribute(
-    snapshot: Arc<impl ReadableSnapshot + 'static>,
-    thing_manager: Arc<ThingManager>,
+    execution_context: &ExecutionContext<impl ReadableSnapshot + 'static>,
     row: MaybeOwnedRow<'_>,
     position: &VariablePosition,
     attribute_type: &AttributeType,
@@ -213,10 +178,10 @@ fn execute_single_attribute(
     match variable_value {
         VariableValue::None => Ok(DocumentNode::Leaf(DocumentLeaf::Empty)),
         VariableValue::Thing(Thing::Entity(entity)) => {
-            execute_attribute_single(entity, *attribute_type, snapshot, thing_manager).map(DocumentNode::Leaf)
+            execute_attribute_single(execution_context, entity, *attribute_type).map(DocumentNode::Leaf)
         }
         VariableValue::Thing(Thing::Relation(relation)) => {
-            execute_attribute_single(relation, *attribute_type, snapshot, thing_manager).map(DocumentNode::Leaf)
+            execute_attribute_single(execution_context, relation, *attribute_type).map(DocumentNode::Leaf)
         }
         VariableValue::Thing(Thing::Attribute(_)) => Err(FetchExecutionError::FetchAttributesOfAttribute {}),
         VariableValue::Type(_) => Err(FetchExecutionError::FetchAttributesOfType {}),
@@ -226,33 +191,27 @@ fn execute_single_attribute(
 }
 
 fn execute_single_function(
-    snapshot: Arc<impl ReadableSnapshot + 'static>,
-    thing_manager: Arc<ThingManager>,
-    function_manager: Arc<FunctionManager>,
-    parameters: Arc<ParameterRegistry>,
+    execution_context: &ExecutionContext<impl ReadableSnapshot + 'static>,
+    query_context: &QueryContext,
     functions_registry: Arc<ExecutableFunctionRegistry>,
-    query_profile: Arc<QueryProfile>,
     row: MaybeOwnedRow<'_>,
     mut interrupt: ExecutionInterrupt,
     variable_positions: &HashMap<Variable, VariablePosition>,
     function: &ExecutableFunction,
 ) -> Result<DocumentNode, FetchExecutionError> {
-    let (mut pattern_executor, context) = prepare_single_function_execution(
-        snapshot,
-        thing_manager,
-        function_manager,
-        parameters,
+    let mut pattern_executor = prepare_single_function_execution(
+        execution_context,
+        query_context,
         functions_registry.clone(),
-        query_profile,
         variable_positions,
         row,
         function,
     )?;
-    let mut tabled_functions = TabledFunctions::new(functions_registry.clone());
+    let mut tabled_functions = TabledFunctions::new(functions_registry.clone(), query_context.profile.clone());
 
     let batch = exactly_one_or_return_err!(
         pattern_executor
-            .compute_next_batch(&context, &mut interrupt, &mut tabled_functions)
+            .compute_next_batch(execution_context, &query_context.parameters, &mut interrupt, &mut tabled_functions)
             .map_err(|err| FetchExecutionError::ReadExecution { typedb_source: Box::new(err) })?,
         FetchExecutionError::FetchSingleFunctionNotSingle { func_name: "func".to_string() } // TODO: Can we get function name here?
     );
@@ -286,66 +245,50 @@ fn execute_single_function(
 }
 
 fn execute_object(
+    execution_context: &ExecutionContext<impl ReadableSnapshot + 'static>,
+    query_context: Arc<QueryContext>,
     fetch_object: &FetchObjectInstruction,
-    snapshot: Arc<impl ReadableSnapshot + 'static>,
-    thing_manager: Arc<ThingManager>,
-    function_manager: Arc<FunctionManager>,
-    parameters: Arc<ParameterRegistry>,
     functions: Arc<ExecutableFunctionRegistry>,
-    query_profile: Arc<QueryProfile>,
     row: MaybeOwnedRow<'_>,
     interrupt: ExecutionInterrupt,
 ) -> Result<DocumentNode, FetchExecutionError> {
     match fetch_object {
         FetchObjectInstruction::Entries(entries) => {
-            let object = execute_object_entries(
-                entries,
-                snapshot,
-                thing_manager,
-                function_manager,
-                parameters,
-                functions,
-                query_profile,
-                row,
-                interrupt,
-            )?;
+            let object = execute_object_entries(execution_context, query_context, entries, functions, row, interrupt)?;
             Ok(DocumentNode::Map(object))
         }
-        FetchObjectInstruction::Attributes(position) => {
-            execute_object_attributes(*position, snapshot, thing_manager, row)
-        }
+        FetchObjectInstruction::Attributes(position) => execute_object_attributes(
+            *position,
+            execution_context.snapshot.as_ref(),
+            &execution_context.thing_manager,
+            row,
+        ),
     }
 }
 
 fn execute_list_function(
-    snapshot: Arc<impl ReadableSnapshot + 'static>,
-    thing_manager: Arc<ThingManager>,
-    function_manager: Arc<FunctionManager>,
-    parameters: Arc<ParameterRegistry>,
+    execution_context: &ExecutionContext<impl ReadableSnapshot + 'static>,
+    query_context: &QueryContext,
     functions_registry: Arc<ExecutableFunctionRegistry>,
-    query_profile: Arc<QueryProfile>,
     row: MaybeOwnedRow<'_>,
     mut interrupt: ExecutionInterrupt,
     variable_positions: &HashMap<Variable, VariablePosition>,
     function: &ExecutableFunction,
 ) -> Result<DocumentNode, FetchExecutionError> {
-    let (mut pattern_executor, context) = prepare_single_function_execution(
-        snapshot,
-        thing_manager,
-        function_manager,
-        parameters,
+    let mut pattern_executor = prepare_single_function_execution(
+        execution_context,
+        query_context,
         functions_registry.clone(),
-        query_profile,
         variable_positions,
         row,
         function,
     )?;
-    let mut tabled_functions = TabledFunctions::new(functions_registry.clone());
+    let mut tabled_functions = TabledFunctions::new(functions_registry.clone(), query_context.profile.clone());
 
     let mut nodes = Vec::new();
     // TODO: We could create an iterator over rows in a single call here instead
     while let Some(batch) = pattern_executor
-        .compute_next_batch(&context, &mut interrupt, &mut tabled_functions)
+        .compute_next_batch(execution_context, &query_context.parameters, &mut interrupt, &mut tabled_functions)
         .map_err(|err| FetchExecutionError::ReadExecution { typedb_source: Box::new(err) })?
     {
         for row in batch {
@@ -359,12 +302,9 @@ fn execute_list_function(
 }
 
 fn execute_list_subfetch(
-    snapshot: Arc<impl ReadableSnapshot + 'static>,
-    thing_manager: Arc<ThingManager>,
-    function_manager: Arc<FunctionManager>,
-    parameters: Arc<ParameterRegistry>,
+    execution_context: &ExecutionContext<impl ReadableSnapshot + 'static>,
+    query_context: Arc<QueryContext>,
     functions_registry: Arc<ExecutableFunctionRegistry>,
-    query_profile: Arc<QueryProfile>,
     row: MaybeOwnedRow<'_>,
     interrupt: ExecutionInterrupt,
     executable_subfetch: &ExecutableFetchListSubFetch,
@@ -378,18 +318,15 @@ fn execute_list_subfetch(
         });
     });
     let pipeline = Pipeline::build_read_pipeline(
-        snapshot,
-        thing_manager,
-        function_manager,
+        execution_context.clone(),
+        query_context,
         variable_registry.variable_names(),
         None,
         functions_registry,
         None,
         stages,
         Some(fetch.clone()),
-        parameters,
         initial_batch,
-        query_profile,
     )
     .map_err(|typedb_source| FetchExecutionError::Pipeline { typedb_source })?;
 
@@ -405,8 +342,7 @@ fn execute_list_subfetch(
 }
 
 fn execute_list_attributes_as_list(
-    snapshot: Arc<impl ReadableSnapshot + 'static>,
-    thing_manager: Arc<ThingManager>,
+    execution_context: &ExecutionContext<impl ReadableSnapshot>,
     row: MaybeOwnedRow<'_>,
     position: &VariablePosition,
     attribute_type: &AttributeType,
@@ -415,10 +351,10 @@ fn execute_list_attributes_as_list(
     match variable_value {
         VariableValue::None => Ok(DocumentNode::Leaf(DocumentLeaf::Empty)),
         VariableValue::Thing(Thing::Entity(entity)) => {
-            execute_attributes_list(entity, *attribute_type, snapshot, thing_manager).map(DocumentNode::List)
+            execute_attributes_list(entity, *attribute_type, execution_context).map(DocumentNode::List)
         }
         VariableValue::Thing(Thing::Relation(relation)) => {
-            execute_attributes_list(relation, *attribute_type, snapshot, thing_manager).map(DocumentNode::List)
+            execute_attributes_list(relation, *attribute_type, execution_context).map(DocumentNode::List)
         }
         VariableValue::Thing(Thing::Attribute(_)) => Err(FetchExecutionError::FetchAttributesOfAttribute {}),
         VariableValue::Type(_) => Err(FetchExecutionError::FetchAttributesOfType {}),
@@ -429,8 +365,8 @@ fn execute_list_attributes_as_list(
 
 fn execute_object_attributes(
     variable_position: VariablePosition,
-    snapshot: Arc<impl ReadableSnapshot>,
-    thing_manager: Arc<ThingManager>,
+    snapshot: &impl ReadableSnapshot,
+    thing_manager: &ThingManager,
     row: MaybeOwnedRow<'_>,
 ) -> Result<DocumentNode, FetchExecutionError> {
     let concept = row.get(variable_position);
@@ -447,11 +383,11 @@ fn execute_object_attributes(
 
 fn execute_attributes_all(
     object: impl ObjectAPI,
-    snapshot: Arc<impl ReadableSnapshot>,
-    thing_manager: Arc<ThingManager>,
+    snapshot: &impl ReadableSnapshot,
+    thing_manager: &ThingManager,
 ) -> Result<DocumentNode, FetchExecutionError> {
     let iter = object
-        .get_has_unordered(snapshot.as_ref(), &thing_manager, StorageCounters::DISABLED)
+        .get_has_unordered(snapshot, &thing_manager, StorageCounters::DISABLED)
         .map_err(|err| FetchExecutionError::ConceptRead { typedb_source: err })?;
     let mut map: HashMap<Arc<Label>, DocumentNode> = HashMap::new();
     for result in iter {
@@ -459,13 +395,13 @@ fn execute_attributes_all(
         let attribute = has.attribute();
         let attribute_type = attribute.type_();
         let label = attribute_type
-            .get_label_arc(snapshot.as_ref(), thing_manager.type_manager())
+            .get_label_arc(snapshot, thing_manager.type_manager())
             .map_err(|err| FetchExecutionError::ConceptRead { typedb_source: err })?;
         let leaf = DocumentNode::Leaf(DocumentLeaf::Concept(Concept::Thing(Thing::Attribute(attribute.clone()))));
 
         let is_bounded_to_one = object
             .type_()
-            .is_owned_attribute_type_bounded_to_one(snapshot.as_ref(), thing_manager.type_manager(), attribute_type)
+            .is_owned_attribute_type_bounded_to_one(snapshot, thing_manager.type_manager(), attribute_type)
             .map_err(|err| FetchExecutionError::ConceptRead { typedb_source: err })?;
         if is_bounded_to_one {
             map.insert(label, leaf);
@@ -480,19 +416,27 @@ fn execute_attributes_all(
 }
 
 fn execute_attribute_single(
+    execution_context: &ExecutionContext<impl ReadableSnapshot>,
     object: impl ObjectAPI,
     attribute_type: AttributeType,
-    snapshot: Arc<impl ReadableSnapshot>,
-    thing_manager: Arc<ThingManager>,
 ) -> Result<DocumentLeaf, FetchExecutionError> {
-    let iter = prepare_attribute_type_has_iterator(object, attribute_type, &snapshot, &thing_manager)?;
+    let iter = prepare_attribute_type_has_iterator(
+        object,
+        attribute_type,
+        execution_context.snapshot.as_ref(),
+        execution_context.thing_manager.as_ref(),
+    )?;
 
     for result in iter {
         let (has, count) = result.map_err(|source| FetchExecutionError::ConceptRead { typedb_source: source })?;
         let attribute = has.attribute();
         let suitable = attribute
             .type_()
-            .is_subtype_transitive_of_or_same(snapshot.as_ref(), thing_manager.type_manager(), attribute_type)
+            .is_subtype_transitive_of_or_same(
+                execution_context.snapshot.as_ref(),
+                execution_context.thing_manager.type_manager(),
+                attribute_type,
+            )
             .map_err(|source| FetchExecutionError::ConceptRead { typedb_source: source })?;
         if suitable {
             debug_assert!(count <= 1);
@@ -502,21 +446,29 @@ fn execute_attribute_single(
     Ok(DocumentLeaf::Empty)
 }
 
-fn execute_attributes_list(
+fn execute_attributes_list<Snapshot: ReadableSnapshot>(
     object: impl ObjectAPI,
     attribute_type: AttributeType,
-    snapshot: Arc<impl ReadableSnapshot>,
-    thing_manager: Arc<ThingManager>,
+    execution_context: &ExecutionContext<Snapshot>,
 ) -> Result<DocumentList, FetchExecutionError> {
     let mut list = DocumentList::new();
-    let iter = prepare_attribute_type_has_iterator(object, attribute_type, &snapshot, &thing_manager)?;
+    let iter = prepare_attribute_type_has_iterator(
+        object,
+        attribute_type,
+        execution_context.snapshot.as_ref(),
+        execution_context.thing_manager.as_ref(),
+    )?;
 
     for result in iter {
         let (has, count) = result.map_err(|source| FetchExecutionError::ConceptRead { typedb_source: source })?;
         let attribute = has.attribute();
         let suitable = attribute
             .type_()
-            .is_subtype_transitive_of_or_same(snapshot.as_ref(), thing_manager.type_manager(), attribute_type)
+            .is_subtype_transitive_of_or_same(
+                execution_context.snapshot.as_ref(),
+                execution_context.thing_manager.type_manager(),
+                attribute_type,
+            )
             .map_err(|source| FetchExecutionError::ConceptRead { typedb_source: source })?;
         if suitable {
             for _ in 0..count {
@@ -529,18 +481,18 @@ fn execute_attributes_list(
     Ok(list)
 }
 
-fn prepare_attribute_type_has_iterator<'a>(
+fn prepare_attribute_type_has_iterator<'a, Snapshot: ReadableSnapshot>(
     object: impl ObjectAPI,
     attribute_type: AttributeType,
-    snapshot: &'a Arc<impl ReadableSnapshot>,
-    thing_manager: &'a Arc<ThingManager>,
+    snapshot: &'a Snapshot,
+    thing_manager: &'a ThingManager,
 ) -> Result<impl Iterator<Item = Result<(Has, u64), Box<ConceptReadError>>> + 'a, FetchExecutionError> {
     let subtypes = attribute_type
-        .get_subtypes_transitive(snapshot.as_ref(), thing_manager.type_manager())
+        .get_subtypes_transitive(snapshot, thing_manager.type_manager())
         .map_err(|source| FetchExecutionError::ConceptRead { typedb_source: source })?;
     let iter = Iterator::filter(
         object
-            .get_has_types_range_unordered(snapshot.as_ref(), thing_manager.as_ref(), StorageCounters::DISABLED)
+            .get_has_types_range_unordered(snapshot, thing_manager, StorageCounters::DISABLED)
             .map_err(|err| FetchExecutionError::ConceptRead { typedb_source: err })?,
         move |result| {
             result.as_ref().is_ok_and(|(has, _count)| {
@@ -552,16 +504,14 @@ fn prepare_attribute_type_has_iterator<'a>(
 }
 
 fn prepare_single_function_execution<Snapshot: ReadableSnapshot + 'static>(
-    snapshot: Arc<Snapshot>,
-    thing_manager: Arc<ThingManager>,
-    function_manager: Arc<FunctionManager>,
-    parameters: Arc<ParameterRegistry>,
+    execution_context: &ExecutionContext<Snapshot>,
+    query_context: &QueryContext,
     functions_registry: Arc<ExecutableFunctionRegistry>,
-    query_profile: Arc<QueryProfile>,
     variable_positions: &HashMap<Variable, VariablePosition>,
     row: MaybeOwnedRow<'_>,
     function: &ExecutableFunction,
-) -> Result<(PatternExecutor, Arc<ExecutionContext<Snapshot>>), FetchExecutionError> {
+    // TODO: verify that this doesn't need to actually return a new ExecutionContext (eg. reuses parameters?)
+) -> Result<PatternExecutor, FetchExecutionError> {
     let mut args = vec![VariableValue::None; function.argument_positions.len()];
     for (var, write_pos) in &function.argument_positions {
         debug_assert!(write_pos.as_usize() < args.len());
@@ -570,21 +520,18 @@ fn prepare_single_function_execution<Snapshot: ReadableSnapshot + 'static>(
     let args = MaybeOwnedRow::new_owned(args, row.multiplicity(), Provenance::INITIAL);
 
     let step_executors =
-        create_executors_for_function(&snapshot, &thing_manager, &functions_registry, query_profile, function)
+        create_executors_for_function(execution_context, &functions_registry, query_context.profile.clone(), function)
             .map_err(|err| FetchExecutionError::ConceptRead { typedb_source: err })?;
     let mut pattern_executor = PatternExecutor::new(next_executable_id(), step_executors);
     pattern_executor.prepare(FixedBatch::from(args));
-    Ok((pattern_executor, Arc::new(ExecutionContext::new(snapshot, thing_manager, function_manager, parameters))))
+    Ok(pattern_executor)
 }
 
 fn execute_object_entries(
+    execution_context: &ExecutionContext<impl ReadableSnapshot + 'static>,
+    query_context: Arc<QueryContext>,
     entries: &HashMap<ParameterID, FetchSomeInstruction>,
-    snapshot: Arc<impl ReadableSnapshot + 'static>,
-    thing_manager: Arc<ThingManager>,
-    function_manager: Arc<FunctionManager>,
-    parameters: Arc<ParameterRegistry>,
     functions: Arc<ExecutableFunctionRegistry>,
-    query_profile: Arc<QueryProfile>,
     row: MaybeOwnedRow<'_>,
     interrupt: ExecutionInterrupt,
 ) -> Result<DocumentMap, FetchExecutionError> {
@@ -593,13 +540,10 @@ fn execute_object_entries(
         map.insert(
             id.clone(),
             execute_fetch_some(
+                execution_context,
+                query_context.clone(),
                 fetch_some,
-                snapshot.clone(),
-                thing_manager.clone(),
-                function_manager.clone(),
-                parameters.clone(),
                 functions.clone(),
-                query_profile.clone(),
                 row.as_reference(),
                 interrupt.clone(),
             )?,

--- a/executor/pipeline/given.rs
+++ b/executor/pipeline/given.rs
@@ -7,10 +7,9 @@ use std::{marker::PhantomData, sync::Arc};
 
 use answer::variable_value::VariableValue;
 use compiler::{annotation::function::FunctionParameterAnnotation, executable::pipeline::GivenExecutable};
-use concept::thing::ThingAPI;
 use encoding::value::ValueEncodable;
 use error::needs_update_when_feature_is_implemented;
-use ir::pattern::variable_category::VariableOptionality;
+use ir::{pattern::variable_category::VariableOptionality, pipeline::QueryContext};
 use lending_iterator::LendingIterator;
 use resource::profile::{StepProfile, StorageCounters};
 use storage::snapshot::ReadableSnapshot;
@@ -46,13 +45,17 @@ where
     fn into_iterator(
         self,
         input_iterator: Self::InputIterator,
-        context: ExecutionContext<Snapshot>,
-        interrupt: ExecutionInterrupt,
+        execution_context: ExecutionContext<Snapshot>,
+        query_context: Arc<QueryContext>,
+        _interrupt: ExecutionInterrupt,
     ) -> Result<
         (Self::OutputIterator, ExecutionContext<Snapshot>),
         (Box<PipelineExecutionError>, ExecutionContext<Snapshot>),
     > {
-        Ok((GivenStageIterator::new(context.clone(), self.executable, input_iterator), context))
+        Ok((
+            GivenStageIterator::new(execution_context.clone(), &query_context, self.executable, input_iterator),
+            execution_context,
+        ))
     }
 }
 
@@ -67,10 +70,11 @@ pub struct GivenStageIterator<Snapshot: ReadableSnapshot + 'static, InputIterato
 impl<Snapshot: ReadableSnapshot + 'static, InputIterator: StageIterator> GivenStageIterator<Snapshot, InputIterator> {
     pub(crate) fn new(
         context: ExecutionContext<Snapshot>,
+        query_context: &QueryContext,
         executable: Arc<GivenExecutable>,
         source_iterator: InputIterator,
     ) -> Self {
-        let stage_profile = context.profile.profile_stage(|| "Given".to_owned(), executable.executable_id);
+        let stage_profile = query_context.profile.profile_stage(|| "Given".to_owned(), executable.executable_id);
         let pattern_profile = stage_profile.create_or_get_pattern(|| "Given".to_owned());
         let profile = pattern_profile.extend_or_get_step(0, || "Given validation".to_owned());
         Self { context, executable, source_iterator, row_counter: 0, profile }

--- a/executor/pipeline/initial.rs
+++ b/executor/pipeline/initial.rs
@@ -8,7 +8,7 @@ use lending_iterator::LendingIterator;
 
 use crate::{
     batch::{Batch, BatchRowIterator},
-    pipeline::{PipelineExecutionError, StageIterator, stage::StageAPI},
+    pipeline::{PipelineExecutionError, StageIterator},
     row::MaybeOwnedRow,
 };
 

--- a/executor/pipeline/insert.rs
+++ b/executor/pipeline/insert.rs
@@ -14,7 +14,7 @@ use compiler::{
     },
 };
 use concept::thing::thing_manager::ThingManager;
-use ir::pipeline::ParameterRegistry;
+use ir::pipeline::{ParameterRegistry, QueryContext};
 use itertools::Itertools;
 use resource::{
     constants::traversal::{BATCH_DEFAULT_CAPACITY, CHECK_INTERRUPT_FREQUENCY_ROWS},
@@ -59,7 +59,8 @@ where
     fn into_iterator(
         self,
         input_iterator: Self::InputIterator,
-        mut context: ExecutionContext<Snapshot>,
+        mut execution_context: ExecutionContext<Snapshot>,
+        query_context: Arc<QueryContext>,
         mut interrupt: ExecutionInterrupt,
     ) -> Result<
         (Self::OutputIterator, ExecutionContext<Snapshot>),
@@ -67,7 +68,7 @@ where
     > {
         let Self { executable, .. } = self;
 
-        let profile = context.profile.profile_stage(|| String::from("Insert"), executable.executable_id);
+        let profile = query_context.profile.profile_stage(|| String::from("Insert"), executable.executable_id);
         let pattern_profile = profile.create_or_get_pattern(|| String::from("Insert pattern"));
         let (concept_profiles, connection_profiles, optional_concept_profiles, optional_connection_profiles) =
             build_step_profiles(&executable, &pattern_profile);
@@ -85,11 +86,11 @@ where
         let mut batch =
             match prepare_output_rows(executable.output_width() as u32, input_iterator, &input_output_mapping) {
                 Ok(output_rows) => output_rows,
-                Err(err) => return Err((err, context)),
+                Err(err) => return Err((err, execution_context)),
             };
 
         // once the previous iterator is complete, this must be the exclusive owner of Arc's, so we can get mut:
-        let snapshot_mut = Arc::get_mut(&mut context.snapshot).unwrap();
+        let snapshot_mut = Arc::get_mut(&mut execution_context.snapshot).unwrap();
         for index in 0..batch.len() {
             // TODO: parallelise -- though this requires our snapshots support parallel writes!
             let mut row = batch.get_row_mut(index);
@@ -97,24 +98,24 @@ where
             if let Err(typedb_source) = execute_insert(
                 &executable,
                 snapshot_mut,
-                &context.thing_manager,
-                &context.parameters,
+                &execution_context.thing_manager,
+                &query_context.parameters,
                 &mut row,
                 &concept_profiles,
                 &connection_profiles,
                 &optional_concept_profiles,
                 &optional_connection_profiles,
             ) {
-                return Err((Box::new(PipelineExecutionError::WriteError { typedb_source }), context));
+                return Err((Box::new(PipelineExecutionError::WriteError { typedb_source }), execution_context));
             }
 
             if index % CHECK_INTERRUPT_FREQUENCY_ROWS == 0 {
                 if let Some(interrupt) = interrupt.check() {
-                    return Err((Box::new(PipelineExecutionError::Interrupted { interrupt }), context));
+                    return Err((Box::new(PipelineExecutionError::Interrupted { interrupt }), execution_context));
                 }
             }
         }
-        Ok((WrittenRowsIterator::new(batch), context))
+        Ok((WrittenRowsIterator::new(batch), execution_context))
     }
 }
 

--- a/executor/pipeline/match_.rs
+++ b/executor/pipeline/match_.rs
@@ -9,6 +9,7 @@ use std::{iter::Peekable, marker::PhantomData, sync::Arc};
 use compiler::executable::{
     function::ExecutableFunctionRegistry, match_::planner::conjunction_executable::ConjunctionExecutable,
 };
+use ir::pipeline::QueryContext;
 use itertools::{Itertools, UniqueBy};
 use lending_iterator::{IntoIter, LendingIterator, adaptors::Map};
 use storage::snapshot::ReadableSnapshot;
@@ -47,7 +48,8 @@ where
     fn into_iterator(
         self,
         input_iterator: Self::InputIterator,
-        context: ExecutionContext<Snapshot>,
+        execution_context: ExecutionContext<Snapshot>,
+        query_context: Arc<QueryContext>,
         interrupt: ExecutionInterrupt,
     ) -> Result<
         (Self::OutputIterator, ExecutionContext<Snapshot>),
@@ -55,14 +57,22 @@ where
     > {
         let Self { executable, function_registry, .. } = self;
         Ok((
-            MatchStageIterator::new(input_iterator, executable, function_registry, context.clone(), interrupt),
-            context,
+            MatchStageIterator::new(
+                input_iterator,
+                executable,
+                function_registry,
+                execution_context.clone(),
+                query_context,
+                interrupt,
+            ),
+            execution_context,
         ))
     }
 }
 
 pub struct MatchStageIterator<Snapshot: ReadableSnapshot + 'static, InputIterator> {
-    context: ExecutionContext<Snapshot>,
+    execution_context: ExecutionContext<Snapshot>,
+    query_context: Arc<QueryContext>,
     executable: Arc<ConjunctionExecutable>,
     function_registry: Arc<ExecutableFunctionRegistry>,
     source_iterator: InputIterator,
@@ -75,10 +85,19 @@ impl<Snapshot: ReadableSnapshot + 'static, InputIterator> MatchStageIterator<Sna
         iterator: InputIterator,
         executable: Arc<ConjunctionExecutable>,
         function_registry: Arc<ExecutableFunctionRegistry>,
-        context: ExecutionContext<Snapshot>,
+        execution_context: ExecutionContext<Snapshot>,
+        query_context: Arc<QueryContext>,
         interrupt: ExecutionInterrupt,
     ) -> Self {
-        Self { context, executable, function_registry, source_iterator: iterator, current_iterator: None, interrupt }
+        Self {
+            execution_context,
+            query_context,
+            executable,
+            function_registry,
+            source_iterator: iterator,
+            current_iterator: None,
+            interrupt,
+        }
     }
 }
 
@@ -91,8 +110,6 @@ where
 
     fn next(&mut self) -> Option<Self::Item<'_>> {
         while !self.current_iterator.as_mut().is_some_and(|iter| iter.peek().is_some()) {
-            let ExecutionContext { snapshot, thing_manager, profile, .. } = &self.context;
-
             let input_row = match self.source_iterator.next()? {
                 Ok(row) => row,
                 Err(err) => return Some(Err(err)),
@@ -100,20 +117,21 @@ where
 
             let executor = MatchExecutor::new(
                 &self.executable,
-                snapshot,
-                thing_manager,
+                &self.execution_context,
                 input_row,
                 self.function_registry.clone(),
-                profile,
+                &self.query_context.profile,
             )
             .map_err(|err| Box::new(PipelineExecutionError::InitialisingMatchIterator { typedb_source: err }));
 
             match executor {
                 Ok(executor) => {
                     self.current_iterator = Some(
-                        unique_rows(as_owned_rows(
-                            executor.into_iterator(self.context.clone(), self.interrupt.clone()),
-                        ))
+                        unique_rows(as_owned_rows(executor.into_iterator(
+                            self.execution_context.clone(),
+                            self.query_context.clone(),
+                            self.interrupt.clone(),
+                        )))
                         .peekable(),
                     );
                 }

--- a/executor/pipeline/modifiers.rs
+++ b/executor/pipeline/modifiers.rs
@@ -12,7 +12,7 @@ use compiler::{
         DistinctExecutable, LimitExecutable, OffsetExecutable, RequireExecutable, SelectExecutable, SortExecutable,
     },
 };
-use ir::pipeline::modifier::SortVariable;
+use ir::pipeline::{QueryContext, modifier::SortVariable};
 use lending_iterator::{LendingIterator, Peekable};
 use resource::profile::StorageCounters;
 use storage::snapshot::ReadableSnapshot;
@@ -50,7 +50,8 @@ where
     fn into_iterator(
         self,
         input_iterator: Self::InputIterator,
-        context: ExecutionContext<Snapshot>,
+        execution_context: ExecutionContext<Snapshot>,
+        query_context: Arc<QueryContext>,
         _interrupt: ExecutionInterrupt,
     ) -> Result<
         (Self::OutputIterator, ExecutionContext<Snapshot>),
@@ -60,17 +61,17 @@ where
         // accumulate once, then we will operate in-place
         let batch = match input_iterator.collect_owned() {
             Ok(batch) => batch,
-            Err(err) => return Err((err, context)),
+            Err(err) => return Err((err, execution_context)),
         };
         let batch_len = batch.len();
-        let profile = context.profile.profile_stage(|| String::from("Sort"), executable.executable_id);
+        let profile = query_context.profile.profile_stage(|| String::from("Sort"), executable.executable_id);
         let pattern_profile = profile.create_or_get_pattern(|| String::from("Sort"));
         let step_profile = pattern_profile.extend_or_get_step(0, || String::from("Sort execution"));
         let measurement = step_profile.start_measurement();
         let sorted_iterator =
-            SortStageIterator::from_unsorted(batch, &executable, &context, step_profile.storage_counters());
+            SortStageIterator::from_unsorted(batch, &executable, &execution_context, step_profile.storage_counters());
         measurement.end(&step_profile, 1, batch_len as u64);
-        Ok((sorted_iterator, context))
+        Ok((sorted_iterator, execution_context))
     }
 }
 
@@ -139,14 +140,15 @@ where
     fn into_iterator(
         self,
         input_iterator: Self::InputIterator,
-        context: ExecutionContext<Snapshot>,
+        execution_context: ExecutionContext<Snapshot>,
+        _query_context: Arc<QueryContext>,
         _interrupt: ExecutionInterrupt,
     ) -> Result<
         (Self::OutputIterator, ExecutionContext<Snapshot>),
         (Box<PipelineExecutionError>, ExecutionContext<Snapshot>),
     > {
         let Self { offset_executable, .. } = self;
-        Ok((OffsetStageIterator::new(input_iterator, offset_executable.offset), context))
+        Ok((OffsetStageIterator::new(input_iterator, offset_executable.offset), execution_context))
     }
 }
 
@@ -205,14 +207,15 @@ where
     fn into_iterator(
         self,
         input_iterator: Self::InputIterator,
-        context: ExecutionContext<Snapshot>,
+        execution_context: ExecutionContext<Snapshot>,
+        _query_context: Arc<QueryContext>,
         _interrupt: ExecutionInterrupt,
     ) -> Result<
         (Self::OutputIterator, ExecutionContext<Snapshot>),
         (Box<PipelineExecutionError>, ExecutionContext<Snapshot>),
     > {
         let Self { limit_executable, .. } = self;
-        Ok((LimitStageIterator::new(input_iterator, limit_executable.limit), context))
+        Ok((LimitStageIterator::new(input_iterator, limit_executable.limit), execution_context))
     }
 }
 
@@ -268,13 +271,17 @@ where
     fn into_iterator(
         self,
         input_iterator: Self::InputIterator,
-        context: ExecutionContext<Snapshot>,
+        execution_context: ExecutionContext<Snapshot>,
+        _query_context: Arc<QueryContext>,
         _interrupt: ExecutionInterrupt,
     ) -> Result<
         (Self::OutputIterator, ExecutionContext<Snapshot>),
         (Box<PipelineExecutionError>, ExecutionContext<Snapshot>),
     > {
-        Ok((SelectStageIterator::new(input_iterator, self.select_executable.retained_positions.clone()), context))
+        Ok((
+            SelectStageIterator::new(input_iterator, self.select_executable.retained_positions.clone()),
+            execution_context,
+        ))
     }
 }
 
@@ -338,14 +345,15 @@ where
     fn into_iterator(
         self,
         input_iterator: Self::InputIterator,
-        context: ExecutionContext<Snapshot>,
+        execution_context: ExecutionContext<Snapshot>,
+        _query_context: Arc<QueryContext>,
         _interrupt: ExecutionInterrupt,
     ) -> Result<
         (Self::OutputIterator, ExecutionContext<Snapshot>),
         (Box<PipelineExecutionError>, ExecutionContext<Snapshot>),
     > {
         let Self { require_executable, .. } = self;
-        Ok((RequireStageIterator::new(input_iterator, require_executable), context))
+        Ok((RequireStageIterator::new(input_iterator, require_executable), execution_context))
     }
 }
 
@@ -407,7 +415,8 @@ where
     fn into_iterator(
         self,
         input_iterator: Self::InputIterator,
-        context: ExecutionContext<Snapshot>,
+        execution_context: ExecutionContext<Snapshot>,
+        _query_context: Arc<QueryContext>,
         _interrupt: ExecutionInterrupt,
     ) -> Result<
         (Self::OutputIterator, ExecutionContext<Snapshot>),
@@ -415,7 +424,7 @@ where
     > {
         let Self { .. } = self;
         let distinct_iterator = DistinctStageIterator::new(input_iterator);
-        Ok((distinct_iterator, context))
+        Ok((distinct_iterator, execution_context))
     }
 }
 

--- a/executor/pipeline/pipeline.rs
+++ b/executor/pipeline/pipeline.rs
@@ -16,11 +16,8 @@ use compiler::{
     },
     query_structure::{ParametrisedPipelineStructure, PipelineStructure},
 };
-use concept::thing::thing_manager::ThingManager;
 use error::typedb_error;
-use function::function_manager::FunctionManager;
-use ir::pipeline::ParameterRegistry;
-use resource::profile::QueryProfile;
+use ir::pipeline::QueryContext;
 use storage::snapshot::{ReadableSnapshot, WritableSnapshot};
 
 use crate::{
@@ -54,7 +51,8 @@ pub struct Pipeline<Snapshot: ReadableSnapshot, Nonterminals: StageAPI<Snapshot>
     named_outputs: HashMap<String, VariablePosition>,
     pipeline_structure: Option<PipelineStructure>,
     fetch: Option<FetchStageExecutor<Snapshot>>,
-    context: ExecutionContext<Snapshot>,
+    execution_context: ExecutionContext<Snapshot>,
+    query_context: Arc<QueryContext>,
 }
 
 impl<Snapshot: ReadableSnapshot + 'static, Nonterminals> Pipeline<Snapshot, Nonterminals>
@@ -69,14 +67,15 @@ where
         stages: Vec<Nonterminals>,
         last_stage_output_positions: HashMap<Variable, VariablePosition>,
         executable_fetch: Option<Arc<ExecutableFetch>>,
-        context: ExecutionContext<Snapshot>,
+        execution_context: ExecutionContext<Snapshot>,
+        query_context: Arc<QueryContext>,
     ) -> Self {
         let named_outputs = last_stage_output_positions
             .iter()
             .filter_map(|(variable, &position)| variable_names.get(variable).map(|name| (name.clone(), position)))
             .collect::<HashMap<_, _>>();
         let fetch = executable_fetch.map(|executable| FetchStageExecutor::new(executable, executable_functions));
-        Self { initial_iterator, named_outputs, stages, fetch, pipeline_structure, context }
+        Self { initial_iterator, named_outputs, stages, fetch, pipeline_structure, execution_context, query_context }
     }
 
     pub fn has_fetch(&self) -> bool {
@@ -93,31 +92,25 @@ where
     pub fn pipeline_structure(&self) -> Option<&PipelineStructure> {
         self.pipeline_structure.as_ref()
     }
+
+    pub fn query_context(&self) -> &QueryContext {
+        &self.query_context
+    }
 }
 
 impl<Snapshot: ReadableSnapshot + 'static> Pipeline<Snapshot, ReadPipelineStage<Snapshot>> {
     pub fn build_read_pipeline(
-        snapshot: Arc<Snapshot>,
-        thing_manager: Arc<ThingManager>,
-        function_manager: Arc<FunctionManager>,
+        execution_context: ExecutionContext<Snapshot>,
+        query_context: Arc<QueryContext>,
         variable_names: &HashMap<Variable, String>,
         pipeline_structure: Option<Arc<ParametrisedPipelineStructure>>,
         executable_functions: Arc<ExecutableFunctionRegistry>,
         executable_given: Option<Arc<GivenExecutable>>,
         executable_stages: &[ExecutableStage],
         executable_fetch: Option<Arc<ExecutableFetch>>,
-        parameters: Arc<ParameterRegistry>,
         given_batch: Batch,
-        query_profile: Arc<QueryProfile>,
     ) -> Result<Self, Box<PipelineError>> {
         let output_variable_positions = executable_stages.last().unwrap().output_row_mapping();
-        let context = ExecutionContext::new_with_profile(
-            snapshot,
-            thing_manager,
-            function_manager,
-            parameters.clone(),
-            query_profile,
-        );
 
         let initial_iterator = InitialStage::new(given_batch);
         let initial_iterator = ReadStageIterator::Initial(Box::new(initial_iterator.into_iterator()));
@@ -179,13 +172,15 @@ impl<Snapshot: ReadableSnapshot + 'static> Pipeline<Snapshot, ReadPipelineStage<
         }
         Ok(Pipeline::build_with_fetch(
             variable_names,
-            pipeline_structure.map(|qs| qs.with_parameters(parameters, &variable_names)),
+            // TODO: this shouldn't clone fresh parameters?
+            pipeline_structure.map(|qs| qs.with_parameters(query_context.parameters.clone(), &variable_names)),
             executable_functions.clone(),
             initial_iterator,
             stages,
             output_variable_positions,
             executable_fetch,
-            context,
+            execution_context,
+            query_context,
         ))
     }
 
@@ -197,8 +192,14 @@ impl<Snapshot: ReadableSnapshot + 'static> Pipeline<Snapshot, ReadPipelineStage<
         (Box<PipelineExecutionError>, ExecutionContext<Snapshot>),
     > {
         match self.fetch {
-            None => Self::run_stages(self.initial_iterator, self.stages, self.context, execution_interrupt),
-            Some(_) => Err((Box::new(PipelineExecutionError::FetchUsedAsRows {}), self.context)),
+            None => Self::run_stages(
+                self.initial_iterator,
+                self.stages,
+                self.execution_context,
+                self.query_context,
+                execution_interrupt,
+            ),
+            Some(_) => Err((Box::new(PipelineExecutionError::FetchUsedAsRows {}), self.execution_context)),
         }
     }
 
@@ -210,13 +211,20 @@ impl<Snapshot: ReadableSnapshot + 'static> Pipeline<Snapshot, ReadPipelineStage<
         (Box<PipelineExecutionError>, ExecutionContext<Snapshot>),
     > {
         match self.fetch {
-            None => Err((Box::new(PipelineExecutionError::RowsUsedAsFetch {}), self.context)),
+            None => Err((Box::new(PipelineExecutionError::RowsUsedAsFetch {}), self.execution_context)),
             Some(fetch_executor) => {
-                let (rows_iterator, context) =
-                    Self::run_stages(self.initial_iterator, self.stages, self.context, execution_interrupt.clone())?;
+                let query_context = self.query_context;
+                let (rows_iterator, execution_context) = Self::run_stages(
+                    self.initial_iterator,
+                    self.stages,
+                    self.execution_context,
+                    query_context.clone(),
+                    execution_interrupt.clone(),
+                )?;
                 Ok(fetch_executor.into_iterator::<ReadPipelineStage<Snapshot>>(
                     rows_iterator,
-                    context,
+                    execution_context,
+                    query_context,
                     execution_interrupt,
                 ))
             }
@@ -226,17 +234,18 @@ impl<Snapshot: ReadableSnapshot + 'static> Pipeline<Snapshot, ReadPipelineStage<
     fn run_stages(
         initial_iterator: ReadStageIterator<Snapshot>,
         stages: Vec<ReadPipelineStage<Snapshot>>,
-        context: ExecutionContext<Snapshot>,
+        execution_context: ExecutionContext<Snapshot>,
+        query_context: Arc<QueryContext>,
         execution_interrupt: ExecutionInterrupt,
     ) -> Result<
         (ReadStageIterator<Snapshot>, ExecutionContext<Snapshot>),
         (Box<PipelineExecutionError>, ExecutionContext<Snapshot>),
     > {
         let mut current_iterator = initial_iterator;
-        let mut context = context;
+        let mut context = execution_context;
         for stage in stages {
             let (next_iterator, next_context) =
-                stage.into_iterator(current_iterator, context, execution_interrupt.clone())?;
+                stage.into_iterator(current_iterator, context, query_context.clone(), execution_interrupt.clone())?;
             current_iterator = next_iterator;
             context = next_context;
         }
@@ -246,27 +255,17 @@ impl<Snapshot: ReadableSnapshot + 'static> Pipeline<Snapshot, ReadPipelineStage<
 
 impl<Snapshot: WritableSnapshot + 'static> Pipeline<Snapshot, WritePipelineStage<Snapshot>> {
     pub fn build_write_pipeline(
-        snapshot: Snapshot,
+        execution_context: ExecutionContext<Snapshot>,
+        query_context: Arc<QueryContext>,
         variable_names: &HashMap<Variable, String>,
         pipeline_structure: Option<Arc<ParametrisedPipelineStructure>>,
-        thing_manager: Arc<ThingManager>,
-        function_manager: Arc<FunctionManager>,
         executable_functions: Arc<ExecutableFunctionRegistry>,
         executable_given: Option<Arc<GivenExecutable>>,
         executable_stages: Vec<ExecutableStage>,
         executable_fetch: Option<Arc<ExecutableFetch>>,
-        parameters: Arc<ParameterRegistry>,
         given_batch: Batch,
-        query_profile: Arc<QueryProfile>,
     ) -> Self {
         let output_variable_positions = executable_stages.last().unwrap().output_row_mapping();
-        let context = ExecutionContext::new_with_profile(
-            Arc::new(snapshot),
-            thing_manager,
-            function_manager,
-            parameters.clone(),
-            query_profile,
-        );
 
         let initial_iterator = WriteStageIterator::Initial(Box::new(InitialIterator::new(given_batch)));
         let mut stages = if let Some(given) = executable_given {
@@ -331,30 +330,33 @@ impl<Snapshot: WritableSnapshot + 'static> Pipeline<Snapshot, WritePipelineStage
         }
         Pipeline::build_with_fetch(
             variable_names,
-            pipeline_structure.map(|qs| qs.with_parameters(parameters, &variable_names)),
+            // TODO: this shouldn't clone
+            pipeline_structure.map(|qs| qs.with_parameters(query_context.parameters.clone(), &variable_names)),
             executable_functions.clone(),
             initial_iterator,
             stages,
             output_variable_positions,
             executable_fetch,
-            context,
+            execution_context,
+            query_context,
         )
     }
 
     fn run_stages(
         initial_iterator: WriteStageIterator<Snapshot>,
         stages: Vec<WritePipelineStage<Snapshot>>,
-        context: ExecutionContext<Snapshot>,
+        execution_context: ExecutionContext<Snapshot>,
+        query_context: Arc<QueryContext>,
         execution_interrupt: ExecutionInterrupt,
     ) -> Result<
         (WriteStageIterator<Snapshot>, ExecutionContext<Snapshot>),
         (Box<PipelineExecutionError>, ExecutionContext<Snapshot>),
     > {
         let mut current_iterator = initial_iterator;
-        let mut context = context;
+        let mut context = execution_context;
         for stage in stages {
             let (next_iterator, next_context) =
-                stage.into_iterator(current_iterator, context, execution_interrupt.clone())?;
+                stage.into_iterator(current_iterator, context, query_context.clone(), execution_interrupt.clone())?;
             current_iterator = next_iterator;
             context = next_context;
         }
@@ -369,8 +371,14 @@ impl<Snapshot: WritableSnapshot + 'static> Pipeline<Snapshot, WritePipelineStage
         (Box<PipelineExecutionError>, ExecutionContext<Snapshot>),
     > {
         match self.fetch {
-            None => Self::run_stages(self.initial_iterator, self.stages, self.context, execution_interrupt),
-            Some(_) => Err((Box::new(PipelineExecutionError::FetchUsedAsRows {}), self.context)),
+            None => Self::run_stages(
+                self.initial_iterator,
+                self.stages,
+                self.execution_context,
+                self.query_context,
+                execution_interrupt,
+            ),
+            Some(_) => Err((Box::new(PipelineExecutionError::FetchUsedAsRows {}), self.execution_context)),
         }
     }
 
@@ -382,13 +390,20 @@ impl<Snapshot: WritableSnapshot + 'static> Pipeline<Snapshot, WritePipelineStage
         (Box<PipelineExecutionError>, ExecutionContext<Snapshot>),
     > {
         match self.fetch {
-            None => Err((Box::new(PipelineExecutionError::RowsUsedAsFetch {}), self.context)),
+            None => Err((Box::new(PipelineExecutionError::RowsUsedAsFetch {}), self.execution_context)),
             Some(fetch_executor) => {
-                let (rows_iterator, context) =
-                    Self::run_stages(self.initial_iterator, self.stages, self.context, execution_interrupt.clone())?;
+                let query_context = self.query_context;
+                let (rows_iterator, execution_context) = Self::run_stages(
+                    self.initial_iterator,
+                    self.stages,
+                    self.execution_context,
+                    query_context.clone(),
+                    execution_interrupt.clone(),
+                )?;
                 Ok(fetch_executor.into_iterator::<WritePipelineStage<Snapshot>>(
                     rows_iterator,
-                    context,
+                    execution_context,
+                    query_context,
                     execution_interrupt,
                 ))
             }

--- a/executor/pipeline/put.rs
+++ b/executor/pipeline/put.rs
@@ -9,6 +9,7 @@ use compiler::{
     VariablePosition,
     executable::{function::ExecutableFunctionRegistry, insert::VariableSource, put::PutExecutable},
 };
+use ir::pipeline::QueryContext;
 use resource::constants::traversal::{BATCH_DEFAULT_CAPACITY, CHECK_INTERRUPT_FREQUENCY_ROWS};
 use storage::snapshot::{ReadableSnapshot, WritableSnapshot};
 
@@ -51,23 +52,32 @@ where
     fn into_iterator(
         self,
         input_iterator: Self::InputIterator,
-        mut context: ExecutionContext<Snapshot>,
+        mut execution_context: ExecutionContext<Snapshot>,
+        query_context: Arc<QueryContext>,
         mut interrupt: ExecutionInterrupt,
     ) -> Result<
         (Self::OutputIterator, ExecutionContext<Snapshot>),
         (Box<PipelineExecutionError>, ExecutionContext<Snapshot>),
     > {
         let Self { executable, function_registry, .. } = self;
-        let result = into_iterator_impl(&mut context, &mut interrupt, &executable, function_registry, input_iterator);
+        let result = into_iterator_impl(
+            &mut execution_context,
+            query_context,
+            &mut interrupt,
+            &executable,
+            function_registry,
+            input_iterator,
+        );
         match result {
-            Ok(written_rows_iterator) => Ok((written_rows_iterator, context)),
-            Err(err) => Err((err, context)),
+            Ok(written_rows_iterator) => Ok((written_rows_iterator, execution_context)),
+            Err(err) => Err((err, execution_context)),
         }
     }
 }
 
 fn into_iterator_impl<Snapshot: WritableSnapshot + 'static>(
     context: &mut ExecutionContext<Snapshot>,
+    query_context: Arc<QueryContext>,
     interrupt: &mut ExecutionInterrupt,
     executable: &PutExecutable,
     function_registry: Arc<ExecutableFunctionRegistry>,
@@ -88,8 +98,14 @@ fn into_iterator_impl<Snapshot: WritableSnapshot + 'static>(
     while let Some(input_row_result) = previous_iterator.next() {
         let input_row = input_row_result?;
         let size_before = output_batch.len();
-        let mut match_iterator =
-            match_iterator_for_row(context, interrupt, executable, function_registry.clone(), input_row.clone())?;
+        let mut match_iterator = match_iterator_for_row(
+            context,
+            query_context.clone(),
+            interrupt,
+            executable,
+            function_registry.clone(),
+            input_row.clone(),
+        )?;
         match_iterator
             .try_for_each(|row_result| {
                 output_batch.append_row(row_result?);
@@ -110,13 +126,14 @@ fn into_iterator_impl<Snapshot: WritableSnapshot + 'static>(
     drop(previous_iterator);
     debug_assert_eq!(output_batch.len(), must_insert.len());
     // once the previous iterator is complete, this must be the exclusive owner of Arc's, so we can get mut:
-    perform_inserts(context, interrupt, executable, &mut output_batch, &must_insert)?;
+    perform_inserts(context, query_context.as_ref(), interrupt, executable, &mut output_batch, &must_insert)?;
 
     Ok(WrittenRowsIterator::new(output_batch))
 }
 
 fn match_iterator_for_row<Snapshot: ReadableSnapshot + 'static>(
-    context: &ExecutionContext<Snapshot>,
+    execution_context: &ExecutionContext<Snapshot>,
+    query_context: Arc<QueryContext>,
     interrupt: &ExecutionInterrupt,
     put_executable: &PutExecutable,
     function_registry: Arc<ExecutableFunctionRegistry>,
@@ -124,28 +141,30 @@ fn match_iterator_for_row<Snapshot: ReadableSnapshot + 'static>(
 ) -> Result<impl Iterator<Item = Result<MaybeOwnedRow<'static>, ReadExecutionError>>, Box<PipelineExecutionError>> {
     let executor = MatchExecutor::new(
         &put_executable.match_,
-        &context.snapshot,
-        &context.thing_manager,
+        execution_context,
         input_row,
         function_registry,
-        &context.profile,
+        &query_context.profile,
     )
     .map_err(|err| Box::new(PipelineExecutionError::InitialisingMatchIterator { typedb_source: err }))?;
-    Ok(crate::pipeline::match_::unique_rows(crate::pipeline::match_::as_owned_rows(
-        executor.into_iterator(context.clone(), interrupt.clone()),
-    ))
+    Ok(crate::pipeline::match_::unique_rows(crate::pipeline::match_::as_owned_rows(executor.into_iterator(
+        execution_context.clone(),
+        query_context,
+        interrupt.clone(),
+    )))
     .peekable())
 }
 
 fn perform_inserts<Snapshot: WritableSnapshot>(
     context: &mut ExecutionContext<Snapshot>,
+    query_context: &QueryContext,
     interrupt: &mut ExecutionInterrupt,
     executable: &PutExecutable,
     output_batch: &mut Batch,
     must_insert: &[bool],
 ) -> Result<(), Box<PipelineExecutionError>> {
     let snapshot_mut = Arc::get_mut(&mut context.snapshot).unwrap();
-    let stage_profile = context.profile.profile_stage(|| String::from("Put"), executable.executable_id as _);
+    let stage_profile = query_context.profile.profile_stage(|| String::from("Put"), executable.executable_id as _);
     let pattern_profile = stage_profile.create_or_get_pattern(|| String::from("Put pattern"));
     let (concept_profiles, connection_profiles, optional_concept_profiles, optional_connection_profiles) =
         crate::pipeline::insert::build_step_profiles(&executable.insert, &pattern_profile);
@@ -157,7 +176,7 @@ fn perform_inserts<Snapshot: WritableSnapshot>(
                 &executable.insert,
                 snapshot_mut,
                 &context.thing_manager,
-                &context.parameters,
+                &query_context.parameters,
                 &mut row,
                 &concept_profiles,
                 &connection_profiles,

--- a/executor/pipeline/reduce.rs
+++ b/executor/pipeline/reduce.rs
@@ -6,6 +6,7 @@
 use std::{marker::PhantomData, sync::Arc};
 
 use compiler::executable::reduce::ReduceExecutable;
+use ir::pipeline::QueryContext;
 use resource::profile::StorageCounters;
 use storage::snapshot::ReadableSnapshot;
 
@@ -41,7 +42,8 @@ where
     fn into_iterator(
         self,
         input_iterator: Self::InputIterator,
-        context: ExecutionContext<Snapshot>,
+        execution_context: ExecutionContext<Snapshot>,
+        query_context: Arc<QueryContext>,
         _interrupt: ExecutionInterrupt,
     ) -> Result<
         (Self::OutputIterator, ExecutionContext<Snapshot>),
@@ -49,7 +51,7 @@ where
     > {
         let Self { executable, .. } = self;
 
-        let stage_profile = context.profile.profile_stage(|| String::from("Reduce"), executable.executable_id);
+        let stage_profile = query_context.profile.profile_stage(|| String::from("Reduce"), executable.executable_id);
         let pattern_profile = stage_profile.create_or_get_pattern(|| String::from("Reduce pattern"));
         let step_profile = pattern_profile.extend_or_get_step(0, || String::from("Reduce execution"));
         let storage_counters = step_profile.storage_counters();
@@ -58,12 +60,13 @@ where
         // so we time the whole iterator drain as one batch and report the
         // count of input rows consumed.
         let measurement = step_profile.start_measurement();
-        let (rows, input_row_count) = match reduce_iterator(&context, executable, input_iterator, &storage_counters) {
-            Ok(out) => out,
-            Err(err) => return Err((err, context)),
-        };
+        let (rows, input_row_count) =
+            match reduce_iterator(&execution_context, executable, input_iterator, &storage_counters) {
+                Ok(out) => out,
+                Err(err) => return Err((err, execution_context)),
+            };
         measurement.end(&step_profile, 1, input_row_count);
-        Ok((WrittenRowsIterator::new(rows), context))
+        Ok((WrittenRowsIterator::new(rows), execution_context))
     }
 }
 

--- a/executor/pipeline/stage.rs
+++ b/executor/pipeline/stage.rs
@@ -7,9 +7,9 @@ use std::sync::Arc;
 
 use concept::{thing::thing_manager::ThingManager, type_::type_manager::TypeManager};
 use function::function_manager::FunctionManager;
-use ir::pipeline::ParameterRegistry;
+use ir::pipeline::QueryContext;
 use lending_iterator::LendingIterator;
-use resource::{constants::traversal::BATCH_DEFAULT_CAPACITY, profile::QueryProfile};
+use resource::constants::traversal::BATCH_DEFAULT_CAPACITY;
 use storage::snapshot::{ReadableSnapshot, WritableSnapshot};
 
 use crate::{
@@ -39,8 +39,6 @@ pub struct ExecutionContext<Snapshot> {
     pub snapshot: Arc<Snapshot>,
     pub thing_manager: Arc<ThingManager>,
     pub function_manager: Arc<FunctionManager>,
-    pub parameters: Arc<ParameterRegistry>,
-    pub profile: Arc<QueryProfile>,
 }
 
 impl<Snapshot> ExecutionContext<Snapshot> {
@@ -48,35 +46,8 @@ impl<Snapshot> ExecutionContext<Snapshot> {
         snapshot: Arc<Snapshot>,
         thing_manager: Arc<ThingManager>,
         function_manager: Arc<FunctionManager>,
-        parameters: Arc<ParameterRegistry>,
     ) -> Self {
-        Self::new_with_profile(
-            snapshot,
-            thing_manager,
-            function_manager,
-            parameters,
-            Arc::new(QueryProfile::new(false)),
-        )
-    }
-
-    pub fn new_with_profile(
-        snapshot: Arc<Snapshot>,
-        thing_manager: Arc<ThingManager>,
-        function_manager: Arc<FunctionManager>,
-        parameters: Arc<ParameterRegistry>,
-        query_profile: Arc<QueryProfile>,
-    ) -> Self {
-        Self { snapshot, thing_manager, function_manager, parameters, profile: query_profile }
-    }
-
-    pub(crate) fn clone_with_replaced_parameters(&self, parameters: Arc<ParameterRegistry>) -> Self {
-        Self {
-            snapshot: self.snapshot.clone(),
-            thing_manager: self.thing_manager.clone(),
-            function_manager: self.function_manager.clone(),
-            parameters,
-            profile: self.profile.clone(),
-        }
+        Self { snapshot, thing_manager, function_manager }
     }
 
     pub(crate) fn snapshot(&self) -> &Arc<Snapshot> {
@@ -94,21 +65,15 @@ impl<Snapshot> ExecutionContext<Snapshot> {
     pub(crate) fn function_manager(&self) -> &FunctionManager {
         &self.function_manager
     }
-
-    pub(crate) fn parameters(&self) -> &ParameterRegistry {
-        &self.parameters
-    }
 }
 
 impl<Snapshot> Clone for ExecutionContext<Snapshot> {
     fn clone(&self) -> Self {
-        let Self { snapshot, thing_manager, parameters, function_manager, profile } = self;
+        let Self { snapshot, thing_manager, function_manager } = self;
         Self {
             snapshot: snapshot.clone(),
             thing_manager: thing_manager.clone(),
             function_manager: function_manager.clone(),
-            parameters: parameters.clone(),
-            profile: profile.clone(),
         }
     }
 }
@@ -121,6 +86,7 @@ pub trait StageAPI<Snapshot> {
         self,
         input_iterator: Self::InputIterator,
         context: ExecutionContext<Snapshot>,
+        query_context: Arc<QueryContext>,
         interrupt: ExecutionInterrupt,
     ) -> Result<
         (Self::OutputIterator, ExecutionContext<Snapshot>),
@@ -190,6 +156,7 @@ impl<Snapshot: ReadableSnapshot + 'static> StageAPI<Snapshot> for ReadPipelineSt
         self,
         input_iterator: Self::InputIterator,
         context: ExecutionContext<Snapshot>,
+        query_context: Arc<QueryContext>,
         interrupt: ExecutionInterrupt,
     ) -> Result<
         (Self::OutputIterator, ExecutionContext<Snapshot>),
@@ -197,39 +164,39 @@ impl<Snapshot: ReadableSnapshot + 'static> StageAPI<Snapshot> for ReadPipelineSt
     > {
         match self {
             ReadPipelineStage::Given(stage) => {
-                let (iterator, snapshot) = stage.into_iterator(input_iterator, context, interrupt)?;
+                let (iterator, snapshot) = stage.into_iterator(input_iterator, context, query_context, interrupt)?;
                 Ok((ReadStageIterator::Given(Box::new(iterator)), snapshot))
             }
             ReadPipelineStage::Match(stage) => {
-                let (iterator, snapshot) = stage.into_iterator(input_iterator, context, interrupt)?;
+                let (iterator, snapshot) = stage.into_iterator(input_iterator, context, query_context, interrupt)?;
                 Ok((ReadStageIterator::Match(Box::new(iterator)), snapshot))
             }
             ReadPipelineStage::Sort(stage) => {
-                let (iterator, snapshot) = stage.into_iterator(input_iterator, context, interrupt)?;
+                let (iterator, snapshot) = stage.into_iterator(input_iterator, context, query_context, interrupt)?;
                 Ok((ReadStageIterator::Sort(iterator), snapshot))
             }
             ReadPipelineStage::Distinct(stage) => {
-                let (iterator, snapshot) = stage.into_iterator(input_iterator, context, interrupt)?;
+                let (iterator, snapshot) = stage.into_iterator(input_iterator, context, query_context, interrupt)?;
                 Ok((ReadStageIterator::Distinct(Box::new(iterator)), snapshot))
             }
             ReadPipelineStage::Offset(stage) => {
-                let (iterator, snapshot) = stage.into_iterator(input_iterator, context, interrupt)?;
+                let (iterator, snapshot) = stage.into_iterator(input_iterator, context, query_context, interrupt)?;
                 Ok((ReadStageIterator::Offset(Box::new(iterator)), snapshot))
             }
             ReadPipelineStage::Limit(stage) => {
-                let (iterator, snapshot) = stage.into_iterator(input_iterator, context, interrupt)?;
+                let (iterator, snapshot) = stage.into_iterator(input_iterator, context, query_context, interrupt)?;
                 Ok((ReadStageIterator::Limit(Box::new(iterator)), snapshot))
             }
             ReadPipelineStage::Select(stage) => {
-                let (iterator, snapshot) = stage.into_iterator(input_iterator, context, interrupt)?;
+                let (iterator, snapshot) = stage.into_iterator(input_iterator, context, query_context, interrupt)?;
                 Ok((ReadStageIterator::Select(Box::new(iterator)), snapshot))
             }
             ReadPipelineStage::Require(stage) => {
-                let (iterator, snapshot) = stage.into_iterator(input_iterator, context, interrupt)?;
+                let (iterator, snapshot) = stage.into_iterator(input_iterator, context, query_context, interrupt)?;
                 Ok((ReadStageIterator::Require(Box::new(iterator)), snapshot))
             }
             ReadPipelineStage::Reduce(stage) => {
-                let (iterator, snapshot) = stage.into_iterator(input_iterator, context, interrupt)?;
+                let (iterator, snapshot) = stage.into_iterator(input_iterator, context, query_context, interrupt)?;
                 Ok((ReadStageIterator::Reduce(Box::new(iterator)), snapshot))
             }
         }
@@ -295,7 +262,8 @@ impl<Snapshot: WritableSnapshot + 'static> StageAPI<Snapshot> for WritePipelineS
     fn into_iterator(
         self,
         input_iterator: Self::InputIterator,
-        context: ExecutionContext<Snapshot>,
+        execution_context: ExecutionContext<Snapshot>,
+        query_context: Arc<QueryContext>,
         interrupt: ExecutionInterrupt,
     ) -> Result<
         (Self::OutputIterator, ExecutionContext<Snapshot>),
@@ -303,55 +271,68 @@ impl<Snapshot: WritableSnapshot + 'static> StageAPI<Snapshot> for WritePipelineS
     > {
         match self {
             WritePipelineStage::Given(stage) => {
-                let (iterator, context) = stage.into_iterator(input_iterator, context, interrupt)?;
+                let (iterator, context) =
+                    stage.into_iterator(input_iterator, execution_context, query_context, interrupt)?;
                 Ok((WriteStageIterator::Given(Box::new(iterator)), context))
             }
             WritePipelineStage::Match(stage) => {
-                let (iterator, context) = stage.into_iterator(input_iterator, context, interrupt)?;
+                let (iterator, context) =
+                    stage.into_iterator(input_iterator, execution_context, query_context, interrupt)?;
                 Ok((WriteStageIterator::Match(Box::new(iterator)), context))
             }
             WritePipelineStage::Insert(stage) => {
-                let (iterator, context) = stage.into_iterator(input_iterator, context, interrupt)?;
+                let (iterator, context) =
+                    stage.into_iterator(input_iterator, execution_context, query_context, interrupt)?;
                 Ok((WriteStageIterator::Write(iterator), context))
             }
             WritePipelineStage::Update(stage) => {
-                let (iterator, context) = stage.into_iterator(input_iterator, context, interrupt)?;
+                let (iterator, context) =
+                    stage.into_iterator(input_iterator, execution_context, query_context, interrupt)?;
                 Ok((WriteStageIterator::Write(iterator), context))
             }
             WritePipelineStage::Put(stage) => {
-                let (iterator, context) = stage.into_iterator(input_iterator, context, interrupt)?;
+                let (iterator, context) =
+                    stage.into_iterator(input_iterator, execution_context, query_context, interrupt)?;
                 Ok((WriteStageIterator::Write(iterator), context))
             }
             WritePipelineStage::Delete(stage) => {
-                let (iterator, context) = stage.into_iterator(input_iterator, context, interrupt)?;
+                let (iterator, context) =
+                    stage.into_iterator(input_iterator, execution_context, query_context, interrupt)?;
                 Ok((WriteStageIterator::Write(iterator), context))
             }
             WritePipelineStage::Sort(stage) => {
-                let (iterator, snapshot) = stage.into_iterator(input_iterator, context, interrupt)?;
+                let (iterator, snapshot) =
+                    stage.into_iterator(input_iterator, execution_context, query_context, interrupt)?;
                 Ok((WriteStageIterator::Sort(iterator), snapshot))
             }
             WritePipelineStage::Distinct(stage) => {
-                let (iterator, snapshot) = stage.into_iterator(input_iterator, context, interrupt)?;
+                let (iterator, snapshot) =
+                    stage.into_iterator(input_iterator, execution_context, query_context, interrupt)?;
                 Ok((WriteStageIterator::Distinct(Box::new(iterator)), snapshot))
             }
             WritePipelineStage::Limit(stage) => {
-                let (iterator, snapshot) = stage.into_iterator(input_iterator, context, interrupt)?;
+                let (iterator, snapshot) =
+                    stage.into_iterator(input_iterator, execution_context, query_context, interrupt)?;
                 Ok((WriteStageIterator::Limit(Box::new(iterator)), snapshot))
             }
             WritePipelineStage::Offset(stage) => {
-                let (iterator, snapshot) = stage.into_iterator(input_iterator, context, interrupt)?;
+                let (iterator, snapshot) =
+                    stage.into_iterator(input_iterator, execution_context, query_context, interrupt)?;
                 Ok((WriteStageIterator::Offset(Box::new(iterator)), snapshot))
             }
             WritePipelineStage::Select(stage) => {
-                let (iterator, snapshot) = stage.into_iterator(input_iterator, context, interrupt)?;
+                let (iterator, snapshot) =
+                    stage.into_iterator(input_iterator, execution_context, query_context, interrupt)?;
                 Ok((WriteStageIterator::Select(Box::new(iterator)), snapshot))
             }
             WritePipelineStage::Require(stage) => {
-                let (iterator, snapshot) = stage.into_iterator(input_iterator, context, interrupt)?;
+                let (iterator, snapshot) =
+                    stage.into_iterator(input_iterator, execution_context, query_context, interrupt)?;
                 Ok((WriteStageIterator::Require(Box::new(iterator)), snapshot))
             }
             WritePipelineStage::Reduce(stage) => {
-                let (iterator, snapshot) = stage.into_iterator(input_iterator, context, interrupt)?;
+                let (iterator, snapshot) =
+                    stage.into_iterator(input_iterator, execution_context, query_context, interrupt)?;
                 Ok((WriteStageIterator::Reduce(iterator), snapshot))
             }
         }

--- a/executor/pipeline/update.rs
+++ b/executor/pipeline/update.rs
@@ -16,7 +16,7 @@ use compiler::{
     },
 };
 use concept::thing::thing_manager::ThingManager;
-use ir::pipeline::ParameterRegistry;
+use ir::pipeline::{ParameterRegistry, QueryContext};
 use itertools::Itertools;
 use resource::{
     constants::traversal::CHECK_INTERRUPT_FREQUENCY_ROWS,
@@ -61,7 +61,8 @@ where
     fn into_iterator(
         self,
         input_iterator: Self::InputIterator,
-        mut context: ExecutionContext<Snapshot>,
+        mut execution_context: ExecutionContext<Snapshot>,
+        query_context: Arc<QueryContext>,
         mut interrupt: ExecutionInterrupt,
     ) -> Result<
         (Self::OutputIterator, ExecutionContext<Snapshot>),
@@ -69,7 +70,7 @@ where
     > {
         let Self { executable, .. } = self;
 
-        let profile = context.profile.profile_stage(|| String::from("Update"), executable.executable_id);
+        let profile = query_context.profile.profile_stage(|| String::from("Update"), executable.executable_id);
         let pattern_profile = profile.create_or_get_pattern(|| String::from("Update pattern"));
         let (concept_profiles, connection_profiles, optional_concept_profiles, optional_connection_profiles) =
             build_step_profiles(&executable, &pattern_profile);
@@ -86,11 +87,11 @@ where
         let mut batch =
             match prepare_output_rows(executable.output_width() as u32, input_iterator, &input_output_mapping) {
                 Ok(output_rows) => output_rows,
-                Err(err) => return Err((err, context)),
+                Err(err) => return Err((err, execution_context)),
             };
 
         // once the previous iterator is complete, this must be the exclusive owner of Arc's, so we can get mut:
-        let snapshot_mut = Arc::get_mut(&mut context.snapshot).unwrap();
+        let snapshot_mut = Arc::get_mut(&mut execution_context.snapshot).unwrap();
         for index in 0..batch.len() {
             // TODO: parallelise -- though this requires our snapshots support parallel writes!
             let mut row = batch.get_row_mut(index);
@@ -98,24 +99,24 @@ where
             if let Err(typedb_source) = execute_update(
                 &executable,
                 snapshot_mut,
-                &context.thing_manager,
-                &context.parameters,
+                &execution_context.thing_manager,
+                &query_context.parameters,
                 &mut row,
                 &concept_profiles,
                 &connection_profiles,
                 &optional_concept_profiles,
                 &optional_connection_profiles,
             ) {
-                return Err((Box::new(PipelineExecutionError::WriteError { typedb_source }), context));
+                return Err((Box::new(PipelineExecutionError::WriteError { typedb_source }), execution_context));
             }
 
             if index % CHECK_INTERRUPT_FREQUENCY_ROWS == 0 {
                 if let Some(interrupt) = interrupt.check() {
-                    return Err((Box::new(PipelineExecutionError::Interrupted { interrupt }), context));
+                    return Err((Box::new(PipelineExecutionError::Interrupted { interrupt }), execution_context));
                 }
             }
         }
-        Ok((WrittenRowsIterator::new(batch), context))
+        Ok((WrittenRowsIterator::new(batch), execution_context))
     }
 }
 

--- a/executor/read/collecting_stage_executor.rs
+++ b/executor/read/collecting_stage_executor.rs
@@ -25,19 +25,25 @@ use crate::{
 
 #[derive(Debug)]
 pub(crate) enum CollectingStageExecutor {
-    Reduce { pattern: PatternExecutor, reduce_rows_executable: Arc<ReduceRowsExecutable> },
-    Sort { pattern: PatternExecutor, sort_on: Arc<Vec<(usize, bool)>> },
+    Reduce { pattern: PatternExecutor, reduce_rows_executable: Arc<ReduceRowsExecutable>, profile: Arc<StepProfile> },
+    Sort { pattern: PatternExecutor, sort_on: Arc<Vec<(usize, bool)>>, profile: Arc<StepProfile> },
 }
 
 impl CollectingStageExecutor {
     pub(crate) fn new_reduce(
         previous_stage: PatternExecutor,
         reduce_rows_executable: Arc<ReduceRowsExecutable>,
+        query_profile: &QueryProfile,
     ) -> Self {
-        Self::Reduce { pattern: previous_stage, reduce_rows_executable }
+        let profile = Self::create_step_profile(query_profile, "Reduce");
+        Self::Reduce { pattern: previous_stage, reduce_rows_executable, profile }
     }
 
-    pub(crate) fn new_sort(previous_stage: PatternExecutor, sort_executable: &SortExecutable) -> Self {
+    pub(crate) fn new_sort(
+        previous_stage: PatternExecutor,
+        sort_executable: &SortExecutable,
+        query_profile: &QueryProfile,
+    ) -> Self {
         let sort_on = sort_executable
             .sort_on
             .iter()
@@ -46,7 +52,14 @@ impl CollectingStageExecutor {
                 SortVariable::Descending(v) => (sort_executable.output_row_mapping.get(v).unwrap().as_usize(), false),
             })
             .collect();
-        Self::Sort { pattern: previous_stage, sort_on: Arc::new(sort_on) }
+        let profile = Self::create_step_profile(query_profile, "Sort");
+        Self::Sort { pattern: previous_stage, sort_on: Arc::new(sort_on), profile }
+    }
+
+    fn create_step_profile(query_profile: &QueryProfile, name: &'static str) -> Arc<StepProfile> {
+        let stage = query_profile.profile_stage(|| String::from(name), 0); // TODO executable id
+        let pattern = stage.create_or_get_pattern(|| format!("{name} pattern"));
+        pattern.extend_or_get_step(0, || format!("{name} execution"))
     }
 
     pub(crate) fn output_width(&self) -> u32 {
@@ -83,23 +96,16 @@ impl CollectingStageExecutor {
             CollectingStageExecutor::Reduce { reduce_rows_executable, .. } => {
                 CollectorEnum::Reduce(ReduceCollector::new(reduce_rows_executable.clone()))
             }
-            CollectingStageExecutor::Sort { sort_on, pattern } => {
+            CollectingStageExecutor::Sort { sort_on, pattern, .. } => {
                 CollectorEnum::Sort(SortCollector::new(pattern.output_width(), sort_on.clone()))
             }
         }
     }
 
-    pub(super) fn step_profile(&self, profile: &QueryProfile) -> Arc<StepProfile> {
+    pub(super) fn step_profile(&self) -> Arc<StepProfile> {
         match self {
-            CollectingStageExecutor::Reduce { .. } => {
-                let stage = profile.profile_stage(|| String::from("Reduce"), 0); // TODO executable id
-                let pattern = stage.create_or_get_pattern(|| String::from("Reduce pattern"));
-                pattern.extend_or_get_step(0, || String::from("Reduce execution"))
-            }
-            CollectingStageExecutor::Sort { .. } => {
-                let stage = profile.profile_stage(|| String::from("Sort"), 0); // TODO executable id
-                let pattern = stage.create_or_get_pattern(|| String::from("Sort pattern"));
-                pattern.extend_or_get_step(0, || String::from("Sort execution"))
+            CollectingStageExecutor::Reduce { profile, .. } | CollectingStageExecutor::Sort { profile, .. } => {
+                profile.clone()
             }
         }
     }

--- a/executor/read/expression_executor.rs
+++ b/executor/read/expression_executor.rs
@@ -64,7 +64,7 @@ impl ExpressionValue {
             VariableValue::Value(value) => Ok(ExpressionValue::Single(value)),
             VariableValue::ValueList(values) => Ok(ExpressionValue::List(values)),
             VariableValue::Thing(Thing::Attribute(attr)) => Ok(ExpressionValue::Single(
-                attr.get_value(&**context.snapshot(), context.thing_manager(), storage_counters)
+                attr.get_value(context.snapshot.as_ref(), context.thing_manager(), storage_counters)
                     .map_err(|source| ExpressionEvaluationError::ConceptRead { typedb_source: source })?
                     .into_owned(),
             )),

--- a/executor/read/immediate_executor.rs
+++ b/executor/read/immediate_executor.rs
@@ -17,7 +17,7 @@ use compiler::{
 };
 use concept::{error::ConceptReadError, thing::thing_manager::ThingManager};
 use error::{UnimplementedFeature, unimplemented_feature};
-use ir::pattern::expression::BuiltinConceptFunctionID;
+use ir::{pattern::expression::BuiltinConceptFunctionID, pipeline::ParameterRegistry};
 use itertools::Itertools;
 use lending_iterator::{LendingIterator, Peekable};
 use resource::profile::StepProfile;
@@ -56,8 +56,8 @@ impl From<ImmediateExecutor> for StepExecutors {
 impl ImmediateExecutor {
     pub(crate) fn new_intersection(
         step: &IntersectionStep,
-        snapshot: &Arc<impl ReadableSnapshot + 'static>,
-        thing_manager: &Arc<ThingManager>,
+        snapshot: &impl ReadableSnapshot,
+        thing_manager: &ThingManager,
         profile: Arc<StepProfile>,
     ) -> Result<Self, Box<ConceptReadError>> {
         let IntersectionStep { sort_variable, instructions, selected_variables, output_width, .. } = step;
@@ -141,9 +141,10 @@ impl ImmediateExecutor {
         &mut self,
         input_batch: FixedBatch,
         context: &ExecutionContext<impl ReadableSnapshot + 'static>,
+        parameters: &ParameterRegistry,
     ) -> Result<(), ReadExecutionError> {
         match self {
-            ImmediateExecutor::SortedJoin(sorted) => sorted.prepare(input_batch, context),
+            ImmediateExecutor::SortedJoin(sorted) => sorted.prepare(input_batch, context, parameters),
             ImmediateExecutor::UnsortedJoin(unsorted) => unsorted.prepare(input_batch, context),
             ImmediateExecutor::Assignment(assignment) => assignment.prepare(input_batch, context),
             ImmediateExecutor::Check(check) => check.prepare(input_batch, context),
@@ -154,13 +155,14 @@ impl ImmediateExecutor {
     pub(crate) fn batch_continue(
         &mut self,
         context: &ExecutionContext<impl ReadableSnapshot + 'static>,
+        parameters: &ParameterRegistry,
         interrupt: &mut ExecutionInterrupt,
     ) -> Result<Option<FixedBatch>, ReadExecutionError> {
         match self {
-            ImmediateExecutor::SortedJoin(sorted) => sorted.batch_continue(context, interrupt),
-            ImmediateExecutor::UnsortedJoin(unsorted) => unsorted.batch_continue(context, interrupt),
-            ImmediateExecutor::Assignment(assignment) => assignment.batch_continue(context, interrupt),
-            ImmediateExecutor::Check(check) => check.batch_continue(context, interrupt),
+            ImmediateExecutor::SortedJoin(sorted) => sorted.batch_continue(context, parameters, interrupt),
+            ImmediateExecutor::UnsortedJoin(unsorted) => unsorted.batch_continue(context, parameters, interrupt),
+            ImmediateExecutor::Assignment(assignment) => assignment.batch_continue(context, parameters, interrupt),
+            ImmediateExecutor::Check(check) => check.batch_continue(context, parameters, interrupt),
             ImmediateExecutor::BuiltinCall(builtin) => builtin.batch_continue(context, interrupt),
         }
     }
@@ -199,15 +201,15 @@ impl IntersectionExecutor {
         instructions: Vec<(ConstraintInstruction<ExecutorVariable>, VariableModes)>,
         output_width: u32,
         select_variables: Vec<VariablePosition>,
-        snapshot: &Arc<impl ReadableSnapshot + 'static>,
-        thing_manager: &Arc<ThingManager>,
+        snapshot: &impl ReadableSnapshot,
+        thing_manager: &ThingManager,
         profile: Arc<StepProfile>,
     ) -> Result<Self, Box<ConceptReadError>> {
         let instruction_count = instructions.len();
         let executors: Vec<InstructionExecutor> = instructions
             .into_iter()
             .map(|(instruction, variable_modes)| {
-                InstructionExecutor::new(instruction, variable_modes, &**snapshot, thing_manager, sort_variable)
+                InstructionExecutor::new(instruction, variable_modes, snapshot, thing_manager, sort_variable)
             })
             .try_collect()?;
 
@@ -237,13 +239,14 @@ impl IntersectionExecutor {
         &mut self,
         input_batch: FixedBatch,
         context: &ExecutionContext<impl ReadableSnapshot + 'static>,
+        parameter_registry: &ParameterRegistry,
     ) -> Result<(), ReadExecutionError> {
         let measurement = self.profile.start_measurement();
         debug_assert!(self.input.is_none() || self.input.as_mut().unwrap().peek().is_none());
         self.reset();
         self.input = Some(Peekable::new(FixedBatchRowIterator::new(Ok(input_batch))));
         debug_assert!(self.input.as_mut().unwrap().peek().is_some());
-        self.may_create_intersection_iterators(context)?;
+        self.may_create_intersection_iterators(context, parameter_registry)?;
         measurement.end(&self.profile, 0, 0);
         Ok(())
     }
@@ -251,20 +254,22 @@ impl IntersectionExecutor {
     fn batch_continue(
         &mut self,
         context: &ExecutionContext<impl ReadableSnapshot + 'static>,
+        parameters: &ParameterRegistry,
         _interrupt: &mut ExecutionInterrupt,
     ) -> Result<Option<FixedBatch>, ReadExecutionError> {
-        self.may_compute_next_batch(context)
+        self.may_compute_next_batch(context, parameters)
     }
 
     fn may_compute_next_batch(
         &mut self,
         context: &ExecutionContext<impl ReadableSnapshot + 'static>,
+        parameters: &ParameterRegistry,
     ) -> Result<Option<FixedBatch>, ReadExecutionError> {
         if self.input_exhausted {
             return Ok(None);
         }
         let measurement = self.profile.start_measurement();
-        let output = if self.compute_next_row(context)? {
+        let output = if self.compute_next_row(context, parameters)? {
             // don't allocate batch until 1 answer is confirmed
             let mut batch = FixedBatch::new(self.output_width);
             batch.append(|mut row| self.write_next_row_into(&mut row));
@@ -273,7 +278,7 @@ impl IntersectionExecutor {
                 if batch.is_full() {
                     break;
                 }
-                if self.compute_next_row(context)? {
+                if self.compute_next_row(context, parameters)? {
                     batch.append(|mut row| self.write_next_row_into(&mut row));
                 } else {
                     self.input_exhausted = true;
@@ -307,10 +312,11 @@ impl IntersectionExecutor {
     fn compute_next_row(
         &mut self,
         context: &ExecutionContext<impl ReadableSnapshot + 'static>,
+        parameters: &ParameterRegistry,
     ) -> Result<bool, ReadExecutionError> {
         loop {
             if self.cartesian_iterator.is_active() {
-                let found = self.cartesian_iterator.find_next(context, &self.instruction_executors)?;
+                let found = self.cartesian_iterator.find_next(context, parameters, &self.instruction_executors)?;
                 if found {
                     return Ok(true);
                 } else {
@@ -332,7 +338,7 @@ impl IntersectionExecutor {
                     if found {
                         self.record_intersection()?;
                         self.advance_intersection_iterators_with_multiplicity()?;
-                        self.may_activate_cartesian(context)?;
+                        self.may_activate_cartesian(context, parameters)?;
                         return Ok(true);
                     } else {
                         self.iterators.clear();
@@ -340,7 +346,7 @@ impl IntersectionExecutor {
                         while self.iterators.is_empty() {
                             let _ = self.input.as_mut().unwrap().next().unwrap().map_err(|err| err.clone());
                             if self.input.as_mut().unwrap().peek().is_some() {
-                                self.may_create_intersection_iterators(context)?;
+                                self.may_create_intersection_iterators(context, parameters)?;
                             } else {
                                 break;
                             }
@@ -431,7 +437,8 @@ impl IntersectionExecutor {
 
     fn may_create_intersection_iterators(
         &mut self,
-        context: &ExecutionContext<impl ReadableSnapshot + 'static>,
+        execution_context: &ExecutionContext<impl ReadableSnapshot + 'static>,
+        parameters: &ParameterRegistry,
     ) -> Result<(), ReadExecutionError> {
         debug_assert!(self.iterators.is_empty());
         let peek = self.input.as_mut().unwrap().peek();
@@ -440,7 +447,12 @@ impl IntersectionExecutor {
             self.intersection_provenance = next_row.provenance();
             for executor in &self.instruction_executors {
                 let mut iterator = executor
-                    .get_iterator(context, next_row.as_reference(), self.profile.storage_counters())
+                    .get_iterator(
+                        execution_context,
+                        parameters,
+                        next_row.as_reference(),
+                        self.profile.storage_counters(),
+                    )
                     .map_err(|err| ReadExecutionError::CreatingIterator {
                         instruction_name: executor.name().to_string(),
                         typedb_source: err,
@@ -525,6 +537,7 @@ impl IntersectionExecutor {
     fn may_activate_cartesian(
         &mut self,
         context: &ExecutionContext<impl ReadableSnapshot + 'static>,
+        parameters: &ParameterRegistry,
     ) -> Result<(), ReadExecutionError> {
         if self.iterators.len() == 1 {
             // don't delegate to cartesian iterator and incur new iterator costs if there cannot be a cartesian product
@@ -548,6 +561,7 @@ impl IntersectionExecutor {
         if cartesian {
             self.cartesian_iterator.activate(
                 context,
+                parameters,
                 &self.instruction_executors,
                 &self.intersection_value,
                 input_row,
@@ -597,6 +611,7 @@ impl CartesianIterator {
     fn activate(
         &mut self,
         context: &ExecutionContext<impl ReadableSnapshot + 'static>,
+        parameters: &ParameterRegistry,
         iterator_executors: &[InstructionExecutor],
         source_intersection_value: &VariableValue<'static>,
         input_row: &[VariableValue<'static>],
@@ -628,9 +643,9 @@ impl CartesianIterator {
                 // reopen/move existing cartesian iterators forward to the intersection point if we can
                 let preexisting_iterator = self.iterators[index].take();
                 let iterator = match preexisting_iterator {
-                    None => self.reopen_iterator(context, &iterator_executors[index])?,
+                    None => self.reopen_iterator(context, parameters, &iterator_executors[index])?,
                     Some(mut iter) => match iter.peek_first_unbound_value() {
-                        None => self.reopen_iterator(context, &iterator_executors[index])?,
+                        None => self.reopen_iterator(context, parameters, &iterator_executors[index])?,
                         Some(Ok(value)) => {
                             if value < source_intersection_value {
                                 iter.advance_until_first_unbound_is(source_intersection_value)
@@ -643,7 +658,7 @@ impl CartesianIterator {
                             } else if value == source_intersection_value {
                                 iter
                             } else {
-                                self.reopen_iterator(context, &iterator_executors[index])?
+                                self.reopen_iterator(context, parameters, &iterator_executors[index])?
                             }
                         }
                         Some(Err(err)) => {
@@ -660,6 +675,7 @@ impl CartesianIterator {
     fn find_next(
         &mut self,
         context: &ExecutionContext<impl ReadableSnapshot + 'static>,
+        parameters: &ParameterRegistry,
         executors: &[InstructionExecutor],
     ) -> Result<bool, ReadExecutionError> {
         debug_assert!(self.is_active);
@@ -680,7 +696,7 @@ impl CartesianIterator {
                     self.is_active = false;
                     return Ok(false);
                 } else {
-                    let reopened = self.reopen_iterator(context, &executors[iterator_index])?;
+                    let reopened = self.reopen_iterator(context, parameters, &executors[iterator_index])?;
                     self.iterators[iterator_index] = Some(reopened);
                     index_of_index -= 1;
                 }
@@ -692,7 +708,8 @@ impl CartesianIterator {
 
     fn reopen_iterator(
         &self,
-        context: &ExecutionContext<impl ReadableSnapshot + 'static>,
+        execution_context: &ExecutionContext<impl ReadableSnapshot + 'static>,
+        parameters: &ParameterRegistry,
         executor: &InstructionExecutor,
     ) -> Result<TupleIterator, ReadExecutionError> {
         /*
@@ -725,7 +742,8 @@ impl CartesianIterator {
          */
         let mut reopened = executor
             .get_iterator(
-                context,
+                execution_context,
+                parameters,
                 MaybeOwnedRow::new_borrowed(&self.input_row, &1, &Provenance::INITIAL),
                 self.profile.storage_counters(),
             )
@@ -793,6 +811,7 @@ impl UnsortedJoinExecutor {
     fn batch_continue(
         &mut self,
         _context: &ExecutionContext<impl ReadableSnapshot + Sized>,
+        _parameters: &ParameterRegistry,
         _interrupt: &mut ExecutionInterrupt,
     ) -> Result<Option<FixedBatch>, ReadExecutionError> {
         unimplemented_feature!(UnsortedJoin)
@@ -838,7 +857,8 @@ impl AssignExecutor {
 
     fn batch_continue(
         &mut self,
-        context: &ExecutionContext<impl ReadableSnapshot + 'static>,
+        execution_context: &ExecutionContext<impl ReadableSnapshot + 'static>,
+        parameters: &ParameterRegistry,
         _interrupt: &mut ExecutionInterrupt,
     ) -> Result<Option<FixedBatch>, ReadExecutionError> {
         if self.prepared_input.is_none() {
@@ -858,12 +878,12 @@ impl AssignExecutor {
                 .map(|&pos| {
                     let value = input_row.get(pos).to_owned();
                     let expression_value =
-                        ExpressionValue::try_from_value(value, context, self.profile.storage_counters())
+                        ExpressionValue::try_from_value(value, execution_context, self.profile.storage_counters())
                             .map_err(|typedb_source| ReadExecutionError::ExpressionEvaluate { typedb_source })?;
                     Ok((pos, expression_value))
                 })
                 .try_collect()?;
-            let output_value = evaluate_expression(&self.expression, input_variables, &context.parameters)
+            let output_value = evaluate_expression(&self.expression, input_variables, parameters)
                 .map_err(|typedb_source| ReadExecutionError::ExpressionEvaluate { typedb_source })?;
             output.append(|mut row| {
                 row.set_multiplicity(input_row.multiplicity());
@@ -925,6 +945,7 @@ impl CheckExecutor {
     fn batch_continue(
         &mut self,
         context: &ExecutionContext<impl ReadableSnapshot + 'static>,
+        parameters: &ParameterRegistry,
         _interrupt: &mut ExecutionInterrupt,
     ) -> Result<Option<FixedBatch>, ReadExecutionError> {
         let Some(input_batch) = self.input.take() else {
@@ -940,7 +961,7 @@ impl CheckExecutor {
             let input_row = row.map_err(|err| err.clone())?;
             if self
                 .checker
-                .filter(context, &input_row, (), self.profile.storage_counters())
+                .filter(context, parameters, &input_row, (), self.profile.storage_counters())
                 .map_err(|err| ReadExecutionError::ConceptRead { typedb_source: err })?
             {
                 output.append(|mut row| {

--- a/executor/read/mod.rs
+++ b/executor/read/mod.rs
@@ -9,11 +9,11 @@ use std::sync::Arc;
 use compiler::executable::{
     function::ExecutableFunctionRegistry, match_::planner::conjunction_executable::ConjunctionExecutable,
 };
-use concept::{error::ConceptReadError, thing::thing_manager::ThingManager};
+use concept::error::ConceptReadError;
 use resource::profile::StageProfile;
 use storage::snapshot::ReadableSnapshot;
 
-use crate::read::pattern_executor::PatternExecutor;
+use crate::{pipeline::stage::ExecutionContext, read::pattern_executor::PatternExecutor};
 
 mod collecting_stage_executor;
 pub(super) mod control_instruction;
@@ -55,8 +55,7 @@ impl std::ops::Deref for ExecutorIndex {
 }
 
 pub(super) fn create_pattern_executor_for_conjunction(
-    snapshot: &Arc<impl ReadableSnapshot + 'static>,
-    thing_manager: &Arc<ThingManager>,
+    execution_context: &ExecutionContext<impl ReadableSnapshot>,
     function_registry: &ExecutableFunctionRegistry,
     conjunction_executable: &ConjunctionExecutable,
     profile: Arc<StageProfile>,
@@ -69,8 +68,7 @@ pub(super) fn create_pattern_executor_for_conjunction(
         )
     });
     let executors = step_executor::create_executors_for_conjunction(
-        snapshot,
-        thing_manager,
+        execution_context,
         function_registry,
         pattern_profile,
         conjunction_executable,

--- a/executor/read/pattern_executor.rs
+++ b/executor/read/pattern_executor.rs
@@ -6,6 +6,7 @@
 
 use std::ops::DerefMut;
 
+use ir::pipeline::ParameterRegistry;
 use lending_iterator::LendingIterator;
 use storage::snapshot::ReadableSnapshot;
 
@@ -52,12 +53,14 @@ impl PatternExecutor {
 
     pub(crate) fn compute_next_batch(
         &mut self,
-        context: &ExecutionContext<impl ReadableSnapshot + 'static>,
+        execution_context: &ExecutionContext<impl ReadableSnapshot + 'static>,
+        parameters: &ParameterRegistry,
         interrupt: &mut ExecutionInterrupt,
         tabled_functions: &mut TabledFunctions,
     ) -> Result<Option<FixedBatch>, ReadExecutionError> {
         let mut suspensions = QueryPatternSuspensions::new_root();
-        let result = self.batch_continue(context, interrupt, tabled_functions, &mut suspensions)?;
+        let result =
+            self.batch_continue(execution_context, parameters, interrupt, tabled_functions, &mut suspensions)?;
         debug_assert!(suspensions.is_empty());
         Ok(result)
     }
@@ -92,7 +95,8 @@ impl PatternExecutor {
 
     pub(super) fn batch_continue(
         &mut self,
-        context: &ExecutionContext<impl ReadableSnapshot + 'static>,
+        execution_context: &ExecutionContext<impl ReadableSnapshot + 'static>,
+        parameters: &ParameterRegistry,
         interrupt: &mut ExecutionInterrupt,
         tabled_functions: &mut TabledFunctions,
         suspensions: &mut QueryPatternSuspensions,
@@ -109,7 +113,7 @@ impl PatternExecutor {
 
             match control_stack.pop().unwrap() {
                 ControlInstruction::PatternStart(PatternStart { input_batch }) => {
-                    self.push_next_instruction(context, ExecutorIndex(0), input_batch)?;
+                    self.push_next_instruction(execution_context, parameters, ExecutorIndex(0), input_batch)?;
                 }
                 ControlInstruction::RestoreSuspension(RestoreSuspension { depth }) => {
                     debug_assert!(depth == suspensions.current_depth()); // Smell. The depth in the step is redundant
@@ -120,9 +124,9 @@ impl PatternExecutor {
                 }
                 ControlInstruction::ExecuteImmediate(ExecuteImmediate { index }) => {
                     let executor = executors[*index].unwrap_immediate();
-                    if let Some(batch) = executor.batch_continue(context, interrupt)? {
+                    if let Some(batch) = executor.batch_continue(execution_context, parameters, interrupt)? {
                         control_stack.push(ExecuteImmediate { index }.into());
-                        self.push_next_instruction(context, index.next(), batch)?;
+                        self.push_next_instruction(execution_context, parameters, index.next(), batch)?;
                     }
                 }
                 ControlInstruction::MapBatchToRowsForNested(MapBatchToRowsForNested { index, mut iterator }) => {
@@ -134,11 +138,15 @@ impl PatternExecutor {
                 }
                 ControlInstruction::ExecuteNegation(ExecuteNegation { index, input }) => {
                     let NegationExecutor { inner } = &mut executors[*index].unwrap_negation();
-                    let result = inner.compute_next_batch(context, interrupt, tabled_functions)?;
+                    let result =
+                        inner.compute_next_batch(execution_context, parameters, interrupt, tabled_functions)?;
                     match result {
-                        None => {
-                            self.push_next_instruction(context, index.next(), FixedBatch::from(input.as_reference()))?
-                        }
+                        None => self.push_next_instruction(
+                            execution_context,
+                            parameters,
+                            index.next(),
+                            FixedBatch::from(input.as_reference()),
+                        )?,
                         Some(batch) => {
                             debug_assert!(!batch.is_empty());
                             inner.reset()
@@ -149,18 +157,18 @@ impl PatternExecutor {
                     let optional = &mut executors[*index].unwrap_optional();
                     let batch_opt = optional
                         .inner
-                        .batch_continue(context, interrupt, tabled_functions, suspensions)?
+                        .batch_continue(execution_context, parameters, interrupt, tabled_functions, suspensions)?
                         .map(|batch| optional.map_output(batch));
                     if let Some(batch) = batch_opt {
                         debug_assert!(!batch.is_empty());
                         control_stack.push(ExecuteOptional { index, input, any_found: true }.into());
-                        self.push_next_instruction(context, index.next(), batch)?;
+                        self.push_next_instruction(execution_context, parameters, index.next(), batch)?;
                     } else if !any_found {
                         // if we never found anything for this input, we still push the next instruction
                         //   this will continue with None for all the new variables
                         //   we also don't re-visit this instruction on backtracking.
                         let batch = optional.map_as_failed_output(input);
-                        self.push_next_instruction(context, index.next(), batch)?;
+                        self.push_next_instruction(execution_context, parameters, index.next(), batch)?;
                     } // else: we've already found some optional values, so we don't need to re-explore and just backtrack
                 }
                 ControlInstruction::ExecuteDisjunctionBranch(ExecuteDisjunctionBranch {
@@ -171,37 +179,43 @@ impl PatternExecutor {
                     let disjunction = &mut executors[*index].unwrap_disjunction();
                     let branch = &mut disjunction.branches[*branch_index];
                     let batch_opt = may_push_nested(suspensions, index, branch_index, &input, |suspensions| {
-                        branch.batch_continue(context, interrupt, tabled_functions, suspensions)
+                        branch.batch_continue(execution_context, parameters, interrupt, tabled_functions, suspensions)
                     })?;
                     if let Some(mapped) = batch_opt.map(|unmapped| disjunction.map_output(branch_index, unmapped)) {
                         control_stack.push(ExecuteDisjunctionBranch { index, branch_index, input }.into());
-                        self.push_next_instruction(context, index.next(), mapped)?;
+                        self.push_next_instruction(execution_context, parameters, index.next(), mapped)?;
                     }
                 }
                 ControlInstruction::ExecuteInlinedFunction(ExecuteInlinedFunction { index, input }) => {
                     let executor = &mut executors[*index].unwrap_inlined_call();
-                    let func_context = &context.clone_with_replaced_parameters(executor.parameter_registry.clone());
                     let batch_opt = may_push_nested(suspensions, index, BranchIndex(0), &input, |suspensions| {
-                        executor.inner.batch_continue(func_context, interrupt, tabled_functions, suspensions)
+                        executor.inner.batch_continue(
+                            execution_context,
+                            &executor.parameter_registry,
+                            interrupt,
+                            tabled_functions,
+                            suspensions,
+                        )
                     })?;
                     if let Some(mapped) = batch_opt.map(|batch| executor.map_output(input.as_reference(), batch)) {
                         control_stack.push(ExecuteInlinedFunction { index, input: input.into_owned() }.into());
-                        self.push_next_instruction(context, index.next(), mapped)?;
+                        self.push_next_instruction(execution_context, parameters, index.next(), mapped)?;
                     }
                 }
                 ControlInstruction::ExecuteStreamModifier(ExecuteStreamModifier { index, mut mapper, input }) => {
                     let inner = &mut executors[*index].unwrap_stream_modifier().inner();
                     let unmapped = may_push_nested(suspensions, index, BranchIndex(0), &input, |suspensions| {
-                        inner.batch_continue(context, interrupt, tabled_functions, suspensions)
+                        inner.batch_continue(execution_context, parameters, interrupt, tabled_functions, suspensions)
                     })?;
                     if let Some(batch) = mapper.map_output(unmapped) {
                         control_stack.push(ExecuteStreamModifier { index, mapper, input: input.into_owned() }.into());
-                        self.push_next_instruction(context, index.next(), batch)?;
+                        self.push_next_instruction(execution_context, parameters, index.next(), batch)?;
                     }
                 }
                 ControlInstruction::ExecuteTabledCall(ExecuteTabledCall { index, last_seen_table_size }) => {
                     self.execute_tabled_call(
-                        context,
+                        execution_context,
+                        parameters,
                         interrupt,
                         tabled_functions,
                         suspensions,
@@ -219,24 +233,26 @@ impl PatternExecutor {
                     let storage_counters = step_profile.storage_counters();
                     let inner = collecting_stage.pattern_mut();
                     let mut batches = 0;
-                    while let Some(batch) = inner.compute_next_batch(context, interrupt, tabled_functions)? {
-                        collector.accept(context, batch, &storage_counters);
+                    while let Some(batch) =
+                        inner.compute_next_batch(execution_context, parameters, interrupt, tabled_functions)?
+                    {
+                        collector.accept(execution_context, batch, &storage_counters);
                         batches += 1;
                     }
-                    let iterator = collector.into_iterator(context, step_profile.storage_counters());
+                    let iterator = collector.into_iterator(execution_context, step_profile.storage_counters());
                     measurement.end(&step_profile, batches, iterator.initial_len() as u64);
                     self.control_stack.push(StreamCollected { index, iterator }.into());
                 }
                 ControlInstruction::StreamCollected(StreamCollected { index, mut iterator }) => {
                     if let Some(batch) = iterator.batch_continue()? {
                         self.control_stack.push(StreamCollected { index, iterator }.into());
-                        self.push_next_instruction(context, index.next(), batch)?;
+                        self.push_next_instruction(execution_context, parameters, index.next(), batch)?;
                     }
                 }
                 ControlInstruction::ReshapeForReturn(ReshapeForReturn { index, to_reshape: batch }) => {
                     let reshape = executors[*index].unwrap_reshape();
                     let output_batch = reshape.map_output(batch);
-                    self.push_next_instruction(context, index.next(), output_batch)?;
+                    self.push_next_instruction(execution_context, parameters, index.next(), output_batch)?;
                 }
                 ControlInstruction::Yield(Yield { batch }) => {
                     return Ok(Some(batch));
@@ -248,7 +264,8 @@ impl PatternExecutor {
 
     fn push_next_instruction(
         &mut self,
-        context: &ExecutionContext<impl ReadableSnapshot + 'static>,
+        execution_context: &ExecutionContext<impl ReadableSnapshot + 'static>,
+        parameters: &ParameterRegistry,
         next_index: ExecutorIndex,
         batch: FixedBatch,
     ) -> Result<(), ReadExecutionError> {
@@ -260,7 +277,7 @@ impl PatternExecutor {
         } else {
             match &mut self.executors[*next_index] {
                 StepExecutors::Immediate(executable) => {
-                    executable.prepare(batch, context)?;
+                    executable.prepare(batch, execution_context, parameters)?;
                     self.control_stack.push(ExecuteImmediate { index: next_index }.into());
                 }
                 StepExecutors::Negation(_)
@@ -275,7 +292,7 @@ impl PatternExecutor {
                 StepExecutors::CollectingStage(collecting_stage) => {
                     collecting_stage.prepare(batch);
                     let collector = collecting_stage.create_collector();
-                    let profile = collecting_stage.step_profile(&context.profile);
+                    let profile = collecting_stage.step_profile();
                     self.control_stack.push(CollectingStage { index: next_index, collector, profile }.into());
                 }
                 StepExecutors::ReshapeForReturn(_) => {
@@ -329,7 +346,8 @@ impl PatternExecutor {
 
     fn execute_tabled_call(
         &mut self,
-        context: &ExecutionContext<impl ReadableSnapshot + 'static>,
+        execution_context: &ExecutionContext<impl ReadableSnapshot + 'static>,
+        parameters: &ParameterRegistry,
         interrupt: &mut ExecutionInterrupt,
         tabled_functions: &mut TabledFunctions,
         caller_suspensions: &mut QueryPatternSuspensions,
@@ -338,7 +356,7 @@ impl PatternExecutor {
     ) -> Result<(), ReadExecutionError> {
         let executor = self.executors[*index].unwrap_tabled_call();
         let call_key = executor.active_call_key().unwrap();
-        let function_state = tabled_functions.get_or_create_function_state(context, call_key)?;
+        let function_state = tabled_functions.get_or_create_function_state(execution_context, call_key)?;
         let found = match executor.try_read_next_batch(&function_state) {
             TabledCallResult::RetrievedFromTable(batch) => Some(batch),
             TabledCallResult::Suspend => {
@@ -349,17 +367,11 @@ impl PatternExecutor {
                 let TabledFunctionPatternExecutorState {
                     pattern_executor,
                     suspensions: function_suspensions,
-                    parameters,
+                    parameters: function_parameters,
                 } = pattern_state_mutex_guard.deref_mut();
-                let context_with_function_parameters = ExecutionContext::new_with_profile(
-                    context.snapshot.clone(),
-                    context.thing_manager.clone(),
-                    context.function_manager.clone(),
-                    parameters.clone(),
-                    context.profile.clone(),
-                );
                 let batch_opt = pattern_executor.batch_continue(
-                    &context_with_function_parameters,
+                    execution_context,
+                    function_parameters,
                     interrupt,
                     tabled_functions,
                     function_suspensions,
@@ -392,7 +404,7 @@ impl PatternExecutor {
             self.control_stack
                 .push(ExecuteTabledCall { index, last_seen_table_size: table_size_at_last_restore }.into());
             let mapped = executor.map_output(batch);
-            self.push_next_instruction(context, index.next(), mapped)?;
+            self.push_next_instruction(execution_context, parameters, index.next(), mapped)?;
         }
         Ok(())
     }

--- a/executor/read/step_executor.rs
+++ b/executor/read/step_executor.rs
@@ -18,7 +18,7 @@ use compiler::{
         pipeline::ExecutableStage,
     },
 };
-use concept::{error::ConceptReadError, thing::thing_manager::ThingManager};
+use concept::error::ConceptReadError;
 use error::UnimplementedFeature;
 use ir::pipeline::function_signature::FunctionID;
 use itertools::Itertools;
@@ -28,6 +28,7 @@ use typeql::schema::definable::function::SingleSelector;
 
 use crate::{
     batch::FixedBatch,
+    pipeline::stage::ExecutionContext,
     read::{
         collecting_stage_executor::CollectingStageExecutor,
         immediate_executor::{BuiltinCallExecutor, ImmediateExecutor},
@@ -150,8 +151,7 @@ impl ReshapeForReturnExecutor {
 }
 
 pub(crate) fn create_executors_for_conjunction(
-    snapshot: &Arc<impl ReadableSnapshot + 'static>,
-    thing_manager: &Arc<ThingManager>,
+    execution_context: &ExecutionContext<impl ReadableSnapshot>,
     function_registry: &ExecutableFunctionRegistry,
     pattern_profile: Arc<PatternProfile>,
     conjunction_executable: &ConjunctionExecutable,
@@ -163,7 +163,12 @@ pub(crate) fn create_executors_for_conjunction(
                 let step_profile = pattern_profile.extend_or_get_step(index, || {
                     format!("{}", inner.make_var_mapped(conjunction_executable.variable_reverse_map()))
                 });
-                let step = ImmediateExecutor::new_intersection(inner, snapshot, thing_manager, step_profile)?;
+                let step = ImmediateExecutor::new_intersection(
+                    inner,
+                    execution_context.snapshot.as_ref(),
+                    &execution_context.thing_manager,
+                    step_profile,
+                )?;
                 steps.push(step.into());
             }
             ExecutionStep::UnsortedJoin(inner) => {
@@ -186,8 +191,7 @@ pub(crate) fn create_executors_for_conjunction(
             ExecutionStep::Negation(negation_step) => {
                 let subpattern_profile = pattern_profile.extend_or_get_subpattern(index, || "Negation".to_string());
                 let inner = create_executors_for_conjunction(
-                    snapshot,
-                    thing_manager,
+                    execution_context,
                     function_registry,
                     subpattern_profile,
                     &negation_step.negation,
@@ -223,8 +227,7 @@ pub(crate) fn create_executors_for_conjunction(
                     } else {
                         let subquery_profile = pattern_profile.extend_or_get_subquery(index, || "FnCall".to_string());
                         let inner_executors = create_executors_for_function(
-                            snapshot,
-                            thing_manager,
+                            execution_context,
                             function_registry,
                             subquery_profile,
                             function,
@@ -248,8 +251,7 @@ pub(crate) fn create_executors_for_conjunction(
                             format!("Branch {} [id: {}]", branch_index, branch_executable.executable_id())
                         });
                         let executors = create_executors_for_conjunction(
-                            snapshot,
-                            thing_manager,
+                            execution_context,
                             function_registry,
                             branch_profile,
                             branch_executable,
@@ -274,8 +276,7 @@ pub(crate) fn create_executors_for_conjunction(
             ExecutionStep::Optional(step) => {
                 let subpattern_profile = pattern_profile.extend_or_get_subpattern(index, || "Optional".to_string());
                 let inner = create_executors_for_conjunction(
-                    snapshot,
-                    thing_manager,
+                    execution_context,
                     function_registry,
                     subpattern_profile,
                     &step.optional,
@@ -295,16 +296,14 @@ pub(crate) fn create_executors_for_conjunction(
 }
 
 pub(crate) fn create_executors_for_function(
-    snapshot: &Arc<impl ReadableSnapshot + 'static>,
-    thing_manager: &Arc<ThingManager>,
+    execution_context: &ExecutionContext<impl ReadableSnapshot>,
     function_registry: &ExecutableFunctionRegistry,
     query_profile: Arc<QueryProfile>,
     executable_function: &ExecutableFunction,
 ) -> Result<Vec<StepExecutors>, Box<ConceptReadError>> {
     let executable_stages = &executable_function.executable_stages;
     let mut steps = create_executors_for_function_pipeline_stages(
-        snapshot,
-        thing_manager,
+        execution_context,
         function_registry,
         &query_profile,
         executable_stages,
@@ -333,6 +332,7 @@ pub(crate) fn create_executors_for_function(
             let step = CollectingStageExecutor::new_reduce(
                 PatternExecutor::new(executable_function.executable_id, steps),
                 executable.clone(),
+                &query_profile,
             );
             Ok(vec![StepExecutors::CollectingStage(step)])
         }
@@ -341,8 +341,7 @@ pub(crate) fn create_executors_for_function(
 
 // TODO: Turn this recursion into iteration to prevent stack overflows of really long functions
 pub(super) fn create_executors_for_function_pipeline_stages(
-    snapshot: &Arc<impl ReadableSnapshot + 'static>,
-    thing_manager: &Arc<ThingManager>,
+    execution_context: &ExecutionContext<impl ReadableSnapshot>,
     function_registry: &ExecutableFunctionRegistry,
     query_profile: &QueryProfile,
     executable_stages: &[ExecutableStage],
@@ -350,8 +349,7 @@ pub(super) fn create_executors_for_function_pipeline_stages(
 ) -> Result<Vec<StepExecutors>, Box<ConceptReadError>> {
     let mut previous_stage_steps = if at_index > 0 {
         create_executors_for_function_pipeline_stages(
-            snapshot,
-            thing_manager,
+            execution_context,
             function_registry,
             query_profile,
             executable_stages,
@@ -373,8 +371,7 @@ pub(super) fn create_executors_for_function_pipeline_stages(
                 )
             });
             let mut executors = create_executors_for_conjunction(
-                snapshot,
-                thing_manager,
+                execution_context,
                 function_registry,
                 pattern_profile,
                 conjunction_executable,
@@ -418,6 +415,7 @@ pub(super) fn create_executors_for_function_pipeline_stages(
             let step = CollectingStageExecutor::new_sort(
                 PatternExecutor::new(next_executable_id(), previous_stage_steps),
                 sort_executable,
+                query_profile,
             );
             Ok(vec![StepExecutors::CollectingStage(step)])
         }
@@ -425,6 +423,7 @@ pub(super) fn create_executors_for_function_pipeline_stages(
             let step = CollectingStageExecutor::new_reduce(
                 PatternExecutor::new(next_executable_id(), previous_stage_steps),
                 reduce_stage_executable.reduce_rows_executable.clone(),
+                query_profile,
             );
             Ok(vec![StepExecutors::CollectingStage(step)])
         }

--- a/executor/read/tabled_functions.rs
+++ b/executor/read/tabled_functions.rs
@@ -14,6 +14,7 @@ use compiler::executable::function::{
     ExecutableFunctionRegistry, FunctionTablingType, StronglyConnectedComponentID, executable::ExecutableReturn,
 };
 use ir::pipeline::{ParameterRegistry, function_signature::FunctionID};
+use resource::profile::QueryProfile;
 use smallvec::SmallVec;
 use storage::snapshot::ReadableSnapshot;
 
@@ -31,12 +32,13 @@ use crate::{
 
 pub struct TabledFunctions {
     function_registry: Arc<ExecutableFunctionRegistry>,
+    profile: Arc<QueryProfile>,
     state: HashMap<CallKey, Arc<TabledFunctionState>>, // TODO: Splitting these by SCCID would be nice.
 }
 
 impl TabledFunctions {
-    pub(crate) fn new(function_registry: Arc<ExecutableFunctionRegistry>) -> Self {
-        Self { state: HashMap::new(), function_registry }
+    pub(crate) fn new(function_registry: Arc<ExecutableFunctionRegistry>, profile: Arc<QueryProfile>) -> Self {
+        Self { state: HashMap::new(), function_registry, profile }
     }
 
     pub(crate) fn get_or_create_function_state(
@@ -46,14 +48,9 @@ impl TabledFunctions {
     ) -> Result<Arc<TabledFunctionState>, ReadExecutionError> {
         if !self.state.contains_key(call_key) {
             let function = &self.function_registry.get(&call_key.function_id).unwrap();
-            let executors = create_executors_for_function(
-                &context.snapshot,
-                &context.thing_manager,
-                &self.function_registry,
-                context.profile.clone(),
-                function,
-            )
-            .map_err(|source| ReadExecutionError::ConceptRead { typedb_source: source })?;
+            let executors =
+                create_executors_for_function(context, &self.function_registry, self.profile.clone(), function)
+                    .map_err(|source| ReadExecutionError::ConceptRead { typedb_source: source })?;
             let pattern_executor = PatternExecutor::new(function.executable_id, executors);
             let width = match &function.returns {
                 ExecutableReturn::Stream(v) | ExecutableReturn::Single(_, v) => v.len() as u32,

--- a/executor/tests/compile_execute.rs
+++ b/executor/tests/compile_execute.rs
@@ -29,7 +29,7 @@ use executor::{
 use function::function_manager::FunctionManager;
 use ir::{
     pattern::Pattern,
-    pipeline::{ParameterRegistry, function_signature::HashMapFunctionSignatureIndex},
+    pipeline::{ParameterRegistry, QueryContext, function_signature::HashMapFunctionSignatureIndex},
     translation::{PipelineTranslationContext, match_::translate_match},
 };
 use itertools::Itertools;
@@ -64,24 +64,22 @@ fn setup(
     let query_manager = QueryManager::new(None);
     let function_manager = FunctionManager::new(Arc::new(DefinitionKeyGenerator::new()), None);
     let mut snapshot = storage.clone().open_snapshot_schema();
-    let define = typeql::parse_query(schema).unwrap().into_structure().into_schema();
-    query_manager
-        .execute_schema(&mut snapshot, &type_manager, &thing_manager, &function_manager, &define, schema)
-        .unwrap();
+    let parsed = query_manager.parse(schema.to_string()).unwrap().into_schema();
+    query_manager.execute_schema(&mut snapshot, &type_manager, &thing_manager, &function_manager, parsed).unwrap();
     snapshot.commit(&mut CommitProfile::DISABLED).unwrap();
 
     let snapshot = storage.clone().open_snapshot_write();
-    let query = typeql::parse_query(data).unwrap().into_structure().into_pipeline();
+    let parsed = query_manager.parse(data.to_string()).unwrap().into_pipeline();
     let pipeline = query_manager
         .prepare_write_pipeline(
             snapshot,
             &type_manager,
             thing_manager.clone(),
             Arc::default(),
-            &query,
+            parsed,
             None::<GivenRowsSimple>,
-            data,
         )
+        .map_err(|(_, err)| err)
         .unwrap();
     let (mut iterator, ExecutionContext { snapshot, .. }) =
         pipeline.into_rows_iterator(ExecutionInterrupt::new_uninterruptible()).unwrap();
@@ -150,18 +148,18 @@ fn test_has_planning_traversal() {
         &ExecutableFunctionRegistry::empty(),
     )
     .unwrap();
+    let context = ExecutionContext::new(snapshot, thing_manager, Arc::default());
     let executor = MatchExecutor::new(
         &conjunction_executable,
-        &snapshot,
-        &thing_manager,
+        &context,
         MaybeOwnedRow::empty(),
         Arc::new(ExecutableFunctionRegistry::empty()),
-        &QueryProfile::new(false),
+        &Arc::new(QueryProfile::new(false)),
     )
     .unwrap();
-
-    let context = ExecutionContext::new(snapshot, thing_manager, Arc::default(), Arc::default());
-    let iterator = executor.into_iterator(context, ExecutionInterrupt::new_uninterruptible());
+    let query_context =
+        Arc::new(QueryContext::new(Arc::new(value_parameters), Arc::default(), Arc::new(QueryProfile::new(false))));
+    let iterator = executor.into_iterator(context, query_context, ExecutionInterrupt::new_uninterruptible());
 
     let rows = iterator
         .map_static(|row| row.map(|row| row.into_owned()).map_err(|err| err.clone()))
@@ -249,18 +247,18 @@ fn test_expression_planning_traversal() {
         &ExecutableFunctionRegistry::empty(),
     )
     .unwrap();
+    let context = ExecutionContext::new(snapshot, thing_manager, Arc::default());
     let executor = MatchExecutor::new(
         &conjunction_executable,
-        &snapshot,
-        &thing_manager,
+        &context,
         MaybeOwnedRow::empty(),
         Arc::new(ExecutableFunctionRegistry::empty()),
-        &QueryProfile::new(false),
+        &Arc::new(QueryProfile::new(false)),
     )
     .unwrap();
-
-    let context = ExecutionContext::new(snapshot, thing_manager, Arc::default(), Arc::new(value_parameters));
-    let iterator = executor.into_iterator(context, ExecutionInterrupt::new_uninterruptible());
+    let query_context =
+        Arc::new(QueryContext::new(Arc::new(value_parameters), Arc::default(), Arc::new(QueryProfile::new(false))));
+    let iterator = executor.into_iterator(context, query_context, ExecutionInterrupt::new_uninterruptible());
 
     let rows = iterator
         .map_static(|row| row.map(|row| row.into_owned()).map_err(|err| err.clone()))
@@ -336,18 +334,17 @@ fn test_links_planning_traversal() {
         &ExecutableFunctionRegistry::empty(),
     )
     .unwrap();
+    let context = ExecutionContext::new(snapshot, thing_manager, Arc::default());
     let executor = MatchExecutor::new(
         &conjunction_executable,
-        &snapshot,
-        &thing_manager,
+        &context,
         MaybeOwnedRow::empty(),
         Arc::new(ExecutableFunctionRegistry::empty()),
-        &QueryProfile::new(false),
+        &Arc::new(QueryProfile::new(false)),
     )
     .unwrap();
-
-    let context = ExecutionContext::new(snapshot, thing_manager, Arc::default(), Arc::default());
-    let iterator = executor.into_iterator(context, ExecutionInterrupt::new_uninterruptible());
+    let query_context = Arc::new(QueryContext::new(Arc::default(), Arc::default(), Arc::new(QueryProfile::new(false))));
+    let iterator = executor.into_iterator(context, query_context, ExecutionInterrupt::new_uninterruptible());
 
     let rows = iterator
         .map_static(|row| row.map(|row| row.into_owned()).map_err(|err| err.clone()))
@@ -430,18 +427,17 @@ fn test_links_intersection() {
         &ExecutableFunctionRegistry::empty(),
     )
     .unwrap();
+    let context = ExecutionContext::new(snapshot, thing_manager, Arc::default());
     let executor = MatchExecutor::new(
         &conjunction_executable,
-        &snapshot,
-        &thing_manager,
+        &context,
         MaybeOwnedRow::empty(),
         Arc::new(ExecutableFunctionRegistry::empty()),
-        &QueryProfile::new(false),
+        &Arc::new(QueryProfile::new(false)),
     )
     .unwrap();
-
-    let context = ExecutionContext::new(snapshot, thing_manager, Arc::default(), Arc::default());
-    let iterator = executor.into_iterator(context, ExecutionInterrupt::new_uninterruptible());
+    let query_context = Arc::new(QueryContext::new(Arc::default(), Arc::default(), Arc::new(QueryProfile::new(false))));
+    let iterator = executor.into_iterator(context, query_context, ExecutionInterrupt::new_uninterruptible());
 
     let rows = iterator
         .map_static(|row| row.map(|row| row.into_owned()).map_err(|err| err.clone()))
@@ -515,18 +511,17 @@ fn test_negation_planning_traversal() {
         &ExecutableFunctionRegistry::empty(),
     )
     .unwrap();
+    let context = ExecutionContext::new(snapshot, thing_manager, Arc::default());
     let executor = MatchExecutor::new(
         &conjunction_executable,
-        &snapshot,
-        &thing_manager,
+        &context,
         MaybeOwnedRow::empty(),
         Arc::new(ExecutableFunctionRegistry::empty()),
-        &QueryProfile::new(false),
+        &Arc::new(QueryProfile::new(false)),
     )
     .unwrap();
-
-    let context = ExecutionContext::new(snapshot, thing_manager, Arc::default(), Arc::default());
-    let iterator = executor.into_iterator(context, ExecutionInterrupt::new_uninterruptible());
+    let query_context = Arc::new(QueryContext::new(Arc::default(), Arc::default(), Arc::new(QueryProfile::new(false))));
+    let iterator = executor.into_iterator(context, query_context, ExecutionInterrupt::new_uninterruptible());
 
     let rows = iterator
         .map_static(|row| row.map(|row| row.into_owned()).map_err(|err| err.clone()))
@@ -622,18 +617,17 @@ fn test_forall_planning_traversal() {
     )
     .unwrap();
 
+    let context = ExecutionContext::new(snapshot, thing_manager, Arc::default());
     let executor = MatchExecutor::new(
         &conjunction_executable,
-        &snapshot,
-        &thing_manager,
+        &context,
         MaybeOwnedRow::empty(),
         Arc::new(ExecutableFunctionRegistry::empty()),
-        &QueryProfile::new(false),
+        &Arc::new(QueryProfile::new(false)),
     )
     .unwrap();
-
-    let context = ExecutionContext::new(snapshot, thing_manager, Arc::default(), Arc::default());
-    let iterator = executor.into_iterator(context, ExecutionInterrupt::new_uninterruptible());
+    let query_context = Arc::new(QueryContext::new(Arc::default(), Arc::default(), Arc::new(QueryProfile::new(false))));
+    let iterator = executor.into_iterator(context, query_context, ExecutionInterrupt::new_uninterruptible());
 
     let rows = iterator
         .map_static(|row| row.map(|row| row.into_owned()).map_err(|err| err.clone()))
@@ -714,18 +708,17 @@ fn test_named_var_select() {
         &ExecutableFunctionRegistry::empty(),
     )
     .unwrap();
+    let context = ExecutionContext::new(snapshot, thing_manager, Arc::default());
     let executor = MatchExecutor::new(
         &conjunction_executable,
-        &snapshot,
-        &thing_manager,
+        &context,
         MaybeOwnedRow::empty(),
         Arc::new(ExecutableFunctionRegistry::empty()),
-        &QueryProfile::new(false),
+        &Arc::new(QueryProfile::new(false)),
     )
     .unwrap();
-
-    let context = ExecutionContext::new(snapshot, thing_manager, Arc::default(), Arc::default());
-    let iterator = executor.into_iterator(context, ExecutionInterrupt::new_uninterruptible());
+    let query_context = Arc::new(QueryContext::new(Arc::default(), Arc::default(), Arc::new(QueryProfile::new(false))));
+    let iterator = executor.into_iterator(context, query_context, ExecutionInterrupt::new_uninterruptible());
 
     let rows = iterator
         .map_static(|row| row.map(|row| row.into_owned()).map_err(|err| err.clone()))
@@ -806,18 +799,17 @@ fn test_disjunction_planning_traversal() {
         &ExecutableFunctionRegistry::empty(),
     )
     .unwrap();
+    let context = ExecutionContext::new(snapshot, thing_manager, Arc::default());
     let executor = MatchExecutor::new(
         &conjunction_executable,
-        &snapshot,
-        &thing_manager,
+        &context,
         MaybeOwnedRow::empty(),
         Arc::new(ExecutableFunctionRegistry::empty()),
-        &QueryProfile::new(false),
+        &Arc::new(QueryProfile::new(false)),
     )
     .unwrap();
-
-    let context = ExecutionContext::new(snapshot, thing_manager, Arc::default(), Arc::default());
-    let iterator = executor.into_iterator(context, ExecutionInterrupt::new_uninterruptible());
+    let query_context = Arc::new(QueryContext::new(Arc::default(), Arc::default(), Arc::new(QueryProfile::new(false))));
+    let iterator = executor.into_iterator(context, query_context, ExecutionInterrupt::new_uninterruptible());
 
     let rows = iterator
         .map_static(|row| row.map(|row| row.into_owned()).map_err(|err| err.clone()))
@@ -902,18 +894,17 @@ fn test_disjunction_planning_nested_negations() {
         &ExecutableFunctionRegistry::empty(),
     )
     .unwrap();
+    let context = ExecutionContext::new(snapshot, thing_manager, Arc::default());
     let executor = MatchExecutor::new(
         &conjunction_executable,
-        &snapshot,
-        &thing_manager,
+        &context,
         MaybeOwnedRow::empty(),
         Arc::new(ExecutableFunctionRegistry::empty()),
-        &QueryProfile::new(false),
+        &Arc::new(QueryProfile::new(false)),
     )
     .unwrap();
-
-    let context = ExecutionContext::new(snapshot, thing_manager, Arc::default(), Arc::default());
-    let iterator = executor.into_iterator(context, ExecutionInterrupt::new_uninterruptible());
+    let query_context = Arc::new(QueryContext::new(Arc::default(), Arc::default(), Arc::new(QueryProfile::new(false))));
+    let iterator = executor.into_iterator(context, query_context, ExecutionInterrupt::new_uninterruptible());
 
     let rows = iterator
         .map_static(|row| row.map(|row| row.into_owned()).map_err(|err| err.clone()))
@@ -961,17 +952,18 @@ fn test_mismatched_input_types() {
         let snapshot = Arc::new(storage.clone().open_snapshot_read());
         let conjunction_executable =
             compile_query(&*snapshot, &type_manager, thing_manager.clone(), &statistics, query);
+        let context = ExecutionContext::new(snapshot, thing_manager.clone(), Arc::default());
         let executor = MatchExecutor::new(
             &conjunction_executable,
-            &snapshot,
-            &thing_manager,
+            &context,
             MaybeOwnedRow::empty(),
             Arc::new(ExecutableFunctionRegistry::empty()),
-            &QueryProfile::new(false),
+            &Arc::new(QueryProfile::new(false)),
         )
         .unwrap();
-        let context = ExecutionContext::new(snapshot, thing_manager.clone(), Arc::default(), Arc::default());
-        let iterator = executor.into_iterator(context, ExecutionInterrupt::new_uninterruptible());
+        let query_context =
+            Arc::new(QueryContext::new(Arc::default(), Arc::default(), Arc::new(QueryProfile::new(false))));
+        let iterator = executor.into_iterator(context, query_context, ExecutionInterrupt::new_uninterruptible());
         let rows = iterator
             .map_static(|row| row.map(|row| row.into_owned()).map_err(|err| err.clone()))
             .into_iter()
@@ -996,17 +988,18 @@ fn test_mismatched_input_types() {
         let snapshot = Arc::new(storage.clone().open_snapshot_read());
         let conjunction_executable =
             compile_query(&*snapshot, &type_manager, thing_manager.clone(), &statistics, query);
+        let context = ExecutionContext::new(snapshot, thing_manager.clone(), Arc::default());
         let executor = MatchExecutor::new(
             &conjunction_executable,
-            &snapshot,
-            &thing_manager,
+            &context,
             MaybeOwnedRow::empty(),
             Arc::new(ExecutableFunctionRegistry::empty()),
-            &QueryProfile::new(false),
+            &Arc::new(QueryProfile::new(false)),
         )
         .unwrap();
-        let context = ExecutionContext::new(snapshot, thing_manager.clone(), Arc::default(), Arc::default());
-        let iterator = executor.into_iterator(context, ExecutionInterrupt::new_uninterruptible());
+        let query_context =
+            Arc::new(QueryContext::new(Arc::default(), Arc::default(), Arc::new(QueryProfile::new(false))));
+        let iterator = executor.into_iterator(context, query_context, ExecutionInterrupt::new_uninterruptible());
         let rows = iterator
             .map_static(|row| row.map(|row| row.into_owned()).map_err(|err| err.clone()))
             .into_iter()

--- a/executor/tests/efficiency.rs
+++ b/executor/tests/efficiency.rs
@@ -51,7 +51,7 @@ use ir::{
         Vertex,
         constraint::{Comparator, IsaKind},
     },
-    pipeline::{ParameterRegistry, block::Block},
+    pipeline::{ParameterRegistry, QueryContext, block::Block},
     translation::PipelineTranslationContext,
 };
 use lending_iterator::LendingIterator;
@@ -444,7 +444,7 @@ fn execute_steps(
     storage: Arc<MVCCStorage<WALClient>>,
     thing_manager: Arc<ThingManager>,
     value_parameters: Arc<ParameterRegistry>,
-    profile: &QueryProfile,
+    profile: &Arc<QueryProfile>,
 ) -> Vec<Result<MaybeOwnedRow<'static>, Box<ReadExecutionError>>> {
     let executable = ConjunctionExecutable::new(
         next_executable_id(),
@@ -456,18 +456,17 @@ fn execute_steps(
 
     // Executor
     let snapshot = Arc::new(storage.clone().open_snapshot_read());
+    let context = ExecutionContext::new(snapshot, thing_manager.clone(), Arc::default());
+    let query_context = Arc::new(QueryContext::new(value_parameters, Arc::default(), profile.clone()));
     let executor = MatchExecutor::new(
         &executable,
-        &snapshot,
-        &thing_manager,
+        &context,
         MaybeOwnedRow::empty(),
         Arc::new(ExecutableFunctionRegistry::empty()),
         profile,
     )
     .unwrap();
-
-    let context = ExecutionContext::new(snapshot, thing_manager.clone(), Arc::default(), value_parameters.clone());
-    let iterator = executor.into_iterator(context, ExecutionInterrupt::new_uninterruptible());
+    let iterator = executor.into_iterator(context, query_context, ExecutionInterrupt::new_uninterruptible());
 
     iterator
         .map_static(|row| row.map(|row| row.as_reference().into_owned()).map_err(|err| Box::new(err.clone())))
@@ -551,7 +550,7 @@ fn value_int_equality_isa_reads() {
         )),
     ];
 
-    let query_profile = QueryProfile::new(true);
+    let query_profile = Arc::new(QueryProfile::new(true));
     let rows =
         execute_steps(steps, variable_positions, row_vars, storage, thing_manager, value_parameters, &query_profile);
 
@@ -646,7 +645,7 @@ fn value_int_equality_has_reverse_reads() {
         2,
     ))];
 
-    let query_profile = QueryProfile::new(true);
+    let query_profile = Arc::new(QueryProfile::new(true));
     let rows =
         execute_steps(steps, variable_positions, row_vars, storage, thing_manager, value_parameters, &query_profile);
 
@@ -753,7 +752,7 @@ fn value_int_equality_has_bound_owner() {
         )),
     ];
 
-    let query_profile = QueryProfile::new(true);
+    let query_profile = Arc::new(QueryProfile::new(true));
     let rows =
         execute_steps(steps, variable_positions, row_vars, storage, thing_manager, value_parameters, &query_profile);
 
@@ -873,7 +872,7 @@ fn value_int_inequality_has_bound_owner() {
         )),
     ];
 
-    let query_profile = QueryProfile::new(true);
+    let query_profile = Arc::new(QueryProfile::new(true));
     let rows =
         execute_steps(steps, variable_positions, row_vars, storage, thing_manager, value_parameters, &query_profile);
     assert_eq!(rows.len(), 2);
@@ -977,7 +976,7 @@ fn value_inline_string_equality_has_bound_owner() {
         )),
     ];
 
-    let query_profile = QueryProfile::new(true);
+    let query_profile = Arc::new(QueryProfile::new(true));
     let rows =
         execute_steps(steps, variable_positions, row_vars, storage, thing_manager, value_parameters, &query_profile);
 
@@ -1084,7 +1083,7 @@ fn value_hashed_string_equality_has_bound_owner() {
         )),
     ];
 
-    let query_profile = QueryProfile::new(true);
+    let query_profile = Arc::new(QueryProfile::new(true));
     let rows =
         execute_steps(steps, variable_positions, row_vars, storage, thing_manager, value_parameters, &query_profile);
 
@@ -1208,7 +1207,7 @@ fn value_string_inequality_reduces_has_reads_bound_owner() {
         )),
     ];
 
-    let query_profile = QueryProfile::new(true);
+    let query_profile = Arc::new(QueryProfile::new(true));
     let rows =
         execute_steps(steps, variable_positions, row_vars, storage, thing_manager, value_parameters, &query_profile);
     assert_eq!(rows.len(), 2);
@@ -1344,7 +1343,7 @@ fn intersection_seeks() {
         )),
     ];
 
-    let query_profile = QueryProfile::new(true);
+    let query_profile = Arc::new(QueryProfile::new(true));
     let rows =
         execute_steps(steps, variable_positions, row_vars, storage, thing_manager, value_parameters, &query_profile);
     for row in rows.iter() {
@@ -1536,7 +1535,7 @@ fn intersections_seeks_with_extra_values() {
         )),
     ];
 
-    let query_profile = QueryProfile::new(true);
+    let query_profile = Arc::new(QueryProfile::new(true));
     let rows =
         execute_steps(steps, variable_positions, row_vars, storage, thing_manager, value_parameters, &query_profile);
     for row in rows.iter() {

--- a/executor/tests/execute_comparison_check.rs
+++ b/executor/tests/execute_comparison_check.rs
@@ -37,7 +37,7 @@ use executor::{
 };
 use ir::{
     pattern::constraint::{Comparator, IsaKind},
-    pipeline::{ParameterRegistry, block::Block},
+    pipeline::{ParameterRegistry, QueryContext, block::Block},
     translation::PipelineTranslationContext,
 };
 use lending_iterator::LendingIterator;
@@ -179,18 +179,17 @@ fn attribute_equality() {
 
     // Executor
     let snapshot = Arc::new(storage.clone().open_snapshot_read());
+    let context = ExecutionContext::new(snapshot, thing_manager, Arc::default());
+    let query_context = Arc::new(QueryContext::new(Arc::default(), Arc::default(), Arc::new(QueryProfile::new(false))));
     let executor = MatchExecutor::new(
         &executable,
-        &snapshot,
-        &thing_manager,
+        &context,
         MaybeOwnedRow::empty(),
         Arc::new(ExecutableFunctionRegistry::empty()),
-        &QueryProfile::new(false),
+        &Arc::new(QueryProfile::new(false)),
     )
     .unwrap();
-
-    let context = ExecutionContext::new(snapshot, thing_manager, Arc::default(), Arc::default());
-    let iterator = executor.into_iterator(context, ExecutionInterrupt::new_uninterruptible());
+    let iterator = executor.into_iterator(context, query_context.clone(), ExecutionInterrupt::new_uninterruptible());
 
     let rows: Vec<Result<MaybeOwnedRow<'static>, Box<ReadExecutionError>>> =
         iterator.map_static(|row| row.map(|row| row.into_owned()).map_err(|err| Box::new(err.clone()))).collect();

--- a/executor/tests/execute_function.rs
+++ b/executor/tests/execute_function.rs
@@ -99,10 +99,8 @@ fn setup_common(schema: &str) -> Context {
     let query_manager = QueryManager::new(None);
 
     let mut snapshot = storage.clone().open_snapshot_schema();
-    let define = typeql::parse_query(schema).unwrap().into_structure().into_schema();
-    query_manager
-        .execute_schema(&mut snapshot, &type_manager, &thing_manager, &function_manager, &define, schema)
-        .unwrap();
+    let parsed = query_manager.parse(schema.to_string()).unwrap().into_schema();
+    query_manager.execute_schema(&mut snapshot, &type_manager, &thing_manager, &function_manager, parsed).unwrap();
     snapshot.commit(&mut CommitProfile::DISABLED).unwrap();
 
     let query_manager = QueryManager::new(Some(Arc::new(QueryCache::new())));
@@ -116,7 +114,7 @@ fn run_read_query(
     query: &str,
 ) -> Result<(Vec<MaybeOwnedRow<'static>>, HashMap<String, VariablePosition>), Box<PipelineExecutionError>> {
     let snapshot = Arc::new(context.storage.clone().open_snapshot_read());
-    let match_ = typeql::parse_query(query).unwrap().into_structure().into_pipeline();
+    let parsed = context.query_manager.parse(query.to_string()).unwrap().into_pipeline();
     let pipeline = context
         .query_manager
         .prepare_read_pipeline(
@@ -124,9 +122,8 @@ fn run_read_query(
             &context.type_manager,
             context.thing_manager.clone(),
             context.function_manager.clone(),
-            &match_,
+            parsed,
             None::<GivenRowsSimple>,
-            query,
         )
         .unwrap();
     let rows_positions = pipeline.rows_positions().unwrap().clone();
@@ -152,7 +149,7 @@ fn run_write_query(
     query: &str,
 ) -> Result<(Vec<MaybeOwnedRow<'static>>, HashMap<String, VariablePosition>), Box<PipelineExecutionError>> {
     let snapshot = context.storage.clone().open_snapshot_write();
-    let query_as_pipeline = typeql::parse_query(query).unwrap().into_structure().into_pipeline();
+    let parsed = context.query_manager.parse(query.to_string()).unwrap().into_pipeline();
     let pipeline = context
         .query_manager
         .prepare_write_pipeline(
@@ -160,10 +157,10 @@ fn run_write_query(
             &context.type_manager,
             context.thing_manager.clone(),
             context.function_manager.clone(),
-            &query_as_pipeline,
+            parsed,
             None::<GivenRowsSimple>,
-            query,
         )
+        .map_err(|(_, err)| err)
         .unwrap();
     let rows_positions = pipeline.rows_positions().unwrap().clone();
     let (iterator, ExecutionContext { snapshot, .. }) =

--- a/executor/tests/execute_has.rs
+++ b/executor/tests/execute_has.rs
@@ -43,7 +43,7 @@ use executor::{
 };
 use ir::{
     pattern::constraint::IsaKind,
-    pipeline::{ParameterRegistry, block::Block},
+    pipeline::{ParameterRegistry, QueryContext, block::Block},
     translation::PipelineTranslationContext,
 };
 use lending_iterator::LendingIterator;
@@ -217,18 +217,17 @@ fn traverse_has_unbounded_sorted_from() {
 
     // Executor
     let snapshot = Arc::new(snapshot);
+    let context = ExecutionContext::new(snapshot, thing_manager, Arc::default());
+    let query_context = Arc::new(QueryContext::new(Arc::default(), Arc::default(), Arc::new(QueryProfile::new(false))));
     let executor = MatchExecutor::new(
         &executable,
-        &snapshot,
-        &thing_manager,
+        &context,
         MaybeOwnedRow::empty(),
         Arc::new(ExecutableFunctionRegistry::empty()),
-        &QueryProfile::new(false),
+        &Arc::new(QueryProfile::new(false)),
     )
     .unwrap();
-
-    let context = ExecutionContext::new(snapshot, thing_manager, Arc::default(), Arc::default());
-    let iterator = executor.into_iterator(context, ExecutionInterrupt::new_uninterruptible());
+    let iterator = executor.into_iterator(context, query_context.clone(), ExecutionInterrupt::new_uninterruptible());
 
     let rows: Vec<Result<MaybeOwnedRow<'static>, Box<ReadExecutionError>>> = iterator
         .map_static(|row| row.map(|row| row.clone().into_owned()).map_err(|err| Box::new(err.clone())))
@@ -324,18 +323,17 @@ fn traverse_has_bounded_sorted_from_chain_intersect() {
 
     // Executor
     let snapshot = Arc::new(snapshot);
+    let context = ExecutionContext::new(snapshot, thing_manager, Arc::default());
+    let query_context = Arc::new(QueryContext::new(Arc::default(), Arc::default(), Arc::new(QueryProfile::new(false))));
     let executor = MatchExecutor::new(
         &executable,
-        &snapshot,
-        &thing_manager,
+        &context,
         MaybeOwnedRow::empty(),
         Arc::new(ExecutableFunctionRegistry::empty()),
-        &QueryProfile::new(false),
+        &Arc::new(QueryProfile::new(false)),
     )
     .unwrap();
-
-    let context = ExecutionContext::new(snapshot, thing_manager, Arc::default(), Arc::default());
-    let iterator = executor.into_iterator(context, ExecutionInterrupt::new_uninterruptible());
+    let iterator = executor.into_iterator(context, query_context.clone(), ExecutionInterrupt::new_uninterruptible());
 
     let rows: Vec<Result<MaybeOwnedRow<'static>, Box<ReadExecutionError>>> = iterator
         .map_static(|row| row.map(|row| row.clone().into_owned()).map_err(|err| Box::new(err.clone())))
@@ -419,18 +417,17 @@ fn traverse_has_unbounded_sorted_from_intersect() {
 
     // Executor
     let snapshot = Arc::new(snapshot);
+    let context = ExecutionContext::new(snapshot, thing_manager, Arc::default());
+    let query_context = Arc::new(QueryContext::new(Arc::default(), Arc::default(), Arc::new(QueryProfile::new(false))));
     let executor = MatchExecutor::new(
         &executable,
-        &snapshot,
-        &thing_manager,
+        &context,
         MaybeOwnedRow::empty(),
         Arc::new(ExecutableFunctionRegistry::empty()),
-        &QueryProfile::new(false),
+        &Arc::new(QueryProfile::new(false)),
     )
     .unwrap();
-
-    let context = ExecutionContext::new(snapshot, thing_manager, Arc::default(), Arc::default());
-    let iterator = executor.into_iterator(context, ExecutionInterrupt::new_uninterruptible());
+    let iterator = executor.into_iterator(context, query_context.clone(), ExecutionInterrupt::new_uninterruptible());
 
     let rows: Vec<Result<MaybeOwnedRow<'static>, Box<ReadExecutionError>>> = iterator
         .map_static(|row| row.map(|row| row.clone().into_owned()).map_err(|err| Box::new(err.clone())))
@@ -502,18 +499,17 @@ fn traverse_has_unbounded_sorted_to_merged() {
 
     // Executor
     let snapshot = Arc::new(snapshot);
+    let context = ExecutionContext::new(snapshot, thing_manager, Arc::default());
+    let query_context = Arc::new(QueryContext::new(Arc::default(), Arc::default(), Arc::new(QueryProfile::new(false))));
     let executor = MatchExecutor::new(
         &executable,
-        &snapshot,
-        &thing_manager,
+        &context,
         MaybeOwnedRow::empty(),
         Arc::new(ExecutableFunctionRegistry::empty()),
-        &QueryProfile::new(false),
+        &Arc::new(QueryProfile::new(false)),
     )
     .unwrap();
-
-    let context = ExecutionContext::new(snapshot, thing_manager, Arc::default(), Arc::default());
-    let iterator = executor.into_iterator(context, ExecutionInterrupt::new_uninterruptible());
+    let iterator = executor.into_iterator(context, query_context.clone(), ExecutionInterrupt::new_uninterruptible());
 
     let rows: Vec<Result<MaybeOwnedRow<'static>, Box<ReadExecutionError>>> = iterator
         .map_static(|row| row.map(|row| row.as_reference().into_owned()).map_err(|err| Box::new(err.clone())))
@@ -601,18 +597,17 @@ fn traverse_has_reverse_unbounded_sorted_from() {
 
     // Executor
     let snapshot = Arc::new(snapshot);
+    let context = ExecutionContext::new(snapshot, thing_manager, Arc::default());
+    let query_context = Arc::new(QueryContext::new(Arc::default(), Arc::default(), Arc::new(QueryProfile::new(false))));
     let executor = MatchExecutor::new(
         &executable,
-        &snapshot,
-        &thing_manager,
+        &context,
         MaybeOwnedRow::empty(),
         Arc::new(ExecutableFunctionRegistry::empty()),
-        &QueryProfile::new(false),
+        &Arc::new(QueryProfile::new(false)),
     )
     .unwrap();
-
-    let context = ExecutionContext::new(snapshot, thing_manager, Arc::default(), Arc::default());
-    let iterator = executor.into_iterator(context, ExecutionInterrupt::new_uninterruptible());
+    let iterator = executor.into_iterator(context, query_context.clone(), ExecutionInterrupt::new_uninterruptible());
 
     let rows: Vec<Result<MaybeOwnedRow<'static>, Box<ReadExecutionError>>> = iterator
         .map_static(|row| row.map(|row| row.clone().into_owned()).map_err(|err| Box::new(err.clone())))

--- a/executor/tests/execute_isa.rs
+++ b/executor/tests/execute_isa.rs
@@ -38,7 +38,7 @@ use executor::{
 };
 use ir::{
     pattern::{Vertex, constraint::IsaKind},
-    pipeline::{ParameterRegistry, block::Block},
+    pipeline::{ParameterRegistry, QueryContext, block::Block},
     translation::PipelineTranslationContext,
 };
 use lending_iterator::LendingIterator;
@@ -149,18 +149,17 @@ fn traverse_isa_unbounded_sorted_thing() {
 
     // Executor
     let snapshot = Arc::new(storage.clone().open_snapshot_read());
+    let context = ExecutionContext::new(snapshot, thing_manager, Arc::default());
+    let query_context = Arc::new(QueryContext::new(Arc::default(), Arc::default(), Arc::new(QueryProfile::new(false))));
     let executor = MatchExecutor::new(
         &executable,
-        &snapshot,
-        &thing_manager,
+        &context,
         MaybeOwnedRow::empty(),
         Arc::new(ExecutableFunctionRegistry::empty()),
-        &QueryProfile::new(false),
+        &Arc::new(QueryProfile::new(false)),
     )
     .unwrap();
-
-    let context = ExecutionContext::new(snapshot, thing_manager, Arc::default(), Arc::default());
-    let iterator = executor.into_iterator(context, ExecutionInterrupt::new_uninterruptible());
+    let iterator = executor.into_iterator(context, query_context.clone(), ExecutionInterrupt::new_uninterruptible());
 
     let rows: Vec<Result<MaybeOwnedRow<'static>, Box<ReadExecutionError>>> =
         iterator.map_static(|row| row.map(|row| row.into_owned()).map_err(|err| Box::new(err.clone()))).collect();
@@ -225,18 +224,17 @@ fn traverse_isa_unbounded_sorted_type() {
 
     // Executor
     let snapshot = Arc::new(storage.clone().open_snapshot_read());
+    let context = ExecutionContext::new(snapshot, thing_manager, Arc::default());
+    let query_context = Arc::new(QueryContext::new(Arc::default(), Arc::default(), Arc::new(QueryProfile::new(false))));
     let executor = MatchExecutor::new(
         &executable,
-        &snapshot,
-        &thing_manager,
+        &context,
         MaybeOwnedRow::empty(),
         Arc::new(ExecutableFunctionRegistry::empty()),
-        &QueryProfile::new(false),
+        &Arc::new(QueryProfile::new(false)),
     )
     .unwrap();
-
-    let context = ExecutionContext::new(snapshot, thing_manager, Arc::default(), Arc::default());
-    let iterator = executor.into_iterator(context, ExecutionInterrupt::new_uninterruptible());
+    let iterator = executor.into_iterator(context, query_context.clone(), ExecutionInterrupt::new_uninterruptible());
 
     let rows: Vec<Result<MaybeOwnedRow<'static>, Box<ReadExecutionError>>> =
         iterator.map_static(|row| row.map(|row| row.into_owned()).map_err(|err| Box::new(err.clone()))).collect();
@@ -315,18 +313,17 @@ fn traverse_isa_bounded_thing() {
 
     // Executor
     let snapshot = Arc::new(storage.clone().open_snapshot_read());
+    let context = ExecutionContext::new(snapshot, thing_manager, Arc::default());
+    let query_context = Arc::new(QueryContext::new(Arc::default(), Arc::default(), Arc::new(QueryProfile::new(false))));
     let executor = MatchExecutor::new(
         &executable,
-        &snapshot,
-        &thing_manager,
+        &context,
         MaybeOwnedRow::empty(),
         Arc::new(ExecutableFunctionRegistry::empty()),
-        &QueryProfile::new(false),
+        &Arc::new(QueryProfile::new(false)),
     )
     .unwrap();
-
-    let context = ExecutionContext::new(snapshot, thing_manager, Arc::default(), Arc::default());
-    let iterator = executor.into_iterator(context, ExecutionInterrupt::new_uninterruptible());
+    let iterator = executor.into_iterator(context, query_context.clone(), ExecutionInterrupt::new_uninterruptible());
 
     let rows: Vec<Result<MaybeOwnedRow<'static>, Box<ReadExecutionError>>> =
         iterator.map_static(|row| row.map(|row| row.into_owned()).map_err(|err| Box::new(err.clone()))).collect();
@@ -393,18 +390,17 @@ fn traverse_isa_reverse_unbounded_sorted_thing() {
 
     // Executor
     let snapshot = Arc::new(storage.clone().open_snapshot_read());
+    let context = ExecutionContext::new(snapshot, thing_manager, Arc::default());
+    let query_context = Arc::new(QueryContext::new(Arc::default(), Arc::default(), Arc::new(QueryProfile::new(false))));
     let executor = MatchExecutor::new(
         &executable,
-        &snapshot,
-        &thing_manager,
+        &context,
         MaybeOwnedRow::empty(),
         Arc::new(ExecutableFunctionRegistry::empty()),
-        &QueryProfile::new(false),
+        &Arc::new(QueryProfile::new(false)),
     )
     .unwrap();
-
-    let context = ExecutionContext::new(snapshot, thing_manager, Arc::default(), Arc::default());
-    let iterator = executor.into_iterator(context, ExecutionInterrupt::new_uninterruptible());
+    let iterator = executor.into_iterator(context, query_context.clone(), ExecutionInterrupt::new_uninterruptible());
 
     let rows: Vec<Result<MaybeOwnedRow<'static>, Box<ReadExecutionError>>> =
         iterator.map_static(|row| row.map(|row| row.into_owned()).map_err(|err| Box::new(err.clone()))).collect();
@@ -469,18 +465,17 @@ fn traverse_isa_reverse_unbounded_sorted_type() {
 
     // Executor
     let snapshot = Arc::new(storage.clone().open_snapshot_read());
+    let context = ExecutionContext::new(snapshot, thing_manager, Arc::default());
+    let query_context = Arc::new(QueryContext::new(Arc::default(), Arc::default(), Arc::new(QueryProfile::new(false))));
     let executor = MatchExecutor::new(
         &executable,
-        &snapshot,
-        &thing_manager,
+        &context,
         MaybeOwnedRow::empty(),
         Arc::new(ExecutableFunctionRegistry::empty()),
-        &QueryProfile::new(false),
+        &Arc::new(QueryProfile::new(false)),
     )
     .unwrap();
-
-    let context = ExecutionContext::new(snapshot, thing_manager, Arc::default(), Arc::default());
-    let iterator = executor.into_iterator(context, ExecutionInterrupt::new_uninterruptible());
+    let iterator = executor.into_iterator(context, query_context.clone(), ExecutionInterrupt::new_uninterruptible());
 
     let rows: Vec<Result<MaybeOwnedRow<'static>, Box<ReadExecutionError>>> =
         iterator.map_static(|row| row.map(|row| row.into_owned()).map_err(|err| Box::new(err.clone()))).collect();
@@ -559,18 +554,17 @@ fn traverse_isa_reverse_bounded_type_exact() {
 
     // Executor
     let snapshot = Arc::new(storage.clone().open_snapshot_read());
+    let context = ExecutionContext::new(snapshot, thing_manager, Arc::default());
+    let query_context = Arc::new(QueryContext::new(Arc::default(), Arc::default(), Arc::new(QueryProfile::new(false))));
     let executor = MatchExecutor::new(
         &executable,
-        &snapshot,
-        &thing_manager,
+        &context,
         MaybeOwnedRow::empty(),
         Arc::new(ExecutableFunctionRegistry::empty()),
-        &QueryProfile::new(false),
+        &Arc::new(QueryProfile::new(false)),
     )
     .unwrap();
-
-    let context = ExecutionContext::new(snapshot, thing_manager, Arc::default(), Arc::default());
-    let iterator = executor.into_iterator(context, ExecutionInterrupt::new_uninterruptible());
+    let iterator = executor.into_iterator(context, query_context.clone(), ExecutionInterrupt::new_uninterruptible());
 
     let rows: Vec<Result<MaybeOwnedRow<'static>, Box<ReadExecutionError>>> =
         iterator.map_static(|row| row.map(|row| row.into_owned()).map_err(|err| Box::new(err.clone()))).collect();
@@ -653,18 +647,17 @@ fn traverse_isa_reverse_bounded_type_subtype() {
 
     // Executor
     let snapshot = Arc::new(storage.clone().open_snapshot_read());
+    let context = ExecutionContext::new(snapshot, thing_manager, Arc::default());
+    let query_context = Arc::new(QueryContext::new(Arc::default(), Arc::default(), Arc::new(QueryProfile::new(false))));
     let executor = MatchExecutor::new(
         &executable,
-        &snapshot,
-        &thing_manager,
+        &context,
         MaybeOwnedRow::empty(),
         Arc::new(ExecutableFunctionRegistry::empty()),
-        &QueryProfile::new(false),
+        &Arc::new(QueryProfile::new(false)),
     )
     .unwrap();
-
-    let context = ExecutionContext::new(snapshot, thing_manager, Arc::default(), Arc::default());
-    let iterator = executor.into_iterator(context, ExecutionInterrupt::new_uninterruptible());
+    let iterator = executor.into_iterator(context, query_context.clone(), ExecutionInterrupt::new_uninterruptible());
 
     let rows: Vec<Result<MaybeOwnedRow<'static>, Box<ReadExecutionError>>> =
         iterator.map_static(|row| row.map(|row| row.into_owned()).map_err(|err| Box::new(err.clone()))).collect();
@@ -732,18 +725,17 @@ fn traverse_isa_reverse_fixed_type_exact() {
 
     // Executor
     let snapshot = Arc::new(storage.clone().open_snapshot_read());
+    let context = ExecutionContext::new(snapshot, thing_manager, Arc::default());
+    let query_context = Arc::new(QueryContext::new(Arc::default(), Arc::default(), Arc::new(QueryProfile::new(false))));
     let executor = MatchExecutor::new(
         &executable,
-        &snapshot,
-        &thing_manager,
+        &context,
         MaybeOwnedRow::empty(),
         Arc::new(ExecutableFunctionRegistry::empty()),
-        &QueryProfile::new(false),
+        &Arc::new(QueryProfile::new(false)),
     )
     .unwrap();
-
-    let context = ExecutionContext::new(snapshot, thing_manager, Arc::default(), Arc::default());
-    let iterator = executor.into_iterator(context, ExecutionInterrupt::new_uninterruptible());
+    let iterator = executor.into_iterator(context, query_context.clone(), ExecutionInterrupt::new_uninterruptible());
 
     let rows: Vec<Result<MaybeOwnedRow<'static>, Box<ReadExecutionError>>> =
         iterator.map_static(|row| row.map(|row| row.into_owned()).map_err(|err| Box::new(err.clone()))).collect();
@@ -808,18 +800,17 @@ fn traverse_isa_reverse_fixed_type_subtype() {
 
     // Executor
     let snapshot = Arc::new(storage.clone().open_snapshot_read());
+    let context = ExecutionContext::new(snapshot, thing_manager, Arc::default());
+    let query_context = Arc::new(QueryContext::new(Arc::default(), Arc::default(), Arc::new(QueryProfile::new(false))));
     let executor = MatchExecutor::new(
         &executable,
-        &snapshot,
-        &thing_manager,
+        &context,
         MaybeOwnedRow::empty(),
         Arc::new(ExecutableFunctionRegistry::empty()),
-        &QueryProfile::new(false),
+        &Arc::new(QueryProfile::new(false)),
     )
     .unwrap();
-
-    let context = ExecutionContext::new(snapshot, thing_manager, Arc::default(), Arc::default());
-    let iterator = executor.into_iterator(context, ExecutionInterrupt::new_uninterruptible());
+    let iterator = executor.into_iterator(context, query_context.clone(), ExecutionInterrupt::new_uninterruptible());
 
     let rows: Vec<Result<MaybeOwnedRow<'static>, Box<ReadExecutionError>>> =
         iterator.map_static(|row| row.map(|row| row.into_owned()).map_err(|err| Box::new(err.clone()))).collect();

--- a/executor/tests/execute_links.rs
+++ b/executor/tests/execute_links.rs
@@ -46,7 +46,7 @@ use executor::{
 };
 use ir::{
     pattern::constraint::IsaKind,
-    pipeline::{ParameterRegistry, block::Block},
+    pipeline::{ParameterRegistry, QueryContext, block::Block},
     translation::PipelineTranslationContext,
 };
 use lending_iterator::LendingIterator;
@@ -331,18 +331,17 @@ fn traverse_links_unbounded_sorted_from() {
 
     // Executor
     let snapshot = Arc::new(storage.clone().open_snapshot_read());
+    let context = ExecutionContext::new(snapshot, thing_manager, Arc::default());
+    let query_context = Arc::new(QueryContext::new(Arc::default(), Arc::default(), Arc::new(QueryProfile::new(false))));
     let executor = MatchExecutor::new(
         &executable,
-        &snapshot,
-        &thing_manager,
+        &context,
         MaybeOwnedRow::empty(),
         Arc::new(ExecutableFunctionRegistry::empty()),
-        &QueryProfile::new(false),
+        &Arc::new(QueryProfile::new(false)),
     )
     .unwrap();
-
-    let context = ExecutionContext::new(snapshot, thing_manager, Arc::default(), Arc::default());
-    let iterator = executor.into_iterator(context, ExecutionInterrupt::new_uninterruptible());
+    let iterator = executor.into_iterator(context, query_context.clone(), ExecutionInterrupt::new_uninterruptible());
 
     let rows: Vec<Result<MaybeOwnedRow<'static>, Box<ReadExecutionError>>> = iterator
         .map_static(|row| row.map(|row| row.as_reference().into_owned()).map_err(|err| Box::new(err.clone())))
@@ -425,18 +424,17 @@ fn traverse_links_unbounded_sorted_to() {
 
     // Executor
     let snapshot = Arc::new(storage.clone().open_snapshot_read());
+    let context = ExecutionContext::new(snapshot, thing_manager, Arc::default());
+    let query_context = Arc::new(QueryContext::new(Arc::default(), Arc::default(), Arc::new(QueryProfile::new(false))));
     let executor = MatchExecutor::new(
         &executable,
-        &snapshot,
-        &thing_manager,
+        &context,
         MaybeOwnedRow::empty(),
         Arc::new(ExecutableFunctionRegistry::empty()),
-        &QueryProfile::new(false),
+        &Arc::new(QueryProfile::new(false)),
     )
     .unwrap();
-
-    let context = ExecutionContext::new(snapshot, thing_manager, Arc::default(), Arc::default());
-    let iterator = executor.into_iterator(context, ExecutionInterrupt::new_uninterruptible());
+    let iterator = executor.into_iterator(context, query_context.clone(), ExecutionInterrupt::new_uninterruptible());
 
     let rows: Vec<Result<MaybeOwnedRow<'static>, Box<ReadExecutionError>>> = iterator
         .map_static(|row| row.map(|row| row.as_reference().into_owned()).map_err(|err| Box::new(err.clone())))
@@ -536,18 +534,17 @@ fn traverse_links_bounded_relation() {
 
     // Executor
     let snapshot = Arc::new(storage.clone().open_snapshot_read());
+    let context = ExecutionContext::new(snapshot, thing_manager, Arc::default());
+    let query_context = Arc::new(QueryContext::new(Arc::default(), Arc::default(), Arc::new(QueryProfile::new(false))));
     let executor = MatchExecutor::new(
         &executable,
-        &snapshot,
-        &thing_manager,
+        &context,
         MaybeOwnedRow::empty(),
         Arc::new(ExecutableFunctionRegistry::empty()),
-        &QueryProfile::new(false),
+        &Arc::new(QueryProfile::new(false)),
     )
     .unwrap();
-
-    let context = ExecutionContext::new(snapshot, thing_manager, Arc::default(), Arc::default());
-    let iterator = executor.into_iterator(context, ExecutionInterrupt::new_uninterruptible());
+    let iterator = executor.into_iterator(context, query_context.clone(), ExecutionInterrupt::new_uninterruptible());
 
     let rows: Vec<Result<MaybeOwnedRow<'static>, Box<ReadExecutionError>>> = iterator
         .map_static(|row| row.map(|row| row.as_reference().into_owned()).map_err(|err| Box::new(err.clone())))
@@ -664,18 +661,17 @@ fn traverse_links_bounded_relation_player() {
 
     // Executor
     let snapshot = Arc::new(storage.clone().open_snapshot_read());
+    let context = ExecutionContext::new(snapshot, thing_manager, Arc::default());
+    let query_context = Arc::new(QueryContext::new(Arc::default(), Arc::default(), Arc::new(QueryProfile::new(false))));
     let executor = MatchExecutor::new(
         &executable,
-        &snapshot,
-        &thing_manager,
+        &context,
         MaybeOwnedRow::empty(),
         Arc::new(ExecutableFunctionRegistry::empty()),
-        &QueryProfile::new(false),
+        &Arc::new(QueryProfile::new(false)),
     )
     .unwrap();
-
-    let context = ExecutionContext::new(snapshot, thing_manager, Arc::default(), Arc::default());
-    let iterator = executor.into_iterator(context, ExecutionInterrupt::new_uninterruptible());
+    let iterator = executor.into_iterator(context, query_context.clone(), ExecutionInterrupt::new_uninterruptible());
 
     let rows: Vec<Result<MaybeOwnedRow<'static>, Box<ReadExecutionError>>> = iterator
         .map_static(|row| row.map(|row| row.as_reference().into_owned()).map_err(|err| Box::new(err.clone())))
@@ -758,18 +754,17 @@ fn traverse_links_reverse_unbounded_sorted_from() {
 
     // Executor
     let snapshot = Arc::new(storage.clone().open_snapshot_read());
+    let context = ExecutionContext::new(snapshot, thing_manager, Arc::default());
+    let query_context = Arc::new(QueryContext::new(Arc::default(), Arc::default(), Arc::new(QueryProfile::new(false))));
     let executor = MatchExecutor::new(
         &executable,
-        &snapshot,
-        &thing_manager,
+        &context,
         MaybeOwnedRow::empty(),
         Arc::new(ExecutableFunctionRegistry::empty()),
-        &QueryProfile::new(false),
+        &Arc::new(QueryProfile::new(false)),
     )
     .unwrap();
-
-    let context = ExecutionContext::new(snapshot, thing_manager, Arc::default(), Arc::default());
-    let iterator = executor.into_iterator(context, ExecutionInterrupt::new_uninterruptible());
+    let iterator = executor.into_iterator(context, query_context.clone(), ExecutionInterrupt::new_uninterruptible());
 
     let rows: Vec<Result<MaybeOwnedRow<'static>, Box<ReadExecutionError>>> = iterator
         .map_static(|row| row.map(|row| row.as_reference().into_owned()).map_err(|err| Box::new(err.clone())))
@@ -853,18 +848,17 @@ fn traverse_links_reverse_unbounded_sorted_to() {
 
     // Executor
     let snapshot = Arc::new(storage.clone().open_snapshot_read());
+    let context = ExecutionContext::new(snapshot, thing_manager, Arc::default());
+    let query_context = Arc::new(QueryContext::new(Arc::default(), Arc::default(), Arc::new(QueryProfile::new(false))));
     let executor = MatchExecutor::new(
         &executable,
-        &snapshot,
-        &thing_manager,
+        &context,
         MaybeOwnedRow::empty(),
         Arc::new(ExecutableFunctionRegistry::empty()),
-        &QueryProfile::new(false),
+        &Arc::new(QueryProfile::new(false)),
     )
     .unwrap();
-
-    let context = ExecutionContext::new(snapshot, thing_manager, Arc::default(), Arc::default());
-    let iterator = executor.into_iterator(context, ExecutionInterrupt::new_uninterruptible());
+    let iterator = executor.into_iterator(context, query_context.clone(), ExecutionInterrupt::new_uninterruptible());
 
     let rows: Vec<Result<MaybeOwnedRow<'static>, Box<ReadExecutionError>>> = iterator
         .map_static(|row| row.map(|row| row.as_reference().into_owned()).map_err(|err| Box::new(err.clone())))
@@ -964,18 +958,17 @@ fn traverse_links_reverse_bounded_player() {
 
     // Executor
     let snapshot = Arc::new(storage.clone().open_snapshot_read());
+    let context = ExecutionContext::new(snapshot, thing_manager, Arc::default());
+    let query_context = Arc::new(QueryContext::new(Arc::default(), Arc::default(), Arc::new(QueryProfile::new(false))));
     let executor = MatchExecutor::new(
         &executable,
-        &snapshot,
-        &thing_manager,
+        &context,
         MaybeOwnedRow::empty(),
         Arc::new(ExecutableFunctionRegistry::empty()),
-        &QueryProfile::new(false),
+        &Arc::new(QueryProfile::new(false)),
     )
     .unwrap();
-
-    let context = ExecutionContext::new(snapshot, thing_manager, Arc::default(), Arc::default());
-    let iterator = executor.into_iterator(context, ExecutionInterrupt::new_uninterruptible());
+    let iterator = executor.into_iterator(context, query_context.clone(), ExecutionInterrupt::new_uninterruptible());
 
     let rows: Vec<Result<MaybeOwnedRow<'static>, Box<ReadExecutionError>>> = iterator
         .map_static(|row| row.map(|row| row.as_reference().into_owned()).map_err(|err| Box::new(err.clone())))
@@ -1092,18 +1085,17 @@ fn traverse_links_reverse_bounded_player_relation() {
 
     // Executor
     let snapshot = Arc::new(storage.clone().open_snapshot_read());
+    let context = ExecutionContext::new(snapshot, thing_manager, Arc::default());
+    let query_context = Arc::new(QueryContext::new(Arc::default(), Arc::default(), Arc::new(QueryProfile::new(false))));
     let executor = MatchExecutor::new(
         &executable,
-        &snapshot,
-        &thing_manager,
+        &context,
         MaybeOwnedRow::empty(),
         Arc::new(ExecutableFunctionRegistry::empty()),
-        &QueryProfile::new(false),
+        &Arc::new(QueryProfile::new(false)),
     )
     .unwrap();
-
-    let context = ExecutionContext::new(snapshot, thing_manager, Arc::default(), Arc::default());
-    let iterator = executor.into_iterator(context, ExecutionInterrupt::new_uninterruptible());
+    let iterator = executor.into_iterator(context, query_context.clone(), ExecutionInterrupt::new_uninterruptible());
 
     let rows: Vec<Result<MaybeOwnedRow<'static>, Box<ReadExecutionError>>> = iterator
         .map_static(|row| row.map(|row| row.as_reference().into_owned()).map_err(|err| Box::new(err.clone())))

--- a/executor/tests/execute_relation_index.rs
+++ b/executor/tests/execute_relation_index.rs
@@ -46,7 +46,7 @@ use ir::{
         Vertex,
         constraint::{Comparator, IsaKind},
     },
-    pipeline::{ParameterRegistry, block::Block},
+    pipeline::{ParameterRegistry, QueryContext, block::Block},
     translation::PipelineTranslationContext,
 };
 use lending_iterator::LendingIterator;
@@ -426,18 +426,18 @@ fn traverse_index_from_unbound() {
 
     // Executor
     let snapshot = Arc::new(storage.clone().open_snapshot_read());
+    let context = ExecutionContext::new(snapshot, thing_manager.clone(), Arc::default());
+    let query_context =
+        Arc::new(QueryContext::new(value_parameters.clone(), Arc::default(), Arc::new(QueryProfile::new(false))));
     let executor = MatchExecutor::new(
         &executable,
-        &snapshot,
-        &thing_manager,
+        &context,
         MaybeOwnedRow::empty(),
         Arc::new(ExecutableFunctionRegistry::empty()),
-        &QueryProfile::new(false),
+        &Arc::new(QueryProfile::new(false)),
     )
     .unwrap();
-
-    let context = ExecutionContext::new(snapshot, thing_manager.clone(), Arc::default(), value_parameters.clone());
-    let iterator = executor.into_iterator(context, ExecutionInterrupt::new_uninterruptible());
+    let iterator = executor.into_iterator(context, query_context, ExecutionInterrupt::new_uninterruptible());
 
     let rows: Vec<Result<MaybeOwnedRow<'static>, Box<ReadExecutionError>>> = iterator
         .map_static(|row| row.map(|row| row.as_reference().into_owned()).map_err(|err| Box::new(err.clone())))
@@ -515,18 +515,18 @@ fn traverse_index_from_unbound() {
 
     // Executor
     let snapshot = Arc::new(storage.clone().open_snapshot_read());
+    let context = ExecutionContext::new(snapshot, thing_manager, Arc::default());
+    let query_context =
+        Arc::new(QueryContext::new(value_parameters, Arc::default(), Arc::new(QueryProfile::new(false))));
     let executor = MatchExecutor::new(
         &executable,
-        &snapshot,
-        &thing_manager,
+        &context,
         MaybeOwnedRow::empty(),
         Arc::new(ExecutableFunctionRegistry::empty()),
-        &QueryProfile::new(false),
+        &Arc::new(QueryProfile::new(false)),
     )
     .unwrap();
-
-    let context = ExecutionContext::new(snapshot, thing_manager, Arc::default(), value_parameters);
-    let iterator = executor.into_iterator(context, ExecutionInterrupt::new_uninterruptible());
+    let iterator = executor.into_iterator(context, query_context, ExecutionInterrupt::new_uninterruptible());
 
     let rows: Vec<Result<MaybeOwnedRow<'static>, Box<ReadExecutionError>>> = iterator
         .map_static(|row| row.map(|row| row.as_reference().into_owned()).map_err(|err| Box::new(err.clone())))
@@ -688,18 +688,18 @@ fn traverse_index_from_bound() {
 
     // Executor
     let snapshot = Arc::new(storage.clone().open_snapshot_read());
+    let context = ExecutionContext::new(snapshot, thing_manager, Arc::default());
+    let query_context =
+        Arc::new(QueryContext::new(Arc::new(value_parameters), Arc::default(), Arc::new(QueryProfile::new(false))));
     let executor = MatchExecutor::new(
         &executable,
-        &snapshot,
-        &thing_manager,
+        &context,
         MaybeOwnedRow::empty(),
         Arc::new(ExecutableFunctionRegistry::empty()),
-        &QueryProfile::new(false),
+        &Arc::new(QueryProfile::new(false)),
     )
     .unwrap();
-
-    let context = ExecutionContext::new(snapshot, thing_manager, Arc::default(), Arc::new(value_parameters));
-    let iterator = executor.into_iterator(context, ExecutionInterrupt::new_uninterruptible());
+    let iterator = executor.into_iterator(context, query_context.clone(), ExecutionInterrupt::new_uninterruptible());
 
     let rows: Vec<Result<MaybeOwnedRow<'static>, Box<ReadExecutionError>>> = iterator
         .map_static(|row| row.map(|row| row.as_reference().into_owned()).map_err(|err| Box::new(err.clone())))
@@ -857,18 +857,18 @@ fn traverse_index_bound_role_type_filtered_correctly() {
 
     // Executor
     let snapshot = Arc::new(storage.clone().open_snapshot_read());
+    let context = ExecutionContext::new(snapshot, thing_manager, Arc::default());
+    let query_context =
+        Arc::new(QueryContext::new(Arc::new(value_parameters), Arc::default(), Arc::new(QueryProfile::new(false))));
     let executor = MatchExecutor::new(
         &executable,
-        &snapshot,
-        &thing_manager,
+        &context,
         MaybeOwnedRow::empty(),
         Arc::new(ExecutableFunctionRegistry::empty()),
-        &QueryProfile::new(false),
+        &Arc::new(QueryProfile::new(false)),
     )
     .unwrap();
-
-    let context = ExecutionContext::new(snapshot, thing_manager, Arc::default(), Arc::new(value_parameters));
-    let iterator = executor.into_iterator(context, ExecutionInterrupt::new_uninterruptible());
+    let iterator = executor.into_iterator(context, query_context.clone(), ExecutionInterrupt::new_uninterruptible());
 
     let rows: Vec<Result<MaybeOwnedRow<'static>, Box<ReadExecutionError>>> = iterator
         .map_static(|row| row.map(|row| row.as_reference().into_owned()).map_err(|err| Box::new(err.clone())))

--- a/executor/tests/execute_select.rs
+++ b/executor/tests/execute_select.rs
@@ -40,7 +40,7 @@ use executor::{
 };
 use ir::{
     pattern::constraint::IsaKind,
-    pipeline::{ParameterRegistry, block::Block},
+    pipeline::{ParameterRegistry, QueryContext, block::Block},
     translation::PipelineTranslationContext,
 };
 use lending_iterator::LendingIterator;
@@ -247,18 +247,17 @@ fn anonymous_vars_not_enumerated_or_counted() {
     // Executor
     let snapshot = Arc::new(storage.clone().open_snapshot_read());
     let (_, thing_manager) = load_managers(storage.clone(), None);
+    let context = ExecutionContext::new(snapshot, thing_manager, Arc::default());
+    let query_context = Arc::new(QueryContext::new(Arc::default(), Arc::default(), Arc::new(QueryProfile::new(false))));
     let executor = MatchExecutor::new(
         &executable,
-        &snapshot,
-        &thing_manager,
+        &context,
         MaybeOwnedRow::empty(),
         Arc::new(ExecutableFunctionRegistry::empty()),
-        &QueryProfile::new(false),
+        &Arc::new(QueryProfile::new(false)),
     )
     .unwrap();
-
-    let context = ExecutionContext::new(snapshot, thing_manager, Arc::default(), Arc::default());
-    let iterator = executor.into_iterator(context, ExecutionInterrupt::new_uninterruptible());
+    let iterator = executor.into_iterator(context, query_context.clone(), ExecutionInterrupt::new_uninterruptible());
 
     let rows: Vec<Result<MaybeOwnedRow<'static>, Box<ReadExecutionError>>> = iterator
         .map_static(|row| row.map(|row| row.as_reference().into_owned()).map_err(|err| Box::new(err.clone())))
@@ -340,18 +339,17 @@ fn unselected_named_vars_counted() {
     // Executor
     let snapshot: Arc<ReadSnapshot<WALClient>> = Arc::new(storage.clone().open_snapshot_read());
     let (_, thing_manager) = load_managers(storage.clone(), None);
+    let context = ExecutionContext::new(snapshot, thing_manager, Arc::default());
+    let query_context = Arc::new(QueryContext::new(Arc::default(), Arc::default(), Arc::new(QueryProfile::new(false))));
     let executor = MatchExecutor::new(
         &executable,
-        &snapshot,
-        &thing_manager,
+        &context,
         MaybeOwnedRow::empty(),
         Arc::new(ExecutableFunctionRegistry::empty()),
-        &QueryProfile::new(false),
+        &Arc::new(QueryProfile::new(false)),
     )
     .unwrap();
-
-    let context = ExecutionContext::new(snapshot, thing_manager, Arc::default(), Arc::default());
-    let iterator = executor.into_iterator(context, ExecutionInterrupt::new_uninterruptible());
+    let iterator = executor.into_iterator(context, query_context.clone(), ExecutionInterrupt::new_uninterruptible());
 
     let rows: Vec<Result<MaybeOwnedRow<'static>, Box<ReadExecutionError>>> = iterator
         .map_static(|row| row.map(|row| row.as_reference().into_owned()).map_err(|err| Box::new(err.clone())))
@@ -453,18 +451,17 @@ fn cartesian_named_counted_checked() {
     // Executor
     let snapshot: Arc<ReadSnapshot<WALClient>> = Arc::new(storage.clone().open_snapshot_read());
     let (_, thing_manager) = load_managers(storage.clone(), None);
+    let context = ExecutionContext::new(snapshot, thing_manager, Arc::default());
+    let query_context = Arc::new(QueryContext::new(Arc::default(), Arc::default(), Arc::new(QueryProfile::new(false))));
     let executor = MatchExecutor::new(
         &conjunction_executable,
-        &snapshot,
-        &thing_manager,
+        &context,
         MaybeOwnedRow::empty(),
         Arc::new(ExecutableFunctionRegistry::empty()),
-        &QueryProfile::new(false),
+        &Arc::new(QueryProfile::new(false)),
     )
     .unwrap();
-
-    let context = ExecutionContext::new(snapshot, thing_manager, Arc::default(), Arc::default());
-    let iterator = executor.into_iterator(context, ExecutionInterrupt::new_uninterruptible());
+    let iterator = executor.into_iterator(context, query_context.clone(), ExecutionInterrupt::new_uninterruptible());
 
     let rows: Vec<Result<MaybeOwnedRow<'static>, Box<ReadExecutionError>>> = iterator
         .map_static(|row| row.map(|row| row.as_reference().into_owned()).map_err(|err| Box::new(err.clone())))

--- a/executor/tests/pipelines.rs
+++ b/executor/tests/pipelines.rs
@@ -54,10 +54,8 @@ fn setup_common() -> Context {
         relation membership relates member, relates group;
     "#;
     let mut snapshot = storage.clone().open_snapshot_schema();
-    let define = typeql::parse_query(schema).unwrap().into_structure().into_schema();
-    query_manager
-        .execute_schema(&mut snapshot, &type_manager, &thing_manager, &function_manager, &define, schema)
-        .unwrap();
+    let parsed = query_manager.parse(schema.to_string()).unwrap().into_schema();
+    query_manager.execute_schema(&mut snapshot, &type_manager, &thing_manager, &function_manager, parsed).unwrap();
     snapshot.commit(&mut CommitProfile::DISABLED).unwrap();
 
     // reload to obtain latest vertex generators and statistics entries
@@ -71,7 +69,7 @@ fn test_insert() {
     let context = setup_common();
     let snapshot = context.storage.clone().open_snapshot_write();
     let query_str = "insert $p isa person, has age 10;";
-    let query = typeql::parse_query(query_str).unwrap().into_structure().into_pipeline();
+    let parsed = context.query_manager.parse(query_str.to_string()).unwrap().into_pipeline();
     let pipeline = context
         .query_manager
         .prepare_write_pipeline(
@@ -79,10 +77,10 @@ fn test_insert() {
             &context.type_manager,
             context.thing_manager.clone(),
             context.function_manager,
-            &query,
+            parsed,
             None::<GivenRowsSimple>,
-            query_str,
         )
+        .map_err(|(_, err)| err)
         .unwrap();
 
     let (mut iterator, ExecutionContext { snapshot, .. }) =
@@ -113,7 +111,7 @@ fn test_insert_insert() {
     insert
         (group: $org, member: $p) isa membership;
     "#;
-    let query = typeql::parse_query(query_str).unwrap().into_structure().into_pipeline();
+    let parsed = context.query_manager.parse(query_str.to_string()).unwrap().into_pipeline();
     let pipeline = context
         .query_manager
         .prepare_write_pipeline(
@@ -121,10 +119,10 @@ fn test_insert_insert() {
             &context.type_manager,
             context.thing_manager.clone(),
             context.function_manager,
-            &query,
+            parsed,
             None::<GivenRowsSimple>,
-            query_str,
         )
+        .map_err(|(_, err)| err)
         .unwrap();
 
     let (mut iterator, ExecutionContext { snapshot, .. }) =
@@ -151,7 +149,7 @@ fn test_match() {
        $q isa person, has age 20, has name 'Alice';
        $r isa person, has age 30, has name 'Harry';
    "#;
-    let query = typeql::parse_query(query_str).unwrap().into_structure().into_pipeline();
+    let parsed = context.query_manager.parse(query_str.to_string()).unwrap().into_pipeline();
     let pipeline = context
         .query_manager
         .prepare_write_pipeline(
@@ -159,10 +157,10 @@ fn test_match() {
             &context.type_manager,
             context.thing_manager.clone(),
             context.function_manager.clone(),
-            &query,
+            parsed,
             None::<GivenRowsSimple>,
-            query_str,
         )
+        .map_err(|(_, err)| err)
         .unwrap();
     let (iterator, ExecutionContext { snapshot, .. }) =
         pipeline.into_rows_iterator(ExecutionInterrupt::new_uninterruptible()).unwrap();
@@ -173,7 +171,7 @@ fn test_match() {
 
     let snapshot = Arc::new(context.storage.open_snapshot_read());
     let query = "match $p isa person;";
-    let match_ = typeql::parse_query(query).unwrap().into_structure().into_pipeline();
+    let parsed = context.query_manager.parse(query.to_string()).unwrap().into_pipeline();
     let pipeline = context
         .query_manager
         .prepare_read_pipeline(
@@ -181,9 +179,8 @@ fn test_match() {
             &context.type_manager,
             context.thing_manager.clone(),
             context.function_manager.clone(),
-            &match_,
+            parsed,
             None::<GivenRowsSimple>,
-            query,
         )
         .unwrap();
     let (iterator, ExecutionContext { snapshot, .. }) =
@@ -192,7 +189,7 @@ fn test_match() {
     assert_eq!(batch.len(), 3);
 
     let query = "match $person isa person, has name 'John', has age $age;";
-    let match_ = typeql::parse_query(query).unwrap().into_structure().into_pipeline();
+    let parsed = context.query_manager.parse(query.to_string()).unwrap().into_pipeline();
     let pipeline = context
         .query_manager
         .prepare_read_pipeline(
@@ -200,9 +197,8 @@ fn test_match() {
             &context.type_manager,
             context.thing_manager.clone(),
             context.function_manager.clone(),
-            &match_,
+            parsed,
             None::<GivenRowsSimple>,
-            query,
         )
         .unwrap();
     let (iterator, ExecutionContext { .. }) =
@@ -221,7 +217,7 @@ fn test_match_match() {
        $q isa person, has age 20, has name 'Alice';
        $r isa person, has age 30, has name 'Harry';
    "#;
-    let query = typeql::parse_query(query_str).unwrap().into_structure().into_pipeline();
+    let parsed = context.query_manager.parse(query_str.to_string()).unwrap().into_pipeline();
     let pipeline = context
         .query_manager
         .prepare_write_pipeline(
@@ -229,10 +225,10 @@ fn test_match_match() {
             &context.type_manager,
             context.thing_manager.clone(),
             context.function_manager.clone(),
-            &query,
+            parsed,
             None::<GivenRowsSimple>,
-            query_str,
         )
+        .map_err(|(_, err)| err)
         .unwrap();
     let (iterator, ExecutionContext { snapshot, .. }) =
         pipeline.into_rows_iterator(ExecutionInterrupt::new_uninterruptible()).unwrap();
@@ -246,7 +242,7 @@ fn test_match_match() {
         match $p isa person;
         match $p has age $a;
     ";
-    let match_ = typeql::parse_query(query).unwrap().into_structure().into_pipeline();
+    let parsed = context.query_manager.parse(query.to_string()).unwrap().into_pipeline();
     let pipeline = context
         .query_manager
         .prepare_read_pipeline(
@@ -254,9 +250,8 @@ fn test_match_match() {
             &context.type_manager,
             context.thing_manager.clone(),
             context.function_manager.clone(),
-            &match_,
+            parsed,
             None::<GivenRowsSimple>,
-            query,
         )
         .unwrap();
     let (iterator, ExecutionContext { snapshot, .. }) =
@@ -265,7 +260,7 @@ fn test_match_match() {
     assert_eq!(batch.len(), 3);
 
     let query = "match $person isa person, has name 'John', has age $age;";
-    let match_ = typeql::parse_query(query).unwrap().into_structure().into_pipeline();
+    let parsed = context.query_manager.parse(query.to_string()).unwrap().into_pipeline();
     let pipeline = context
         .query_manager
         .prepare_read_pipeline(
@@ -273,9 +268,8 @@ fn test_match_match() {
             &context.type_manager,
             context.thing_manager.clone(),
             context.function_manager.clone(),
-            &match_,
+            parsed,
             None::<GivenRowsSimple>,
-            query,
         )
         .unwrap();
     let (iterator, ExecutionContext { .. }) =
@@ -289,7 +283,7 @@ fn test_match_delete_has() {
     let context = setup_common();
     let snapshot = context.storage.clone().open_snapshot_write();
     let insert_query_str = "insert $p isa person, has age 10;";
-    let insert_query = typeql::parse_query(insert_query_str).unwrap().into_structure().into_pipeline();
+    let parsed = context.query_manager.parse(insert_query_str.to_string()).unwrap().into_pipeline();
     let pipeline = context
         .query_manager
         .prepare_write_pipeline(
@@ -297,10 +291,10 @@ fn test_match_delete_has() {
             &context.type_manager,
             context.thing_manager.clone(),
             context.function_manager.clone(),
-            &insert_query,
+            parsed,
             None::<GivenRowsSimple>,
-            insert_query_str,
         )
+        .map_err(|(_, err)| err)
         .unwrap();
     let (mut iterator, ExecutionContext { snapshot, .. }) =
         pipeline.into_rows_iterator(ExecutionInterrupt::new_uninterruptible()).unwrap();
@@ -327,7 +321,7 @@ fn test_match_delete_has() {
         delete has $a of $p;
     "#;
 
-    let delete_query = typeql::parse_query(delete_query_str).unwrap().into_structure().into_pipeline();
+    let parsed = context.query_manager.parse(delete_query_str.to_string()).unwrap().into_pipeline();
     let pipeline = context
         .query_manager
         .prepare_write_pipeline(
@@ -335,10 +329,10 @@ fn test_match_delete_has() {
             &context.type_manager,
             context.thing_manager.clone(),
             context.function_manager.clone(),
-            &delete_query,
+            parsed,
             None::<GivenRowsSimple>,
-            delete_query_str,
         )
+        .map_err(|(_, err)| err)
         .unwrap();
 
     let (mut iterator, ExecutionContext { snapshot, .. }) =
@@ -370,7 +364,7 @@ fn test_insert_match_insert() {
        $q isa person, has age 20, has name 'Alice';
        $r isa person, has age 30, has name 'Harry';
    "#;
-    let query = typeql::parse_query(query_str).unwrap().into_structure().into_pipeline();
+    let parsed = context.query_manager.parse(query_str.to_string()).unwrap().into_pipeline();
     let pipeline = context
         .query_manager
         .prepare_write_pipeline(
@@ -378,10 +372,10 @@ fn test_insert_match_insert() {
             &context.type_manager,
             context.thing_manager.clone(),
             context.function_manager.clone(),
-            &query,
+            parsed,
             None::<GivenRowsSimple>,
-            query_str,
         )
+        .map_err(|(_, err)| err)
         .unwrap();
     let (iterator, ExecutionContext { snapshot, .. }) =
         pipeline.into_rows_iterator(ExecutionInterrupt::new_uninterruptible()).unwrap();
@@ -400,7 +394,7 @@ fn test_insert_match_insert() {
         (group: $org, member: $p) isa membership;
     "#;
 
-    let query = typeql::parse_query(query_str).unwrap().into_structure().into_pipeline();
+    let parsed = context.query_manager.parse(query_str.to_string()).unwrap().into_pipeline();
     let pipeline = context
         .query_manager
         .prepare_write_pipeline(
@@ -408,10 +402,10 @@ fn test_insert_match_insert() {
             &context.type_manager,
             context.thing_manager.clone(),
             context.function_manager.clone(),
-            &query,
+            parsed,
             None::<GivenRowsSimple>,
-            query_str,
         )
+        .map_err(|(_, err)| err)
         .unwrap();
 
     let (mut iterator, ExecutionContext { snapshot, .. }) =
@@ -433,7 +427,7 @@ fn test_match_sort() {
     let context = setup_common();
     let snapshot = context.storage.clone().open_snapshot_write();
     let insert_query_str = "insert $p isa person, has age 1, has age 2, has age 3, has age 4;";
-    let insert_query = typeql::parse_query(insert_query_str).unwrap().into_structure().into_pipeline();
+    let parsed = context.query_manager.parse(insert_query_str.to_string()).unwrap().into_pipeline();
     let pipeline = context
         .query_manager
         .prepare_write_pipeline(
@@ -441,10 +435,10 @@ fn test_match_sort() {
             &context.type_manager,
             context.thing_manager.clone(),
             context.function_manager.clone(),
-            &insert_query,
+            parsed,
             None::<GivenRowsSimple>,
-            insert_query_str,
         )
+        .map_err(|(_, err)| err)
         .unwrap();
     let (mut iterator, ExecutionContext { snapshot, .. }) =
         pipeline.into_rows_iterator(ExecutionInterrupt::new_uninterruptible()).unwrap();
@@ -456,7 +450,7 @@ fn test_match_sort() {
 
     let snapshot = Arc::new(context.storage.open_snapshot_read());
     let query = "match $age isa age; sort $age desc;";
-    let match_ = typeql::parse_query(query).unwrap().into_structure().into_pipeline();
+    let parsed = context.query_manager.parse(query.to_string()).unwrap().into_pipeline();
     let pipeline = context
         .query_manager
         .prepare_read_pipeline(
@@ -464,9 +458,8 @@ fn test_match_sort() {
             &context.type_manager,
             context.thing_manager.clone(),
             context.function_manager.clone(),
-            &match_,
+            parsed,
             None::<GivenRowsSimple>,
-            query,
         )
         .unwrap();
     let named_outputs = pipeline.rows_positions().unwrap().clone();
@@ -498,7 +491,7 @@ fn test_select() {
     let insert_query_str = r#"insert
         $p1 isa person, has name "Alice", has age 1;
         $p2 isa person, has name "Bob", has age 2;"#;
-    let insert_query = typeql::parse_query(insert_query_str).unwrap().into_structure().into_pipeline();
+    let parsed = context.query_manager.parse(insert_query_str.to_string()).unwrap().into_pipeline();
     let pipeline = context
         .query_manager
         .prepare_write_pipeline(
@@ -506,10 +499,10 @@ fn test_select() {
             &context.type_manager,
             context.thing_manager.clone(),
             context.function_manager.clone(),
-            &insert_query,
+            parsed,
             None::<GivenRowsSimple>,
-            insert_query_str,
         )
+        .map_err(|(_, err)| err)
         .unwrap();
     let (mut iterator, ExecutionContext { snapshot, .. }) =
         pipeline.into_rows_iterator(ExecutionInterrupt::new_uninterruptible()).unwrap();
@@ -522,7 +515,7 @@ fn test_select() {
     {
         let snapshot = Arc::new(context.storage.clone().open_snapshot_read());
         let query = "match $p isa person, has name \"Alice\", has age $age;";
-        let match_ = typeql::parse_query(query).unwrap().into_structure().into_pipeline();
+        let parsed = context.query_manager.parse(query.to_string()).unwrap().into_pipeline();
         let pipeline = context
             .query_manager
             .prepare_read_pipeline(
@@ -530,9 +523,8 @@ fn test_select() {
                 &context.type_manager,
                 context.thing_manager.clone(),
                 context.function_manager.clone(),
-                &match_,
+                parsed,
                 None::<GivenRowsSimple>,
-                query,
             )
             .unwrap();
         let named_outputs = pipeline.rows_positions().unwrap();
@@ -542,7 +534,7 @@ fn test_select() {
     {
         let snapshot = Arc::new(context.storage.clone().open_snapshot_read());
         let query = "match $p isa person, has name \"Alice\", has age $age; select $age;";
-        let match_ = typeql::parse_query(query).unwrap().into_structure().into_pipeline();
+        let parsed = context.query_manager.parse(query.to_string()).unwrap().into_pipeline();
         let pipeline = context
             .query_manager
             .prepare_read_pipeline(
@@ -550,9 +542,8 @@ fn test_select() {
                 &context.type_manager,
                 context.thing_manager.clone(),
                 context.function_manager.clone(),
-                &match_,
+                parsed,
                 None::<GivenRowsSimple>,
-                query,
             )
             .unwrap();
         let named_outputs = pipeline.rows_positions().unwrap();
@@ -568,7 +559,7 @@ fn test_require() {
     let insert_query_str = r#"insert
         $p1 isa person, has name "Alice", has age 1;
         $p2 isa person, has name "Bob", has age 2;"#;
-    let insert_query = typeql::parse_query(insert_query_str).unwrap().into_structure().into_pipeline();
+    let parsed = context.query_manager.parse(insert_query_str.to_string()).unwrap().into_pipeline();
     let pipeline = context
         .query_manager
         .prepare_write_pipeline(
@@ -576,10 +567,10 @@ fn test_require() {
             &context.type_manager,
             context.thing_manager.clone(),
             context.function_manager.clone(),
-            &insert_query,
+            parsed,
             None::<GivenRowsSimple>,
-            insert_query_str,
         )
+        .map_err(|(_, err)| err)
         .unwrap();
     let (mut iterator, ExecutionContext { snapshot, .. }) =
         pipeline.into_rows_iterator(ExecutionInterrupt::new_uninterruptible()).unwrap();
@@ -592,7 +583,7 @@ fn test_require() {
     {
         let snapshot = Arc::new(context.storage.clone().open_snapshot_read());
         let query = "match $p isa person, has name \"Alice\", has age $age; require $age;";
-        let match_ = typeql::parse_query(query).unwrap().into_structure().into_pipeline();
+        let parsed = context.query_manager.parse(query.to_string()).unwrap().into_pipeline();
         let pipeline = context
             .query_manager
             .prepare_read_pipeline(
@@ -600,9 +591,8 @@ fn test_require() {
                 &context.type_manager,
                 context.thing_manager.clone(),
                 context.function_manager.clone(),
-                &match_,
+                parsed,
                 None::<GivenRowsSimple>,
-                query,
             )
             .unwrap();
         let named_outputs = pipeline.rows_positions().unwrap();

--- a/executor/tests/writes.rs
+++ b/executor/tests/writes.rs
@@ -31,7 +31,7 @@ use executor::{
     write::WriteError,
 };
 use ir::{
-    pipeline::{ParameterRegistry, function_signature::HashMapFunctionSignatureIndex},
+    pipeline::{ParameterRegistry, QueryContext, function_signature::HashMapFunctionSignatureIndex},
     translation::PipelineTranslationContext,
 };
 use itertools::Itertools;
@@ -201,20 +201,14 @@ fn execute_insert<Snapshot: WritableSnapshot + 'static>(
     println!("Insert output row schema: {:?}", &insert_plan.output_row_schema);
 
     let snapshot = Arc::new(snapshot);
-    let initial = ShimStage::new(
-        input_rows,
-        ExecutionContext {
-            snapshot,
-            thing_manager,
-            function_manager: Arc::default(),
-            parameters: Arc::new(value_parameters),
-            profile: Arc::new(QueryProfile::new(false)),
-        },
-    );
+    let initial =
+        ShimStage::new(input_rows, ExecutionContext { snapshot, thing_manager, function_manager: Arc::default() });
+    let query_context =
+        Arc::new(QueryContext::new(Arc::new(value_parameters), Arc::default(), Arc::new(QueryProfile::new(false))));
     let (input_iter, context) = initial.into_iterator();
     let insert_executor: InsertStageExecutor<ShimIterator> = InsertStageExecutor::new(Arc::new(insert_plan));
     let (output_iter, context) = insert_executor
-        .into_iterator(input_iter, context, ExecutionInterrupt::new_uninterruptible())
+        .into_iterator(input_iter, context, query_context, ExecutionInterrupt::new_uninterruptible())
         .map_err(|(err, _)| match *err {
             PipelineExecutionError::WriteError { typedb_source } => typedb_source.clone(),
             _ => unreachable!(),
@@ -291,20 +285,14 @@ fn execute_delete<Snapshot: WritableSnapshot + 'static>(
     .unwrap();
 
     let snapshot = Arc::new(snapshot);
-    let initial = ShimStage::new(
-        input_rows,
-        ExecutionContext {
-            snapshot,
-            thing_manager,
-            function_manager: Arc::default(),
-            parameters: Arc::new(value_parameters),
-            profile: Arc::new(QueryProfile::new(false)),
-        },
-    );
+    let initial =
+        ShimStage::new(input_rows, ExecutionContext { snapshot, thing_manager, function_manager: Arc::default() });
+    let query_context =
+        Arc::new(QueryContext::new(Arc::new(value_parameters), Arc::default(), Arc::new(QueryProfile::new(false))));
     let (input_iter, context) = initial.into_iterator();
     let delete_executor: DeleteStageExecutor<ShimIterator> = DeleteStageExecutor::new(Arc::new(delete_plan));
     let (output_iter, context) = delete_executor
-        .into_iterator(input_iter, context, ExecutionInterrupt::new_uninterruptible())
+        .into_iterator(input_iter, context, query_context, ExecutionInterrupt::new_uninterruptible())
         .map_err(|(err, _)| match *err {
             PipelineExecutionError::WriteError { typedb_source } => typedb_source,
             _ => unreachable!(),

--- a/ir/BUILD
+++ b/ir/BUILD
@@ -28,6 +28,7 @@ rust_library(
         "//durability",
         "//encoding",
         "//storage",
+        "//resource",
 
         "@typeql//rust:typeql",
 

--- a/ir/Cargo.toml
+++ b/ir/Cargo.toml
@@ -15,9 +15,6 @@ features = {}
 
 [dev-dependencies]
 
-	[dev-dependencies.resource]
-		workspace = true
-
 	[dev-dependencies.test_utils_storage]
 		workspace = true
 
@@ -30,6 +27,9 @@ features = {}
 		workspace = true
 
 	[dependencies.primitive]
+		workspace = true
+
+	[dependencies.resource]
 		workspace = true
 
 	[dependencies.structural_equality]

--- a/ir/pattern/constraint.rs
+++ b/ir/pattern/constraint.rs
@@ -25,10 +25,7 @@ use crate::{
         conjunction::Conjunction,
         expression::{ExpressionRepresentationError, ExpressionTree},
         function_call::FunctionCall,
-        variable_category::{
-            VariableCategory, VariableOptionality,
-            VariableOptionality::{Optional, Required},
-        },
+        variable_category::{VariableCategory, VariableOptionality},
     },
     pipeline::{
         ParameterRegistry, VariableRegistry, block::BlockBuilderContext, function_signature::FunctionSignature,

--- a/ir/pipeline/mod.rs
+++ b/ir/pipeline/mod.rs
@@ -15,6 +15,7 @@ use encoding::{
 };
 use error::typedb_error;
 use itertools::Itertools;
+use resource::profile::QueryProfile;
 use storage::snapshot::{SnapshotGetError, iterator::SnapshotIteratorError};
 use typeql::{
     common::Span,
@@ -393,6 +394,19 @@ pub enum VariableCategorySource {
     ArgumentOrGiven,
     Delete,
     Variable(Variable),
+}
+
+#[derive(Debug, Clone)]
+pub struct QueryContext {
+    pub parameters: Arc<ParameterRegistry>,
+    pub source_query: Arc<String>,
+    pub profile: Arc<QueryProfile>,
+}
+
+impl QueryContext {
+    pub fn new(parameters: Arc<ParameterRegistry>, source_query: Arc<String>, profile: Arc<QueryProfile>) -> Self {
+        Self { parameters, source_query, profile }
+    }
 }
 
 #[derive(Clone, Debug, Default, Eq, PartialEq)]

--- a/ir/pipeline/mod.rs
+++ b/ir/pipeline/mod.rs
@@ -15,6 +15,7 @@ use encoding::{
 };
 use error::typedb_error;
 use itertools::Itertools;
+use resource::profile::QueryProfile;
 use storage::snapshot::{SnapshotGetError, iterator::SnapshotIteratorError};
 use typeql::{
     common::Span,
@@ -406,6 +407,19 @@ pub enum VariableCategorySource {
     ArgumentOrGiven,
     Delete,
     Variable(Variable),
+}
+
+#[derive(Debug, Clone)]
+pub struct QueryContext {
+    pub parameters: Arc<ParameterRegistry>,
+    pub source_query: Arc<String>,
+    pub profile: Arc<QueryProfile>,
+}
+
+impl QueryContext {
+    pub fn new(parameters: Arc<ParameterRegistry>, source_query: Arc<String>, profile: Arc<QueryProfile>) -> Self {
+        Self { parameters, source_query, profile }
+    }
 }
 
 #[derive(Clone, Debug, Default, Eq, PartialEq)]

--- a/ir/tests/BUILD
+++ b/ir/tests/BUILD
@@ -12,6 +12,7 @@ rust_test(
     srcs =  ["pattern.rs"],
     deps = [
         "//ir:ir",
+        "//resource",
         "@typeql//rust:typeql",
     ],
 )
@@ -25,6 +26,7 @@ rust_test(
         "//common/bytes",
         "//encoding",
         "//ir:ir",
+        "//resource",
         "@typeql//rust:typeql",
     ],
 )
@@ -53,6 +55,7 @@ rust_test(
     srcs =  ["binding_modes.rs"],
     deps = [
         "//ir:ir",
+        "//resource:resource",
         "@typeql//rust:typeql",
 
         "@crates//:itertools",

--- a/ir/tests/binding_modes.rs
+++ b/ir/tests/binding_modes.rs
@@ -3,7 +3,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
-use std::collections::HashSet;
+use std::{collections::HashSet, sync::Arc};
 
 use ir::{
     RepresentationError,
@@ -246,7 +246,9 @@ fn test_disjoint_disjunction_again() {
       match { $x isa person; } or { $x isa company; } or { $a isa name; };
     "#;
     let parsed = typeql::parse_query(query).unwrap().into_structure();
-    let translation_error = translate_pipeline(&empty_function_index, &parsed.into_pipeline()).unwrap_err();
+    let translation_error =
+        translate_pipeline(&empty_function_index, &parsed.into_pipeline(), Arc::new(query.to_string()), Arc::default())
+            .unwrap_err();
     assert!(match *translation_error {
         RepresentationError::UnboundRequiredVariable { variable, .. } => {
             variable == "x"
@@ -297,7 +299,9 @@ fn test_negation_with_inputs() {
         not { $x has $y; };
     "#;
     let parsed = typeql::parse_query(query).unwrap().into_structure();
-    let translated_pipeline = translate_pipeline(&empty_function_index, &parsed.into_pipeline()).unwrap();
+    let translated_pipeline =
+        translate_pipeline(&empty_function_index, &parsed.into_pipeline(), Arc::new(query.to_string()), Arc::default())
+            .unwrap();
     let TranslatedStage::Match { block: second_block, .. } = &translated_pipeline.translated_stages[1] else {
         unreachable!();
     };
@@ -320,7 +324,9 @@ fn test_disjunction_with_inputs() {
         { $x has height 16; } or { $y has name "Alice"; };
     "#;
     let parsed = typeql::parse_query(query).unwrap().into_structure();
-    let translated_pipeline = translate_pipeline(&empty_function_index, &parsed.into_pipeline()).unwrap();
+    let translated_pipeline =
+        translate_pipeline(&empty_function_index, &parsed.into_pipeline(), Arc::new(query.to_string()), Arc::default())
+            .unwrap();
     let TranslatedStage::Match { block: first_block, .. } = &translated_pipeline.translated_stages[0] else {
         unreachable!();
     };
@@ -359,7 +365,9 @@ fn test_optional_with_inputs() {
         try { $x has $y;};
     "#;
     let parsed = typeql::parse_query(query).unwrap().into_structure();
-    let translated_pipeline = translate_pipeline(&empty_function_index, &parsed.into_pipeline()).unwrap();
+    let translated_pipeline =
+        translate_pipeline(&empty_function_index, &parsed.into_pipeline(), Arc::new(query.to_string()), Arc::default())
+            .unwrap();
     let TranslatedStage::Match { block: first_block, .. } = &translated_pipeline.translated_stages[0] else {
         unreachable!();
     };
@@ -388,7 +396,9 @@ fn test_optional_skip_a_stage() {
         try { $x has $y;};
     "#;
     let parsed = typeql::parse_query(query).unwrap().into_structure();
-    let translated_pipeline = translate_pipeline(&empty_function_index, &parsed.into_pipeline()).unwrap();
+    let translated_pipeline =
+        translate_pipeline(&empty_function_index, &parsed.into_pipeline(), Arc::new(query.to_string()), Arc::default())
+            .unwrap();
     let TranslatedStage::Match { block: first_block, .. } = &translated_pipeline.translated_stages[0] else {
         unreachable!();
     };
@@ -421,7 +431,9 @@ fn test_nested_negation() {
         };
     "#;
     let parsed = typeql::parse_query(query).unwrap().into_structure();
-    let translated_pipeline = translate_pipeline(&empty_function_index, &parsed.into_pipeline()).unwrap();
+    let translated_pipeline =
+        translate_pipeline(&empty_function_index, &parsed.into_pipeline(), Arc::new(query.to_string()), Arc::default())
+            .unwrap();
     let TranslatedStage::Match { block, .. } = &translated_pipeline.translated_stages[0] else {
         unreachable!();
     };
@@ -448,7 +460,9 @@ fn test_nested_optional() {
         };
     "#;
     let parsed = typeql::parse_query(query).unwrap().into_structure();
-    let translated_pipeline = translate_pipeline(&empty_function_index, &parsed.into_pipeline()).unwrap();
+    let translated_pipeline =
+        translate_pipeline(&empty_function_index, &parsed.into_pipeline(), Arc::new(query.to_string()), Arc::default())
+            .unwrap();
     let TranslatedStage::Match { block, .. } = &translated_pipeline.translated_stages[0] else {
         unreachable!();
     };
@@ -476,7 +490,8 @@ fn test_optional_return() {
     let preamble_signatures = HashMapFunctionSignatureIndex::build(
         parsed.preambles.iter().enumerate().map(|(i, preamble)| (FunctionID::Preamble(i), &preamble.function)),
     );
-    let translated_pipeline = translate_pipeline(&preamble_signatures, &parsed).unwrap();
+    let translated_pipeline =
+        translate_pipeline(&preamble_signatures, &parsed, Arc::new(query.to_string()), Arc::default()).unwrap();
     let TranslatedStage::Match { block, .. } = &translated_pipeline.translated_stages[0] else {
         unreachable!();
     };

--- a/ir/tests/pipeline.rs
+++ b/ir/tests/pipeline.rs
@@ -4,6 +4,8 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
+use std::sync::Arc;
+
 use encoding::{
     graph::definition::definition_key::{DefinitionID, DefinitionKey},
     layout::prefix::Prefix,
@@ -91,6 +93,8 @@ fn optional_writes() {
     let translation_result = translate_pipeline(
         &HashMapFunctionSignatureIndex::empty(),
         &typeql::parse_query(query).unwrap().into_structure().into_pipeline(),
+        Arc::new(query.to_string()),
+        Arc::default(),
     );
     assert!(translation_result.is_ok(), "{translation_result:?}");
 
@@ -101,6 +105,8 @@ fn optional_writes() {
     let translation_result = translate_pipeline(
         &HashMapFunctionSignatureIndex::empty(),
         &typeql::parse_query(query).unwrap().into_structure().into_pipeline(),
+        Arc::new(query.to_string()),
+        Arc::default(),
     );
     assert!(translation_result.is_ok(), "{translation_result:?}");
 
@@ -112,6 +118,8 @@ fn optional_writes() {
     let translation_result = translate_pipeline(
         &HashMapFunctionSignatureIndex::empty(),
         &typeql::parse_query(query).unwrap().into_structure().into_pipeline(),
+        Arc::new(query.to_string()),
+        Arc::default(),
     );
     assert!(translation_result.is_ok(), "{translation_result:?}");
 
@@ -122,6 +130,8 @@ fn optional_writes() {
     let translation_result = translate_pipeline(
         &HashMapFunctionSignatureIndex::empty(),
         &typeql::parse_query(query).unwrap().into_structure().into_pipeline(),
+        Arc::new(query.to_string()),
+        Arc::default(),
     );
     assert!(translation_result.is_ok(), "{translation_result:?}");
 
@@ -132,6 +142,8 @@ fn optional_writes() {
     let translation_result = translate_pipeline(
         &HashMapFunctionSignatureIndex::empty(),
         &typeql::parse_query(query).unwrap().into_structure().into_pipeline(),
+        Arc::new(query.to_string()),
+        Arc::default(),
     );
     assert!(translation_result.is_ok(), "{translation_result:?}");
 }
@@ -145,6 +157,8 @@ fn multiple_optional_writes_in_a_block() {
     let translation_result = translate_pipeline(
         &HashMapFunctionSignatureIndex::empty(),
         &typeql::parse_query(query).unwrap().into_structure().into_pipeline(),
+        Arc::new(query.to_string()),
+        Arc::default(),
     );
     assert!(translation_result.is_ok(), "{translation_result:?}");
 
@@ -155,6 +169,8 @@ fn multiple_optional_writes_in_a_block() {
     let translation_result = translate_pipeline(
         &HashMapFunctionSignatureIndex::empty(),
         &typeql::parse_query(query).unwrap().into_structure().into_pipeline(),
+        Arc::new(query.to_string()),
+        Arc::default(),
     );
     assert!(translation_result.is_ok(), "{translation_result:?}");
 
@@ -165,6 +181,8 @@ fn multiple_optional_writes_in_a_block() {
     let translation_result = translate_pipeline(
         &HashMapFunctionSignatureIndex::empty(),
         &typeql::parse_query(query).unwrap().into_structure().into_pipeline(),
+        Arc::new(query.to_string()),
+        Arc::default(),
     );
     assert!(translation_result.is_ok(), "{translation_result:?}");
 
@@ -175,6 +193,8 @@ fn multiple_optional_writes_in_a_block() {
     let translation_result = translate_pipeline(
         &HashMapFunctionSignatureIndex::empty(),
         &typeql::parse_query(query).unwrap().into_structure().into_pipeline(),
+        Arc::new(query.to_string()),
+        Arc::default(),
     );
     assert!(translation_result.is_ok(), "{translation_result:?}");
 
@@ -185,6 +205,8 @@ fn multiple_optional_writes_in_a_block() {
     let translation_result = translate_pipeline(
         &HashMapFunctionSignatureIndex::empty(),
         &typeql::parse_query(query).unwrap().into_structure().into_pipeline(),
+        Arc::new(query.to_string()),
+        Arc::default(),
     );
     assert!(translation_result.is_ok(), "{translation_result:?}");
 
@@ -195,6 +217,8 @@ fn multiple_optional_writes_in_a_block() {
     let translation_result = translate_pipeline(
         &HashMapFunctionSignatureIndex::empty(),
         &typeql::parse_query(query).unwrap().into_structure().into_pipeline(),
+        Arc::new(query.to_string()),
+        Arc::default(),
     );
     assert!(translation_result.is_ok(), "{translation_result:?}");
 
@@ -205,6 +229,8 @@ fn multiple_optional_writes_in_a_block() {
     let translation_result = translate_pipeline(
         &HashMapFunctionSignatureIndex::empty(),
         &typeql::parse_query(query).unwrap().into_structure().into_pipeline(),
+        Arc::new(query.to_string()),
+        Arc::default(),
     );
     assert!(translation_result.is_ok(), "{translation_result:?}");
 }
@@ -217,8 +243,12 @@ fn nested_optional_blocks_in_write() {
     "#;
     if let Ok(parsed) = typeql::parse_query(query) {
         // currently nested try blocks don't even parse in delete
-        let translation_result =
-            translate_pipeline(&HashMapFunctionSignatureIndex::empty(), &parsed.into_structure().into_pipeline());
+        let translation_result = translate_pipeline(
+            &HashMapFunctionSignatureIndex::empty(),
+            &parsed.into_structure().into_pipeline(),
+            Arc::new(query.to_string()),
+            Arc::default(),
+        );
         assert!(translation_result.is_err(), "Nested try blocks are not yet supported in write stages: {query}");
     }
 
@@ -229,6 +259,8 @@ fn nested_optional_blocks_in_write() {
     let translation_result = translate_pipeline(
         &HashMapFunctionSignatureIndex::empty(),
         &typeql::parse_query(query).unwrap().into_structure().into_pipeline(),
+        Arc::new(query.to_string()),
+        Arc::default(),
     );
     assert!(translation_result.is_err(), "Nested try blocks are not yet supported in write stages: {query}");
 
@@ -239,6 +271,8 @@ fn nested_optional_blocks_in_write() {
     let translation_result = translate_pipeline(
         &HashMapFunctionSignatureIndex::empty(),
         &typeql::parse_query(query).unwrap().into_structure().into_pipeline(),
+        Arc::new(query.to_string()),
+        Arc::default(),
     );
     assert!(translation_result.is_err(), "Nested try blocks are not yet supported in write stages: {query}");
 
@@ -249,6 +283,8 @@ fn nested_optional_blocks_in_write() {
     let translation_result = translate_pipeline(
         &HashMapFunctionSignatureIndex::empty(),
         &typeql::parse_query(query).unwrap().into_structure().into_pipeline(),
+        Arc::new(query.to_string()),
+        Arc::default(),
     );
     assert!(translation_result.is_err(), "Nested try blocks are not yet supported in write stages: {query}");
 }

--- a/ir/tests/structural_equality.rs
+++ b/ir/tests/structural_equality.rs
@@ -4,6 +4,8 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
+use std::sync::Arc;
+
 use ir::{
     pipeline::function_signature::HashMapFunctionSignatureIndex,
     translation::{
@@ -144,6 +146,8 @@ fetch {
     let TranslatedPipeline { translated_preamble, translated_stages, translated_fetch, .. } = translate_pipeline(
         &HashMapFunctionSignatureIndex::empty(),
         &typeql::parse_query(pipeline).unwrap().into_structure().into_pipeline(),
+        Arc::new(pipeline.to_string()),
+        Arc::default(),
     )
     .unwrap();
     assert!(translated_preamble.equals(&translated_preamble));
@@ -181,6 +185,8 @@ fetch {
     } = translate_pipeline(
         &HashMapFunctionSignatureIndex::empty(),
         &typeql::parse_query(structurally_equivalent_pipeline).unwrap().into_structure().into_pipeline(),
+        Arc::new(structurally_equivalent_pipeline.to_string()),
+        Arc::default(),
     )
     .unwrap();
 
@@ -188,9 +194,9 @@ fetch {
     assert!(equivalent_translated_stages.equals(&equivalent_translated_stages));
     assert!(equivalent_translated_fetch.equals(&equivalent_translated_fetch));
 
-    assert!(is_structurally_equivalent(&translated_preamble, &equivalent_translated_preamble));
-    assert!(is_structurally_equivalent(&translated_stages, &equivalent_translated_stages));
-    assert!(is_structurally_equivalent(&translated_fetch, &equivalent_translated_fetch));
+    assert!(is_structurally_equivalent(translated_preamble.as_ref(), &equivalent_translated_preamble));
+    assert!(is_structurally_equivalent(translated_stages.as_ref(), &equivalent_translated_stages));
+    assert!(is_structurally_equivalent(translated_fetch.as_ref(), &equivalent_translated_fetch));
 }
 
 #[test]
@@ -220,6 +226,8 @@ fetch {
     let TranslatedPipeline { translated_preamble, translated_stages, translated_fetch, .. } = translate_pipeline(
         &HashMapFunctionSignatureIndex::empty(),
         &typeql::parse_query(pipeline).unwrap().into_structure().into_pipeline(),
+        Arc::new(pipeline.to_string()),
+        Arc::default(),
     )
     .unwrap();
     assert!(translated_preamble.equals(&translated_preamble));
@@ -255,6 +263,8 @@ fetch {
     } = translate_pipeline(
         &HashMapFunctionSignatureIndex::empty(),
         &typeql::parse_query(different).unwrap().into_structure().into_pipeline(),
+        Arc::new(different.to_string()),
+        Arc::default(),
     )
     .unwrap();
 
@@ -262,9 +272,9 @@ fetch {
     assert!(different_translated_stages.equals(&different_translated_stages));
     assert!(different_translated_fetch.equals(&different_translated_fetch));
 
-    assert!(!is_structurally_equivalent(&translated_preamble, &different_translated_preamble));
-    assert!(!is_structurally_equivalent(&translated_stages, &different_translated_stages));
-    assert!(!is_structurally_equivalent(&translated_fetch, &different_translated_fetch));
+    assert!(!is_structurally_equivalent(translated_preamble.as_ref(), &different_translated_preamble));
+    assert!(!is_structurally_equivalent(translated_stages.as_ref(), &different_translated_stages));
+    assert!(!is_structurally_equivalent(translated_fetch.as_ref(), &different_translated_fetch));
 }
 
 #[test]
@@ -273,6 +283,8 @@ fn test_anonymous_non_equivalence() {
     let TranslatedPipeline { translated_stages, .. } = translate_pipeline(
         &HashMapFunctionSignatureIndex::empty(),
         &typeql::parse_query(query).unwrap().into_structure().into_pipeline(),
+        Arc::new(query.to_string()),
+        Arc::default(),
     )
     .unwrap();
     assert!(translated_stages.equals(&translated_stages));
@@ -281,9 +293,11 @@ fn test_anonymous_non_equivalence() {
     let TranslatedPipeline { translated_stages: different_translated_stages, .. } = translate_pipeline(
         &HashMapFunctionSignatureIndex::empty(),
         &typeql::parse_query(non_equivalent_query).unwrap().into_structure().into_pipeline(),
+        Arc::new(non_equivalent_query.to_string()),
+        Arc::default(),
     )
     .unwrap();
     assert!(different_translated_stages.equals(&different_translated_stages));
 
-    assert!(!is_structurally_equivalent(&translated_stages, &different_translated_stages));
+    assert!(!is_structurally_equivalent(translated_stages.as_ref(), &different_translated_stages));
 }

--- a/ir/translation/mod.rs
+++ b/ir/translation/mod.rs
@@ -4,7 +4,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-use std::{collections::HashMap, io::Read};
+use std::collections::HashMap;
 
 use answer::variable::Variable;
 use bytes::byte_array::ByteArray;

--- a/ir/translation/pipeline.rs
+++ b/ir/translation/pipeline.rs
@@ -8,9 +8,11 @@ use std::{
     hash::{DefaultHasher, Hasher},
     iter::empty,
     mem,
+    sync::Arc,
 };
 
 use answer::variable::Variable;
+use resource::profile::QueryProfile;
 use structural_equality::StructuralEquality;
 use typeql::{
     common::{Span, Spanned},
@@ -27,7 +29,7 @@ use crate::{
         nested_pattern::NestedPattern,
     },
     pipeline::{
-        ParameterRegistry, VariableRegistry,
+        ParameterRegistry, QueryContext, VariableRegistry,
         block::Block,
         fetch::FetchObject,
         function::Function,
@@ -50,30 +52,30 @@ use crate::{
 
 #[derive(Debug, Clone)]
 pub struct TranslatedPipeline {
-    pub translated_preamble: Vec<Function>,
-    pub translated_given: Option<TranslatedGiven>,
-    pub translated_stages: Vec<TranslatedStage>,
-    pub translated_fetch: Option<FetchObject>,
+    pub translated_preamble: Arc<Vec<Function>>,
+    pub translated_given: Arc<Option<TranslatedGiven>>,
+    pub translated_stages: Arc<Vec<TranslatedStage>>,
+    pub translated_fetch: Arc<Option<FetchObject>>,
     pub variable_registry: VariableRegistry,
-    pub value_parameters: ParameterRegistry,
+    pub query_context: QueryContext,
 }
 
 impl TranslatedPipeline {
     pub(crate) fn new(
         translation_context: PipelineTranslationContext,
-        value_parameters: ParameterRegistry,
         translated_preamble: Vec<Function>,
         translated_given: Option<TranslatedGiven>,
         translated_stages: Vec<TranslatedStage>,
         translated_fetch: Option<FetchObject>,
+        query_context: QueryContext,
     ) -> Self {
         TranslatedPipeline {
-            translated_preamble,
-            translated_given,
-            translated_stages,
-            translated_fetch,
+            translated_preamble: Arc::new(translated_preamble),
+            translated_given: Arc::new(translated_given),
+            translated_stages: Arc::new(translated_stages),
+            translated_fetch: Arc::new(translated_fetch),
             variable_registry: translation_context.variable_registry,
-            value_parameters,
+            query_context,
         }
     }
 }
@@ -173,6 +175,8 @@ impl StructuralEquality for TranslatedStage {
 pub fn translate_pipeline(
     all_function_signatures: &impl FunctionSignatureIndex,
     query: &typeql::query::Pipeline,
+    source_query: Arc<String>,
+    query_profile: Arc<QueryProfile>,
 ) -> Result<TranslatedPipeline, Box<RepresentationError>> {
     // all_function_signatures contains the preambles already!
     let translated_preamble = query
@@ -191,13 +195,15 @@ pub fn translate_pipeline(
         &query.stages,
     )?;
 
+    let query_context = QueryContext::new(Arc::new(value_parameters), source_query, query_profile);
+
     Ok(TranslatedPipeline::new(
         translation_context,
-        value_parameters,
         translated_preamble,
         translated_given,
         translated_stages,
         translated_fetch,
+        query_context,
     ))
 }
 

--- a/ir/translation/pipeline.rs
+++ b/ir/translation/pipeline.rs
@@ -8,9 +8,11 @@ use std::{
     hash::{DefaultHasher, Hasher},
     iter::empty,
     mem,
+    sync::Arc,
 };
 
 use answer::variable::Variable;
+use resource::profile::QueryProfile;
 use structural_equality::StructuralEquality;
 use typeql::{
     common::{Span, Spanned},
@@ -22,7 +24,7 @@ use crate::{
     RepresentationError,
     pattern::Pattern,
     pipeline::{
-        ParameterRegistry, VariableRegistry,
+        ParameterRegistry, QueryContext, VariableRegistry,
         block::Block,
         fetch::FetchObject,
         function::Function,
@@ -45,30 +47,30 @@ use crate::{
 
 #[derive(Debug, Clone)]
 pub struct TranslatedPipeline {
-    pub translated_preamble: Vec<Function>,
-    pub translated_given: Option<TranslatedGiven>,
-    pub translated_stages: Vec<TranslatedStage>,
-    pub translated_fetch: Option<FetchObject>,
+    pub translated_preamble: Arc<Vec<Function>>,
+    pub translated_given: Arc<Option<TranslatedGiven>>,
+    pub translated_stages: Arc<Vec<TranslatedStage>>,
+    pub translated_fetch: Arc<Option<FetchObject>>,
     pub variable_registry: VariableRegistry,
-    pub value_parameters: ParameterRegistry,
+    pub query_context: QueryContext,
 }
 
 impl TranslatedPipeline {
     pub(crate) fn new(
         translation_context: PipelineTranslationContext,
-        value_parameters: ParameterRegistry,
         translated_preamble: Vec<Function>,
         translated_given: Option<TranslatedGiven>,
         translated_stages: Vec<TranslatedStage>,
         translated_fetch: Option<FetchObject>,
+        query_context: QueryContext,
     ) -> Self {
         TranslatedPipeline {
-            translated_preamble,
-            translated_given,
-            translated_stages,
-            translated_fetch,
+            translated_preamble: Arc::new(translated_preamble),
+            translated_given: Arc::new(translated_given),
+            translated_stages: Arc::new(translated_stages),
+            translated_fetch: Arc::new(translated_fetch),
             variable_registry: translation_context.variable_registry,
-            value_parameters,
+            query_context,
         }
     }
 }
@@ -168,6 +170,8 @@ impl StructuralEquality for TranslatedStage {
 pub fn translate_pipeline(
     all_function_signatures: &impl FunctionSignatureIndex,
     query: &typeql::query::Pipeline,
+    source_query: Arc<String>,
+    query_profile: Arc<QueryProfile>,
 ) -> Result<TranslatedPipeline, Box<RepresentationError>> {
     // all_function_signatures contains the preambles already!
     let translated_preamble = query
@@ -186,13 +190,15 @@ pub fn translate_pipeline(
         &query.stages,
     )?;
 
+    let query_context = QueryContext::new(Arc::new(value_parameters), source_query, query_profile);
+
     Ok(TranslatedPipeline::new(
         translation_context,
-        value_parameters,
         translated_preamble,
         translated_given,
         translated_stages,
         translated_fetch,
+        query_context,
     ))
 }
 

--- a/query/Cargo.toml
+++ b/query/Cargo.toml
@@ -126,3 +126,7 @@ features = {}
 	path = "tests/define.rs"
 	name = "test_define"
 
+[[test]]
+	path = "tests/parse_cache.rs"
+	name = "test_parse_cache"
+

--- a/query/Cargo.toml
+++ b/query/Cargo.toml
@@ -130,3 +130,7 @@ features = {}
 	path = "tests/define.rs"
 	name = "test_define"
 
+[[test]]
+	path = "tests/parse_cache.rs"
+	name = "test_parse_cache"
+

--- a/query/analyse.rs
+++ b/query/analyse.rs
@@ -41,7 +41,7 @@ use storage::snapshot::ReadableSnapshot;
 
 #[derive(Debug)]
 pub struct AnalysedQuery {
-    pub source: String,
+    pub source: Arc<String>,
     pub structure: QueryStructure,
     pub annotations: QueryStructureAnnotations,
 }

--- a/query/benches/bench_insert_queries.rs
+++ b/query/benches/bench_insert_queries.rs
@@ -121,18 +121,17 @@ fn execute_insert<Snapshot: WritableSnapshot + 'static>(
     query_manager: QueryManager,
     query_str: &str,
 ) -> Result<(Vec<HashMap<String, VariableValue<'static>>>, Snapshot), (Box<QueryError>, Snapshot)> {
-    let typeql_insert = typeql::parse_query(query_str).unwrap().into_structure().into_pipeline();
     let function_manager = Arc::new(FunctionManager::new(Arc::new(DefinitionKeyGenerator::new()), None));
 
+    let parsed = query_manager.parse(query_str.to_string()).unwrap().into_pipeline();
     let pipeline = query_manager
         .prepare_write_pipeline(
             snapshot,
             type_manager,
             thing_manager,
             function_manager,
-            &typeql_insert,
+            parsed,
             None::<GivenRowsSimple>,
-            query_str,
         )
         .map_err(|(snapshot, err)| (err, snapshot))?;
     let outputs = pipeline.rows_positions().unwrap().clone();

--- a/query/benches/bench_insert_queries_multithreaded.rs
+++ b/query/benches/bench_insert_queries_multithreaded.rs
@@ -115,18 +115,17 @@ fn execute_insert<Snapshot: WritableSnapshot + 'static>(
     query_manager: QueryManager,
     query_str: &str,
 ) -> Result<(Vec<HashMap<String, VariableValue<'static>>>, Snapshot), (Box<QueryError>, Snapshot)> {
-    let typeql_insert = typeql::parse_query(query_str).unwrap().into_structure().into_pipeline();
     let function_manager: Arc<FunctionManager> = Arc::default();
 
+    let parsed = query_manager.parse(query_str.to_string()).unwrap().into_pipeline();
     let pipeline = query_manager
         .prepare_write_pipeline(
             snapshot,
             type_manager,
             thing_manager,
             function_manager,
-            &typeql_insert,
+            parsed,
             None::<GivenRowsSimple>,
-            query_str,
         )
         .map_err(|(snapshot, err)| (err, snapshot))?;
     let outputs = pipeline.rows_positions().unwrap().clone();

--- a/query/query_cache.rs
+++ b/query/query_cache.rs
@@ -13,20 +13,21 @@ use answer::Type;
 use compiler::executable::pipeline::ExecutablePipeline;
 use concept::thing::statistics::Statistics;
 use ir::{
-    pipeline::{fetch::FetchObject, function::Function},
+    pipeline::{ParameterRegistry, QueryContext, VariableRegistry, fetch::FetchObject, function::Function},
     translation::pipeline::{TranslatedGiven, TranslatedPipeline, TranslatedStage},
 };
 use moka::sync::{Cache, CacheBuilder};
 use resource::{
     constants::database::{
-        QUERY_PARSE_CACHE_SIZE, QUERY_PLAN_CACHE_FLUSH_ANY_STATISTIC_CHANGE_FRACTION, QUERY_PLAN_CACHE_SIZE,
+        QUERY_CACHE_FLUSH_ANY_STATISTIC_CHANGE_FRACTION, QUERY_EXECUTABLE_CACHE_SIZE, QUERY_PARSE_CACHE_SIZE,
         QUERY_TRANSLATION_CACHE_SIZE,
     },
-    perf_counters::QUERY_CACHE_FLUSH,
+    perf_counters::QUERY_EXECUTABLE_CACHE_FLUSH,
+    profile::QueryProfile,
 };
 use storage::sequence_number::SequenceNumber;
 use structural_equality::StructuralEquality;
-use typeql::query::{Pipeline, SchemaQuery};
+use typeql::query::Pipeline;
 
 #[derive(Debug)]
 struct ValidityRequirements {
@@ -37,25 +38,19 @@ struct ValidityRequirements {
 #[derive(Debug)]
 pub struct QueryCache {
     parse_cache: Cache<String, Arc<Pipeline>>,
-    translation_cache: Cache<String, TranslatedPipeline>,
-    executable_cache: Cache<IRQuery, ExecutablePipeline>,
+    translate_cache: Cache<String, (CachedTranslatedPipeline, Arc<ParameterRegistry>)>,
+    executable_cache: Cache<TranslatedPipelineKey, ExecutablePipeline>,
     validity_requirements: RwLock<ValidityRequirements>,
-}
-
-#[derive(Debug)]
-pub enum ParsedQuery {
-    Schema(SchemaQuery),
-    Pipeline(Arc<Pipeline>),
 }
 
 impl QueryCache {
     pub fn new() -> Self {
         let parse_cache = CacheBuilder::new(QUERY_PARSE_CACHE_SIZE).build();
-        let translation_cache = CacheBuilder::new(QUERY_TRANSLATION_CACHE_SIZE).build();
-        let executable_cache = CacheBuilder::new(QUERY_PLAN_CACHE_SIZE).support_invalidation_closures().build();
+        let translate_cache = CacheBuilder::new(QUERY_TRANSLATION_CACHE_SIZE).build();
+        let executable_cache = CacheBuilder::new(QUERY_EXECUTABLE_CACHE_SIZE).support_invalidation_closures().build();
         let validity_requirements =
             RwLock::new(ValidityRequirements { latest_statistics: None, latest_schema_commit: None });
-        QueryCache { parse_cache, translation_cache, executable_cache, validity_requirements }
+        QueryCache { parse_cache, translate_cache, executable_cache, validity_requirements }
     }
 
     pub fn get_parsed(&self, query: &str) -> Option<Arc<Pipeline>> {
@@ -66,36 +61,47 @@ impl QueryCache {
         self.parse_cache.insert(source_query.to_owned(), pipeline);
     }
 
-    pub fn get_translated(&self, query: &str) -> Option<TranslatedPipeline> {
-        self.translation_cache.get(query)
+    pub fn get_translated(
+        &self,
+        source_query: Arc<String>,
+        query_profile: Arc<QueryProfile>,
+    ) -> Option<TranslatedPipeline> {
+        let cached = self.translate_cache.get(source_query.as_ref());
+        cached.map(|(cached_pipeline, parameters)| {
+            let query_context = QueryContext::new(parameters, source_query, query_profile);
+            cached_pipeline.into_translated_pipeline(query_context)
+        })
     }
 
     pub(crate) fn may_insert_translated(
         &self,
         statistics_sequence_number: SequenceNumber,
         source_query: &str,
-        translated: TranslatedPipeline,
+        translated: &TranslatedPipeline,
     ) {
         let read_lock = self.validity_requirements.read().unwrap();
         let may_insert = read_lock
             .latest_schema_commit
             .map_or(true, |latest_schema_commit_number| statistics_sequence_number >= latest_schema_commit_number);
         if may_insert {
-            self.translation_cache.insert(source_query.to_owned(), translated);
+            let cachable_translated = CachedTranslatedPipeline {
+                preamble: translated.translated_preamble.clone(),
+                given: translated.translated_given.clone(),
+                stages: translated.translated_stages.clone(),
+                fetch: translated.translated_fetch.clone(),
+                variable_registry: Arc::new(translated.variable_registry.clone()),
+            };
+            self.translate_cache
+                .insert(source_query.to_owned(), (cachable_translated, translated.query_context.parameters.clone()));
         }
         drop(read_lock);
     }
 
-    pub(crate) fn get_executable(
-        &self,
-        preamble: Arc<Vec<Function>>,
-        given: Arc<Option<TranslatedGiven>>,
-        stages: Arc<Vec<TranslatedStage>>,
-        fetch: Arc<Option<FetchObject>>,
-    ) -> Option<ExecutablePipeline> {
-        let key = IRQuery::new(preamble.clone(), given, stages, fetch);
+    pub(crate) fn get_executable(&self, pipeline: &TranslatedPipeline) -> Option<ExecutablePipeline> {
+        let key = TranslatedPipelineKey::from(pipeline);
         self.executable_cache.get(&key).map(|mut found| {
-            let replacement = preamble.iter().map(|func| Arc::new(func.parameters.clone())).enumerate();
+            let replacement =
+                pipeline.translated_preamble.iter().map(|func| Arc::new(func.parameters.clone())).enumerate();
             found.executable_functions.replace_preamble_parameters(replacement);
             found
         })
@@ -104,13 +110,10 @@ impl QueryCache {
     pub(crate) fn may_insert_executable(
         &self,
         statistics_sequence_number: SequenceNumber,
-        preamble: Arc<Vec<Function>>,
-        given: Arc<Option<TranslatedGiven>>,
-        stages: Arc<Vec<TranslatedStage>>,
-        fetch: Arc<Option<FetchObject>>,
+        translated_pipeline: &TranslatedPipeline,
         pipeline: ExecutablePipeline,
     ) {
-        let key = IRQuery::new(preamble, given, stages, fetch);
+        let key = TranslatedPipelineKey::from(translated_pipeline);
         let read_lock = self.validity_requirements.read().unwrap();
         let ValidityRequirements { latest_schema_commit, latest_statistics } = &*read_lock;
         let may_insert = latest_schema_commit
@@ -138,9 +141,9 @@ impl QueryCache {
         let mut write_lock = self.validity_requirements.write().unwrap();
         (*write_lock).latest_schema_commit = Some(statistics.sequence_number);
         drop(write_lock);
-        self.translation_cache.invalidate_all();
+        self.translate_cache.invalidate_all();
         self.executable_cache.invalidate_all();
-        QUERY_CACHE_FLUSH.increment();
+        QUERY_EXECUTABLE_CACHE_FLUSH.increment();
     }
 }
 
@@ -166,44 +169,66 @@ fn is_pipeline_type_populations_outdated(statistics: &Statistics, pipeline: &Exe
             _ => panic!("NaN?!"),
         }
     }
-    total_increase >= QUERY_PLAN_CACHE_FLUSH_ANY_STATISTIC_CHANGE_FRACTION
-        || total_decrease >= QUERY_PLAN_CACHE_FLUSH_ANY_STATISTIC_CHANGE_FRACTION
+    total_increase >= QUERY_CACHE_FLUSH_ANY_STATISTIC_CHANGE_FRACTION
+        || total_decrease >= QUERY_CACHE_FLUSH_ANY_STATISTIC_CHANGE_FRACTION
 }
 
-#[derive(Debug)]
-struct IRQuery {
+#[derive(Debug, Clone)]
+struct CachedTranslatedPipeline {
+    preamble: Arc<Vec<Function>>,
+    given: Arc<Option<TranslatedGiven>>,
+    stages: Arc<Vec<TranslatedStage>>,
+    fetch: Arc<Option<FetchObject>>,
+    variable_registry: Arc<VariableRegistry>,
+}
+
+impl CachedTranslatedPipeline {
+    fn into_translated_pipeline(self, query_context: QueryContext) -> TranslatedPipeline {
+        TranslatedPipeline {
+            translated_preamble: self.preamble,
+            translated_given: self.given,
+            translated_stages: self.stages,
+            translated_fetch: self.fetch,
+            variable_registry: self.variable_registry.as_ref().clone(),
+            query_context,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+struct TranslatedPipelineKey {
     preamble: Arc<Vec<Function>>,
     given: Arc<Option<TranslatedGiven>>,
     stages: Arc<Vec<TranslatedStage>>,
     fetch: Arc<Option<FetchObject>>,
 }
 
-impl IRQuery {
-    fn new(
-        preamble: Arc<Vec<Function>>,
-        given: Arc<Option<TranslatedGiven>>,
-        stages: Arc<Vec<TranslatedStage>>,
-        fetch: Arc<Option<FetchObject>>,
-    ) -> Self {
-        Self { preamble: preamble, given, stages, fetch }
+impl From<&TranslatedPipeline> for TranslatedPipelineKey {
+    fn from(pipeline: &TranslatedPipeline) -> Self {
+        Self {
+            preamble: pipeline.translated_preamble.clone(),
+            given: pipeline.translated_given.clone(),
+            stages: pipeline.translated_stages.clone(),
+            fetch: pipeline.translated_fetch.clone(),
+        }
     }
 }
 
-impl Hash for IRQuery {
+impl Hash for TranslatedPipelineKey {
     fn hash<H: Hasher>(&self, state: &mut H) {
         self.hash_into(state);
     }
 }
 
-impl PartialEq<Self> for IRQuery {
+impl PartialEq<Self> for TranslatedPipelineKey {
     fn eq(&self, other: &Self) -> bool {
         self.equals(other)
     }
 }
 
-impl Eq for IRQuery {}
+impl Eq for TranslatedPipelineKey {}
 
-impl StructuralEquality for IRQuery {
+impl StructuralEquality for TranslatedPipelineKey {
     fn hash(&self) -> u64 {
         let mut hasher = DefaultHasher::new();
         self.preamble.hash_into(&mut hasher);

--- a/query/query_cache.rs
+++ b/query/query_cache.rs
@@ -13,20 +13,21 @@ use answer::Type;
 use compiler::executable::pipeline::ExecutablePipeline;
 use concept::thing::statistics::Statistics;
 use ir::{
-    pipeline::{fetch::FetchObject, function::Function},
+    pipeline::{ParameterRegistry, QueryContext, VariableRegistry, fetch::FetchObject, function::Function},
     translation::pipeline::{TranslatedGiven, TranslatedPipeline, TranslatedStage},
 };
 use moka::sync::{Cache, CacheBuilder};
 use resource::{
     constants::database::{
-        QUERY_PARSE_CACHE_SIZE, QUERY_PLAN_CACHE_FLUSH_ANY_STATISTIC_CHANGE_FRACTION,
-        QUERY_PLAN_CACHE_FLUSH_STATIC_SMOOTH_THRESHOLD, QUERY_PLAN_CACHE_SIZE, QUERY_TRANSLATION_CACHE_SIZE,
+        QUERY_CACHE_FLUSH_ANY_STATISTIC_CHANGE_FRACTION, QUERY_CACHE_FLUSH_STATIC_SMOOTH_THRESHOLD,
+        QUERY_EXECUTABLE_CACHE_SIZE, QUERY_PARSE_CACHE_SIZE, QUERY_TRANSLATION_CACHE_SIZE,
     },
-    perf_counters::QUERY_CACHE_FLUSH,
+    perf_counters::QUERY_EXECUTABLE_CACHE_FLUSH,
+    profile::QueryProfile,
 };
 use storage::sequence_number::SequenceNumber;
 use structural_equality::StructuralEquality;
-use typeql::query::{Pipeline, SchemaQuery};
+use typeql::query::Pipeline;
 
 #[derive(Debug)]
 struct ValidityRequirements {
@@ -37,25 +38,19 @@ struct ValidityRequirements {
 #[derive(Debug)]
 pub struct QueryCache {
     parse_cache: Cache<String, Arc<Pipeline>>,
-    translation_cache: Cache<String, TranslatedPipeline>,
-    executable_cache: Cache<IRQuery, ExecutablePipeline>,
+    translate_cache: Cache<String, (CachedTranslatedPipeline, Arc<ParameterRegistry>)>,
+    executable_cache: Cache<TranslatedPipelineKey, ExecutablePipeline>,
     validity_requirements: RwLock<ValidityRequirements>,
-}
-
-#[derive(Debug)]
-pub enum ParsedQuery {
-    Schema(SchemaQuery),
-    Pipeline(Arc<Pipeline>),
 }
 
 impl QueryCache {
     pub fn new() -> Self {
         let parse_cache = CacheBuilder::new(QUERY_PARSE_CACHE_SIZE).build();
-        let translation_cache = CacheBuilder::new(QUERY_TRANSLATION_CACHE_SIZE).build();
-        let executable_cache = CacheBuilder::new(QUERY_PLAN_CACHE_SIZE).support_invalidation_closures().build();
+        let translate_cache = CacheBuilder::new(QUERY_TRANSLATION_CACHE_SIZE).build();
+        let executable_cache = CacheBuilder::new(QUERY_EXECUTABLE_CACHE_SIZE).support_invalidation_closures().build();
         let validity_requirements =
             RwLock::new(ValidityRequirements { latest_statistics: None, latest_schema_commit: None });
-        QueryCache { parse_cache, translation_cache, executable_cache, validity_requirements }
+        QueryCache { parse_cache, translate_cache, executable_cache, validity_requirements }
     }
 
     pub fn get_parsed(&self, query: &str) -> Option<Arc<Pipeline>> {
@@ -66,36 +61,47 @@ impl QueryCache {
         self.parse_cache.insert(source_query.to_owned(), pipeline);
     }
 
-    pub fn get_translated(&self, query: &str) -> Option<TranslatedPipeline> {
-        self.translation_cache.get(query)
+    pub fn get_translated(
+        &self,
+        source_query: Arc<String>,
+        query_profile: Arc<QueryProfile>,
+    ) -> Option<TranslatedPipeline> {
+        let cached = self.translate_cache.get(source_query.as_ref());
+        cached.map(|(cached_pipeline, parameters)| {
+            let query_context = QueryContext::new(parameters, source_query, query_profile);
+            cached_pipeline.into_translated_pipeline(query_context)
+        })
     }
 
     pub(crate) fn may_insert_translated(
         &self,
         statistics_sequence_number: SequenceNumber,
         source_query: &str,
-        translated: TranslatedPipeline,
+        translated: &TranslatedPipeline,
     ) {
         let read_lock = self.validity_requirements.read().unwrap();
         let may_insert = read_lock
             .latest_schema_commit
             .map_or(true, |latest_schema_commit_number| statistics_sequence_number >= latest_schema_commit_number);
         if may_insert {
-            self.translation_cache.insert(source_query.to_owned(), translated);
+            let cachable_translated = CachedTranslatedPipeline {
+                preamble: translated.translated_preamble.clone(),
+                given: translated.translated_given.clone(),
+                stages: translated.translated_stages.clone(),
+                fetch: translated.translated_fetch.clone(),
+                variable_registry: Arc::new(translated.variable_registry.clone()),
+            };
+            self.translate_cache
+                .insert(source_query.to_owned(), (cachable_translated, translated.query_context.parameters.clone()));
         }
         drop(read_lock);
     }
 
-    pub(crate) fn get_executable(
-        &self,
-        preamble: Arc<Vec<Function>>,
-        given: Arc<Option<TranslatedGiven>>,
-        stages: Arc<Vec<TranslatedStage>>,
-        fetch: Arc<Option<FetchObject>>,
-    ) -> Option<ExecutablePipeline> {
-        let key = IRQuery::new(preamble.clone(), given, stages, fetch);
+    pub(crate) fn get_executable(&self, pipeline: &TranslatedPipeline) -> Option<ExecutablePipeline> {
+        let key = TranslatedPipelineKey::from(pipeline);
         self.executable_cache.get(&key).map(|mut found| {
-            let replacement = preamble.iter().map(|func| Arc::new(func.parameters.clone())).enumerate();
+            let replacement =
+                pipeline.translated_preamble.iter().map(|func| Arc::new(func.parameters.clone())).enumerate();
             found.executable_functions.replace_preamble_parameters(replacement);
             found
         })
@@ -104,13 +110,10 @@ impl QueryCache {
     pub(crate) fn may_insert_executable(
         &self,
         statistics_sequence_number: SequenceNumber,
-        preamble: Arc<Vec<Function>>,
-        given: Arc<Option<TranslatedGiven>>,
-        stages: Arc<Vec<TranslatedStage>>,
-        fetch: Arc<Option<FetchObject>>,
+        translated_pipeline: &TranslatedPipeline,
         pipeline: ExecutablePipeline,
     ) {
-        let key = IRQuery::new(preamble, given, stages, fetch);
+        let key = TranslatedPipelineKey::from(translated_pipeline);
         let read_lock = self.validity_requirements.read().unwrap();
         let ValidityRequirements { latest_schema_commit, latest_statistics } = &*read_lock;
         let may_insert = latest_schema_commit
@@ -138,9 +141,9 @@ impl QueryCache {
         let mut write_lock = self.validity_requirements.write().unwrap();
         (*write_lock).latest_schema_commit = Some(statistics.sequence_number);
         drop(write_lock);
-        self.translation_cache.invalidate_all();
+        self.translate_cache.invalidate_all();
         self.executable_cache.invalidate_all();
-        QUERY_CACHE_FLUSH.increment();
+        QUERY_EXECUTABLE_CACHE_FLUSH.increment();
     }
 }
 
@@ -160,15 +163,15 @@ fn is_pipeline_type_populations_outdated(statistics: &Statistics, pipeline: &Exe
             Type::Attribute(ty) => statistics.attribute_counts.get(&ty).copied().unwrap_or_default(),
             Type::RoleType(ty) => statistics.role_counts.get(&ty).copied().unwrap_or_default(),
         };
-        let smoothing = smoothstep(type_count, 1, QUERY_PLAN_CACHE_FLUSH_STATIC_SMOOTH_THRESHOLD);
+        let smoothing = smoothstep(type_count, 1, QUERY_CACHE_FLUSH_STATIC_SMOOTH_THRESHOLD);
         match u64::max(type_count, 1) as f64 / u64::max(pop, 1) as f64 {
             increase @ 1.0.. => total_increase *= increase.powf(smoothing),
             decrease @ ..1.0 => total_decrease /= decrease.powf(smoothing),
             _ => panic!("NaN?!"),
         }
     }
-    total_increase >= QUERY_PLAN_CACHE_FLUSH_ANY_STATISTIC_CHANGE_FRACTION
-        || total_decrease >= QUERY_PLAN_CACHE_FLUSH_ANY_STATISTIC_CHANGE_FRACTION
+    total_increase >= QUERY_CACHE_FLUSH_ANY_STATISTIC_CHANGE_FRACTION
+        || total_decrease >= QUERY_CACHE_FLUSH_ANY_STATISTIC_CHANGE_FRACTION
 }
 
 fn smoothstep(pop: u64, min: u64, max: u64) -> f64 {
@@ -177,40 +180,62 @@ fn smoothstep(pop: u64, min: u64, max: u64) -> f64 {
     (3.0 - 2.0 * x) * x * x
 }
 
-#[derive(Debug)]
-struct IRQuery {
+#[derive(Debug, Clone)]
+struct CachedTranslatedPipeline {
+    preamble: Arc<Vec<Function>>,
+    given: Arc<Option<TranslatedGiven>>,
+    stages: Arc<Vec<TranslatedStage>>,
+    fetch: Arc<Option<FetchObject>>,
+    variable_registry: Arc<VariableRegistry>,
+}
+
+impl CachedTranslatedPipeline {
+    fn into_translated_pipeline(self, query_context: QueryContext) -> TranslatedPipeline {
+        TranslatedPipeline {
+            translated_preamble: self.preamble,
+            translated_given: self.given,
+            translated_stages: self.stages,
+            translated_fetch: self.fetch,
+            variable_registry: self.variable_registry.as_ref().clone(),
+            query_context,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+struct TranslatedPipelineKey {
     preamble: Arc<Vec<Function>>,
     given: Arc<Option<TranslatedGiven>>,
     stages: Arc<Vec<TranslatedStage>>,
     fetch: Arc<Option<FetchObject>>,
 }
 
-impl IRQuery {
-    fn new(
-        preamble: Arc<Vec<Function>>,
-        given: Arc<Option<TranslatedGiven>>,
-        stages: Arc<Vec<TranslatedStage>>,
-        fetch: Arc<Option<FetchObject>>,
-    ) -> Self {
-        Self { preamble: preamble, given, stages, fetch }
+impl From<&TranslatedPipeline> for TranslatedPipelineKey {
+    fn from(pipeline: &TranslatedPipeline) -> Self {
+        Self {
+            preamble: pipeline.translated_preamble.clone(),
+            given: pipeline.translated_given.clone(),
+            stages: pipeline.translated_stages.clone(),
+            fetch: pipeline.translated_fetch.clone(),
+        }
     }
 }
 
-impl Hash for IRQuery {
+impl Hash for TranslatedPipelineKey {
     fn hash<H: Hasher>(&self, state: &mut H) {
         self.hash_into(state);
     }
 }
 
-impl PartialEq<Self> for IRQuery {
+impl PartialEq<Self> for TranslatedPipelineKey {
     fn eq(&self, other: &Self) -> bool {
         self.equals(other)
     }
 }
 
-impl Eq for IRQuery {}
+impl Eq for TranslatedPipelineKey {}
 
-impl StructuralEquality for IRQuery {
+impl StructuralEquality for TranslatedPipelineKey {
     fn hash(&self) -> u64 {
         let mut hasher = DefaultHasher::new();
         self.preamble.hash_into(&mut hasher);

--- a/query/query_manager.rs
+++ b/query/query_manager.rs
@@ -11,61 +11,46 @@ use std::{
 
 use compiler::{
     VariablePosition,
-    annotation::{
-        expression::compiled_expression::ExpressionValueType,
-        function::FunctionParameterAnnotation,
-        pipeline::{AnnotatedPipeline, annotate_preamble_and_pipeline},
-    },
-    executable::pipeline::{ExecutablePipeline, ExecutableStage, GivenExecutable, compile_pipeline_and_functions},
+    annotation::pipeline::{AnnotatedPipeline, annotate_preamble_and_pipeline},
+    executable::pipeline::{ExecutablePipeline, GivenExecutable, compile_pipeline_and_functions},
     query_structure::{extract_pipeline_structure_from, extract_query_structure_from},
     transformation::transform::apply_transformations,
 };
-use concept::{
-    thing::{ThingAPI, thing_manager::ThingManager},
-    type_::type_manager::TypeManager,
-};
+use concept::{thing::thing_manager::ThingManager, type_::type_manager::TypeManager};
 use executor::{
     batch::Batch,
     pipeline::{
         pipeline::Pipeline,
-        stage::{ReadPipelineStage, WritePipelineStage},
+        stage::{ExecutionContext, ReadPipelineStage, WritePipelineStage},
     },
 };
 use function::function_manager::{FunctionManager, ReadThroughFunctionSignatureIndex, validate_no_cycles};
 use ir::{
-    LiteralParseError, RepresentationError,
-    pattern::{Vertex, variable_category::VariableOptionality},
+    pattern::variable_category::VariableOptionality,
     pipeline::{
-        ParameterRegistry, VariableRegistry,
-        fetch::FetchObject,
-        function::Function,
+        VariableRegistry,
         function_signature::{FunctionID, HashMapFunctionSignatureIndex},
     },
-    translation::{
-        literal::{FromTypeQLLiteral, translate_literal},
-        pipeline::{TranslatedGiven, TranslatedPipeline, TranslatedStage},
-    },
+    translation::pipeline::TranslatedPipeline,
 };
 use resource::{
     constants::query::MAX_PIPELINE_STAGES,
     perf_counters::{
-        QUERY_CACHE_HITS, QUERY_CACHE_MISSES, QUERY_PARSE_CACHE_HITS, QUERY_PARSE_CACHE_MISSES,
+        QUERY_EXECUTABLE_CACHE_HITS, QUERY_EXECUTABLE_CACHE_MISSES, QUERY_PARSE_CACHE_HITS, QUERY_PARSE_CACHE_MISSES,
         QUERY_TRANSLATION_CACHE_HITS, QUERY_TRANSLATION_CACHE_MISSES,
     },
-    profile::{CompileIRProfile, QueryProfile},
+    profile::QueryProfile,
 };
 use storage::snapshot::{ReadableSnapshot, WritableSnapshot};
 use tracing::{Level, event};
 use typeql::query::{QueryStructure, SchemaQuery};
 
 use crate::{
-    analyse::{
-        AnalysedQuery, FetchStructureAnnotationsFields, FunctionStructureAnnotations, QueryStructureAnnotations,
-    },
+    analyse::{AnalysedQuery, QueryStructureAnnotations},
     define,
     error::QueryError,
-    given_rows::{GivenRowDecodeError, GivenRows},
-    query_cache::{ParsedQuery, QueryCache},
+    given_rows::GivenRows,
+    query_cache::QueryCache,
     redefine, undefine,
 };
 
@@ -74,48 +59,130 @@ pub struct QueryManager {
     cache: Option<Arc<QueryCache>>,
 }
 
+#[derive(Debug)]
+pub enum ParsedQuery {
+    Schema(ParsedSchemaQuery),
+    Pipeline(ParsedPipeline),
+}
+
+impl ParsedQuery {
+    pub fn into_schema(self) -> ParsedSchemaQuery {
+        match self {
+            ParsedQuery::Schema(schema) => schema,
+            ParsedQuery::Pipeline(_) => panic!("Expected a schema query, but got a data pipeline"),
+        }
+    }
+
+    pub fn into_pipeline(self) -> ParsedPipeline {
+        match self {
+            ParsedQuery::Pipeline(pipeline) => pipeline,
+            ParsedQuery::Schema(_) => panic!("Expected a data pipeline, but got a schema query"),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct ParsedSchemaQuery {
+    query: SchemaQuery,
+    source_query: Arc<String>,
+    query_profile: Arc<QueryProfile>,
+}
+
+impl ParsedSchemaQuery {
+    pub fn new(query: SchemaQuery, source_query: Arc<String>, query_profile: QueryProfile) -> Self {
+        Self { query, source_query, query_profile: Arc::new(query_profile) }
+    }
+
+    pub fn source_query(&self) -> &str {
+        &self.source_query
+    }
+}
+
+#[derive(Debug)]
+pub struct ParsedPipeline {
+    pipeline: Arc<typeql::query::Pipeline>,
+    source_query: Arc<String>,
+    query_profile: Arc<QueryProfile>,
+}
+
+impl ParsedPipeline {
+    pub fn new(pipeline: Arc<typeql::query::Pipeline>, source_query: Arc<String>, query_profile: QueryProfile) -> Self {
+        Self { pipeline, source_query, query_profile: Arc::new(query_profile) }
+    }
+
+    pub fn source_query(&self) -> Arc<String> {
+        self.source_query.clone()
+    }
+
+    pub fn pipeline(&self) -> &typeql::query::Pipeline {
+        &self.pipeline
+    }
+}
+
 impl QueryManager {
     pub fn new(cache: Option<Arc<QueryCache>>) -> Self {
         Self { cache }
     }
 
-    pub fn parse(&self, query: &str) -> Result<ParsedQuery, Box<QueryError>> {
-        if let Some(pipeline) = self.cache.as_ref().and_then(|cache| cache.get_parsed(query)) {
+    pub fn parse(&self, query: String) -> Result<ParsedQuery, Box<QueryError>> {
+        self.parse_with_profile(query, QueryProfile::new(tracing::enabled!(Level::TRACE)))
+    }
+
+    pub fn parse_with_profile(&self, query: String, profile: QueryProfile) -> Result<ParsedQuery, Box<QueryError>> {
+        profile.compilation_profile().set_stage_timer();
+        if let Some(pipeline) = self.cache.as_ref().and_then(|cache| cache.get_parsed(&query)) {
             QUERY_PARSE_CACHE_HITS.increment();
-            return Ok(ParsedQuery::Pipeline(pipeline));
+            profile.compilation_profile().parsing_finished();
+            return Ok(ParsedQuery::Pipeline(ParsedPipeline::new(pipeline, Arc::new(query), profile)));
         }
-        let parsed = typeql::parse_query(query)
-            .map_err(|err| QueryError::ParseError { source_query: query.to_owned(), typedb_source: err })?;
+        let parsed = typeql::parse_query(&query)
+            .map_err(|err| QueryError::ParseError { source_query: query.clone(), typedb_source: err })?;
         match parsed.into_structure() {
-            QueryStructure::Schema(schema_query) => Ok(ParsedQuery::Schema(schema_query)),
+            QueryStructure::Schema(schema_query) => {
+                profile.compilation_profile().parsing_finished();
+                Ok(ParsedQuery::Schema(ParsedSchemaQuery::new(schema_query, Arc::new(query), profile)))
+            }
             QueryStructure::Pipeline(pipeline) => {
                 QUERY_PARSE_CACHE_MISSES.increment();
                 let pipeline = Arc::new(pipeline);
                 if let Some(cache) = self.cache.as_ref() {
-                    cache.insert_parsed(query, pipeline.clone());
+                    cache.insert_parsed(&query, pipeline.clone());
                 }
-                Ok(ParsedQuery::Pipeline(pipeline))
+                profile.compilation_profile().parsing_finished();
+                Ok(ParsedQuery::Pipeline(ParsedPipeline::new(pipeline, Arc::new(query), profile)))
             }
         }
     }
 
     fn translate(
         &self,
-        query: &str,
-        pipeline: &typeql::query::Pipeline,
+        parsed: ParsedPipeline,
         snapshot: &impl ReadableSnapshot,
         function_manager: &FunctionManager,
         thing_manager: &ThingManager,
     ) -> Result<TranslatedPipeline, Box<QueryError>> {
-        if let Some(translated) = self.cache.as_ref().and_then(|cache| cache.get_translated(query)) {
-            QUERY_TRANSLATION_CACHE_HITS.increment();
-            return Ok(translated);
-        }
-        QUERY_TRANSLATION_CACHE_MISSES.increment();
-        let translated = translate_pipeline(snapshot, function_manager, pipeline, query)?;
-        if let Some(cache) = self.cache.as_ref() {
-            cache.may_insert_translated(thing_manager.statistics().sequence_number, query, translated.clone());
-        }
+        let ParsedPipeline { pipeline, source_query, query_profile } = parsed;
+        query_profile.compilation_profile().set_stage_timer();
+        let translated = match self
+            .cache
+            .as_ref()
+            .and_then(|cache| cache.get_translated(source_query.clone(), query_profile.clone()))
+        {
+            Some(translated) => {
+                QUERY_TRANSLATION_CACHE_HITS.increment();
+                translated
+            }
+            None => {
+                QUERY_TRANSLATION_CACHE_MISSES.increment();
+                let translated =
+                    translate_pipeline(snapshot, function_manager, &pipeline, source_query.clone(), query_profile)?;
+                if let Some(cache) = self.cache.as_ref() {
+                    cache.may_insert_translated(thing_manager.statistics().sequence_number, &source_query, &translated);
+                }
+                translated
+            }
+        };
+        translated.query_context.profile.compilation_profile().translation_finished();
         Ok(translated)
     }
 
@@ -125,15 +192,14 @@ impl QueryManager {
         type_manager: &TypeManager,
         thing_manager: &ThingManager,
         function_manager: &FunctionManager,
-        query: &SchemaQuery,
-        source_query: &str,
+        parsed: ParsedSchemaQuery,
     ) -> Result<(), Box<QueryError>> {
+        let ParsedSchemaQuery { query, source_query, query_profile } = parsed;
         event!(Level::TRACE, "Running schema query:\n{}", query);
-        let query_profile = QueryProfile::new(tracing::enabled!(Level::TRACE));
         let result = match &query {
             SchemaQuery::Define(define) => {
-                let profile = query_profile.profile_stage(|| String::from("Define"), 0); // TODO executable id
-                let pattern_profile = profile.create_or_get_pattern(|| String::from("Define pattern"));
+                let stage_profile = query_profile.profile_stage(|| String::from("Define"), 0); // TODO executable id
+                let pattern_profile = stage_profile.create_or_get_pattern(|| String::from("Define pattern"));
                 let step_profile = pattern_profile.extend_or_get_step(0, || String::from("Define execution"));
                 define::execute(
                     snapshot,
@@ -148,8 +214,8 @@ impl QueryManager {
                 })
             }
             SchemaQuery::Redefine(redefine) => {
-                let profile = query_profile.profile_stage(|| String::from("Redefine"), 0); // TODO executable id
-                let pattern_profile = profile.create_or_get_pattern(|| String::from("Redefine pattern"));
+                let stage_profile = query_profile.profile_stage(|| String::from("Redefine"), 0); // TODO executable id
+                let pattern_profile = stage_profile.create_or_get_pattern(|| String::from("Redefine pattern"));
                 let step_profile = pattern_profile.extend_or_get_step(0, || String::from("Redefine execution"));
                 redefine::execute(
                     snapshot,
@@ -183,66 +249,35 @@ impl QueryManager {
         type_manager: &TypeManager,
         thing_manager: Arc<ThingManager>,
         function_manager: Arc<FunctionManager>,
-        pipeline: &typeql::query::Pipeline,
+        parsed: ParsedPipeline,
         given_rows: Option<impl GivenRows>,
-        source_query: &str,
     ) -> Result<Pipeline<Snapshot, ReadPipelineStage<Snapshot>>, Box<QueryError>> {
-        event!(Level::TRACE, "Running read query:\n{}", source_query);
-        let pipeline = self.translate(source_query, pipeline, snapshot.as_ref(), &function_manager, &thing_manager)?;
-        let mut query_profile = QueryProfile::new(tracing::enabled!(Level::TRACE));
-        let compile_profile = query_profile.compilation_profile();
-        compile_profile.start();
-        let TranslatedPipeline {
-            translated_preamble,
-            translated_given,
-            translated_stages,
-            translated_fetch,
-            mut variable_registry,
-            value_parameters: parameters,
-        } = pipeline;
-        let arced_preamble = Arc::new(translated_preamble);
-        let arced_given = Arc::new(translated_given);
-        let arced_stages = Arc::new(translated_stages);
-        let arced_fetch = Arc::new(translated_fetch);
-        let arced_parameters = Arc::new(parameters);
-        let executable_pipeline = match self.cache.as_ref().and_then(|cache| {
-            cache.get_executable(arced_preamble.clone(), arced_given.clone(), arced_stages.clone(), arced_fetch.clone())
-        }) {
+        let mut pipeline = self.translate(parsed, snapshot.as_ref(), &function_manager, &thing_manager)?;
+        event!(Level::TRACE, "Preparing read query:\n{}", pipeline.query_context.source_query);
+        pipeline.query_context.profile.compilation_profile().set_stage_timer();
+        let executable_pipeline = match self.cache.as_ref().and_then(|cache| cache.get_executable(&pipeline)) {
             Some(executable_pipeline) => {
-                QUERY_CACHE_HITS.increment();
+                QUERY_EXECUTABLE_CACHE_HITS.increment();
                 executable_pipeline
             }
             None => {
                 let executable_pipeline = annotate_and_compile_query(
                     snapshot.as_ref(),
-                    source_query,
                     type_manager,
                     thing_manager.clone(),
                     &function_manager,
-                    compile_profile,
-                    &mut variable_registry,
-                    arced_parameters.clone(),
-                    arced_preamble.clone(),
-                    arced_given.clone(),
-                    arced_stages.clone(),
-                    arced_fetch.clone(),
+                    &mut pipeline,
                 )?;
                 if let Some(cache) = self.cache.as_ref() {
                     let seq = thing_manager.statistics().sequence_number;
-                    cache.may_insert_executable(
-                        seq,
-                        arced_preamble,
-                        arced_given,
-                        arced_stages,
-                        arced_fetch,
-                        executable_pipeline.clone(),
-                    )
+                    cache.may_insert_executable(seq, &pipeline, executable_pipeline.clone())
                 }
-                QUERY_CACHE_MISSES.increment();
+                QUERY_EXECUTABLE_CACHE_MISSES.increment();
                 executable_pipeline
             }
         };
 
+        let TranslatedPipeline { variable_registry, query_context, .. } = pipeline;
         let ExecutablePipeline {
             executable_functions,
             executable_given,
@@ -253,24 +288,27 @@ impl QueryManager {
         } = executable_pipeline;
         let given_batch = validate_and_decode_given(executable_given.clone(), given_rows, &variable_registry)?;
 
+        let execution_context = ExecutionContext::new(snapshot, thing_manager, function_manager);
+        let query_context = Arc::new(query_context);
         // 4: Executor
-        Pipeline::build_read_pipeline(
-            snapshot,
-            thing_manager,
-            function_manager,
+        let pipeline = Pipeline::build_read_pipeline(
+            execution_context,
+            query_context.clone(),
             variable_registry.variable_names(),
             (variable_registry.branch_ids_allocated() < 64).then_some(pipeline_structure),
             Arc::new(executable_functions),
             executable_given,
             &executable_stages,
             executable_fetch,
-            arced_parameters,
             given_batch,
-            Arc::new(query_profile),
         )
         .map_err(|typedb_source| {
-            Box::new(QueryError::Pipeline { source_query: source_query.to_string(), typedb_source })
-        })
+            Box::new(QueryError::Pipeline {
+                source_query: query_context.source_query.as_ref().to_owned(),
+                typedb_source,
+            })
+        })?;
+        Ok(pipeline)
     }
 
     pub fn prepare_write_pipeline<Snapshot: WritableSnapshot>(
@@ -279,67 +317,39 @@ impl QueryManager {
         type_manager: &TypeManager,
         thing_manager: Arc<ThingManager>,
         function_manager: Arc<FunctionManager>,
-        pipeline: &typeql::query::Pipeline,
+        parsed: ParsedPipeline,
         given_rows: Option<impl GivenRows>,
-        source_query: &str,
     ) -> Result<Pipeline<Snapshot, WritePipelineStage<Snapshot>>, (Snapshot, Box<QueryError>)> {
-        event!(Level::TRACE, "Running write query:\n{}", source_query);
-        let pipeline = match self.translate(source_query, pipeline, &snapshot, &function_manager, &thing_manager) {
+        let mut pipeline = match self.translate(parsed, &snapshot, &function_manager, &thing_manager) {
             Ok(translated) => translated,
             Err(err) => return Err((snapshot, err)),
         };
-        let mut query_profile = QueryProfile::new(tracing::enabled!(Level::TRACE));
-        let compile_profile = query_profile.compilation_profile();
-        compile_profile.start();
-        let TranslatedPipeline {
-            translated_preamble,
-            translated_given,
-            translated_stages,
-            translated_fetch,
-            mut variable_registry,
-            value_parameters,
-        } = pipeline;
-        let arced_preamble = Arc::new(translated_preamble);
-        let arced_given = Arc::new(translated_given);
-        let arced_stages = Arc::new(translated_stages);
-        let arced_fetch = Arc::new(translated_fetch);
-        let arced_parameters = Arc::new(value_parameters);
+        event!(Level::TRACE, "Preparing write query:\n{}", pipeline.query_context.source_query);
+        pipeline.query_context.profile.compilation_profile().set_stage_timer();
 
-        let executable_pipeline = match self.cache.as_ref().and_then(|cache| {
-            cache.get_executable(arced_preamble.clone(), arced_given.clone(), arced_stages.clone(), arced_fetch.clone())
-        }) {
+        let executable_pipeline = match self.cache.as_ref().and_then(|cache| cache.get_executable(&pipeline)) {
             Some(executable_pipeline) => {
-                QUERY_CACHE_HITS.increment();
+                QUERY_EXECUTABLE_CACHE_HITS.increment();
                 executable_pipeline
             }
             None => {
                 let executable_pipeline_result = annotate_and_compile_query(
                     &snapshot,
-                    source_query,
                     type_manager,
                     thing_manager.clone(),
                     &function_manager,
-                    compile_profile,
-                    &mut variable_registry,
-                    arced_parameters.clone(),
-                    arced_preamble.clone(),
-                    arced_given.clone(),
-                    arced_stages.clone(),
-                    arced_fetch.clone(),
+                    &mut pipeline,
                 );
                 match executable_pipeline_result {
                     Ok(executable_pipeline) => {
                         if let Some(cache) = self.cache.as_ref() {
                             cache.may_insert_executable(
                                 thing_manager.statistics().sequence_number,
-                                arced_preamble,
-                                arced_given,
-                                arced_stages,
-                                arced_fetch,
+                                &pipeline,
                                 executable_pipeline.clone(),
                             )
                         }
-                        QUERY_CACHE_MISSES.increment();
+                        QUERY_EXECUTABLE_CACHE_MISSES.increment();
                         executable_pipeline
                     }
                     Err(err) => {
@@ -349,6 +359,7 @@ impl QueryManager {
             }
         };
 
+        let TranslatedPipeline { variable_registry, query_context, .. } = pipeline;
         let ExecutablePipeline {
             executable_functions,
             executable_given,
@@ -363,20 +374,19 @@ impl QueryManager {
         };
 
         // 4: Executor
-        Ok(Pipeline::build_write_pipeline(
-            snapshot,
+        let execution_context = ExecutionContext::new(Arc::new(snapshot), thing_manager, function_manager);
+        let pipeline = Pipeline::build_write_pipeline(
+            execution_context,
+            Arc::new(query_context),
             variable_registry.variable_names(),
             (variable_registry.branch_ids_allocated() < 64).then_some(pipeline_structure),
-            thing_manager,
-            function_manager,
             Arc::new(executable_functions),
             executable_given,
             executable_stages,
             executable_fetch,
-            arced_parameters.clone(),
             given_batch,
-            Arc::new(query_profile),
-        ))
+        );
+        Ok(pipeline)
     }
 
     pub fn analyse<Snapshot: ReadableSnapshot + 'static>(
@@ -385,42 +395,36 @@ impl QueryManager {
         type_manager: &TypeManager,
         function_manager: &FunctionManager,
         thing_manager: &ThingManager,
-        pipeline: &typeql::query::Pipeline,
-        source_query: &str,
+        parsed: ParsedPipeline,
     ) -> Result<AnalysedQuery, Box<QueryError>> {
-        event!(Level::TRACE, "Running analyse query:\n{}", source_query);
-        let pipeline = self.translate(source_query, pipeline, snapshot.as_ref(), function_manager, thing_manager)?;
-        let mut query_profile = QueryProfile::new(tracing::enabled!(Level::TRACE));
-        let compile_profile = query_profile.compilation_profile();
-        compile_profile.start();
         let TranslatedPipeline {
             translated_preamble,
             translated_given,
             translated_stages,
             translated_fetch,
             mut variable_registry,
-            value_parameters: parameters,
-        } = pipeline;
-        let arced_preamble = Arc::new(translated_preamble);
-        let arced_given = translated_given.map(Arc::new);
-        let arced_stages = Arc::new(translated_stages);
-        let arced_fetch = Arc::new(translated_fetch);
+            query_context,
+        } = self.translate(parsed, snapshot.as_ref(), function_manager, thing_manager)?;
+        event!(Level::TRACE, "Running analyse query:\n{}", query_context.source_query);
+        query_context.profile.compilation_profile().set_stage_timer();
 
-        match validate_no_cycles(&arced_preamble.iter().enumerate().collect()) {
+        match validate_no_cycles(&translated_preamble.iter().enumerate().collect()) {
             Ok(_) => {}
             Err(typedb_source) => {
                 return Err(Box::new(QueryError::FunctionDefinition {
-                    source_query: source_query.to_string(),
+                    source_query: query_context.source_query.as_ref().to_owned(),
                     typedb_source,
                 }));
             }
         }
-        compile_profile.validation_finished();
+        query_context.profile.compilation_profile().validation_finished();
 
         // 2: Annotate
-        let annotated_schema_functions =
-            function_manager.get_annotated_functions(snapshot.as_ref(), type_manager).map_err(|err| {
-                QueryError::FunctionDefinition { source_query: source_query.to_string(), typedb_source: *err }
+        let annotated_schema_functions = function_manager
+            .get_annotated_functions(snapshot.as_ref(), type_manager)
+            .map_err(|err| QueryError::FunctionDefinition {
+                source_query: query_context.source_query.as_ref().to_owned(),
+                typedb_source: *err,
             })?;
 
         let annotated_pipeline = annotate_preamble_and_pipeline(
@@ -428,49 +432,57 @@ impl QueryManager {
             type_manager,
             annotated_schema_functions.clone(),
             &mut variable_registry,
-            &parameters,
-            (*arced_preamble).clone(),
-            arced_given.map(|given| (*given).clone()),
-            (*arced_stages).clone(),
-            (*arced_fetch).clone(),
+            query_context.parameters.as_ref(),
+            translated_preamble.clone(),
+            translated_given.clone(),
+            translated_stages.clone(),
+            translated_fetch.clone(),
         )
-        .map_err(|err| QueryError::Annotation { source_query: source_query.to_string(), typedb_source: err })?;
-        compile_profile.annotation_finished();
-
-        let arced_parameters = Arc::new(parameters);
+        .map_err(|err| QueryError::Annotation {
+            source_query: query_context.source_query.as_ref().to_owned(),
+            typedb_source: err,
+        })?;
+        query_context.profile.compilation_profile().annotation_finished();
 
         let query_structure = extract_query_structure_from(
             &variable_registry,
-            arced_parameters.clone(),
+            query_context.parameters.clone(),
             &annotated_pipeline,
-            source_query,
+            &query_context.source_query,
         );
         let query_structure_annotations = QueryStructureAnnotations::build(
             snapshot.as_ref(),
             type_manager,
             &variable_registry,
-            arced_parameters,
-            source_query,
+            query_context.parameters.clone(),
+            &query_context.source_query,
             &annotated_pipeline,
             &query_structure,
         )
         .map_err(|source| {
-            Box::new(QueryError::QueryAnalysisFailed { source_query: source_query.to_owned(), typedb_source: source })
+            Box::new(QueryError::QueryAnalysisFailed {
+                source_query: query_context.source_query.as_ref().to_owned(),
+                typedb_source: source,
+            })
         })?;
 
+        if query_context.profile.is_enabled() {
+            event!(Level::INFO, "Analyse query done.\n{}", query_context.profile);
+        }
         Ok(AnalysedQuery {
-            source: source_query.to_owned(),
+            source: query_context.source_query.clone(),
             structure: query_structure,
             annotations: query_structure_annotations,
         })
     }
 }
 
-pub fn translate_pipeline<Snapshot: ReadableSnapshot>(
+fn translate_pipeline<Snapshot: ReadableSnapshot>(
     snapshot: &Snapshot,
     function_manager: &FunctionManager,
     query: &typeql::query::Pipeline,
-    source_query: &str,
+    source_query: Arc<String>,
+    query_profile: Arc<QueryProfile>,
 ) -> Result<TranslatedPipeline, Box<QueryError>> {
     if query.stages.len() > MAX_PIPELINE_STAGES {
         return Err(Box::new(QueryError::PipelineStagesLimitExceeded {
@@ -484,36 +496,35 @@ pub fn translate_pipeline<Snapshot: ReadableSnapshot>(
     );
     let all_function_signatures =
         ReadThroughFunctionSignatureIndex::new(snapshot, function_manager, preamble_signatures);
-    ir::translation::pipeline::translate_pipeline(&all_function_signatures, query).map_err(|err| {
-        Box::new(QueryError::Representation { source_query: source_query.to_string(), typedb_source: err })
-    })
+    ir::translation::pipeline::translate_pipeline(&all_function_signatures, query, source_query.clone(), query_profile)
+        .map_err(|err| {
+            Box::new(QueryError::Representation { source_query: source_query.to_string(), typedb_source: err })
+        })
 }
 
 fn annotate_and_compile_query(
     snapshot: &impl ReadableSnapshot,
-    source_query: &str,
     type_manager: &TypeManager,
     thing_manager: Arc<ThingManager>,
     function_manager: &FunctionManager,
-    compile_profile: &mut CompileIRProfile,
-    variable_registry: &mut VariableRegistry,
-    arced_parameters: Arc<ParameterRegistry>,
-    arced_preamble: Arc<Vec<Function>>,
-    arced_given: Arc<Option<TranslatedGiven>>,
-    arced_stages: Arc<Vec<TranslatedStage>>,
-    arced_fetch: Arc<Option<FetchObject>>,
+    translated_pipeline: &mut TranslatedPipeline,
 ) -> Result<ExecutablePipeline, Box<QueryError>> {
-    if let Err(typedb_source) = validate_no_cycles(&arced_preamble.iter().enumerate().collect()) {
-        return Err(Box::new(QueryError::FunctionDefinition { source_query: source_query.to_string(), typedb_source }));
+    if let Err(typedb_source) =
+        validate_no_cycles(&translated_pipeline.translated_preamble.iter().enumerate().collect())
+    {
+        return Err(Box::new(QueryError::FunctionDefinition {
+            source_query: translated_pipeline.query_context.source_query.as_ref().to_owned(),
+            typedb_source,
+        }));
     }
-    compile_profile.validation_finished();
+    translated_pipeline.query_context.profile.compilation_profile().validation_finished();
 
     // 2: Annotate
     let annotated_schema_functions = match function_manager.get_annotated_functions(snapshot, type_manager) {
         Ok(functions) => functions,
         Err(err) => {
             return Err(Box::new(QueryError::FunctionDefinition {
-                source_query: source_query.to_string(),
+                source_query: translated_pipeline.query_context.source_query.as_ref().to_owned(),
                 typedb_source: *err,
             }));
         }
@@ -523,37 +534,42 @@ fn annotate_and_compile_query(
         snapshot,
         type_manager,
         annotated_schema_functions.clone(),
-        variable_registry,
-        &arced_parameters,
-        (*arced_preamble).clone(),
-        (*arced_given).clone(),
-        (*arced_stages).clone(),
-        (*arced_fetch).clone(),
+        &mut translated_pipeline.variable_registry,
+        &translated_pipeline.query_context.parameters,
+        translated_pipeline.translated_preamble.clone(),
+        translated_pipeline.translated_given.clone(),
+        translated_pipeline.translated_stages.clone(),
+        translated_pipeline.translated_fetch.clone(),
     );
 
     let mut annotated_pipeline = match annotated_pipeline {
         Ok(annotated_pipeline) => annotated_pipeline,
         Err(err) => {
             return Err(Box::new(QueryError::Annotation {
-                source_query: source_query.to_string(),
+                source_query: translated_pipeline.query_context.source_query.as_ref().to_owned(),
                 typedb_source: err,
             }));
         }
     };
-    compile_profile.annotation_finished();
+    translated_pipeline.query_context.profile.compilation_profile().annotation_finished();
     // TODO: We can avoid this for the regular query path when we break studio backwards compatibility
     let pipeline_structure = Arc::new(extract_pipeline_structure_from(
-        variable_registry,
+        &mut translated_pipeline.variable_registry,
         annotated_pipeline.annotated_given.as_ref(),
         &annotated_pipeline.annotated_stages,
-        source_query,
+        translated_pipeline.query_context.source_query.as_ref(),
     ));
 
-    match apply_transformations(snapshot, type_manager, variable_registry, &mut annotated_pipeline) {
+    match apply_transformations(
+        snapshot,
+        type_manager,
+        &mut translated_pipeline.variable_registry,
+        &mut annotated_pipeline,
+    ) {
         Ok(_) => {}
         Err(err) => {
             return Err(Box::new(QueryError::Transformation {
-                source_query: source_query.to_string(),
+                source_query: translated_pipeline.query_context.source_query.as_ref().to_owned(),
                 typedb_source: err,
             }));
         }
@@ -565,7 +581,7 @@ fn annotate_and_compile_query(
     // 3: Compile
     let executable_pipeline = match compile_pipeline_and_functions(
         thing_manager.statistics(),
-        variable_registry,
+        &translated_pipeline.variable_registry,
         &annotated_schema_functions,
         annotated_preamble,
         annotated_given,
@@ -576,12 +592,12 @@ fn annotate_and_compile_query(
         Ok(executable) => executable,
         Err(err) => {
             return Err(Box::new(QueryError::ExecutableCompilation {
-                source_query: source_query.to_string(),
+                source_query: translated_pipeline.query_context.source_query.as_ref().to_owned(),
                 typedb_source: err,
             }));
         }
     };
-    compile_profile.compilation_finished();
+    translated_pipeline.query_context.profile.compilation_profile().compilation_finished();
     Ok(executable_pipeline)
 }
 

--- a/query/tests/define.rs
+++ b/query/tests/define.rs
@@ -28,9 +28,7 @@ fn basic() {
     attribute name value string;
     entity person owns name;
     "#;
-    let schema_query = typeql::parse_query(query_str).unwrap().into_structure().into_schema();
-    query_manager
-        .execute_schema(&mut snapshot, &type_manager, &thing_manager, &function_manager, &schema_query, query_str)
-        .unwrap();
+    let parsed = query_manager.parse(query_str.to_string()).unwrap().into_schema();
+    query_manager.execute_schema(&mut snapshot, &type_manager, &thing_manager, &function_manager, parsed).unwrap();
     snapshot.commit(&mut CommitProfile::DISABLED).unwrap();
 }

--- a/query/tests/fetch.rs
+++ b/query/tests/fetch.rs
@@ -32,10 +32,8 @@ fn define_schema(
       relation friendship relates friend @card(0..);
       entity person owns name @card(0..), owns age, plays friendship:friend @card(0..);
     "#;
-    let schema_query = typeql::parse_query(query_str).unwrap().into_structure().into_schema();
-    query_manager
-        .execute_schema(&mut snapshot, type_manager, thing_manager, function_manager, &schema_query, query_str)
-        .unwrap();
+    let parsed = query_manager.parse(query_str.to_string()).unwrap().into_schema();
+    query_manager.execute_schema(&mut snapshot, type_manager, thing_manager, function_manager, parsed).unwrap();
     snapshot.commit(&mut CommitProfile::DISABLED).unwrap();
 }
 
@@ -48,17 +46,17 @@ fn insert_data(
 ) {
     let snapshot = storage.clone().open_snapshot_write();
     let query_manager = QueryManager::new(Some(Arc::new(QueryCache::new())));
-    let query = typeql::parse_query(query_string).unwrap().into_structure().into_pipeline();
+    let parsed = query_manager.parse(query_string.to_string()).unwrap().into_pipeline();
     let pipeline = query_manager
         .prepare_write_pipeline(
             snapshot,
             type_manager,
             thing_manager,
             function_manager,
-            &query,
+            parsed,
             None::<GivenRowsSimple>,
-            query_string,
         )
+        .map_err(|(_, err)| err)
         .unwrap();
     let (_iterator, context) = pipeline.into_rows_iterator(ExecutionInterrupt::new_uninterruptible()).unwrap();
     let snapshot = Arc::into_inner(context.snapshot).unwrap();
@@ -124,19 +122,17 @@ fetch {
 #    "list attributes": $x.name[], # TODO: Uncomment when it's implemented
     "all attributes": { $x.* }
 };"#;
-    let query = typeql::parse_query(query_str).unwrap();
-
-    let pipeline = query.into_structure().into_pipeline();
+    let query_manager = QueryManager::new(Some(Arc::new(QueryCache::new())));
+    let parsed = query_manager.parse(query_str.to_string()).unwrap().into_pipeline();
     let snapshot = Arc::new(storage.clone().open_snapshot_read());
-    let pipeline = QueryManager::new(Some(Arc::new(QueryCache::new())))
+    let pipeline = query_manager
         .prepare_read_pipeline(
             snapshot.clone(),
             &type_manager,
             thing_manager.clone(),
             function_manager,
-            &pipeline,
+            parsed,
             None::<GivenRowsSimple>,
-            query_str,
         )
         .unwrap();
 

--- a/query/tests/pipeline_stages_limit.rs
+++ b/query/tests/pipeline_stages_limit.rs
@@ -8,11 +8,7 @@ use std::sync::Arc;
 
 use encoding::graph::definition::definition_key_generator::DefinitionKeyGenerator;
 use function::function_manager::FunctionManager;
-use query::{
-    error::QueryError,
-    given_rows::GivenRowsSimple,
-    query_manager::{QueryManager, translate_pipeline},
-};
+use query::{error::QueryError, given_rows::GivenRowsSimple, query_manager::QueryManager};
 use resource::{constants::query::MAX_PIPELINE_STAGES, profile::CommitProfile};
 use storage::snapshot::CommittableSnapshot;
 use test_utils_concept::{load_managers, setup_concept_storage};
@@ -42,10 +38,8 @@ fn setup() -> (
 
     let schema = "define entity person;";
     let mut snapshot = storage.clone().open_snapshot_schema();
-    let schema_query = typeql::parse_query(schema).unwrap().into_structure().into_schema();
-    query_manager
-        .execute_schema(&mut snapshot, &type_manager, &thing_manager, &function_manager, &schema_query, schema)
-        .unwrap();
+    let parsed = query_manager.parse(schema.to_string()).unwrap().into_schema();
+    query_manager.execute_schema(&mut snapshot, &type_manager, &thing_manager, &function_manager, parsed).unwrap();
     snapshot.commit(&mut CommitProfile::DISABLED).unwrap();
 
     let (type_manager, thing_manager) = load_managers(storage.clone(), None);
@@ -57,8 +51,8 @@ fn pipeline_at_limit_is_accepted() {
     let (_tmp_dir, storage, type_manager, thing_manager, function_manager, query_manager) = setup();
 
     let query_str = build_pipeline_query(MAX_PIPELINE_STAGES);
-    let pipeline = typeql::parse_query(&query_str).unwrap().into_structure().into_pipeline();
-    assert_eq!(pipeline.stages.len(), MAX_PIPELINE_STAGES);
+    let parsed = query_manager.parse(query_str.to_string()).unwrap().into_pipeline();
+    assert_eq!(parsed.pipeline().stages.len(), MAX_PIPELINE_STAGES);
 
     let snapshot = Arc::new(storage.clone().open_snapshot_read());
     let result = query_manager.prepare_read_pipeline(
@@ -66,9 +60,8 @@ fn pipeline_at_limit_is_accepted() {
         &type_manager,
         thing_manager.clone(),
         function_manager,
-        &pipeline,
+        parsed,
         None::<GivenRowsSimple>,
-        &query_str,
     );
 
     assert!(result.is_ok());
@@ -76,15 +69,22 @@ fn pipeline_at_limit_is_accepted() {
 
 #[test]
 fn pipeline_over_limit_is_rejected() {
-    let (_tmp_dir, storage, _type_manager, _thing_manager, function_manager, _query_manager) = setup();
+    let (_tmp_dir, storage, type_manager, thing_manager, function_manager, query_manager) = setup();
 
     let over = MAX_PIPELINE_STAGES + 1;
     let query_str = build_pipeline_query(over);
-    let pipeline = typeql::parse_query(&query_str).unwrap().into_structure().into_pipeline();
-    assert_eq!(pipeline.stages.len(), over);
+    let parsed = query_manager.parse(query_str.to_string()).unwrap().into_pipeline();
+    assert_eq!(parsed.pipeline().stages.len(), over);
 
-    let snapshot = storage.clone().open_snapshot_read();
-    let result = translate_pipeline(&snapshot, &function_manager, &pipeline, &query_str);
+    let snapshot = Arc::new(storage.clone().open_snapshot_read());
+    let result = query_manager.prepare_read_pipeline(
+        snapshot,
+        &type_manager,
+        thing_manager,
+        function_manager,
+        parsed,
+        None::<GivenRowsSimple>,
+    );
     let err = match result {
         Ok(_) => panic!("query with too many stages should fail"),
         Err(err) => err,

--- a/query/tests/query_cache.rs
+++ b/query/tests/query_cache.rs
@@ -14,10 +14,10 @@ use encoding::graph::definition::definition_key_generator::DefinitionKeyGenerato
 use function::function_manager::FunctionManager;
 use query::{
     given_rows::GivenRowsSimple,
-    query_cache::{ParsedQuery, QueryCache},
-    query_manager::QueryManager,
+    query_cache::QueryCache,
+    query_manager::{ParsedQuery, ParsedSchemaQuery, QueryManager},
 };
-use resource::profile::CommitProfile;
+use resource::profile::{CommitProfile, QueryProfile};
 use storage::{
     MVCCStorage, durability_client::WALClient, sequence_number::SequenceNumber, snapshot::CommittableSnapshot,
 };
@@ -50,7 +50,13 @@ fn setup() -> Context {
     let mut snapshot = storage.clone().open_snapshot_schema();
     let define = typeql::parse_query(SCHEMA).unwrap().into_structure().into_schema();
     QueryManager::new(None)
-        .execute_schema(&mut snapshot, &type_manager, &thing_manager, &function_manager, &define, SCHEMA)
+        .execute_schema(
+            &mut snapshot,
+            &type_manager,
+            &thing_manager,
+            &function_manager,
+            ParsedSchemaQuery::new(define, Arc::new(SCHEMA.to_string()), QueryProfile::new(false)),
+        )
         .unwrap();
     snapshot.commit(&mut CommitProfile::DISABLED).unwrap();
 
@@ -63,9 +69,7 @@ fn setup() -> Context {
 
 fn prepare(context: &Context) {
     let snapshot = Arc::new(context.storage.clone().open_snapshot_read());
-    let ParsedQuery::Pipeline(pipeline) = context.query_manager.parse(QUERY).unwrap() else {
-        panic!("expected a data pipeline");
-    };
+    let parsed = context.query_manager.parse(QUERY.to_string()).unwrap().into_pipeline();
     context
         .query_manager
         .prepare_read_pipeline(
@@ -73,9 +77,8 @@ fn prepare(context: &Context) {
             &context.type_manager,
             context.thing_manager.clone(),
             context.function_manager.clone(),
-            &pipeline,
+            parsed,
             None::<GivenRowsSimple>,
-            QUERY,
         )
         .unwrap();
 }
@@ -87,7 +90,7 @@ fn identical_query_string_hits_parse_cache() {
     // Cold: the parse cache has no entry for this string.
     assert!(context.cache.get_parsed(QUERY).is_none());
 
-    assert!(matches!(context.query_manager.parse(QUERY).unwrap(), ParsedQuery::Pipeline(_)));
+    assert!(matches!(context.query_manager.parse(QUERY.to_string()).unwrap(), ParsedQuery::Pipeline(..)));
 
     // Warm: the identical query string now resolves straight from the parse cache.
     assert!(context.cache.get_parsed(QUERY).is_some(), "an identical query string should hit the parse cache");
@@ -98,13 +101,13 @@ fn identical_query_string_hits_translation_cache() {
     let context = setup();
 
     // Cold: the translation cache has no entry for this string.
-    assert!(context.cache.get_translated(QUERY).is_none());
+    assert!(context.cache.get_translated(Arc::new(QUERY.to_owned()), Arc::default()).is_none());
 
     prepare(&context);
 
     // Warm: the identical query string now resolves straight to translated IR.
     assert!(
-        context.cache.get_translated(QUERY).is_some(),
+        context.cache.get_translated(Arc::new(QUERY.to_owned()), Arc::default()).is_some(),
         "an identical query string should hit the translation cache"
     );
 }
@@ -115,11 +118,14 @@ fn schema_reset_invalidates_translation_but_keeps_parse_cache() {
 
     prepare(&context);
     assert!(context.cache.get_parsed(QUERY).is_some());
-    assert!(context.cache.get_translated(QUERY).is_some());
+    assert!(context.cache.get_translated(Arc::new(QUERY.to_string()), Arc::default()).is_some());
 
     // A schema commit can change function resolution, so it flushes the translation cache. Parsing
     // is purely syntactic, so the parse cache must survive.
     context.cache.force_reset(&Statistics::new(SequenceNumber::MIN));
-    assert!(context.cache.get_translated(QUERY).is_none(), "a schema reset should invalidate the translation cache");
+    assert!(
+        context.cache.get_translated(Arc::new(QUERY.to_string()), Arc::default()).is_none(),
+        "a schema reset should invalidate the translation cache"
+    );
     assert!(context.cache.get_parsed(QUERY).is_some(), "a schema reset must not invalidate the parse cache");
 }

--- a/query/tests/query_profile.rs
+++ b/query/tests/query_profile.rs
@@ -39,10 +39,8 @@ fn define_schema(
                     owns nickname @card(0..1),
                     plays friendship:friend @card(0..);
     "#;
-    let schema_query = typeql::parse_query(query_str).unwrap().into_structure().into_schema();
-    query_manager
-        .execute_schema(&mut snapshot, type_manager, thing_manager, function_manager, &schema_query, query_str)
-        .unwrap();
+    let parsed = query_manager.parse(query_str.to_string()).unwrap().into_schema();
+    query_manager.execute_schema(&mut snapshot, type_manager, thing_manager, function_manager, parsed).unwrap();
     snapshot.commit(&mut CommitProfile::DISABLED).unwrap();
 }
 
@@ -55,17 +53,17 @@ fn insert_data(
 ) {
     let snapshot = storage.clone().open_snapshot_write();
     let query_manager = QueryManager::new(Some(Arc::new(QueryCache::new())));
-    let query = typeql::parse_query(query_string).unwrap().into_structure().into_pipeline();
+    let parsed = query_manager.parse(query_string.to_string()).unwrap().into_pipeline();
     let pipeline = query_manager
         .prepare_write_pipeline(
             snapshot,
             type_manager,
             thing_manager,
             function_manager,
-            &query,
+            parsed,
             None::<GivenRowsSimple>,
-            query_string,
         )
+        .map_err(|(_, err)| err)
         .unwrap();
     let (_iterator, context) = pipeline.into_rows_iterator(ExecutionInterrupt::new_uninterruptible()).unwrap();
     let snapshot = Arc::into_inner(context.snapshot).unwrap();
@@ -177,29 +175,31 @@ fn query_profile_tree_structure() {
         offset 0;
         limit 10;
     "#;
-    let query = typeql::parse_query(query_str).unwrap().into_structure().into_pipeline();
+    let query_manager = QueryManager::new(Some(Arc::new(QueryCache::new())));
+    let parsed =
+        query_manager.parse_with_profile(query_str.to_string(), QueryProfile::new(true)).unwrap().into_pipeline();
     let snapshot = Arc::new(storage.clone().open_snapshot_read());
-    let pipeline = QueryManager::new(Some(Arc::new(QueryCache::new())))
+    let pipeline = query_manager
         .prepare_read_pipeline(
             snapshot,
             &type_manager,
             thing_manager.clone(),
             function_manager.clone(),
-            &query,
+            parsed,
             None::<GivenRowsSimple>,
-            query_str,
         )
         .unwrap();
 
-    let (iterator, context) = pipeline.into_rows_iterator(ExecutionInterrupt::new_uninterruptible()).unwrap();
+    let query_context = pipeline.query_context().clone();
+    let (iterator, _context) = pipeline.into_rows_iterator(ExecutionInterrupt::new_uninterruptible()).unwrap();
     let _: Vec<_> =
         iterator.map_static(|row| row.map(|row| row.into_owned()).map_err(|err| err.clone())).into_iter().collect();
 
-    assert!(context.profile.is_enabled(), "expected profile to be enabled under TRACE-level tracing");
+    assert!(query_context.profile.is_enabled(), "expected profile to be enabled under TRACE-level tracing");
 
-    let rendered = format!("{}", context.profile);
+    let rendered = format!("{}", query_context.profile);
 
-    let actual = QueryProfileShape::from_profile(&context.profile);
+    let actual = QueryProfileShape::from_profile(&query_context.profile);
 
     assert_eq!(actual.stages.len(), 2, "expected exactly 2 stages, got {:#?}\n{}", actual.stages, rendered);
 

--- a/query/tests/unimplemented.rs
+++ b/query/tests/unimplemented.rs
@@ -44,10 +44,8 @@ fn setup_common(schema: &str) -> Context {
     let query_manager = QueryManager::new(None);
 
     let mut snapshot = storage.clone().open_snapshot_schema();
-    let define = typeql::parse_query(schema).unwrap().into_structure().into_schema();
-    query_manager
-        .execute_schema(&mut snapshot, &type_manager, &thing_manager, &function_manager, &define, schema)
-        .unwrap();
+    let parsed = query_manager.parse(schema.to_string()).unwrap().into_schema();
+    query_manager.execute_schema(&mut snapshot, &type_manager, &thing_manager, &function_manager, parsed).unwrap();
     snapshot.commit(&mut CommitProfile::DISABLED).unwrap();
 
     let query_manager = QueryManager::new(Some(Arc::new(QueryCache::new())));
@@ -64,7 +62,7 @@ fn run_read_query(
     Either<Box<QueryError>, Box<PipelineExecutionError>>,
 > {
     let snapshot = Arc::new(context.storage.clone().open_snapshot_read());
-    let match_ = typeql::parse_query(query).unwrap().into_structure().into_pipeline();
+    let parsed = context.query_manager.parse(query.to_string()).map_err(Either::Left)?.into_pipeline();
     let pipeline = context
         .query_manager
         .prepare_read_pipeline(
@@ -72,9 +70,8 @@ fn run_read_query(
             &context.type_manager,
             context.thing_manager.clone(),
             context.function_manager.clone(),
-            &match_,
+            parsed,
             None::<GivenRowsSimple>,
-            query,
         )
         .map_err(|query_error| Either::Left(query_error))?;
     let rows_positions = pipeline.rows_positions().unwrap().clone();
@@ -91,7 +88,7 @@ fn run_write_query(
     query: &str,
 ) -> Result<(Vec<MaybeOwnedRow<'static>>, HashMap<String, VariablePosition>), Box<PipelineExecutionError>> {
     let snapshot = context.storage.clone().open_snapshot_write();
-    let query_as_pipeline = typeql::parse_query(query).unwrap().into_structure().into_pipeline();
+    let parsed = context.query_manager.parse(query.to_string()).unwrap().into_pipeline();
     let pipeline = context
         .query_manager
         .prepare_write_pipeline(
@@ -99,10 +96,10 @@ fn run_write_query(
             &context.type_manager,
             context.thing_manager.clone(),
             context.function_manager.clone(),
-            &query_as_pipeline,
+            parsed,
             None::<GivenRowsSimple>,
-            query,
         )
+        .map_err(|(_, err)| err)
         .unwrap();
     let rows_positions = pipeline.rows_positions().unwrap().clone();
     let (iterator, ExecutionContext { snapshot, .. }) =

--- a/resource/constants.rs
+++ b/resource/constants.rs
@@ -112,10 +112,10 @@ pub mod database {
 
     // anything lower than 2.0 will cause too much replanning
     // anything over 8.0 often does not plan frequently enough, as the data scales
-    pub const QUERY_PLAN_CACHE_FLUSH_ANY_STATISTIC_CHANGE_FRACTION: f64 = 3.0;
-    pub const QUERY_PLAN_CACHE_SIZE: u64 = 100;
+    pub const QUERY_CACHE_FLUSH_ANY_STATISTIC_CHANGE_FRACTION: f64 = 3.0;
     pub const QUERY_PARSE_CACHE_SIZE: u64 = 200;
     pub const QUERY_TRANSLATION_CACHE_SIZE: u64 = 200;
+    pub const QUERY_EXECUTABLE_CACHE_SIZE: u64 = 100;
     pub const STATISTICS_DURABLE_WRITE_CHANGE_COUNT: u64 = 10_000;
     pub const STATISTICS_DURABLE_WRITE_SEQ_NUMBERS: usize = 1_000;
     pub const STATISTICS_UPDATE_INTERVAL: Duration = Duration::from_millis(50);

--- a/resource/constants.rs
+++ b/resource/constants.rs
@@ -112,11 +112,11 @@ pub mod database {
 
     // anything lower than 2.0 will cause too much replanning
     // anything over 8.0 often does not plan frequently enough, as the data scales
-    pub const QUERY_PLAN_CACHE_FLUSH_STATIC_SMOOTH_THRESHOLD: u64 = 100;
-    pub const QUERY_PLAN_CACHE_FLUSH_ANY_STATISTIC_CHANGE_FRACTION: f64 = 3.0;
-    pub const QUERY_PLAN_CACHE_SIZE: u64 = 100;
+    pub const QUERY_CACHE_FLUSH_STATIC_SMOOTH_THRESHOLD: u64 = 100;
+    pub const QUERY_CACHE_FLUSH_ANY_STATISTIC_CHANGE_FRACTION: f64 = 3.0;
     pub const QUERY_PARSE_CACHE_SIZE: u64 = 200;
     pub const QUERY_TRANSLATION_CACHE_SIZE: u64 = 200;
+    pub const QUERY_EXECUTABLE_CACHE_SIZE: u64 = 100;
     pub const STATISTICS_DURABLE_WRITE_CHANGE_COUNT: u64 = 10_000;
     pub const STATISTICS_DURABLE_WRITE_SEQ_NUMBERS: usize = 1_000;
     pub const STATISTICS_UPDATE_INTERVAL: Duration = Duration::from_millis(50);

--- a/resource/perf_counters.rs
+++ b/resource/perf_counters.rs
@@ -27,9 +27,9 @@ impl Counter {
     }
 }
 
-pub static QUERY_CACHE_HITS: Counter = Counter::new(PERF_COUNTERS_ENABLED);
-pub static QUERY_CACHE_MISSES: Counter = Counter::new(PERF_COUNTERS_ENABLED);
-pub static QUERY_CACHE_FLUSH: Counter = Counter::new(PERF_COUNTERS_ENABLED);
+pub static QUERY_EXECUTABLE_CACHE_HITS: Counter = Counter::new(PERF_COUNTERS_ENABLED);
+pub static QUERY_EXECUTABLE_CACHE_MISSES: Counter = Counter::new(PERF_COUNTERS_ENABLED);
+pub static QUERY_EXECUTABLE_CACHE_FLUSH: Counter = Counter::new(PERF_COUNTERS_ENABLED);
 pub static QUERY_PARSE_CACHE_HITS: Counter = Counter::new(PERF_COUNTERS_ENABLED);
 pub static QUERY_PARSE_CACHE_MISSES: Counter = Counter::new(PERF_COUNTERS_ENABLED);
 pub static QUERY_TRANSLATION_CACHE_HITS: Counter = Counter::new(PERF_COUNTERS_ENABLED);

--- a/resource/profile.rs
+++ b/resource/profile.rs
@@ -9,7 +9,7 @@ use std::{
     fmt,
     fmt::{Display, Formatter},
     sync::{
-        Arc, OnceLock, RwLock,
+        Arc, Mutex, MutexGuard, OnceLock, RwLock,
         atomic::{AtomicU64, Ordering},
     },
     time::{Duration, Instant},
@@ -434,22 +434,26 @@ impl CommitProfileData {
 
 #[derive(Debug)]
 pub struct QueryProfile {
-    compile_profile: CompileIRProfile,
+    compile_profile: Mutex<CompileProfile>,
     stage_profiles: RwLock<HashMap<u64, Arc<StageProfile>>>,
     enabled: bool,
 }
 
 impl QueryProfile {
     pub fn new(enabled: bool) -> Self {
-        Self { compile_profile: CompileIRProfile::new(enabled), stage_profiles: RwLock::new(HashMap::new()), enabled }
+        Self {
+            compile_profile: Mutex::new(CompileProfile::new(enabled)),
+            stage_profiles: RwLock::new(HashMap::new()),
+            enabled,
+        }
     }
 
     pub fn is_enabled(&self) -> bool {
         self.enabled
     }
 
-    pub fn compilation_profile(&mut self) -> &mut CompileIRProfile {
-        &mut self.compile_profile
+    pub fn compilation_profile(&self) -> MutexGuard<'_, CompileProfile> {
+        self.compile_profile.lock().unwrap()
     }
 
     pub fn profile_stage(&self, description_fn: impl Fn() -> String, id: u64) -> Arc<StageProfile> {
@@ -478,7 +482,13 @@ impl QueryProfile {
             .values()
             .map(|stage_profile| stage_profile.pattern_profile.get().map_or(0, |profile| profile.total_nanos()))
             .sum();
-        self.compile_profile.total_nanos() + stage_nanos
+        self.compilation_profile().total_nanos() + stage_nanos
+    }
+}
+
+impl Default for QueryProfile {
+    fn default() -> Self {
+        Self::new(false)
     }
 }
 
@@ -493,7 +503,7 @@ impl IndentDisplay for QueryProfile {
         let total_micros = self.total_nanos() as f64 / 1000.0;
         write_indent(f, indent)?;
         writeln!(f, "Query profile[measurements_enabled={}, total micros: {}]", self.enabled, total_micros)?;
-        self.compile_profile.indent_fmt(f, indent + 1)?;
+        self.compilation_profile().indent_fmt(f, indent + 1)?;
         let stage_profiles = self.stage_profiles.read().unwrap();
         for (id, stage_profile) in stage_profiles.iter().sorted_by_key(|(id, _)| *id) {
             write_indent(f, indent + 1)?;
@@ -507,16 +517,18 @@ impl IndentDisplay for QueryProfile {
 }
 
 #[derive(Debug)]
-pub struct CompileIRProfile {
-    data: Option<CompileIRProfileData>,
+pub struct CompileProfile {
+    data: Option<CompileProfileData>,
 }
 
-impl CompileIRProfile {
+impl CompileProfile {
     fn new(enabled: bool) -> Self {
         if enabled {
             Self {
-                data: Some(CompileIRProfileData {
+                data: Some(CompileProfileData {
                     stage_start: Instant::now(), // irrelevant
+                    parsing: Duration::ZERO,
+                    translation: Duration::ZERO,
                     validation: Duration::ZERO,
                     annotation: Duration::ZERO,
                     compilation: Duration::ZERO,
@@ -527,9 +539,23 @@ impl CompileIRProfile {
         }
     }
 
-    pub fn start(&mut self) {
+    pub fn set_stage_timer(&mut self) {
         if let Some(data) = &mut self.data {
             data.stage_start = Instant::now()
+        }
+    }
+
+    pub fn parsing_finished(&mut self) {
+        if let Some(data) = &mut self.data {
+            data.parsing = data.stage_start.elapsed();
+            data.stage_start = Instant::now();
+        }
+    }
+
+    pub fn translation_finished(&mut self) {
+        if let Some(data) = &mut self.data {
+            data.translation = data.stage_start.elapsed();
+            data.stage_start = Instant::now();
         }
     }
 
@@ -557,18 +583,23 @@ impl CompileIRProfile {
     fn total_nanos(&self) -> u64 {
         match &self.data {
             None => 0,
-            Some(data) => (data.validation + data.annotation + data.compilation).as_nanos() as u64,
+            Some(data) => (data.parsing + data.translation + data.validation + data.annotation + data.compilation)
+                .as_nanos() as u64,
         }
     }
 }
 
-impl IndentDisplay for CompileIRProfile {
+impl IndentDisplay for CompileProfile {
     fn indent_fmt(&self, f: &mut Formatter<'_>, indent: usize) -> fmt::Result {
         write_indent(f, indent)?;
         match &self.data {
-            None => writeln!(f, "CompileIR[enabled=false]"),
+            None => writeln!(f, "Compile[enabled=false]"),
             Some(data) => {
-                writeln!(f, "CompileIR[enabled=true, total micros={}]", self.total_nanos() as f64 / 1000.0)?;
+                writeln!(f, "Compile[enabled=true, total micros={}]", self.total_nanos() as f64 / 1000.0)?;
+                write_indent(f, indent + 1)?;
+                writeln!(f, "parsing micros: {}", data.parsing.as_nanos() as f64 / 1000.0)?;
+                write_indent(f, indent + 1)?;
+                writeln!(f, "translation micros: {}", data.translation.as_nanos() as f64 / 1000.0)?;
                 write_indent(f, indent + 1)?;
                 writeln!(f, "validation micros: {}", data.validation.as_nanos() as f64 / 1000.0)?;
                 write_indent(f, indent + 1)?;
@@ -583,8 +614,10 @@ impl IndentDisplay for CompileIRProfile {
 /// Record the time different stages of a query compilation take.
 /// This struct is simplified to expect that we execute exactly these steps in a fixed order with no other (significant) operations.
 #[derive(Debug)]
-struct CompileIRProfileData {
+struct CompileProfileData {
     stage_start: Instant,
+    parsing: Duration,
+    translation: Duration,
     validation: Duration,
     annotation: Duration,
     compilation: Duration,

--- a/server/service/grpc/analyze.rs
+++ b/server/service/grpc/analyze.rs
@@ -93,7 +93,13 @@ pub fn encode_analyzed_query(
                 .map(|object| analyze_proto::Fetch { node: Some(analyze_proto::fetch::Node::Object(object)) })
         })
         .transpose()?;
-    Ok(typedb_protocol::analyze::res::AnalyzedQuery { source, query: Some(query), preamble, fetch, given })
+    Ok(typedb_protocol::analyze::res::AnalyzedQuery {
+        source: source.as_ref().to_owned(),
+        query: Some(query),
+        preamble,
+        fetch,
+        given,
+    })
 }
 
 fn encode_function(

--- a/server/service/grpc/transaction_service.rs
+++ b/server/service/grpc/transaction_service.rs
@@ -44,10 +44,9 @@ use options::QueryOptions;
 use query::{
     error::QueryError,
     given_rows::{GivenRowDecodeError, GivenRowEntry, GivenRows},
-    query_cache::ParsedQuery,
-    query_manager::QueryManager,
+    query_manager::{ParsedPipeline, ParsedQuery, ParsedSchemaQuery, QueryManager},
 };
-use resource::profile::{EncodingProfile, QueryProfile, StorageCounters};
+use resource::profile::{EncodingProfile, StorageCounters};
 use storage::snapshot::ReadableSnapshot;
 use tokio::{
     spawn,
@@ -65,7 +64,6 @@ use typedb_protocol::{
     query::Type::{Read, Write},
     transaction::{Server as ProtocolServer, stream_signal::Req},
 };
-use typeql::query::{Pipeline as TypeQLPipeline, SchemaQuery};
 use uuid::Uuid;
 
 use crate::{
@@ -148,7 +146,7 @@ pub(crate) struct TransactionService {
     is_open: bool,
     transaction: Option<Transaction>,
     query_manager: Option<Arc<QueryManager>>,
-    query_queue: VecDeque<(Uuid, QueueOptions, Arc<TypeQLPipeline>, Option<GivenRowsGrpc>, String)>,
+    query_queue: VecDeque<(Uuid, QueueOptions, ParsedPipeline, Option<GivenRowsGrpc>)>,
     query_responders: HashMap<Uuid, (JoinHandle<()>, QueryStreamTransmitter)>,
     running_write_query: Option<(Uuid, JoinHandle<(Transaction, WriteQueryResult)>)>,
 
@@ -644,11 +642,9 @@ impl TransactionService {
 
     async fn cancel_queued_read_queries(&mut self, interrupt: InterruptType) -> ControlFlow<(), ()> {
         let mut write_queries = VecDeque::with_capacity(self.query_queue.len());
-        for (req_id, query_options, pipeline, given_rows, source_query) in
-            self.query_queue.drain(0..self.query_queue.len())
-        {
-            if query_options.is_query() && is_write_pipeline(&pipeline) {
-                write_queries.push_back((req_id, query_options, pipeline, given_rows, source_query));
+        for (req_id, query_options, parsed, given_rows) in self.query_queue.drain(0..self.query_queue.len()) {
+            if query_options.is_query() && is_write_pipeline(parsed.pipeline()) {
+                write_queries.push_back((req_id, query_options, parsed, given_rows));
             } else {
                 Self::respond_query_response(
                     &self.response_sender,
@@ -708,8 +704,8 @@ impl TransactionService {
 
     async fn cancel_queued_write_queries(&mut self, interrupt: InterruptType) -> ControlFlow<(), ()> {
         let mut read_queries = VecDeque::with_capacity(self.query_queue.len());
-        for (req_id, options, pipeline, given_rows, source_query) in self.query_queue.drain(0..self.query_queue.len()) {
-            if options.is_query() && is_write_pipeline(&pipeline) {
+        for (req_id, options, parsed, given_rows) in self.query_queue.drain(0..self.query_queue.len()) {
+            if options.is_query() && is_write_pipeline(parsed.pipeline()) {
                 Self::respond_query_response(
                     &self.response_sender,
                     req_id,
@@ -719,7 +715,7 @@ impl TransactionService {
                 )
                 .await?;
             } else {
-                read_queries.push_back((req_id, options, pipeline, given_rows, source_query));
+                read_queries.push_back((req_id, options, parsed, given_rows));
             }
         }
         self.query_queue = read_queries;
@@ -729,14 +725,14 @@ impl TransactionService {
     async fn finish_queued_write_queries(&mut self, interrupt: InterruptType) -> Result<(), Status> {
         self.finish_running_write_query_no_transmit(interrupt).await?;
         let requests: Vec<_> = self.query_queue.drain(0..self.query_queue.len()).collect();
-        for (req_id, query_queue_options, pipeline, given_rows, source_query) in requests.into_iter() {
-            match (query_queue_options, is_write_pipeline(&pipeline)) {
+        for (req_id, query_queue_options, parsed, given_rows) in requests.into_iter() {
+            match (query_queue_options, is_write_pipeline(parsed.pipeline())) {
                 (QueueOptions::Query(query_options), true) => {
-                    self.run_write_query(req_id, query_options, pipeline, given_rows, source_query).await;
+                    self.run_write_query(req_id, query_options, parsed, given_rows).await;
                     self.finish_running_write_query_no_transmit(interrupt).await?;
                 }
                 (queue_options, _) => {
-                    self.query_queue.push_back((req_id, queue_options, pipeline, given_rows, source_query));
+                    self.query_queue.push_back((req_id, queue_options, parsed, given_rows));
                 }
             }
         }
@@ -746,18 +742,18 @@ impl TransactionService {
     async fn may_accept_from_queue(&mut self) {
         debug_assert!(self.running_write_query.is_none());
         // unblock requests until the first write request, which we begin executing if it exists
-        while let Some((req_id, queue_options, pipeline, given_rows, source_query)) = self.query_queue.pop_front() {
-            match (queue_options, is_write_pipeline(&pipeline)) {
+        while let Some((req_id, queue_options, parsed, given_rows)) = self.query_queue.pop_front() {
+            match (queue_options, is_write_pipeline(parsed.pipeline())) {
                 (QueueOptions::Analyze, _) => {
                     debug_assert!(given_rows.is_none());
-                    self.run_analyse_query(req_id, pipeline, source_query).await;
+                    self.run_analyse_query(req_id, parsed).await;
                 }
                 (QueueOptions::Query(query_options), true) => {
-                    self.run_write_query(req_id, query_options, pipeline, given_rows, source_query).await;
+                    self.run_write_query(req_id, query_options, parsed, given_rows).await;
                     return;
                 }
                 (QueueOptions::Query(query_options), false) => {
-                    self.run_and_activate_read_transmitter(req_id, query_options, pipeline, given_rows, source_query);
+                    self.run_and_activate_read_transmitter(req_id, query_options, parsed, given_rows);
                 }
             }
         }
@@ -768,10 +764,9 @@ impl TransactionService {
         req_id: Uuid,
         analyse_req: typedb_protocol::analyze::Req,
     ) -> Result<ControlFlow<(), ()>, Status> {
-        let query = analyse_req.query;
-        let pipeline = match self.query_manager.as_ref().expect("transaction is open").parse(&query) {
-            Ok(ParsedQuery::Pipeline(pipeline)) => pipeline,
-            Ok(ParsedQuery::Schema(_)) => {
+        let parsed = match self.query_manager.as_ref().expect("transaction is open").parse(analyse_req.query) {
+            Ok(ParsedQuery::Pipeline(parsed)) => parsed,
+            Ok(ParsedQuery::Schema(..)) => {
                 let response =
                     ImmediateAnalyzeResponse::non_fatal_err(TransactionServiceError::AnalyseQueryExpectsPipeline {});
                 return Ok(Self::respond_analyze_response(&self.response_sender, req_id, response).await);
@@ -783,11 +778,11 @@ impl TransactionService {
             }
         };
         if !self.query_queue.is_empty() || self.running_write_query.is_some() {
-            self.query_queue.push_back((req_id, QueueOptions::Analyze, pipeline, None, query));
+            self.query_queue.push_back((req_id, QueueOptions::Analyze, parsed, None));
             // queued queries are not handled yet so there will be no query response yet
             Ok(Continue(()))
         } else {
-            self.run_analyse_query(req_id, pipeline, query).await;
+            self.run_analyse_query(req_id, parsed).await;
             // running read queries have no response on the main loop and will respond asynchronously
             Ok(Continue(()))
         }
@@ -811,13 +806,12 @@ impl TransactionService {
             m.record_query();
         }
 
-        let query = query_req.query;
         let given_rows = query_req.given.map(GivenRowsGrpc);
-        let pipeline = match self.query_manager.as_ref().expect("transaction is open").parse(&query) {
-            Ok(ParsedQuery::Pipeline(pipeline)) => pipeline,
-            Ok(ParsedQuery::Schema(schema_query)) => {
+        let parsed = match self.query_manager.as_ref().expect("transaction is open").parse(query_req.query) {
+            Ok(ParsedQuery::Pipeline(parsed)) => parsed,
+            Ok(ParsedQuery::Schema(parsed)) => {
                 // schema queries are handled immediately so there is a query response or a fatal Status
-                let response = self.handle_query_schema(schema_query, query).await?;
+                let response = self.handle_query_schema(parsed).await?;
                 return Ok(Self::respond_query_response(&self.response_sender, req_id, response).await);
             }
             Err(typedb_source) => {
@@ -827,24 +821,20 @@ impl TransactionService {
             }
         };
         if !self.query_queue.is_empty() || self.running_write_query.is_some() {
-            self.query_queue.push_back((req_id, QueueOptions::Query(query_options), pipeline, given_rows, query));
+            self.query_queue.push_back((req_id, QueueOptions::Query(query_options), parsed, given_rows));
             // queued queries are not handled yet so there will be no query response yet
             Ok(Continue(()))
-        } else if is_write_pipeline(&pipeline) {
-            self.run_write_query(req_id, query_options, pipeline, given_rows, query).await;
+        } else if is_write_pipeline(parsed.pipeline()) {
+            self.run_write_query(req_id, query_options, parsed, given_rows).await;
             Ok(Continue(()))
         } else {
-            self.run_and_activate_read_transmitter(req_id, query_options, pipeline, given_rows, query);
+            self.run_and_activate_read_transmitter(req_id, query_options, parsed, given_rows);
             // running read queries have no response on the main loop and will respond asynchronously
             Ok(Continue(()))
         }
     }
 
-    async fn handle_query_schema(
-        &mut self,
-        query: SchemaQuery,
-        source_query: String,
-    ) -> Result<ImmediateQueryResponse, Status> {
+    async fn handle_query_schema(&mut self, parsed: ParsedSchemaQuery) -> Result<ImmediateQueryResponse, Status> {
         self.interrupt_and_close_responders(InterruptType::SchemaQueryExecution).await;
         let _ = self.cancel_queued_read_queries(InterruptType::SchemaQueryExecution).await;
         self.finish_queued_write_queries(InterruptType::SchemaQueryExecution).await?;
@@ -857,7 +847,7 @@ impl TransactionService {
                         schema_transaction.database.name_arc(),
                     );
                     let (transaction, result) =
-                        spawn_blocking(move || execute_schema_query(schema_transaction, query, source_query))
+                        spawn_blocking(move || execute_schema_query(schema_transaction, parsed))
                             .await
                             .expect("Expected schema query execution finishing");
                     schema_metrics.observe_finished();
@@ -877,7 +867,7 @@ impl TransactionService {
         Ok(ImmediateQueryResponse::non_fatal_err(TransactionServiceError::SchemaQueryRequiresSchemaTransaction {}))
     }
 
-    async fn run_analyse_query(&mut self, req_id: Uuid, pipeline: Arc<TypeQLPipeline>, source_query: String) {
+    async fn run_analyse_query(&mut self, req_id: Uuid, parsed: ParsedPipeline) {
         with_readable_transaction!(self.transaction.as_ref().unwrap(), |transaction| {
             let snapshot = transaction.snapshot.clone();
             let type_manager = transaction.type_manager.clone();
@@ -886,14 +876,7 @@ impl TransactionService {
             let query_manager = transaction.query_manager.clone();
 
             let result = spawn_blocking(move || {
-                query_manager.analyse(
-                    snapshot,
-                    &type_manager,
-                    &function_manager,
-                    &thing_manager,
-                    &pipeline,
-                    &source_query,
-                )
+                query_manager.analyse(snapshot, &type_manager, &function_manager, &thing_manager, parsed)
             })
             .await
             .expect("Expected analyse query execution finishing");
@@ -914,13 +897,12 @@ impl TransactionService {
         &mut self,
         req_id: Uuid,
         query_options: QueryOptions,
-        pipeline: Arc<TypeQLPipeline>,
+        parsed: ParsedPipeline,
         given_rows: Option<GivenRowsGrpc>,
-        source_query: String,
     ) {
         debug_assert!(self.running_write_query.is_none());
         self.interrupt_and_close_responders(InterruptType::WriteQueryExecution).await;
-        let handle = match self.spawn_blocking_execute_write_query(query_options, pipeline, given_rows, source_query) {
+        let handle = match self.spawn_blocking_execute_write_query(query_options, parsed, given_rows) {
             Ok(handle) => {
                 // running write queries have no valid response yet (until they finish) and will respond asynchronously
                 handle
@@ -960,13 +942,12 @@ impl TransactionService {
         &mut self,
         req_id: Uuid,
         query_options: QueryOptions,
-        pipeline: Arc<TypeQLPipeline>,
+        parsed: ParsedPipeline,
         given_rows: Option<GivenRowsGrpc>,
-        source_query: String,
     ) {
         let prefetch_size = query_options.prefetch_size;
         let (sender, receiver) = channel(prefetch_size);
-        let worker_handle = self.blocking_read_query_worker(sender, query_options, pipeline, given_rows, source_query);
+        let worker_handle = self.blocking_read_query_worker(sender, query_options, parsed, given_rows);
         let stream_transmitter = QueryStreamTransmitter::start_new(
             self.response_sender.clone(),
             receiver,
@@ -980,34 +961,21 @@ impl TransactionService {
     fn spawn_blocking_execute_write_query(
         &mut self,
         query_options: QueryOptions,
-        pipeline: Arc<TypeQLPipeline>,
+        parsed: ParsedPipeline,
         given_rows: Option<GivenRowsGrpc>,
-        source_query: String,
     ) -> Result<JoinHandle<(Transaction, WriteQueryResult)>, TransactionServiceError> {
         debug_assert!(self.running_write_query.is_none());
         debug_assert!(self.transaction.is_some());
         let interrupt = self.query_interrupt_receiver.clone();
         match self.transaction.take() {
             Some(Transaction::Schema(schema_transaction)) => Ok(spawn_blocking(move || {
-                let (transaction, result) = execute_write_query_in_schema(
-                    schema_transaction,
-                    query_options,
-                    pipeline,
-                    given_rows,
-                    source_query,
-                    interrupt,
-                );
+                let (transaction, result) =
+                    execute_write_query_in_schema(schema_transaction, query_options, parsed, given_rows, interrupt);
                 (Transaction::Schema(transaction), result)
             })),
             Some(Transaction::Write(write_transaction)) => Ok(spawn_blocking(move || {
-                let (transaction, result) = execute_write_query_in_write(
-                    write_transaction,
-                    query_options,
-                    pipeline,
-                    given_rows,
-                    source_query,
-                    interrupt,
-                );
+                let (transaction, result) =
+                    execute_write_query_in_write(write_transaction, query_options, parsed, given_rows, interrupt);
                 (Transaction::Write(transaction), result)
             })),
             Some(Transaction::Read(transaction)) => {
@@ -1202,9 +1170,8 @@ impl TransactionService {
         &self,
         sender: Sender<StreamQueryResponse>,
         query_options: QueryOptions,
-        pipeline: Arc<TypeQLPipeline>,
+        parsed: ParsedPipeline,
         given_rows: Option<GivenRowsGrpc>,
-        source_query: String,
     ) -> JoinHandle<()> {
         debug_assert!(self.query_queue.is_empty() && self.running_write_query.is_none() && self.transaction.is_some());
         let timeout_at = self.timeout_at;
@@ -1220,16 +1187,15 @@ impl TransactionService {
             spawn_blocking(move || {
                 let start_time = Instant::now();
                 let mut read_metrics = ReadQueryMetrics::new(diagnostics_manager, database_name);
-                let pipeline = query_manager.prepare_read_pipeline(
+                let executable = query_manager.prepare_read_pipeline(
                     snapshot.clone(),
                     &type_manager,
                     thing_manager.clone(),
                     function_manager.clone(),
-                    &pipeline,
+                    parsed,
                     given_rows,
-                    &source_query,
                 );
-                let pipeline = unwrap_or_execute_and_return!(pipeline, |err| {
+                let executable = unwrap_or_execute_and_return!(executable, |err| {
                     Self::submit_read_response_with_metrics(
                         &sender,
                         StreamQueryResponse::done_err(err),
@@ -1238,8 +1204,7 @@ impl TransactionService {
                 });
                 Self::respond_read_query_sync(
                     query_options,
-                    pipeline,
-                    &source_query,
+                    executable,
                     timeout_at,
                     interrupt,
                     &sender,
@@ -1256,7 +1221,6 @@ impl TransactionService {
     fn respond_read_query_sync<Snapshot: ReadableSnapshot>(
         query_options: QueryOptions,
         pipeline: Pipeline<Snapshot, ReadPipelineStage<Snapshot>>,
-        source_query: &str,
         timeout_at: Instant,
         mut interrupt: ExecutionInterrupt,
         sender: &Sender<StreamQueryResponse>,
@@ -1266,9 +1230,8 @@ impl TransactionService {
         start_time: Instant,
         read_metrics: &mut ReadQueryMetrics,
     ) {
-        let query_profile: Arc<QueryProfile>;
         let encoding_profile: EncodingProfile;
-
+        let query_context = pipeline.query_context().clone();
         if pipeline.has_fetch() {
             let initial_response = StreamQueryResponse::init_ok_documents(Read);
             Self::submit_response_sync(sender, initial_response);
@@ -1277,16 +1240,14 @@ impl TransactionService {
                     Self::submit_read_response_with_metrics(
                         sender,
                         StreamQueryResponse::done_err(QueryError::ReadPipelineExecution {
-                            source_query: source_query.to_string(),
+                            source_query: query_context.source_query.as_ref().to_owned(),
                             typedb_source: err,
                         }),
                         read_metrics,
                     );
                 });
-            query_profile = context.profile;
-            encoding_profile = EncodingProfile::new(query_profile.is_enabled());
+            encoding_profile = EncodingProfile::new(query_context.profile.is_enabled());
 
-            let parameters = context.parameters;
             for next in iterator {
                 if let Some(interrupt) = interrupt.check() {
                     Self::submit_read_response_with_metrics(
@@ -1314,7 +1275,7 @@ impl TransactionService {
                     snapshot.as_ref(),
                     type_manager,
                     &thing_manager,
-                    &parameters,
+                    &query_context.parameters,
                     encoding_profile.storage_counters(),
                 );
                 match encoded_document {
@@ -1356,14 +1317,13 @@ impl TransactionService {
                     Self::submit_read_response_with_metrics(
                         sender,
                         StreamQueryResponse::done_err(QueryError::ReadPipelineExecution {
-                            source_query: source_query.to_string(),
+                            source_query: query_context.source_query.as_ref().to_owned(),
                             typedb_source: err,
                         }),
                         read_metrics,
                     );
                 });
-            query_profile = context.profile;
-            encoding_profile = EncodingProfile::new(query_profile.is_enabled());
+            encoding_profile = EncodingProfile::new(query_context.profile.is_enabled());
 
             while let Some(next) = iterator.next() {
                 if let Some(interrupt) = interrupt.check() {
@@ -1415,13 +1375,13 @@ impl TransactionService {
             }
         }
 
-        if query_profile.is_enabled() {
+        if query_context.profile.is_enabled() {
             let micros = Instant::now().duration_since(start_time).as_micros();
             event!(
                 Level::INFO,
                 "Read query done (including network request time) in {} micros.\n{}\n{}",
                 micros,
-                query_profile,
+                query_context.profile,
                 encoding_profile
             );
         }

--- a/server/service/http/message/analyze/mod.rs
+++ b/server/service/http/message/analyze/mod.rs
@@ -78,7 +78,7 @@ pub fn encode_analyzed_query(
                 .map(|fields| FetchStructureAnnotationsResponse::Object { possible_fields: fields })
         })
         .transpose()?;
-    Ok(AnalysedQueryResponse { source, given, query, preamble, fetch })
+    Ok(AnalysedQueryResponse { source: source.as_ref().to_owned(), given, query, preamble, fetch })
 }
 
 #[cfg(debug_assertions)]

--- a/server/service/http/message/error.rs
+++ b/server/service/http/message/error.rs
@@ -78,7 +78,6 @@ impl IntoResponse for HttpServiceError {
                 TransactionServiceError::TransactionFailed { .. } => StatusCode::BAD_REQUEST,
                 TransactionServiceError::DataCommitFailed { .. } => StatusCode::BAD_REQUEST,
                 TransactionServiceError::SchemaCommitFailed { .. } => StatusCode::BAD_REQUEST,
-                TransactionServiceError::QueryParseFailed { .. } => StatusCode::BAD_REQUEST,
                 TransactionServiceError::SchemaQueryRequiresSchemaTransaction { .. } => StatusCode::BAD_REQUEST,
                 TransactionServiceError::WriteQueryRequiresSchemaOrWriteTransaction { .. } => StatusCode::BAD_REQUEST,
                 TransactionServiceError::SchemaQueryFailedAbortingTransaction { .. } => StatusCode::BAD_REQUEST,

--- a/server/service/http/message/query/mod.rs
+++ b/server/service/http/message/query/mod.rs
@@ -12,7 +12,6 @@ use ::concept::{
 use answer::{Thing, Type};
 use axum::response::{IntoResponse, Response};
 use bytes::util::HexBytesFormatter;
-use clap::builder::TypedValueParser;
 use compiler::annotation::function::FunctionParameterAnnotation;
 use encoding::{
     graph::thing::{ThingVertex, vertex_attribute::AttributeVertex, vertex_object::ObjectVertex},

--- a/server/service/http/transaction_service.rs
+++ b/server/service/http/transaction_service.rs
@@ -34,7 +34,10 @@ use ir::pipeline::ParameterRegistry;
 use itertools::{Either, Itertools};
 use lending_iterator::LendingIterator;
 use options::{QueryOptions, TransactionOptions};
-use query::{error::QueryError, query_cache::ParsedQuery, query_manager::QueryManager};
+use query::{
+    error::QueryError,
+    query_manager::{ParsedPipeline, ParsedQuery, ParsedSchemaQuery, QueryManager},
+};
 use resource::profile::StorageCounters;
 use storage::snapshot::ReadableSnapshot;
 use tokio::{
@@ -48,7 +51,6 @@ use tokio::{
     time::Instant,
 };
 use tracing::{Level, event};
-use typeql::query::{Pipeline as TypeQLPipeline, SchemaQuery};
 
 use crate::{
     service::{
@@ -157,7 +159,7 @@ pub(crate) struct TransactionService {
 
     transaction: Option<Transaction>,
     query_manager: Option<QueryManager>,
-    query_queue: VecDeque<(TransactionResponder, QueueOptions, Arc<TypeQLPipeline>, Option<GivenRowsHttp>, String)>,
+    query_queue: VecDeque<(TransactionResponder, QueueOptions, ParsedPipeline, Option<GivenRowsHttp>)>,
     running_write_query: Option<(TransactionResponder, JoinHandle<(Transaction, WriteQueryResult)>)>,
 
     close_sender: Sender<()>,
@@ -513,11 +515,9 @@ impl TransactionService {
 
     async fn cancel_queued_read_queries(&mut self, interrupt: InterruptType) -> ControlFlow<(), ()> {
         let mut write_queries = VecDeque::with_capacity(self.query_queue.len());
-        for (responder, query_options, pipeline, given_rows, source_query) in
-            self.query_queue.drain(0..self.query_queue.len())
-        {
-            if query_options.is_query() && is_write_pipeline(&pipeline) {
-                write_queries.push_back((responder, query_options, pipeline, given_rows, source_query));
+        for (responder, query_options, parsed, given_rows) in self.query_queue.drain(0..self.query_queue.len()) {
+            if query_options.is_query() && is_write_pipeline(parsed.pipeline()) {
+                write_queries.push_back((responder, query_options, parsed, given_rows));
             } else {
                 respond_else_return_break!(
                     responder,
@@ -562,14 +562,14 @@ impl TransactionService {
 
     async fn cancel_queued_write_queries(&mut self, interrupt: InterruptType) -> ControlFlow<(), ()> {
         let mut read_queries = VecDeque::with_capacity(self.query_queue.len());
-        for (responder, options, pipeline, given_rows, source) in self.query_queue.drain(0..self.query_queue.len()) {
-            if options.is_query() && is_write_pipeline(&pipeline) {
+        for (responder, options, parsed, given_rows) in self.query_queue.drain(0..self.query_queue.len()) {
+            if options.is_query() && is_write_pipeline(parsed.pipeline()) {
                 respond_else_return_break!(
                     responder,
                     TransactionServiceResponse::Err(TransactionServiceError::QueryInterrupted { interrupt })
                 );
             } else {
-                read_queries.push_back((responder, options, pipeline, given_rows, source));
+                read_queries.push_back((responder, options, parsed, given_rows));
             }
         }
         self.query_queue = read_queries;
@@ -579,19 +579,17 @@ impl TransactionService {
     async fn finish_queued_write_queries(&mut self, interrupt: InterruptType) -> ControlFlow<(), ()> {
         self.finish_running_write_query_no_transmit(interrupt).await?;
         let requests: Vec<_> = self.query_queue.drain(0..self.query_queue.len()).collect();
-        for (responder, options, pipeline, given_rows, source_query) in requests.into_iter() {
-            if options.is_query() && is_write_pipeline(&pipeline) {
+        for (responder, options, parsed, given_rows) in requests.into_iter() {
+            if options.is_query() && is_write_pipeline(parsed.pipeline()) {
                 let QueueOptions::Query(query_options) = options else { unreachable!() };
-                if let Break(()) =
-                    self.run_write_query(responder, query_options, pipeline, given_rows, source_query).await
-                {
+                if let Break(()) = self.run_write_query(responder, query_options, parsed, given_rows).await {
                     return Break(());
                 }
                 if let Break(()) = self.finish_running_write_query_no_transmit(interrupt).await {
                     return Break(());
                 }
             } else {
-                self.query_queue.push_back((responder, options, pipeline, given_rows, source_query));
+                self.query_queue.push_back((responder, options, parsed, given_rows));
             }
         }
         Continue(())
@@ -601,25 +599,24 @@ impl TransactionService {
         debug_assert!(self.running_write_query.is_none());
 
         // unblock requests until the first write request, which we begin executing if it exists
-        while let Some((responder, queue_options, pipeline, given_rows, source_query)) = self.query_queue.pop_front() {
-            let is_write = is_write_pipeline(&pipeline);
+        while let Some((responder, queue_options, parsed, given_rows)) = self.query_queue.pop_front() {
+            let is_write = is_write_pipeline(parsed.pipeline());
             match (queue_options, is_write) {
                 (QueueOptions::Analyze, _) => {
                     debug_assert!(given_rows.is_none());
-                    if let Break(()) = self.run_analyse_query(responder, pipeline, source_query).await {
+                    if let Break(()) = self.run_analyse_query(responder, parsed).await {
                         return Break(());
                     }
                 }
                 (QueueOptions::Query(query_options), true) => {
-                    return self.run_write_query(responder, query_options, pipeline, given_rows, source_query).await;
+                    return self.run_write_query(responder, query_options, parsed, given_rows).await;
                 }
                 (QueueOptions::Query(query_options), false) => {
                     self.blocking_read_query_worker(
                         responder,
                         query_options,
-                        pipeline,
+                        parsed,
                         given_rows,
-                        source_query,
                         StorageCounters::DISABLED,
                     )
                     .await
@@ -641,12 +638,11 @@ impl TransactionService {
             m.record_query();
         }
 
-        // Step 1 (parse) needs no transaction, so this is safe even while a write holds it.
-        let pipeline = match self.query_manager.as_ref().expect("transaction is open").parse(&query) {
-            Ok(ParsedQuery::Pipeline(pipeline)) => pipeline,
-            Ok(ParsedQuery::Schema(schema_query)) => {
+        let parsed = match self.query_manager.as_ref().expect("transaction is open").parse(query) {
+            Ok(ParsedQuery::Pipeline(parsed)) => parsed,
+            Ok(ParsedQuery::Schema(parsed)) => {
                 // schema queries are handled immediately so there is a query response or a fatal error
-                return match self.handle_query_schema(schema_query, query).await {
+                return match self.handle_query_schema(parsed).await {
                     Ok(response) => {
                         respond_else_return_break!(responder, response);
                         Continue(())
@@ -664,29 +660,21 @@ impl TransactionService {
         };
 
         if !self.query_queue.is_empty() || self.running_write_query.is_some() {
-            self.query_queue.push_back((responder, QueueOptions::Query(query_options), pipeline, given_rows, query));
+            self.query_queue.push_back((responder, QueueOptions::Query(query_options), parsed, given_rows));
             // queued queries are not handled yet so there will be no query response yet
             Continue(())
-        } else if is_write_pipeline(&pipeline) {
-            self.run_write_query(responder, query_options, pipeline, given_rows, query).await
+        } else if is_write_pipeline(parsed.pipeline()) {
+            self.run_write_query(responder, query_options, parsed, given_rows).await
         } else {
-            self.blocking_read_query_worker(
-                responder,
-                query_options,
-                pipeline,
-                given_rows,
-                query,
-                StorageCounters::DISABLED,
-            )
-            .await
-            .expect("Expected read query completion")
+            self.blocking_read_query_worker(responder, query_options, parsed, given_rows, StorageCounters::DISABLED)
+                .await
+                .expect("Expected read query completion")
         }
     }
 
     async fn handle_query_schema(
         &mut self,
-        query: SchemaQuery,
-        source_query: String,
+        parsed: ParsedSchemaQuery,
     ) -> Result<TransactionServiceResponse, TransactionServiceError> {
         self.interrupt(InterruptType::SchemaQueryExecution).await;
         if let Break(()) = self.cancel_queued_read_queries(InterruptType::SchemaQueryExecution).await {
@@ -704,7 +692,7 @@ impl TransactionService {
                         schema_transaction.database.name_arc(),
                     );
                     let (transaction, result) =
-                        spawn_blocking(move || execute_schema_query(schema_transaction, query, source_query))
+                        spawn_blocking(move || execute_schema_query(schema_transaction, parsed))
                             .await
                             .expect("Expected schema query execution finishing");
                     schema_metrics.observe_finished();
@@ -729,13 +717,12 @@ impl TransactionService {
         &mut self,
         responder: TransactionResponder,
         query_options: QueryOptions,
-        pipeline: Arc<TypeQLPipeline>,
+        parsed: ParsedPipeline,
         given_rows: Option<GivenRowsHttp>,
-        source_query: String,
     ) -> ControlFlow<(), ()> {
         debug_assert!(self.running_write_query.is_none());
         self.interrupt(InterruptType::WriteQueryExecution).await;
-        match self.spawn_blocking_execute_write_query(query_options, pipeline, given_rows, source_query) {
+        match self.spawn_blocking_execute_write_query(query_options, parsed, given_rows) {
             Ok(handle) => {
                 // running write queries have no valid response yet (until they finish) and will respond asynchronously
                 self.running_write_query = Some((responder, tokio::spawn(async move { handle.await.unwrap() })));
@@ -806,34 +793,21 @@ impl TransactionService {
     fn spawn_blocking_execute_write_query(
         &mut self,
         query_options: QueryOptions,
-        pipeline: Arc<TypeQLPipeline>,
+        parsed: ParsedPipeline,
         given_rows: Option<GivenRowsHttp>,
-        source_query: String,
     ) -> Result<JoinHandle<(Transaction, WriteQueryResult)>, TransactionServiceError> {
         debug_assert!(self.running_write_query.is_none());
         debug_assert!(self.transaction.is_some());
         let interrupt = self.query_interrupt_receiver.clone();
         match self.transaction.take() {
             Some(Transaction::Schema(schema_transaction)) => Ok(spawn_blocking(move || {
-                let (transaction, result) = execute_write_query_in_schema(
-                    schema_transaction,
-                    query_options,
-                    pipeline,
-                    given_rows,
-                    source_query,
-                    interrupt,
-                );
+                let (transaction, result) =
+                    execute_write_query_in_schema(schema_transaction, query_options, parsed, given_rows, interrupt);
                 (Transaction::Schema(transaction), result)
             })),
             Some(Transaction::Write(write_transaction)) => Ok(spawn_blocking(move || {
-                let (transaction, result) = execute_write_query_in_write(
-                    write_transaction,
-                    query_options,
-                    pipeline,
-                    given_rows,
-                    source_query,
-                    interrupt,
-                );
+                let (transaction, result) =
+                    execute_write_query_in_write(write_transaction, query_options, parsed, given_rows, interrupt);
                 (Transaction::Write(transaction), result)
             })),
             Some(Transaction::Read(transaction)) => {
@@ -968,9 +942,8 @@ impl TransactionService {
         &self,
         responder: TransactionResponder,
         query_options: QueryOptions,
-        pipeline: Arc<TypeQLPipeline>,
+        parsed: ParsedPipeline,
         given_rows: Option<GivenRowsHttp>,
-        source_query: String,
         storage_counters: StorageCounters,
     ) -> JoinHandle<ControlFlow<(), ()>> {
         debug_assert!(self.query_queue.is_empty() && self.running_write_query.is_none() && self.transaction.is_some());
@@ -991,9 +964,8 @@ impl TransactionService {
                     &type_manager,
                     thing_manager.clone(),
                     function_manager.clone(),
-                    &pipeline,
+                    parsed,
                     given_rows,
-                    &source_query,
                 );
                 let pipeline = match pipeline_result {
                     Ok(pipeline) => pipeline,
@@ -1008,7 +980,6 @@ impl TransactionService {
                 Self::respond_read_query_sync(
                     query_options,
                     pipeline,
-                    &source_query,
                     timeout_at,
                     interrupt,
                     responder,
@@ -1025,7 +996,6 @@ impl TransactionService {
     fn respond_read_query_sync<Snapshot: ReadableSnapshot>(
         query_options: QueryOptions,
         pipeline: Pipeline<Snapshot, ReadPipelineStage<Snapshot>>,
-        source_query: &str,
         timeout_at: Instant,
         mut interrupt: ExecutionInterrupt,
         responder: TransactionResponder,
@@ -1035,21 +1005,21 @@ impl TransactionService {
         storage_counters: StorageCounters,
         read_metrics: &mut ReadQueryMetrics,
     ) -> ControlFlow<(), ()> {
-        let query_profile = if pipeline.has_fetch() {
-            let (iterator, context) = unwrap_or_execute_else_respond_error_and_return_break!(
+        let query_context = pipeline.query_context().clone();
+        if pipeline.has_fetch() {
+            let (iterator, _context) = unwrap_or_execute_else_respond_error_and_return_break!(
                 pipeline.into_documents_iterator(interrupt.clone()),
                 responder,
                 |(err, _)| {
                     TransactionServiceError::QueryFailed {
                         typedb_source: Box::new(QueryError::ReadPipelineExecution {
-                            source_query: source_query.to_string(),
+                            source_query: query_context.source_query.as_ref().to_owned(),
                             typedb_source: err,
                         }),
                     }
                 }
             );
 
-            let parameters = context.parameters;
             let mut result = vec![];
             let mut warning = None;
             for next in iterator {
@@ -1073,7 +1043,7 @@ impl TransactionService {
                     snapshot.as_ref(),
                     type_manager,
                     &thing_manager,
-                    &parameters,
+                    &query_context.parameters,
                     storage_counters.clone(),
                 );
                 match encoded_document {
@@ -1093,7 +1063,6 @@ impl TransactionService {
                 responder,
                 TransactionServiceResponse::Query(QueryAnswer::ResDocuments((QueryType::Read, result, warning)))
             );
-            context.profile
         } else {
             let named_outputs = pipeline.rows_positions().unwrap();
             let descriptor: StreamQueryOutputDescriptor = named_outputs.clone().into_iter().sorted().collect();
@@ -1107,13 +1076,13 @@ impl TransactionService {
                         typedb_source: PipelineExecutionError::ConceptRead { typedb_source },
                     }
                 });
-            let (mut iterator, context) = unwrap_or_execute_else_respond_error_and_return_break!(
+            let (mut iterator, _context) = unwrap_or_execute_else_respond_error_and_return_break!(
                 pipeline.into_rows_iterator(interrupt.clone()),
                 responder,
                 |(err, _)| {
                     TransactionServiceError::QueryFailed {
                         typedb_source: Box::new(QueryError::ReadPipelineExecution {
-                            source_query: source_query.to_string(),
+                            source_query: query_context.source_query.as_ref().to_owned(),
                             typedb_source: err,
                         }),
                     }
@@ -1169,19 +1138,17 @@ impl TransactionService {
                     warning
                 )))
             );
-            context.profile
         };
-        if query_profile.is_enabled() {
-            event!(Level::INFO, "Read query done (including network request time).\n{}", query_profile);
+        if query_context.profile.is_enabled() {
+            event!(Level::INFO, "Read query done (including network request time).\n{}", query_context.profile);
         }
         Continue(())
     }
 
     async fn handle_analyse_query(&mut self, query: String, responder: TransactionResponder) -> ControlFlow<(), ()> {
-        // Step 1 (parse) needs no transaction, so this is safe even while a write holds it.
-        let pipeline = match self.query_manager.as_ref().expect("transaction is open").parse(&query) {
-            Ok(ParsedQuery::Pipeline(pipeline)) => pipeline,
-            Ok(ParsedQuery::Schema(_)) => {
+        let parsed = match self.query_manager.as_ref().expect("transaction is open").parse(query) {
+            Ok(ParsedQuery::Pipeline(parsed)) => parsed,
+            Ok(ParsedQuery::Schema(..)) => {
                 respond_error_and_return_break!(responder, TransactionServiceError::AnalyseQueryExpectsPipeline {});
             }
             Err(typedb_source) => {
@@ -1194,18 +1161,17 @@ impl TransactionService {
         };
         if !self.query_queue.is_empty() || self.running_write_query.is_some() {
             // queued queries are not handled yet so there will be no query response yet
-            self.query_queue.push_back((responder, QueueOptions::Analyze, pipeline, None, query));
+            self.query_queue.push_back((responder, QueueOptions::Analyze, parsed, None));
             Continue(())
         } else {
-            self.run_analyse_query(responder, pipeline, query).await
+            self.run_analyse_query(responder, parsed).await
         }
     }
 
     async fn run_analyse_query(
         &mut self,
         responder: TransactionResponder,
-        pipeline: Arc<TypeQLPipeline>,
-        source_query: String,
+        parsed: ParsedPipeline,
     ) -> ControlFlow<(), ()> {
         debug_assert!(self.query_queue.is_empty() && self.running_write_query.is_none() && self.transaction.is_some());
         with_readable_transaction!(self.transaction.as_ref().unwrap(), |transaction| {
@@ -1215,14 +1181,9 @@ impl TransactionService {
             let function_manager = transaction.function_manager.clone();
             let query_manager = transaction.query_manager.clone();
             spawn_blocking(move || {
-                let analyse_result = query_manager.analyse(
-                    snapshot.clone(),
-                    &type_manager,
-                    &function_manager,
-                    &thing_manager,
-                    &pipeline,
-                    &source_query,
-                );
+                let source_query = parsed.source_query();
+                let analyse_result =
+                    query_manager.analyse(snapshot.clone(), &type_manager, &function_manager, &thing_manager, parsed);
                 let analysed = unwrap_or_execute_else_respond_error_and_return_break!(
                     analyse_result,
                     responder,
@@ -1233,7 +1194,10 @@ impl TransactionService {
                     responder,
                     |typedb_source| {
                         TransactionServiceError::AnalyseQueryFailed {
-                            typedb_source: QueryError::QueryAnalysisFailed { source_query, typedb_source },
+                            typedb_source: QueryError::QueryAnalysisFailed {
+                                source_query: (*source_query).clone(),
+                                typedb_source,
+                            },
                         }
                     }
                 );

--- a/server/service/transaction_service.rs
+++ b/server/service/transaction_service.rs
@@ -101,7 +101,6 @@ typedb_error! {
         TransactionFailed(4, "Transaction failed.", typedb_source: TransactionError),
         DataCommitFailed(5, "Data transaction commit failed.", typedb_source: ArcServerStateError),
         SchemaCommitFailed(6, "Schema transaction commit failed.", typedb_source: ArcServerStateError),
-        QueryParseFailed(7, "Query parsing failed.", typedb_source: typeql::Error),
         SchemaQueryRequiresSchemaTransaction(8, "Schema modification queries require schema transactions."),
         WriteQueryRequiresSchemaOrWriteTransaction(9, "Data modification queries require either write or schema transactions."),
         SchemaQueryFailedAbortingTransaction(10, "Aborting transaction due to failed schema query.", typedb_source: Box<QueryError>),
@@ -134,7 +133,6 @@ impl TransactionServiceError {
             | TransactionServiceError::CannotCommitReadTransaction { .. }
             | TransactionServiceError::CannotRollbackReadTransaction { .. }
             | TransactionServiceError::TransactionFailed { .. }
-            | TransactionServiceError::QueryParseFailed { .. }
             | TransactionServiceError::SchemaQueryRequiresSchemaTransaction { .. }
             | TransactionServiceError::WriteQueryRequiresSchemaOrWriteTransaction { .. }
             | TransactionServiceError::SchemaQueryFailedAbortingTransaction { .. }

--- a/server/system_init.rs
+++ b/server/system_init.rs
@@ -9,10 +9,11 @@ use database::{
     Database,
     transaction::{CommitIntent, SchemaCommitIntent},
 };
+use query::query_manager::ParsedSchemaQuery;
 use resource::{
     constants::server::{DEFAULT_USER_NAME, DEFAULT_USER_PASSWORD},
     internal_database_prefix,
-    profile::TransactionProfile,
+    profile::{QueryProfile, TransactionProfile},
 };
 use storage::durability_client::WALClient;
 use system::{
@@ -86,7 +87,8 @@ pub fn get_system_database_schema_commit_intent(
                 })
                 .into_structure()
                 .into_schema();
-            query_mgr.execute_schema(snapshot, type_mgr, thing_mgr, fn_mgr, &query, SCHEMA).unwrap_or_else(|error| {
+            let parsed = ParsedSchemaQuery::new(query, Arc::new(SCHEMA.to_owned()), QueryProfile::new(false));
+            query_mgr.execute_schema(snapshot, type_mgr, thing_mgr, fn_mgr, parsed).unwrap_or_else(|error| {
                 panic!("Unexpected error occurred when defining the schema for the {SYSTEM_DB} database: {error:?}")
             });
         });

--- a/system/util.rs
+++ b/system/util.rs
@@ -131,7 +131,12 @@ pub mod query_util {
         pipeline::stage::{ExecutionContext, StageIterator},
     };
     use function::function_manager::FunctionManager;
-    use query::{error::QueryError, given_rows::GivenRowsSimple, query_manager::QueryManager};
+    use query::{
+        error::QueryError,
+        given_rows::GivenRowsSimple,
+        query_manager::{ParsedPipeline, QueryManager},
+    };
+    use resource::profile::QueryProfile;
     use storage::{durability_client::WALClient, snapshot::WriteSnapshot};
     use typeql::query::Pipeline;
 
@@ -142,22 +147,23 @@ pub mod query_util {
         pipeline: Pipeline,
         source_query: &str,
     ) -> (TransactionRead<WALClient>, Result<Vec<HashMap<String, VariableValue<'static>>>, Box<QueryError>>) {
-        let prepared_pipeline = match tx.query_manager.prepare_read_pipeline(
+        let parsed =
+            ParsedPipeline::new(Arc::new(pipeline), Arc::new(source_query.to_owned()), QueryProfile::new(false));
+        let executable_pipeline = match tx.query_manager.prepare_read_pipeline(
             tx.snapshot.clone(),
             &tx.type_manager,
             tx.thing_manager.clone(),
             tx.function_manager.clone(),
-            &pipeline,
+            parsed,
             None::<GivenRowsSimple>,
-            source_query,
         ) {
-            Ok(pipeline) => pipeline,
+            Ok(executable_pipeline) => executable_pipeline,
             Err(err) => return (tx, Err(err)),
         };
 
-        let named_outputs = prepared_pipeline.rows_positions().unwrap().clone();
+        let named_outputs = executable_pipeline.rows_positions().unwrap().clone();
 
-        let result_as_batch = match prepared_pipeline.into_rows_iterator(ExecutionInterrupt::new_uninterruptible()) {
+        let result_as_batch = match executable_pipeline.into_rows_iterator(ExecutionInterrupt::new_uninterruptible()) {
             Ok((iterator, _)) => iterator.collect_owned(),
             Err((typedb_source, _)) => {
                 return (
@@ -191,23 +197,24 @@ pub mod query_util {
         pipeline: Pipeline,
         source_query: &str,
     ) -> (Result<Vec<HashMap<String, VariableValue<'static>>>, Box<QueryError>>, Arc<WriteSnapshot<WALClient>>) {
-        let prepared_pipeline = match query_manager.prepare_write_pipeline(
+        let parsed =
+            ParsedPipeline::new(Arc::new(pipeline), Arc::new(source_query.to_owned()), QueryProfile::new(false));
+        let executable_pipeline = match query_manager.prepare_write_pipeline(
             snapshot,
             type_manager,
             thing_manager,
             function_manager,
-            &pipeline,
+            parsed,
             None::<GivenRowsSimple>,
-            source_query,
         ) {
-            Ok(pipeline) => pipeline,
+            Ok(executable_pipeline) => executable_pipeline,
             Err((snapshot, err)) => return (Err(err), Arc::new(snapshot)),
         };
 
-        let named_outputs = prepared_pipeline.rows_positions().unwrap().clone();
+        let named_outputs = executable_pipeline.rows_positions().unwrap().clone();
 
         let (result_as_batch, snapshot) =
-            match prepared_pipeline.into_rows_iterator(ExecutionInterrupt::new_uninterruptible()) {
+            match executable_pipeline.into_rows_iterator(ExecutionInterrupt::new_uninterruptible()) {
                 Ok((iterator, ExecutionContext { snapshot, .. })) => (iterator.collect_owned(), snapshot),
                 Err((typedb_source, ExecutionContext { snapshot, .. })) => {
                     return (

--- a/tests/behaviour/steps/connection/mod.rs
+++ b/tests/behaviour/steps/connection/mod.rs
@@ -4,15 +4,9 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-use std::{
-    error::Error,
-    fmt,
-    path::PathBuf,
-    sync::{Arc, Mutex},
-};
+use std::{error::Error, fmt};
 
 use macro_rules_attribute::apply;
-use tokio::sync::OnceCell;
 
 use crate::{Context, generic_step};
 

--- a/tests/behaviour/steps/connection/transaction.rs
+++ b/tests/behaviour/steps/connection/transaction.rs
@@ -201,6 +201,11 @@ fn execute_schema_transaction(
     let mut transaction = TransactionSchema::open(reimport, TransactionOptions::default())
         .map_err(|err| Box::new(err) as Box<dyn TypeDBError>)?;
     let schema_define = format!("define\n{}", types_syntax);
+    let parsed = transaction
+        .query_manager
+        .parse(schema_define.clone())
+        .map_err(|err| err as Box<dyn TypeDBError>)?
+        .into_schema();
     transaction
         .query_manager
         .execute_schema(
@@ -208,13 +213,9 @@ fn execute_schema_transaction(
             &transaction.type_manager,
             &transaction.thing_manager,
             &transaction.function_manager,
-            &typeql::parse_query(&schema_define)
-                .map_err(|err| Box::new(err) as Box<dyn TypeDBError>)?
-                .into_structure()
-                .into_schema(),
-            &schema_define,
+            parsed,
         )
-        .map_err(|err| Box::new(err) as Box<dyn TypeDBError>)?;
+        .map_err(|err| err as Box<dyn TypeDBError>)?;
     let (mut profile, result) = transaction.finalise();
     result
         .and_then(|intent| intent.commit(profile.commit_profile()))

--- a/tests/behaviour/steps/query/typeql.rs
+++ b/tests/behaviour/steps/query/typeql.rs
@@ -15,16 +15,13 @@ use concept::{
 };
 use cucumber::gherkin::Step;
 use encoding::{
-    Prefixed,
     graph::{
         thing::{
-            ThingVertex,
             vertex_attribute::{AttributeID, AttributeVertex},
             vertex_object::{ObjectID, ObjectVertex},
         },
         type_::vertex::TypeID,
     },
-    layout::prefix::Prefix,
     value::{ValueEncodable, label::Label, value_type::ValueType},
 };
 use executor::{
@@ -32,7 +29,6 @@ use executor::{
     batch::Batch,
     pipeline::stage::{ExecutionContext, StageIterator},
 };
-use futures::StreamExt;
 use itertools::{Either, Itertools};
 use lending_iterator::LendingIterator;
 use macro_rules_attribute::apply;
@@ -88,24 +84,24 @@ fn row_answers_to_string(rows: &[HashMap<String, VariableValue<'static>>]) -> St
 
 fn execute_read_query(
     context: &Context,
-    query: typeql::Query,
+    _query: typeql::Query,
     given_rows: Option<GivenRowsSimple>,
     source_query: &str,
 ) -> Result<QueryAnswer, Box<QueryError>> {
     with_read_tx!(context, |tx| {
-        let parsed_pipeline = query.into_structure().into_pipeline();
+        let parsed = tx.query_manager.parse(source_query.to_string())?.into_pipeline();
         let pipeline = tx.query_manager.prepare_read_pipeline(
             tx.snapshot.clone(),
             &tx.type_manager,
             tx.thing_manager.clone(),
             tx.function_manager.clone(),
-            &parsed_pipeline,
+            parsed,
             given_rows,
-            source_query,
         )?;
         if pipeline.has_fetch() {
+            let parameters = pipeline.query_context().parameters.clone();
             match pipeline.into_documents_iterator(ExecutionInterrupt::new_uninterruptible()) {
-                Ok((iterator, ExecutionContext { parameters, .. })) => {
+                Ok((iterator, ExecutionContext { .. })) => {
                     let documents = iterator.try_collect().map_err(|err| QueryError::ReadPipelineExecution {
                         source_query: source_query.to_string(),
                         typedb_source: err,
@@ -141,7 +137,7 @@ fn execute_read_query(
 
 fn execute_write_query(
     context: &mut Context,
-    query: typeql::Query,
+    _query: typeql::Query,
     given_rows: Option<GivenRowsSimple>,
     source_query: &str,
 ) -> Result<QueryAnswer, BehaviourTestExecutionError> {
@@ -156,68 +152,78 @@ fn execute_write_query(
                                            query_manager,
                                            _db,
                                            _opts| {
-        let parsed_pipeline = query.into_structure().into_pipeline();
-        let pipeline_result = query_manager.prepare_write_pipeline(
-            Arc::try_unwrap(snapshot).unwrap_or_else(|_| panic!("Expected unique ownership of snapshot")),
-            &type_manager,
-            thing_manager.clone(),
-            function_manager.clone(),
-            &parsed_pipeline,
-            given_rows,
-            source_query,
-        );
+        match query_manager.parse(source_query.to_string()) {
+            Err(error) => (Err(BehaviourTestExecutionError::Query(*error)), snapshot),
+            Ok(parsed) => {
+                let parsed_pipeline = parsed.into_pipeline();
+                let pipeline_result = query_manager.prepare_write_pipeline(
+                    Arc::try_unwrap(snapshot).unwrap_or_else(|_| panic!("Expected unique ownership of snapshot")),
+                    &type_manager,
+                    thing_manager.clone(),
+                    function_manager.clone(),
+                    parsed_pipeline,
+                    given_rows,
+                );
 
-        match pipeline_result {
-            Err((snapshot, error)) => (Err(BehaviourTestExecutionError::Query(*error)), Arc::new(snapshot)),
-            Ok(pipeline) => {
-                if pipeline.has_fetch() {
-                    match pipeline.into_documents_iterator(ExecutionInterrupt::new_uninterruptible()) {
-                        Ok((iterator, ExecutionContext { parameters, snapshot, .. })) => (
-                            match iterator.collect() {
-                                Ok(documents) => Ok(QueryAnswer::ConceptDocuments(documents, parameters)),
-                                Err(err) => {
+                match pipeline_result {
+                    Err((snapshot, error)) => (Err(BehaviourTestExecutionError::Query(*error)), Arc::new(snapshot)),
+                    Ok(pipeline) => {
+                        if pipeline.has_fetch() {
+                            let parameters = pipeline.query_context().parameters.clone();
+                            match pipeline.into_documents_iterator(ExecutionInterrupt::new_uninterruptible()) {
+                                Ok((iterator, ExecutionContext { snapshot, .. })) => (
+                                    match iterator.collect() {
+                                        Ok(documents) => Ok(QueryAnswer::ConceptDocuments(documents, parameters)),
+                                        Err(err) => Err(BehaviourTestExecutionError::Query(
+                                            QueryError::WritePipelineExecution {
+                                                source_query: source_query.to_string(),
+                                                typedb_source: err,
+                                            },
+                                        )),
+                                    },
+                                    snapshot,
+                                ),
+                                Err((err, ExecutionContext { snapshot, .. })) => (
                                     Err(BehaviourTestExecutionError::Query(QueryError::WritePipelineExecution {
                                         source_query: source_query.to_string(),
                                         typedb_source: err,
-                                    }))
-                                }
-                            },
-                            snapshot,
-                        ),
-                        Err((err, ExecutionContext { snapshot, .. })) => (
-                            Err(BehaviourTestExecutionError::Query(QueryError::WritePipelineExecution {
-                                source_query: source_query.to_string(),
-                                typedb_source: err,
-                            })),
-                            snapshot,
-                        ),
-                    }
-                } else {
-                    let named_outputs = pipeline.rows_positions().expect("Expected unfetched result").clone();
-                    match pipeline.into_rows_iterator(ExecutionInterrupt::new_uninterruptible()) {
-                        Ok((iterator, ExecutionContext { snapshot, .. })) => {
-                            let result_as_batch = iterator.collect_owned();
-                            match result_as_batch {
-                                Ok(batch) => (
-                                    Ok(QueryAnswer::ConceptRows(row_batch_result_to_answer(batch, named_outputs))),
+                                    })),
                                     snapshot,
                                 ),
-                                Err(typedb_source) => (
-                                    Err(BehaviourTestExecutionError::Query(QueryError::WritePipelineExecution {
+                            }
+                        } else {
+                            let named_outputs = pipeline.rows_positions().expect("Expected unfetched result").clone();
+                            match pipeline.into_rows_iterator(ExecutionInterrupt::new_uninterruptible()) {
+                                Ok((iterator, ExecutionContext { snapshot, .. })) => {
+                                    let result_as_batch = iterator.collect_owned();
+                                    match result_as_batch {
+                                        Ok(batch) => (
+                                            Ok(QueryAnswer::ConceptRows(row_batch_result_to_answer(
+                                                batch,
+                                                named_outputs,
+                                            ))),
+                                            snapshot,
+                                        ),
+                                        Err(typedb_source) => (
+                                            Err(BehaviourTestExecutionError::Query(
+                                                QueryError::WritePipelineExecution {
+                                                    source_query: source_query.to_string(),
+                                                    typedb_source,
+                                                },
+                                            )),
+                                            snapshot,
+                                        ),
+                                    }
+                                }
+                                Err((err, ExecutionContext { snapshot, .. })) => (
+                                    Err(BehaviourTestExecutionError::Query(QueryError::ReadPipelineExecution {
                                         source_query: source_query.to_string(),
-                                        typedb_source,
+                                        typedb_source: err,
                                     })),
                                     snapshot,
                                 ),
                             }
                         }
-                        Err((err, ExecutionContext { snapshot, .. })) => (
-                            Err(BehaviourTestExecutionError::Query(QueryError::ReadPipelineExecution {
-                                source_query: source_query.to_string(),
-                                typedb_source: err,
-                            })),
-                            snapshot,
-                        ),
                     }
                 }
             }
@@ -227,20 +233,17 @@ fn execute_write_query(
 
 fn execute_analyze(
     context: &mut Context,
-    query: typeql::Query,
+    _query: typeql::Query,
     source_query: &str,
 ) -> Result<AnalysedQuery, BehaviourTestExecutionError> {
     with_read_tx!(context, |tx| {
-        let parsed_pipeline = query.into_structure().into_pipeline();
+        let parsed = tx
+            .query_manager
+            .parse(source_query.to_string())
+            .map_err(|source| BehaviourTestExecutionError::Query(*source))?
+            .into_pipeline();
         tx.query_manager
-            .analyse(
-                tx.snapshot.clone(),
-                &tx.type_manager,
-                &tx.function_manager,
-                &tx.thing_manager,
-                &parsed_pipeline,
-                source_query,
-            )
+            .analyse(tx.snapshot.clone(), &tx.type_manager, &tx.function_manager, &tx.thing_manager, parsed)
             .map_err(|source| BehaviourTestExecutionError::Query(*source))
     })
 }
@@ -270,7 +273,6 @@ async fn typeql_schema_query(context: &mut Context, may_error: params::TypeQLMay
     if let Either::Right(_) = may_error.check_parsing(parse_result.as_ref()) {
         return;
     }
-    let typeql_schema = parse_result.unwrap().into_structure().into_schema();
 
     if !matches!(context.transaction().expect("Expected an active transaction"), Schema(_)) {
         may_error.check_logic::<(), BehaviourTestExecutionError>(Err(
@@ -280,13 +282,13 @@ async fn typeql_schema_query(context: &mut Context, may_error: params::TypeQLMay
     }
 
     with_schema_tx!(context, |tx| {
+        let parsed = tx.query_manager.parse(query.to_string()).unwrap().into_schema();
         let result = tx.query_manager.execute_schema(
             Arc::get_mut(&mut tx.snapshot).unwrap(),
             &tx.type_manager,
             &tx.thing_manager,
             &tx.function_manager,
-            &typeql_schema,
-            query,
+            parsed,
         );
         if let Either::Right(_err) = may_error.check_logic(result) {
             context.close_active_transaction();

--- a/tests/benchmarks/concurrent_ops/BUILD
+++ b/tests/benchmarks/concurrent_ops/BUILD
@@ -14,6 +14,7 @@ rust_test(
         "//diagnostics",
         "//executor",
         "//query",
+        "//resource",
         "//storage",
 
         "//util/test:test_utils",

--- a/tests/benchmarks/concurrent_ops/bench_concurrency.rs
+++ b/tests/benchmarks/concurrent_ops/bench_concurrency.rs
@@ -26,8 +26,12 @@ use database::{
 use diagnostics::diagnostics_manager::DiagnosticsManager;
 use executor::{ExecutionInterrupt, pipeline::stage::StageIterator};
 use options::{QueryOptions, TransactionOptions, byte_size::ByteSize};
-use query::given_rows::GivenRowsSimple;
+use query::{
+    given_rows::GivenRowsSimple,
+    query_manager::{ParsedPipeline, ParsedSchemaQuery},
+};
 use rand_core::RngCore;
+use resource::profile::QueryProfile;
 use storage::durability_client::WALClient;
 use test_utils::{TempDir, create_tmp_storage_dir};
 use xoshiro::Xoshiro256Plus;
@@ -153,7 +157,8 @@ fn create_database(schema: &str) -> (TempDir, Arc<Database<WALClient>>) {
 
     let schema_query = typeql::parse_query(schema).unwrap().into_structure().into_schema();
     let tx = TransactionSchema::open(database.clone(), TransactionOptions::default()).unwrap();
-    let (tx, result) = execute_schema_query(tx, schema_query, schema.to_string());
+    let parsed = ParsedSchemaQuery::new(schema_query, Arc::new(schema.to_string()), QueryProfile::new(false));
+    let (tx, result) = execute_schema_query(tx, parsed);
     result.unwrap();
     let (mut profile, intent) = tx.finalise();
     intent.unwrap().commit(profile.commit_profile()).unwrap();
@@ -175,9 +180,8 @@ fn seed_persons(database: &Arc<Database<WALClient>>, count: usize) {
             let (returned_tx, result) = execute_write_query_in_write(
                 tx,
                 QueryOptions::default_grpc(),
-                Arc::new(pipeline),
+                ParsedPipeline::new(Arc::new(pipeline), Arc::new(query_str), QueryProfile::new(false)),
                 None::<GivenRowsSimple>,
-                query_str,
                 ExecutionInterrupt::new_uninterruptible(),
             );
             result.unwrap();
@@ -210,9 +214,8 @@ fn execute_insert_batch(
         let (returned_tx, result) = execute_write_query_in_write(
             tx,
             QueryOptions::default_grpc(),
-            Arc::new(pipeline),
+            ParsedPipeline::new(Arc::new(pipeline), Arc::new(query_str), QueryProfile::new(false)),
             None::<GivenRowsSimple>,
-            query_str,
             ExecutionInterrupt::new_uninterruptible(),
         );
         result.unwrap();
@@ -247,9 +250,8 @@ fn execute_update_batch(
         let (returned_tx, result) = execute_write_query_in_write(
             tx,
             QueryOptions::default_grpc(),
-            Arc::new(pipeline),
+            ParsedPipeline::new(Arc::new(pipeline), Arc::new(query_str), QueryProfile::new(false)),
             None::<GivenRowsSimple>,
-            query_str,
             ExecutionInterrupt::new_uninterruptible(),
         );
         result.unwrap();
@@ -286,9 +288,8 @@ fn execute_relation_batch(
         let (returned_tx, result) = execute_write_query_in_write(
             tx,
             QueryOptions::default_grpc(),
-            Arc::new(pipeline),
+            ParsedPipeline::new(Arc::new(pipeline), Arc::new(query_str), QueryProfile::new(false)),
             None::<GivenRowsSimple>,
-            query_str,
             ExecutionInterrupt::new_uninterruptible(),
         );
         result.unwrap();
@@ -308,16 +309,15 @@ fn execute_relation_batch(
 fn execute_read_query(database: &Arc<Database<WALClient>>, query_str: &str) {
     let tx = TransactionRead::open(database.clone(), TransactionOptions::default()).unwrap();
     let TransactionRead { snapshot, query_manager, type_manager, thing_manager, function_manager, .. } = &tx;
-    let query = typeql::parse_query(query_str).unwrap().into_structure().into_pipeline();
+    let parsed = query_manager.parse(query_str.to_string()).unwrap().into_pipeline();
     let pipeline = query_manager
         .prepare_read_pipeline(
             snapshot.clone(),
             type_manager,
             thing_manager.clone(),
             function_manager.clone(),
-            &query,
+            parsed,
             None::<GivenRowsSimple>,
-            query_str,
         )
         .unwrap();
     let (rows, _context) = pipeline.into_rows_iterator(ExecutionInterrupt::new_uninterruptible()).unwrap();

--- a/tests/benchmarks/iam/bench_iam.rs
+++ b/tests/benchmarks/iam/bench_iam.rs
@@ -28,7 +28,6 @@ fn load_schema_tql(database: Arc<Database<WALClient>>, schema_tql: &Path) {
     let mut contents = Vec::new();
     File::open(schema_tql).unwrap().read_to_end(&mut contents).unwrap();
     let schema_str = String::from_utf8(contents).unwrap();
-    let schema_query = typeql::parse_query(schema_str.as_str()).unwrap().into_structure().into_schema();
 
     let tx = TransactionSchema::open(database.clone(), TransactionOptions::default()).unwrap();
     let TransactionSchema {
@@ -41,17 +40,11 @@ fn load_schema_tql(database: Arc<Database<WALClient>>, schema_tql: &Path) {
         transaction_options,
         profile,
     } = tx;
+    let parsed = query_manager.parse(schema_str).unwrap().into_schema();
     let mut inner_snapshot =
         Arc::try_unwrap(snapshot).unwrap_or_else(|_| panic!("Expected unique ownership of snapshot"));
     query_manager
-        .execute_schema(
-            &mut inner_snapshot,
-            &type_manager,
-            &thing_manager,
-            &function_manager,
-            &schema_query,
-            &schema_str,
-        )
+        .execute_schema(&mut inner_snapshot, &type_manager, &thing_manager, &function_manager, parsed)
         .unwrap();
     let tx = TransactionSchema::from_parts(
         Arc::new(inner_snapshot),
@@ -72,7 +65,6 @@ fn load_data_tql(database: Arc<Database<WALClient>>, data_tql: &Path) {
 
     File::open(data_tql).unwrap().read_to_end(&mut contents).unwrap();
     let data_str = String::from_utf8(contents).unwrap();
-    let data_query = typeql::parse_query(data_str.as_str()).unwrap().into_structure().into_pipeline();
     let tx = TransactionWrite::open(database.clone(), TransactionOptions::default()).unwrap();
     let TransactionWrite {
         snapshot,
@@ -84,16 +76,17 @@ fn load_data_tql(database: Arc<Database<WALClient>>, data_tql: &Path) {
         transaction_options,
         profile,
     } = tx;
+    let parsed = query_manager.parse(data_str).unwrap().into_pipeline();
     let write_pipeline = query_manager
         .prepare_write_pipeline(
             Arc::try_unwrap(snapshot).unwrap_or_else(|_| panic!("Expected unique ownership of snapshot")),
             &type_manager,
             thing_manager.clone(),
             function_manager.clone(),
-            &data_query,
+            parsed,
             None::<GivenRowsSimple>,
-            &data_str,
         )
+        .map_err(|(_, err)| err)
         .unwrap();
     let (_output, context) = write_pipeline.into_rows_iterator(ExecutionInterrupt::new_uninterruptible()).unwrap();
     let tx = TransactionWrite::from_parts(
@@ -145,16 +138,15 @@ fn setup() -> Arc<Database<WALClient>> {
 fn run_query(database: Arc<Database<WALClient>>, query_str: &str) -> Batch {
     let tx = TransactionRead::open(database.clone(), TransactionOptions::default()).unwrap();
     let TransactionRead { snapshot, query_manager, type_manager, thing_manager, function_manager, .. } = &tx;
-    let query = typeql::parse_query(query_str).unwrap().into_structure().into_pipeline();
+    let parsed = query_manager.parse(query_str.to_string()).unwrap().into_pipeline();
     let pipeline = query_manager
         .prepare_read_pipeline(
             snapshot.clone(),
             type_manager,
             thing_manager.clone(),
             function_manager.clone(),
-            &query,
+            parsed,
             None::<GivenRowsSimple>,
-            query_str,
         )
         .unwrap();
     let (rows, _context) = pipeline.into_rows_iterator(ExecutionInterrupt::new_uninterruptible()).unwrap();


### PR DESCRIPTION
Profiling data and per-query parameters were passed ad hoc through the translate and compile steps. Introduce a QueryContext that is owned through the whole query lifecycle and threaded into every parse/translate/compile call, giving one place to carry per-query state and unifying profiling (the QueryProfile is now shared as an Arc and borrowed through compilation). QueryManager owns the context across translate/compile and yields a CompiledPipeline.

This is a wide but mechanical change: every site that parsed, translated, or compiled a query now threads the context, so it reaches the gRPC/HTTP transaction services, executor/ir tests, benches, and behaviour steps. As part of the context-owned flow the cache values are Arc'ed and the compile-cache key is slimmed. Builds on the query front-end caches.

## Product change and motivation

Summarize new feature, bugs fixed, or internal change. Include: relevant examples and related issues. 

## Implementation

Include architectural decisions, new assumptions, unimplemented paths/technical debt and tests written.
