### PR TITLE
Fix add_or_intersect change condition

### DIFF
--- a/compiler/annotation/inference/match_inference.rs
+++ b/compiler/annotation/inference/match_inference.rs
@@ -49,7 +49,7 @@ impl VertexAnnotations {
         if let Some(existing_annotations) = self.get_mut(vertex) {
             let size_before = existing_annotations.len();
             existing_annotations.retain(|x| new_annotations.contains(x));
-            existing_annotations.len() == size_before
+            existing_annotations.len() != size_before
         } else {
             self.insert(vertex.clone(), new_annotations.into_owned());
             true


### PR DESCRIPTION
## Product change and motivation
Fixes the condition that determines whether add_or_intersect changed the type annotations of the vertex
