### PR TITLE
Make query cache eviction less sensitive to relative changes in small databases

### DIFF
--- a/query/query_cache.rs
+++ b/query/query_cache.rs
@@ -19,8 +19,8 @@ use ir::{
 use moka::sync::{Cache, CacheBuilder};
 use resource::{
     constants::database::{
-        QUERY_PARSE_CACHE_SIZE, QUERY_PLAN_CACHE_FLUSH_ANY_STATISTIC_CHANGE_FRACTION, QUERY_PLAN_CACHE_SIZE,
-        QUERY_TRANSLATION_CACHE_SIZE,
+        QUERY_PARSE_CACHE_SIZE, QUERY_PLAN_CACHE_FLUSH_ANY_STATISTIC_CHANGE_FRACTION,
+        QUERY_PLAN_CACHE_FLUSH_STATIC_SMOOTH_THRESHOLD, QUERY_PLAN_CACHE_SIZE, QUERY_TRANSLATION_CACHE_SIZE,
     },
     perf_counters::QUERY_CACHE_FLUSH,
 };
@@ -160,14 +160,21 @@ fn is_pipeline_type_populations_outdated(statistics: &Statistics, pipeline: &Exe
             Type::Attribute(ty) => statistics.attribute_counts.get(&ty).copied().unwrap_or_default(),
             Type::RoleType(ty) => statistics.role_counts.get(&ty).copied().unwrap_or_default(),
         };
+        let smoothing = smoothstep(type_count, 1, QUERY_PLAN_CACHE_FLUSH_STATIC_SMOOTH_THRESHOLD);
         match u64::max(type_count, 1) as f64 / u64::max(pop, 1) as f64 {
-            increase @ 1.0.. => total_increase *= increase,
-            decrease @ ..1.0 => total_decrease /= decrease,
+            increase @ 1.0.. => total_increase *= increase.powf(smoothing),
+            decrease @ ..1.0 => total_decrease /= decrease.powf(smoothing),
             _ => panic!("NaN?!"),
         }
     }
     total_increase >= QUERY_PLAN_CACHE_FLUSH_ANY_STATISTIC_CHANGE_FRACTION
         || total_decrease >= QUERY_PLAN_CACHE_FLUSH_ANY_STATISTIC_CHANGE_FRACTION
+}
+
+fn smoothstep(pop: u64, min: u64, max: u64) -> f64 {
+    debug_assert!(max > min);
+    let x = (pop.clamp(min, max) - min) as f64 / (max - min) as f64;
+    (3.0 - 2.0 * x) * x * x
 }
 
 #[derive(Debug)]

--- a/resource/constants.rs
+++ b/resource/constants.rs
@@ -112,6 +112,7 @@ pub mod database {
 
     // anything lower than 2.0 will cause too much replanning
     // anything over 8.0 often does not plan frequently enough, as the data scales
+    pub const QUERY_PLAN_CACHE_FLUSH_STATIC_SMOOTH_THRESHOLD: u64 = 1000;
     pub const QUERY_PLAN_CACHE_FLUSH_ANY_STATISTIC_CHANGE_FRACTION: f64 = 3.0;
     pub const QUERY_PLAN_CACHE_SIZE: u64 = 100;
     pub const QUERY_PARSE_CACHE_SIZE: u64 = 200;

--- a/resource/constants.rs
+++ b/resource/constants.rs
@@ -112,7 +112,7 @@ pub mod database {
 
     // anything lower than 2.0 will cause too much replanning
     // anything over 8.0 often does not plan frequently enough, as the data scales
-    pub const QUERY_PLAN_CACHE_FLUSH_STATIC_SMOOTH_THRESHOLD: u64 = 1000;
+    pub const QUERY_PLAN_CACHE_FLUSH_STATIC_SMOOTH_THRESHOLD: u64 = 100;
     pub const QUERY_PLAN_CACHE_FLUSH_ANY_STATISTIC_CHANGE_FRACTION: f64 = 3.0;
     pub const QUERY_PLAN_CACHE_SIZE: u64 = 100;
     pub const QUERY_PARSE_CACHE_SIZE: u64 = 200;


### PR DESCRIPTION
## Product change and motivation

Reduce the impact on query cache eviction of large relative changes when the amount of data is small for the type considered.

## Implementation

The heuristic of query plan cache eviction considers the product of the relative changes in the population of each type used in the query as an approximation of how much the cost of the full query would have changed.

This PR makes it so the changes of populations of types with few instances (< `QUERY_PLAN_CACHE_FLUSH_STATIC_SMOOTH_THRESHOLD`) are reduced, getting closer to 1 the closer the population is to 0.