### PR TITLE
Validate conjunction can have valid plans in IR

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -190,7 +190,7 @@ bazel_dep(name = "typedb_behaviour", version = "0.0.0")
 git_override(
     module_name = "typedb_behaviour",
     remote = "https://github.com/krishnangovindraj/typedb-behaviour",
-    commit = "90ab3a0087a8fe6c2d06ddcbe6818461bfefa294",
+    commit = "684b89627af40df80c29fe14d00ed4a6c22017e6",
 )
 
 http_file = use_repo_rule("@bazel_tools//tools/build_defs/repo:http.bzl", "http_file")

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -190,7 +190,7 @@ bazel_dep(name = "typedb_behaviour", version = "0.0.0")
 git_override(
     module_name = "typedb_behaviour",
     remote = "https://github.com/krishnangovindraj/typedb-behaviour",
-    commit = "9eed41317a96045d4c8b5ce3c8a3b60bcb76c95c",
+    commit = "6fddbea2c65bede919655cc6ad2a154148bbb85c",
 )
 
 http_file = use_repo_rule("@bazel_tools//tools/build_defs/repo:http.bzl", "http_file")

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -189,8 +189,8 @@ git_override(
 bazel_dep(name = "typedb_behaviour", version = "0.0.0")
 git_override(
     module_name = "typedb_behaviour",
-    remote = "https://github.com/typedb/typedb-behaviour",
-    commit = "60841abfb8e4239b48a43789fcde7159c50bfaa6",
+    remote = "https://github.com/krishnangovindraj/typedb-behaviour",
+    commit = "90ab3a0087a8fe6c2d06ddcbe6818461bfefa294",
 )
 
 http_file = use_repo_rule("@bazel_tools//tools/build_defs/repo:http.bzl", "http_file")

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -189,8 +189,8 @@ git_override(
 bazel_dep(name = "typedb_behaviour", version = "0.0.0")
 git_override(
     module_name = "typedb_behaviour",
-    remote = "https://github.com/krishnangovindraj/typedb-behaviour",
-    commit = "6fddbea2c65bede919655cc6ad2a154148bbb85c",
+    remote = "https://github.com/typedb/typedb-behaviour",
+    commit = "ac5d5733a484cea1d8809a2968029a818fdae24f",
 )
 
 http_file = use_repo_rule("@bazel_tools//tools/build_defs/repo:http.bzl", "http_file")

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -190,7 +190,7 @@ bazel_dep(name = "typedb_behaviour", version = "0.0.0")
 git_override(
     module_name = "typedb_behaviour",
     remote = "https://github.com/krishnangovindraj/typedb-behaviour",
-    commit = "684b89627af40df80c29fe14d00ed4a6c22017e6",
+    commit = "9eed41317a96045d4c8b5ce3c8a3b60bcb76c95c",
 )
 
 http_file = use_repo_rule("@bazel_tools//tools/build_defs/repo:http.bzl", "http_file")

--- a/compiler/annotation/type_inference.rs
+++ b/compiler/annotation/type_inference.rs
@@ -626,7 +626,7 @@ pub mod tests {
         conjunction.constraints_mut().add_isa(IsaKind::Subtype, var_name, var_name_type.into(), None).unwrap();
         conjunction.constraints_mut().add_has(var_animal, var_name, None).unwrap();
 
-        let mut disj = conjunction.add_disjunction();
+        let mut disj = conjunction.add_disjunction(None);
 
         let mut branch1 = disj.add_conjunction();
         let b1_var_animal_type = branch1.constraints_mut().get_or_declare_variable("b1_animal_type", None).unwrap();

--- a/ir/lib.rs
+++ b/ir/lib.rs
@@ -315,9 +315,9 @@ typedb_error! {
         ),
         UnplannableConjunction(
             55,
-            "An unplannable conjunction was detected. Planning could not satisfy the input variables for the constraints:\n{unplannable_constraints}",
+            "The conjunction cannot have a valid plan. The required input variables for the following constraints could not be satisfied:\n{unplannable_constraints}",
             unplannable_constraints: UnplannableConstraints,
-            // TODO: Add span of conjunction?
+            span: Option<Span>, // of the conjunction
         ),
         InternalNotAValueBuiltin(
             100,

--- a/ir/lib.rs
+++ b/ir/lib.rs
@@ -18,6 +18,7 @@ use crate::{
     pipeline::{FunctionReadError, FunctionRepresentationError},
     translation::fetch::FetchRepresentationError,
 };
+use crate::pipeline::block::UnplannableConstraints;
 
 pub mod pattern;
 pub mod pipeline;
@@ -312,6 +313,12 @@ typedb_error! {
             54,
             "Given clauses must be the first clause in a query pipeline.",
             source_span: Option<Span>,
+        ),
+        UnplannableConjunction(
+            55,
+            "An unplannable conjunction was detected. Planning could not satisfy the input variables for the constraints:\n{remaining_constraints}",
+            remaining_constraints: UnplannableConstraints,
+            // TODO: Add span of conjunction?
         ),
         InternalNotAValueBuiltin(
             100,

--- a/ir/lib.rs
+++ b/ir/lib.rs
@@ -15,10 +15,9 @@ use typeql::{common::Span, statement::InIterable, token, value::StringLiteral};
 
 use crate::{
     pattern::{expression::ExpressionRepresentationError, variable_category::VariableCategory},
-    pipeline::{FunctionReadError, FunctionRepresentationError},
+    pipeline::{FunctionReadError, FunctionRepresentationError, block::UnplannableConstraints},
     translation::fetch::FetchRepresentationError,
 };
-use crate::pipeline::block::UnplannableConstraints;
 
 pub mod pattern;
 pub mod pipeline;
@@ -316,8 +315,8 @@ typedb_error! {
         ),
         UnplannableConjunction(
             55,
-            "An unplannable conjunction was detected. Planning could not satisfy the input variables for the constraints:\n{remaining_constraints}",
-            remaining_constraints: UnplannableConstraints,
+            "An unplannable conjunction was detected. Planning could not satisfy the input variables for the constraints:\n{unplannable_constraints}",
+            unplannable_constraints: UnplannableConstraints,
             // TODO: Add span of conjunction?
         ),
         InternalNotAValueBuiltin(

--- a/ir/lib.rs
+++ b/ir/lib.rs
@@ -317,7 +317,7 @@ typedb_error! {
             55,
             "The conjunction cannot have a valid plan. The required input variables for the following constraints could not be satisfied:\n{unplannable_constraints}",
             unplannable_constraints: UnplannableConstraints,
-            span: Option<Span>, // of the conjunction
+            span: Option<Span>,
         ),
         InternalNotAValueBuiltin(
             100,

--- a/ir/lib.rs
+++ b/ir/lib.rs
@@ -258,7 +258,7 @@ typedb_error! {
         ),
         UnboundRequiredVariable(
             44,
-            "The variable '{variable}' is required to be bound to a value before it's used.",
+            "The variable '{variable}' must be bound to a value before it's used.",
             variable: String,
             source_span: Option<Span>,
             _all_spans: Vec<Span>,
@@ -315,7 +315,7 @@ typedb_error! {
         ),
         UnplannableConjunction(
             55,
-            "The conjunction cannot have a valid plan. The required input variables for the following constraints could not be satisfied:\n{unplannable_constraints}",
+            "The required input variables for the following constraints could not be satisfied (there may be a circular dependency):\n{unplannable_constraints}",
             unplannable_constraints: UnplannableConstraints,
             span: Option<Span>,
         ),

--- a/ir/pattern/conjunction.rs
+++ b/ir/pattern/conjunction.rs
@@ -213,20 +213,20 @@ impl<'ctx, 'reg> ConjunctionBuilderWithContext<'ctx, 'reg> {
         ConstraintsBuilder::new(self.context, &mut self.conjunction.constraints)
     }
 
-    pub fn add_disjunction(&mut self) -> DisjunctionBuilderWithContext<'_, 'reg> {
+    pub fn add_disjunction(&mut self, source_span: Option<Span>) -> DisjunctionBuilderWithContext<'_, 'reg> {
         let nested_scope_id = self.context.next_scope_id();
         self.conjunction
             .nested_patterns
-            .push(NestedPatternBuilder::Disjunction(DisjunctionBuilder::new(nested_scope_id)));
+            .push(NestedPatternBuilder::Disjunction(DisjunctionBuilder::new(nested_scope_id, source_span)));
         let NestedPatternBuilder::Disjunction(builder) = self.conjunction.nested_patterns.last_mut().unwrap() else {
             unreachable!();
         };
         DisjunctionBuilderWithContext::new(self.context, builder)
     }
 
-    pub fn add_negation(&mut self) -> ConjunctionBuilderWithContext<'_, 'reg> {
+    pub fn add_negation(&mut self, source_span: Option<Span>) -> ConjunctionBuilderWithContext<'_, 'reg> {
         let nested_scope_id = self.context.next_scope_id();
-        let negation = NegationBuilder::new(nested_scope_id);
+        let negation = NegationBuilder::new(nested_scope_id, source_span);
         self.conjunction.nested_patterns.push(NestedPatternBuilder::Negation(negation));
         let Some(NestedPatternBuilder::Negation(builder)) = self.conjunction.nested_patterns.last_mut() else {
             unreachable!()
@@ -239,8 +239,7 @@ impl<'ctx, 'reg> ConjunctionBuilderWithContext<'ctx, 'reg> {
         source_span: Option<Span>,
     ) -> Result<ConjunctionBuilderWithContext<'_, 'reg>, RepresentationError> {
         let nested_scope_id = self.context.next_scope_id();
-        let conjunction = ConjunctionBuilder::new(nested_scope_id);
-        let optional = OptionalBuilder::new(nested_scope_id, self.context.next_branch_id());
+        let optional = OptionalBuilder::new(nested_scope_id, self.context.next_branch_id(), source_span);
         self.conjunction.nested_patterns.push(NestedPatternBuilder::Optional(optional));
         let Some(NestedPatternBuilder::Optional(optional)) = self.conjunction.nested_patterns.last_mut() else {
             unreachable!()

--- a/ir/pattern/disjunction.rs
+++ b/ir/pattern/disjunction.rs
@@ -9,6 +9,7 @@ use std::{collections::HashMap, fmt};
 use answer::variable::Variable;
 use itertools::Itertools;
 use structural_equality::StructuralEquality;
+use typeql::common::Span;
 
 use crate::{
     pattern::{
@@ -26,6 +27,7 @@ pub struct Disjunction {
     branch_ids: Vec<BranchID>,
     scope_id: ScopeId,
     pattern_variables: PatternVariables,
+    source_span: Option<Span>,
 }
 
 impl Disjunction {
@@ -39,6 +41,10 @@ impl Disjunction {
 
     pub fn conjunctions_mut(&mut self) -> &mut [Conjunction] {
         &mut self.conjunctions
+    }
+
+    pub(crate) fn source_span(&self) -> Option<Span> {
+        self.source_span
     }
 
     pub fn optimise_away_unsatisfiable_branches(&mut self, unsatisfiable: Vec<ScopeId>) {
@@ -80,26 +86,23 @@ impl fmt::Display for Disjunction {
 pub struct DisjunctionBuilder {
     conjunctions: Vec<(BranchID, ConjunctionBuilder)>,
     scope_id: ScopeId,
+    source_span: Option<Span>,
 }
 
 impl DisjunctionBuilder {
-    pub fn new(scope_id: ScopeId) -> Self {
-        Self { scope_id, conjunctions: Vec::new() }
+    pub fn new(scope_id: ScopeId, source_span: Option<Span>) -> Self {
+        Self { scope_id, conjunctions: Vec::new(), source_span }
     }
 
     pub(crate) fn finish(self, parent_modes: &ContextualisedBindingMode) -> NestedPattern {
+        let source_span = self.source_span;
         let binding_modes = ContextualisedBindingMode::from(self.variable_binding_modes(), parent_modes);
         let scope_id = self.scope_id;
         let branch_ids = self.conjunctions.iter().map(|(bid, _)| *bid).collect();
         let conjunctions =
             self.conjunctions.into_iter().map(|(_, conjunction)| conjunction.finish(&binding_modes)).collect();
-        let variable_requirements = PatternVariables::from(&binding_modes);
-        NestedPattern::Disjunction(Disjunction {
-            scope_id,
-            branch_ids,
-            conjunctions,
-            pattern_variables: variable_requirements,
-        })
+        let pattern_variables = PatternVariables::from(&binding_modes);
+        NestedPattern::Disjunction(Disjunction { scope_id, branch_ids, conjunctions, pattern_variables, source_span })
     }
 
     pub(crate) fn conjunctions(&self) -> impl Iterator<Item = &ConjunctionBuilder> {

--- a/ir/pattern/negation.rs
+++ b/ir/pattern/negation.rs
@@ -8,6 +8,7 @@ use std::{collections::HashMap, fmt};
 
 use answer::variable::Variable;
 use structural_equality::StructuralEquality;
+use typeql::common::Span;
 
 use crate::pattern::{
     BindingMode, ContextualisedBindingMode, Pattern, PatternVariables, Scope, ScopeId,
@@ -20,6 +21,7 @@ use crate::pattern::{
 pub struct Negation {
     conjunction: Conjunction,
     pattern_variables: PatternVariables,
+    source_span: Option<Span>,
 }
 
 impl Negation {
@@ -29,6 +31,10 @@ impl Negation {
 
     pub fn conjunction_mut(&mut self) -> &mut Conjunction {
         &mut self.conjunction
+    }
+
+    pub(crate) fn source_span(&self) -> Option<Span> {
+        self.source_span
     }
 }
 
@@ -59,18 +65,20 @@ impl fmt::Display for Negation {
 #[derive(Debug)]
 pub(crate) struct NegationBuilder {
     conjunction: ConjunctionBuilder,
+    source_span: Option<Span>,
 }
 
 impl NegationBuilder {
-    pub(crate) fn new(scope_id: ScopeId) -> Self {
-        Self { conjunction: ConjunctionBuilder::new(scope_id) }
+    pub(crate) fn new(scope_id: ScopeId, source_span: Option<Span>) -> Self {
+        Self { conjunction: ConjunctionBuilder::new(scope_id), source_span }
     }
 
     pub(crate) fn finish(self, parent_modes: &ContextualisedBindingMode) -> NestedPattern {
+        let source_span = self.source_span;
         let binding_modes = ContextualisedBindingMode::from(self.variable_binding_modes(), parent_modes);
         let conjunction = self.conjunction.finish(&binding_modes);
-        let variable_requirements = PatternVariables::from(&binding_modes);
-        NestedPattern::Negation(Negation { conjunction, pattern_variables: variable_requirements })
+        let pattern_variables = PatternVariables::from(&binding_modes);
+        NestedPattern::Negation(Negation { conjunction, pattern_variables, source_span })
     }
 
     pub(crate) fn conjunction(&self) -> &ConjunctionBuilder {

--- a/ir/pattern/nested_pattern.rs
+++ b/ir/pattern/nested_pattern.rs
@@ -7,6 +7,7 @@
 use std::{fmt, mem};
 
 use structural_equality::StructuralEquality;
+use typeql::common::Span;
 
 use crate::pattern::{disjunction::Disjunction, negation::Negation, optional::Optional};
 
@@ -36,6 +37,14 @@ impl NestedPattern {
         match self {
             NestedPattern::Optional(optional) => Some(optional),
             _ => None,
+        }
+    }
+
+    pub fn source_span(&self) -> Option<Span> {
+        match self {
+            NestedPattern::Disjunction(inner) => inner.source_span(),
+            NestedPattern::Negation(inner) => inner.source_span(),
+            NestedPattern::Optional(inner) => inner.source_span(),
         }
     }
 }

--- a/ir/pattern/optional.rs
+++ b/ir/pattern/optional.rs
@@ -8,6 +8,7 @@ use std::{collections::HashMap, fmt};
 
 use answer::variable::Variable;
 use structural_equality::StructuralEquality;
+use typeql::common::Span;
 
 use crate::pattern::{
     BindingMode, BranchID, ContextualisedBindingMode, Pattern, PatternVariables, Scope, ScopeId,
@@ -21,6 +22,7 @@ pub struct Optional {
     conjunction: Conjunction,
     branch_id: BranchID,
     pattern_variables: PatternVariables,
+    source_span: Option<Span>,
 }
 
 impl Optional {
@@ -34,6 +36,10 @@ impl Optional {
 
     pub fn conjunction_mut(&mut self) -> &mut Conjunction {
         &mut self.conjunction
+    }
+
+    pub(crate) fn source_span(&self) -> Option<Span> {
+        self.source_span
     }
 }
 
@@ -65,20 +71,22 @@ impl fmt::Display for Optional {
 pub(crate) struct OptionalBuilder {
     conjunction: ConjunctionBuilder,
     branch_id: BranchID,
+    source_span: Option<Span>,
 }
 
 impl OptionalBuilder {
-    pub(crate) fn new(scope_id: ScopeId, branch_id: BranchID) -> Self {
+    pub(crate) fn new(scope_id: ScopeId, branch_id: BranchID, source_span: Option<Span>) -> Self {
         let conjunction = ConjunctionBuilder::new(scope_id);
-        Self { conjunction, branch_id }
+        Self { conjunction, branch_id, source_span }
     }
 
     pub(crate) fn finish(self, parent_modes: &ContextualisedBindingMode) -> NestedPattern {
+        let source_span = self.source_span;
         let binding_modes = ContextualisedBindingMode::from(self.variable_binding_modes(), parent_modes);
         let branch_id = self.branch_id;
         let conjunction = self.conjunction.finish(&binding_modes);
-        let variable_requirements = PatternVariables::from(&binding_modes);
-        NestedPattern::Optional(Optional { branch_id, conjunction, pattern_variables: variable_requirements })
+        let pattern_variables = PatternVariables::from(&binding_modes);
+        NestedPattern::Optional(Optional { branch_id, conjunction, pattern_variables, source_span })
     }
 
     pub(crate) fn conjunction(&self) -> &ConjunctionBuilder {

--- a/ir/pipeline/block.rs
+++ b/ir/pipeline/block.rs
@@ -4,25 +4,28 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-use std::collections::{BTreeSet, HashMap, HashSet};
+use std::{
+    collections::{BTreeSet, HashMap, HashSet},
+    fmt,
+};
 
 use answer::variable::Variable;
 use itertools::Itertools;
 use structural_equality::StructuralEquality;
 use typeql::common::Span;
+
 use crate::{
     RepresentationError,
     pattern::{
-        BindingMode, BranchID, ContextualisedBindingMode, ScopeId,
+        BindingMode, BranchID, ContextualisedBindingMode, Pattern, ScopeId,
         conjunction::{Conjunction, ConjunctionBuilder, ConjunctionBuilderWithContext, NestedPatternBuilder},
         constraint::Constraint,
+        disjunction::Disjunction,
+        nested_pattern::NestedPattern,
         variable_category::VariableCategory,
     },
     pipeline::{ParameterRegistry, VariableCategorySource, VariableRegistry},
 };
-use crate::pattern::disjunction::Disjunction;
-use crate::pattern::nested_pattern::NestedPattern;
-use crate::pattern::Pattern;
 
 #[derive(Debug, Clone)]
 pub struct Block {
@@ -87,7 +90,11 @@ impl<'reg> BlockBuilder<'reg> {
             .retain(|_, var| block_binding_modes.get(var).copied() != Some(BindingMode::LocallyBindingInChild));
         let conjunction = self.conjunction.finish(&ContextualisedBindingMode::for_block(block_binding_modes));
 
-        validate_is_plannable(&conjunction, &self.context.input_variables().collect(), &self.context.variable_registry)?;
+        validate_is_plannable(
+            &conjunction,
+            &self.context.input_variables().collect(),
+            &self.context.variable_registry,
+        )?;
 
         let block_context = self.context.block_context;
         Ok(Block { conjunction, block_context })
@@ -286,82 +293,87 @@ fn validate_optional_returns_recursive(
     }
 }
 
-#[derive(Debug)]
-enum Plannable<'conj> {
-    Constraint(&'conj Constraint<Variable>),
-    Disjunction(&'conj Disjunction),
-}
-
-impl<'conj> Plannable<'conj> {
-    fn all_variables(&self) -> Box<dyn Iterator<Item=Variable>> {
-        match self {
-            Plannable::Disjunction(d) => Box::new(d.visible_referenced_variables()),
-            Plannable::Constraint(c) => Box::new(c.ids())
-        }
-    }
-
-    fn required_variables(&self) -> Box<dyn Iterator<Item=Variable>> {
-        match self {
-            Plannable::Disjunction(disjunction) => {
-                Box::new(disjunction.required_inputs())
-            }
-            Plannable::Constraint(c) => {
-                Box::new(c.binding_modes().filter_map(|(id, mode)| mode.is_require_prebound().then_some(id)))
-            }
-        }
-    }
-}
-
-fn validate_is_plannable(conjunction: &Conjunction, input_variables: &BTreeSet<Variable>, variable_registry: &VariableRegistry) -> Result<(), Box<RepresentationError>> {
+fn validate_is_plannable(
+    conjunction: &Conjunction,
+    input_variables: &BTreeSet<Variable>,
+    variable_registry: &VariableRegistry,
+) -> Result<(), Box<RepresentationError>> {
     let bound_variables = validate_is_plannable_impl(conjunction, input_variables, variable_registry)?;
-    conjunction.nested_patterns().iter().try_for_each(|nested| {
-        match nested {
-             NestedPattern::Disjunction(disjunction) => {
-                 disjunction.conjunctions().iter().try_for_each(|inner| {
-                     validate_is_plannable(inner, &bound_variables, variable_registry)
-                 })
-             }
-            NestedPattern::Optional(inner) => {
-                validate_is_plannable(inner.conjunction(), &bound_variables, variable_registry)
-            }
-            NestedPattern::Negation(inner) => {
-                validate_is_plannable(inner.conjunction(), &bound_variables, variable_registry)
-            }
+    conjunction.nested_patterns().iter().try_for_each(|nested| match nested {
+        NestedPattern::Disjunction(disjunction) => disjunction
+            .conjunctions()
+            .iter()
+            .try_for_each(|inner| validate_is_plannable(inner, &bound_variables, variable_registry)),
+        NestedPattern::Optional(inner) => {
+            validate_is_plannable(inner.conjunction(), &bound_variables, variable_registry)
+        }
+        NestedPattern::Negation(inner) => {
+            validate_is_plannable(inner.conjunction(), &bound_variables, variable_registry)
         }
     })?;
     Ok(())
 }
 
+fn validate_is_plannable_impl<'conj>(
+    conjunction: &'conj Conjunction,
+    input_variables: &BTreeSet<Variable>,
+    variable_registry: &VariableRegistry,
+) -> Result<BTreeSet<Variable>, Box<RepresentationError>> {
+    let constraint_at = |i: usize| &conjunction.constraints()[i];
 
-fn validate_is_plannable_impl(conjunction: &Conjunction, input_variables: &BTreeSet<Variable>, variable_registry: &VariableRegistry) -> Result<BTreeSet<Variable>, Box<RepresentationError>> {
-    let mut remaining = BTreeSet::new(); // Could be a LinkedList
-    remaining.extend(conjunction.constraints().iter().map(|c| Plannable::Constraint(c)));
-    remaining.extend(conjunction.nested_patterns().iter().filter_map(|nested| {
-        match nested {
-            NestedPattern::Disjunction(disjunction) => Some(Plannable::Disjunction(disjunction)),
-            NestedPattern::Negation(_) | NestedPattern::Optional(_) => None,
-        }
-    }));
+    let disjunction_at = |i: usize| conjunction.nested_patterns()[i].as_disjunction().unwrap();
+
+    let mut remaining_constraint_indices: HashSet<usize> =
+        conjunction.constraints().iter().enumerate().map(|(i, _)| i).collect();
+    let mut remaining_disjunction_indices: HashSet<usize> =
+        conjunction.nested_patterns().iter().enumerate().filter_map(|(i, n)| n.as_disjunction().map(|_| i)).collect();
 
     let mut bound_variables = input_variables.clone();
 
-    let mut prev_remaining_len = remaining.len();
-    let mut plannables_tmp = Vec::with_capacity(remaining.len());
-    while !remaining.len() != 0 && prev_remaining_len != remaining.len() {
-        let enabled_plannables = remaining.iter().filter(|p| {
-            p.required_variables().all(|v| bound_variables.contains(&v))
-        });
-        plannables_tmp.clear();
-        plannables_tmp.extend(enabled_plannables);
-        bound_variables.extend(plannables_tmp.iter().flat_map(|c| c.all_variables()));
-        prev_remaining_len = remaining.len();
-        remaining.retain(|p| !plannables_tmp.contains(p));
+    let mut has_changed = true;
+    while has_changed {
+        has_changed = false;
+        let mut enabled_constraint_indices = remaining_constraint_indices
+            .iter()
+            .copied()
+            .filter(|i| {
+                let mut required_vars =
+                    constraint_at(*i).binding_modes().filter_map(|(id, mode)| mode.is_require_prebound().then_some(id));
+                required_vars.all(|v| bound_variables.contains(&v))
+            })
+            .collect::<HashSet<usize>>();
+        let fresh_constraint_vars = enabled_constraint_indices.iter().flat_map(|i| constraint_at(*i).ids());
+
+        let enabled_disjunction_indices = remaining_disjunction_indices
+            .iter()
+            .copied()
+            .filter(|i| {
+                let mut required_vars = disjunction_at(*i).required_inputs();
+                required_vars.all(|v| bound_variables.contains(&v))
+            })
+            .collect::<HashSet<usize>>();
+        let fresh_disjunction_vars =
+            enabled_disjunction_indices.iter().flat_map(|i| disjunction_at(*i).visible_referenced_variables());
+
+        remaining_constraint_indices.retain(|i| !enabled_constraint_indices.contains(i));
+        remaining_disjunction_indices.retain(|i| !enabled_disjunction_indices.contains(i));
+
+        bound_variables.extend(fresh_constraint_vars);
+        bound_variables.extend(fresh_disjunction_vars);
+
+        has_changed = !(enabled_constraint_indices.is_empty() && enabled_disjunction_indices.is_empty());
     }
-    if !remaining.is_empty() {
-        Ok(())
+
+    if remaining_constraint_indices.is_empty() && remaining_disjunction_indices.is_empty() {
+        Ok(bound_variables)
     } else {
-        let remaining_constraints = UnplannableConstraints::from_remaining(remaining, bound_variables, variable_registry);
-        Err(Box::new(RepresentationError::UnplannableConjunction { remaining_constraints }))
+        let unplannable_constraints = UnplannableConstraints::build(
+            &bound_variables,
+            variable_registry,
+            remaining_constraint_indices.iter().map(|i| constraint_at(*i)),
+            remaining_disjunction_indices.iter().map(|i| disjunction_at(*i)),
+        );
+        Err(Box::new(RepresentationError::UnplannableConjunction { unplannable_constraints }))
     }
 }
 
@@ -371,18 +383,36 @@ pub struct UnplannableConstraints {
 }
 
 impl UnplannableConstraints {
-    fn from_remaining(remaining: Vec<Plannable<'_>>, bound_variables: &BTreeSet<Variable>, variable_registry: &VariableRegistry) -> Self {
-        let constraints_and_requirements = remaining.iter().map(|c| {
-            let required_vars = c.required_inputs().map(|v| {
-                variable_registry.get_variable_name_or_unnamed(v)
-            }).join(", ");
-            let name = match c {
-                Plannable::Constraint(c) => c.name().to_owned(),
-                Plannable::Disjunction(d) => "[Disjunction]".to_owned(),
-            };
-            (name, required_vars)
-        }).collect();
+    fn build<'conj>(
+        bound_variables: &BTreeSet<Variable>,
+        variable_registry: &VariableRegistry,
+        mut remaining_constraints: impl Iterator<Item = &'conj Constraint<Variable>>,
+        mut remaining_disjunctions: impl Iterator<Item = &'conj Disjunction>,
+    ) -> Self {
+        let mut constraints_and_requirements = Vec::new();
+        constraints_and_requirements.extend(remaining_constraints.map(|c| {
+            let required_vars = c
+                .binding_modes()
+                .filter(|(_, mode)| mode.is_require_prebound())
+                .map(|(id, _)| variable_registry.get_variable_name_or_unnamed(id))
+                .join(", ");
+            (c.name().to_owned(), required_vars)
+        }));
+        constraints_and_requirements.extend(remaining_disjunctions.map(|d| {
+            let required_vars =
+                d.required_inputs().map(|id| variable_registry.get_variable_name_or_unnamed(id)).join(", ");
+            ("Disjunction".to_owned(), required_vars)
+        }));
         Self { constraints_and_requirements }
+    }
+}
+
+impl fmt::Display for UnplannableConstraints {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        for (name, required_vars) in &self.constraints_and_requirements {
+            writeln!(f, "- {name}: [{required_vars}]")?;
+        }
+        Ok(())
     }
 }
 

--- a/ir/pipeline/block.rs
+++ b/ir/pipeline/block.rs
@@ -20,7 +20,6 @@ use crate::{
         BindingMode, BranchID, ContextualisedBindingMode, Pattern, ScopeId,
         conjunction::{Conjunction, ConjunctionBuilder, ConjunctionBuilderWithContext, NestedPatternBuilder},
         constraint::Constraint,
-        disjunction::Disjunction,
         nested_pattern::NestedPattern,
         variable_category::VariableCategory,
     },
@@ -391,22 +390,26 @@ fn validate_is_plannable_impl<'conj>(
     if unplannable_constraints.constraints_and_requirements.is_empty() {
         Ok(bound_variables)
     } else {
-        let span = None; // TODO: conjunction.span()
-        Err(Box::new(RepresentationError::UnplannableConjunction { span, unplannable_constraints }))
+        let earliest_span = unplannable_constraints
+            .constraints_and_requirements
+            .iter()
+            .filter_map(|(_, _, span)| *span)
+            .reduce(|x, y| if x.begin_offset < y.begin_offset { x } else { y });
+        Err(Box::new(RepresentationError::UnplannableConjunction { span: earliest_span, unplannable_constraints }))
     }
 }
 
 #[derive(Debug, Clone)]
 pub struct UnplannableConstraints {
-    constraints_and_requirements: Vec<(String, String)>,
+    constraints_and_requirements: Vec<(String, String, Option<Span>)>,
 }
 
 impl UnplannableConstraints {
     fn build<'conj>(
         bound_variables: &BTreeSet<Variable>,
         variable_registry: &VariableRegistry,
-        mut remaining_constraints: impl Iterator<Item = &'conj Constraint<Variable>>,
-        mut remaining_nested_patterns: impl Iterator<Item = &'conj NestedPattern>,
+        remaining_constraints: impl Iterator<Item = &'conj Constraint<Variable>>,
+        remaining_nested_patterns: impl Iterator<Item = &'conj NestedPattern>,
     ) -> Self {
         macro_rules! unsatisfied_vars {
             ($iter: expr) => {
@@ -419,7 +422,7 @@ impl UnplannableConstraints {
         let mut constraints_and_requirements = Vec::new();
         constraints_and_requirements.extend(remaining_constraints.map(|c| {
             let required_vars = c.binding_modes().filter_map(|(id, mode)| mode.is_require_prebound().then_some(id));
-            (c.name().to_owned(), unsatisfied_vars!(required_vars))
+            (c.name().to_owned(), unsatisfied_vars!(required_vars), c.source_span())
         }));
         constraints_and_requirements.extend(remaining_nested_patterns.map(|nested| {
             let (name, required_vars) = match nested {
@@ -427,7 +430,7 @@ impl UnplannableConstraints {
                 NestedPattern::Negation(negation) => ("Negation", unsatisfied_vars!(negation.required_inputs())),
                 NestedPattern::Optional(optional) => ("Optional", unsatisfied_vars!(optional.required_inputs())),
             };
-            (name.to_owned(), required_vars)
+            (name.to_owned(), required_vars, nested.source_span())
         }));
         Self { constraints_and_requirements }
     }
@@ -435,7 +438,7 @@ impl UnplannableConstraints {
 
 impl fmt::Display for UnplannableConstraints {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        for (name, required_vars) in &self.constraints_and_requirements {
+        for (name, required_vars, _span) in &self.constraints_and_requirements {
             writeln!(f, "- {name}: [{required_vars}]")?;
         }
         Ok(())

--- a/ir/pipeline/block.rs
+++ b/ir/pipeline/block.rs
@@ -391,7 +391,8 @@ fn validate_is_plannable_impl<'conj>(
     if unplannable_constraints.constraints_and_requirements.is_empty() {
         Ok(bound_variables)
     } else {
-        Err(Box::new(RepresentationError::UnplannableConjunction { unplannable_constraints }))
+        let span = None; // TODO: conjunction.span()
+        Err(Box::new(RepresentationError::UnplannableConjunction { span, unplannable_constraints }))
     }
 }
 

--- a/ir/pipeline/block.rs
+++ b/ir/pipeline/block.rs
@@ -370,9 +370,15 @@ fn validate_is_plannable_impl<'conj>(
         .enumerate()
         .filter(|(i, nested)| {
             match nested {
-                NestedPattern::Disjunction(_) => remaining_disjunction_indices.contains(i), // In remaining_disjunction_indices,
-                NestedPattern::Optional(optional) => optional.required_inputs().all(|id| bound_variables.contains(&id)),
-                NestedPattern::Negation(negation) => negation.required_inputs().all(|id| bound_variables.contains(&id)),
+                NestedPattern::Disjunction(_) => {
+                    remaining_disjunction_indices.contains(i) // In remaining_disjunction_indices,
+                }
+                NestedPattern::Optional(optional) => {
+                    optional.required_inputs().any(|id| !bound_variables.contains(&id))
+                }
+                NestedPattern::Negation(negation) => {
+                    negation.required_inputs().any(|id| !bound_variables.contains(&id))
+                }
             }
         })
         .map(|(i, nested)| nested);

--- a/ir/pipeline/block.rs
+++ b/ir/pipeline/block.rs
@@ -363,16 +363,28 @@ fn validate_is_plannable_impl<'conj>(
 
         has_changed = !(enabled_constraint_indices.is_empty() && enabled_disjunction_indices.is_empty());
     }
-
-    if remaining_constraint_indices.is_empty() && remaining_disjunction_indices.is_empty() {
+    let remaining_constraints = remaining_constraint_indices.iter().map(|i| constraint_at(*i));
+    let remaining_nested_patterns = conjunction
+        .nested_patterns()
+        .iter()
+        .enumerate()
+        .filter(|(i, nested)| {
+            match nested {
+                NestedPattern::Disjunction(_) => remaining_disjunction_indices.contains(i), // In remaining_disjunction_indices,
+                NestedPattern::Optional(optional) => optional.required_inputs().all(|id| bound_variables.contains(&id)),
+                NestedPattern::Negation(negation) => negation.required_inputs().all(|id| bound_variables.contains(&id)),
+            }
+        })
+        .map(|(i, nested)| nested);
+    let unplannable_constraints = UnplannableConstraints::build(
+        &bound_variables,
+        variable_registry,
+        remaining_constraints,
+        remaining_nested_patterns,
+    );
+    if unplannable_constraints.constraints_and_requirements.is_empty() {
         Ok(bound_variables)
     } else {
-        let unplannable_constraints = UnplannableConstraints::build(
-            &bound_variables,
-            variable_registry,
-            remaining_constraint_indices.iter().map(|i| constraint_at(*i)),
-            remaining_disjunction_indices.iter().map(|i| disjunction_at(*i)),
-        );
         Err(Box::new(RepresentationError::UnplannableConjunction { unplannable_constraints }))
     }
 }
@@ -387,21 +399,28 @@ impl UnplannableConstraints {
         bound_variables: &BTreeSet<Variable>,
         variable_registry: &VariableRegistry,
         mut remaining_constraints: impl Iterator<Item = &'conj Constraint<Variable>>,
-        mut remaining_disjunctions: impl Iterator<Item = &'conj Disjunction>,
+        mut remaining_nested_patterns: impl Iterator<Item = &'conj NestedPattern>,
     ) -> Self {
+        macro_rules! unsatisfied_vars {
+            ($iter: expr) => {
+                $iter
+                    .filter(|id| !bound_variables.contains(id))
+                    .map(|id| variable_registry.get_variable_name_or_unnamed(id))
+                    .join(", ")
+            };
+        }
         let mut constraints_and_requirements = Vec::new();
         constraints_and_requirements.extend(remaining_constraints.map(|c| {
-            let required_vars = c
-                .binding_modes()
-                .filter(|(_, mode)| mode.is_require_prebound())
-                .map(|(id, _)| variable_registry.get_variable_name_or_unnamed(id))
-                .join(", ");
-            (c.name().to_owned(), required_vars)
+            let required_vars = c.binding_modes().filter_map(|(id, mode)| mode.is_require_prebound().then_some(id));
+            (c.name().to_owned(), unsatisfied_vars!(required_vars))
         }));
-        constraints_and_requirements.extend(remaining_disjunctions.map(|d| {
-            let required_vars =
-                d.required_inputs().map(|id| variable_registry.get_variable_name_or_unnamed(id)).join(", ");
-            ("Disjunction".to_owned(), required_vars)
+        constraints_and_requirements.extend(remaining_nested_patterns.map(|nested| {
+            let (name, required_vars) = match nested {
+                NestedPattern::Disjunction(disj) => ("Disjunction", unsatisfied_vars!(disj.required_inputs())),
+                NestedPattern::Negation(negation) => ("Negation", unsatisfied_vars!(negation.required_inputs())),
+                NestedPattern::Optional(optional) => ("Optional", unsatisfied_vars!(optional.required_inputs())),
+            };
+            (name.to_owned(), required_vars)
         }));
         Self { constraints_and_requirements }
     }

--- a/ir/pipeline/block.rs
+++ b/ir/pipeline/block.rs
@@ -297,7 +297,7 @@ fn validate_is_plannable(
     input_variables: &BTreeSet<Variable>,
     variable_registry: &VariableRegistry,
 ) -> Result<(), Box<RepresentationError>> {
-    validate_is_plannable_impl(conjunction, input_variables, variable_registry)?;
+    validate_conjunction_has_valid_constraint_ordering(conjunction, input_variables, variable_registry)?;
     // Note: Passing ONLY required inputs may be too strict if we change behaviour in future.
     // Then just push this recursive check alongside the shallow check in the _impl method.
     conjunction.nested_patterns().iter().try_for_each(|nested| match nested {
@@ -320,8 +320,8 @@ fn validate_is_plannable(
     Ok(())
 }
 
-fn validate_is_plannable_impl<'conj>(
-    conjunction: &'conj Conjunction,
+fn validate_conjunction_has_valid_constraint_ordering(
+    conjunction: &Conjunction,
     input_variables: &BTreeSet<Variable>,
     variable_registry: &VariableRegistry,
 ) -> Result<(), Box<RepresentationError>> {
@@ -332,14 +332,12 @@ fn validate_is_plannable_impl<'conj>(
     let mut remaining_constraint_indices: HashSet<usize> =
         conjunction.constraints().iter().enumerate().map(|(i, _)| i).collect();
     let mut remaining_disjunction_indices: HashSet<usize> =
-        conjunction.nested_patterns().iter().enumerate().filter_map(|(i, n)| n.as_disjunction().map(|_| i)).collect();
+        conjunction.nested_patterns().iter().positions(|n| n.as_disjunction().is_some()).collect();
 
     let mut bound_variables = input_variables.clone();
 
-    let mut has_changed = true;
-    while has_changed {
-        has_changed = false;
-        let mut enabled_constraint_indices = remaining_constraint_indices
+    loop {
+        let enabled_constraint_indices = remaining_constraint_indices
             .iter()
             .copied()
             .filter(|i| {
@@ -366,8 +364,9 @@ fn validate_is_plannable_impl<'conj>(
 
         bound_variables.extend(fresh_constraint_vars);
         bound_variables.extend(fresh_disjunction_vars);
-
-        has_changed = !(enabled_constraint_indices.is_empty() && enabled_disjunction_indices.is_empty());
+        if enabled_constraint_indices.is_empty() && enabled_disjunction_indices.is_empty() {
+            break;
+        }
     }
     let remaining_constraints = remaining_constraint_indices.iter().map(|i| constraint_at(*i));
     let remaining_nested_patterns = conjunction
@@ -401,7 +400,7 @@ fn validate_is_plannable_impl<'conj>(
             .constraints_and_requirements
             .iter()
             .filter_map(|(_, _, span)| *span)
-            .reduce(|x, y| if x.begin_offset < y.begin_offset { x } else { y });
+            .min_by_key(|span| span.begin_offset);
         Err(Box::new(RepresentationError::UnplannableConjunction { span: earliest_span, unplannable_constraints }))
     }
 }
@@ -419,7 +418,7 @@ impl UnplannableConstraints {
         remaining_nested_patterns: impl Iterator<Item = &'conj NestedPattern>,
     ) -> Self {
         macro_rules! unsatisfied_vars {
-            ($iter: expr) => {
+            ($iter:expr) => {
                 $iter
                     .filter(|id| !bound_variables.contains(id))
                     .map(|id| variable_registry.get_variable_name_or_unnamed(id))

--- a/ir/pipeline/block.rs
+++ b/ir/pipeline/block.rs
@@ -297,18 +297,24 @@ fn validate_is_plannable(
     input_variables: &BTreeSet<Variable>,
     variable_registry: &VariableRegistry,
 ) -> Result<(), Box<RepresentationError>> {
-    let bound_variables = validate_is_plannable_impl(conjunction, input_variables, variable_registry)?;
-    // TODO: BUG: You can't do disjunctions with all the bound variables because that contains all variables from the disjunction itself.
+    validate_is_plannable_impl(conjunction, input_variables, variable_registry)?;
+    // Note: Passing ONLY required inputs may be too strict if we change behaviour in future.
+    // Then just push this recursive check alongside the shallow check in the _impl method.
     conjunction.nested_patterns().iter().try_for_each(|nested| match nested {
-        NestedPattern::Disjunction(disjunction) => disjunction
-            .conjunctions()
-            .iter()
-            .try_for_each(|inner| validate_is_plannable(inner, &bound_variables, variable_registry)),
+        NestedPattern::Disjunction(disjunction) => {
+            let inner_inputs = disjunction.required_inputs().collect();
+            disjunction
+                .conjunctions()
+                .iter()
+                .try_for_each(|inner| validate_is_plannable(inner, &inner_inputs, variable_registry))
+        }
         NestedPattern::Optional(inner) => {
-            validate_is_plannable(inner.conjunction(), &bound_variables, variable_registry)
+            let inner_inputs = inner.required_inputs().collect();
+            validate_is_plannable(inner.conjunction(), &inner_inputs, variable_registry)
         }
         NestedPattern::Negation(inner) => {
-            validate_is_plannable(inner.conjunction(), &bound_variables, variable_registry)
+            let inner_inputs = inner.required_inputs().collect();
+            validate_is_plannable(inner.conjunction(), &inner_inputs, variable_registry)
         }
     })?;
     Ok(())
@@ -318,7 +324,7 @@ fn validate_is_plannable_impl<'conj>(
     conjunction: &'conj Conjunction,
     input_variables: &BTreeSet<Variable>,
     variable_registry: &VariableRegistry,
-) -> Result<BTreeSet<Variable>, Box<RepresentationError>> {
+) -> Result<(), Box<RepresentationError>> {
     let constraint_at = |i: usize| &conjunction.constraints()[i];
 
     let disjunction_at = |i: usize| conjunction.nested_patterns()[i].as_disjunction().unwrap();
@@ -389,7 +395,7 @@ fn validate_is_plannable_impl<'conj>(
         remaining_nested_patterns,
     );
     if unplannable_constraints.constraints_and_requirements.is_empty() {
-        Ok(bound_variables)
+        Ok(())
     } else {
         let earliest_span = unplannable_constraints
             .constraints_and_requirements

--- a/ir/pipeline/block.rs
+++ b/ir/pipeline/block.rs
@@ -4,13 +4,12 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeSet, HashMap, HashSet};
 
 use answer::variable::Variable;
 use itertools::Itertools;
 use structural_equality::StructuralEquality;
 use typeql::common::Span;
-
 use crate::{
     RepresentationError,
     pattern::{
@@ -21,6 +20,9 @@ use crate::{
     },
     pipeline::{ParameterRegistry, VariableCategorySource, VariableRegistry},
 };
+use crate::pattern::disjunction::Disjunction;
+use crate::pattern::nested_pattern::NestedPattern;
+use crate::pattern::Pattern;
 
 #[derive(Debug, Clone)]
 pub struct Block {
@@ -84,6 +86,9 @@ impl<'reg> BlockBuilder<'reg> {
             .variable_names_index
             .retain(|_, var| block_binding_modes.get(var).copied() != Some(BindingMode::LocallyBindingInChild));
         let conjunction = self.conjunction.finish(&ContextualisedBindingMode::for_block(block_binding_modes));
+
+        validate_is_plannable(&conjunction, &self.context.input_variables().collect(), &self.context.variable_registry)?;
+
         let block_context = self.context.block_context;
         Ok(Block { conjunction, block_context })
     }
@@ -278,6 +283,106 @@ fn validate_optional_returns_recursive(
         Ok(())
     } else {
         Ok(())
+    }
+}
+
+#[derive(Debug)]
+enum Plannable<'conj> {
+    Constraint(&'conj Constraint<Variable>),
+    Disjunction(&'conj Disjunction),
+}
+
+impl<'conj> Plannable<'conj> {
+    fn all_variables(&self) -> Box<dyn Iterator<Item=Variable>> {
+        match self {
+            Plannable::Disjunction(d) => Box::new(d.visible_referenced_variables()),
+            Plannable::Constraint(c) => Box::new(c.ids())
+        }
+    }
+
+    fn required_variables(&self) -> Box<dyn Iterator<Item=Variable>> {
+        match self {
+            Plannable::Disjunction(disjunction) => {
+                Box::new(disjunction.required_inputs())
+            }
+            Plannable::Constraint(c) => {
+                Box::new(c.binding_modes().filter_map(|(id, mode)| mode.is_require_prebound().then_some(id)))
+            }
+        }
+    }
+}
+
+fn validate_is_plannable(conjunction: &Conjunction, input_variables: &BTreeSet<Variable>, variable_registry: &VariableRegistry) -> Result<(), Box<RepresentationError>> {
+    let bound_variables = validate_is_plannable_impl(conjunction, input_variables, variable_registry)?;
+    conjunction.nested_patterns().iter().try_for_each(|nested| {
+        match nested {
+             NestedPattern::Disjunction(disjunction) => {
+                 disjunction.conjunctions().iter().try_for_each(|inner| {
+                     validate_is_plannable(inner, &bound_variables, variable_registry)
+                 })
+             }
+            NestedPattern::Optional(inner) => {
+                validate_is_plannable(inner.conjunction(), &bound_variables, variable_registry)
+            }
+            NestedPattern::Negation(inner) => {
+                validate_is_plannable(inner.conjunction(), &bound_variables, variable_registry)
+            }
+        }
+    })?;
+    Ok(())
+}
+
+
+fn validate_is_plannable_impl(conjunction: &Conjunction, input_variables: &BTreeSet<Variable>, variable_registry: &VariableRegistry) -> Result<BTreeSet<Variable>, Box<RepresentationError>> {
+    let mut remaining = BTreeSet::new(); // Could be a LinkedList
+    remaining.extend(conjunction.constraints().iter().map(|c| Plannable::Constraint(c)));
+    remaining.extend(conjunction.nested_patterns().iter().filter_map(|nested| {
+        match nested {
+            NestedPattern::Disjunction(disjunction) => Some(Plannable::Disjunction(disjunction)),
+            NestedPattern::Negation(_) | NestedPattern::Optional(_) => None,
+        }
+    }));
+
+    let mut bound_variables = input_variables.clone();
+
+    let mut prev_remaining_len = remaining.len();
+    let mut plannables_tmp = Vec::with_capacity(remaining.len());
+    while !remaining.len() != 0 && prev_remaining_len != remaining.len() {
+        let enabled_plannables = remaining.iter().filter(|p| {
+            p.required_variables().all(|v| bound_variables.contains(&v))
+        });
+        plannables_tmp.clear();
+        plannables_tmp.extend(enabled_plannables);
+        bound_variables.extend(plannables_tmp.iter().flat_map(|c| c.all_variables()));
+        prev_remaining_len = remaining.len();
+        remaining.retain(|p| !plannables_tmp.contains(p));
+    }
+    if !remaining.is_empty() {
+        Ok(())
+    } else {
+        let remaining_constraints = UnplannableConstraints::from_remaining(remaining, bound_variables, variable_registry);
+        Err(Box::new(RepresentationError::UnplannableConjunction { remaining_constraints }))
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct UnplannableConstraints {
+    constraints_and_requirements: Vec<(String, String)>,
+}
+
+impl UnplannableConstraints {
+    fn from_remaining(remaining: Vec<Plannable<'_>>, bound_variables: &BTreeSet<Variable>, variable_registry: &VariableRegistry) -> Self {
+        let constraints_and_requirements = remaining.iter().map(|c| {
+            let required_vars = c.required_inputs().map(|v| {
+                variable_registry.get_variable_name_or_unnamed(v)
+            }).join(", ");
+            let name = match c {
+                Plannable::Constraint(c) => c.name().to_owned(),
+                Plannable::Disjunction(d) => "[Disjunction]".to_owned(),
+            };
+            (name, required_vars)
+        }).collect();
+        Self { constraints_and_requirements }
     }
 }
 

--- a/ir/pipeline/block.rs
+++ b/ir/pipeline/block.rs
@@ -298,6 +298,7 @@ fn validate_is_plannable(
     variable_registry: &VariableRegistry,
 ) -> Result<(), Box<RepresentationError>> {
     let bound_variables = validate_is_plannable_impl(conjunction, input_variables, variable_registry)?;
+    // TODO: BUG: You can't do disjunctions with all the bound variables because that contains all variables from the disjunction itself.
     conjunction.nested_patterns().iter().try_for_each(|nested| match nested {
         NestedPattern::Disjunction(disjunction) => disjunction
             .conjunctions()

--- a/ir/translation/match_.rs
+++ b/ir/translation/match_.rs
@@ -3,6 +3,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
+use typeql::common::Span;
 
 use crate::{
     RepresentationError,
@@ -47,7 +48,7 @@ fn add_disjunction(
     conjunction: &mut ConjunctionBuilderWithContext<'_, '_>,
     disjunction: &typeql::pattern::Disjunction,
 ) -> Result<(), Box<RepresentationError>> {
-    let mut disjunction_builder = conjunction.add_disjunction();
+    let mut disjunction_builder = conjunction.add_disjunction(disjunction.span);
     disjunction.branches.iter().try_for_each(|branch| {
         let mut conj = disjunction_builder.add_conjunction();
         add_patterns(function_index, &mut conj, branch)
@@ -60,7 +61,7 @@ fn add_negation(
     conjunction: &mut ConjunctionBuilderWithContext<'_, '_>,
     negation: &typeql::pattern::Negation,
 ) -> Result<(), Box<RepresentationError>> {
-    let mut negation_builder = conjunction.add_negation();
+    let mut negation_builder = conjunction.add_negation(negation.span);
     add_patterns(function_index, &mut negation_builder, &negation.patterns)
 }
 


### PR DESCRIPTION
## Product change and motivation
We use the variable binding modes to ensure there are no subpatterns whose inputs cannot be satisfied.

## Implementation
* `ir/pattern/block.rs` is the only file with any logic change. The rest is plumbing to get the span into the nested patterns.
* There's a test failure in `expression.feature` because our current validation is too coarse (yay/boo)