### PR TITLE
Ban expressions in write stage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5872,7 +5872,7 @@ checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 [[package]]
 name = "typeql"
 version = "0.0.0"
-source = "git+https://github.com/typedb/typeql?rev=9bd7d56a907e8bf60ac5a5a7ca609131bf1b24f3#9bd7d56a907e8bf60ac5a5a7ca609131bf1b24f3"
+source = "git+https://github.com/typedb/typeql?tag=3.12.2#7f4cac93fa8eee8643aa9f75eb60cacb5a454842"
 dependencies = [
  "chrono",
  "itertools 0.14.0",

--- a/common/error/error.rs
+++ b/common/error/error.rs
@@ -395,6 +395,7 @@ pub enum UnimplementedFeature {
     QueryingAnnotations,
 
     NestedOptionalWrites,
+    ExpressionInWrites,
 }
 impl std::fmt::Display for UnimplementedFeature {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/common/error/error.rs
+++ b/common/error/error.rs
@@ -395,8 +395,8 @@ pub enum UnimplementedFeature {
     QueryingAnnotations,
 
     NestedOptionalWrites,
-    ExpressionInWrites,
 }
+
 impl std::fmt::Display for UnimplementedFeature {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{self:?}")

--- a/ir/lib.rs
+++ b/ir/lib.rs
@@ -343,6 +343,11 @@ typedb_error! {
             offset: String,
             source_span: Option<Span>,
         ),
+        UnimplementedExpressionsInWrite(
+            254,
+            "Expressions are not supported in write stages. Please move it to a preceding match stage.",
+            source_span: Option<Span>,
+        ),
         UnimplementedLanguageFeature(
             254,
             "The language feature is not yet implemented: {feature}.",

--- a/ir/lib.rs
+++ b/ir/lib.rs
@@ -344,8 +344,8 @@ typedb_error! {
             source_span: Option<Span>,
         ),
         UnimplementedExpressionsInWrite(
-            254,
-            "Expressions are not supported in write stages. Please move it to a preceding match stage.",
+            253,
+            "Expressions are currently not supported in write stages. Please move it to a preceding match stage.",
             source_span: Option<Span>,
         ),
         UnimplementedLanguageFeature(

--- a/ir/translation/pipeline.rs
+++ b/ir/translation/pipeline.rs
@@ -11,6 +11,7 @@ use std::{
 };
 
 use answer::variable::Variable;
+use error::UnimplementedFeature;
 use structural_equality::StructuralEquality;
 use typeql::{
     common::{Span, Spanned},
@@ -20,7 +21,12 @@ use typeql::{
 
 use crate::{
     RepresentationError,
-    pattern::Pattern,
+    pattern::{
+        Pattern,
+        conjunction::Conjunction,
+        constraint::{Constraint, ExpressionBinding},
+        nested_pattern::NestedPattern,
+    },
     pipeline::{
         ParameterRegistry, VariableRegistry,
         block::Block,
@@ -209,7 +215,29 @@ pub(crate) fn translate_pipeline_stages(
     for (i, stage) in stages.iter().enumerate() {
         let translated = translate_stage(translation_context, value_parameters, all_function_signatures, stage)?;
         match translated {
-            TranslatedPipelinePart::Stage(stage) => translated_stages.push(stage),
+            TranslatedPipelinePart::Stage(stage) => {
+                match &stage {
+                    TranslatedStage::Insert { block, .. }
+                    | TranslatedStage::Update { block, .. }
+                    | TranslatedStage::Put { block, .. }
+                    | TranslatedStage::Delete { block, .. } => {
+                        if find_expressions_recursive(block.conjunction()).is_some() {
+                            return Err(Box::new(RepresentationError::UnimplementedLanguageFeature {
+                                feature: UnimplementedFeature::ExpressionInWrites,
+                            }));
+                        }
+                    }
+                    TranslatedStage::Match { .. }
+                    | TranslatedStage::Select(_)
+                    | TranslatedStage::Sort(_)
+                    | TranslatedStage::Offset(_)
+                    | TranslatedStage::Limit(_)
+                    | TranslatedStage::Require(_)
+                    | TranslatedStage::Reduce(_)
+                    | TranslatedStage::Distinct(_) => {}
+                }
+                translated_stages.push(stage)
+            }
             TranslatedPipelinePart::Given(given) => {
                 if i != 0 {
                     return Err(Box::new(RepresentationError::NonInitialGiven { source_span: stage.span() }));
@@ -328,4 +356,19 @@ enum TranslatedPipelinePart {
     Given(TranslatedGiven),
     Stage(TranslatedStage),
     Fetch(FetchObject),
+}
+
+fn find_expressions_recursive(conjunction: &Conjunction) -> Option<&ExpressionBinding<Variable>> {
+    if let Some(expr) = conjunction.constraints().iter().find_map(|c| match c {
+        Constraint::ExpressionBinding(expr) => Some(expr),
+        _ => None,
+    }) {
+        return Some(expr);
+    }
+
+    conjunction.nested_patterns().iter().find_map(|nested| match nested {
+        NestedPattern::Disjunction(d) => d.conjunctions().iter().find_map(|c| find_expressions_recursive(c)),
+        NestedPattern::Optional(o) => find_expressions_recursive(o.conjunction()),
+        NestedPattern::Negation(n) => find_expressions_recursive(n.conjunction()),
+    })
 }

--- a/ir/translation/pipeline.rs
+++ b/ir/translation/pipeline.rs
@@ -221,9 +221,9 @@ pub(crate) fn translate_pipeline_stages(
                     | TranslatedStage::Update { block, .. }
                     | TranslatedStage::Put { block, .. }
                     | TranslatedStage::Delete { block, .. } => {
-                        if find_expressions_recursive(block.conjunction()).is_some() {
-                            return Err(Box::new(RepresentationError::UnimplementedLanguageFeature {
-                                feature: UnimplementedFeature::ExpressionInWrites,
+                        if let Some(e) = find_expressions_recursive(block.conjunction()) {
+                            return Err(Box::new(RepresentationError::UnimplementedExpressionsInWrite {
+                                source_span: e.source_span(),
                             }));
                         }
                     }

--- a/ir/translation/pipeline.rs
+++ b/ir/translation/pipeline.rs
@@ -11,7 +11,6 @@ use std::{
 };
 
 use answer::variable::Variable;
-use error::UnimplementedFeature;
 use structural_equality::StructuralEquality;
 use typeql::{
     common::{Span, Spanned},


### PR DESCRIPTION
## Implementation
Checks for expressions in write stages (insert, put, update, delete). If found, we error instead of crashing downstream.
