### PR TITLE
Add "manual" tag to mac-installer targets

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -495,6 +495,7 @@ mac_pkg_installer(
 
     verbose = False, # True for debugging
     target_compatible_with = constraint_mac_x86_64,
+    tags = ["manual"],
 )
 
 mac_pkg_installer(
@@ -522,6 +523,7 @@ mac_pkg_installer(
 
     verbose = True,
     target_compatible_with = constraint_mac_arm64,
+    tags = ["manual"],
 )
 
 deploy_artifact(
@@ -531,6 +533,8 @@ deploy_artifact(
     release = deployment["artifact"]["release"]["upload"],
     snapshot = deployment["artifact"]["snapshot"]["upload"],
     target = ":assemble-all-mac-x86_64-installer-pkg",
+    target_compatible_with = constraint_mac_x86_64,
+    tags = ["manual"],
 )
 
 deploy_artifact(
@@ -540,6 +544,8 @@ deploy_artifact(
     release = deployment["artifact"]["release"]["upload"],
     snapshot = deployment["artifact"]["snapshot"]["upload"],
     target = ":assemble-all-mac-arm64-installer-pkg",
+    target_compatible_with = constraint_mac_arm64,
+    tags = ["manual"],
 )
 
 alias(

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5872,7 +5872,7 @@ checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 [[package]]
 name = "typeql"
 version = "0.0.0"
-source = "git+https://github.com/typedb/typeql?rev=9bd7d56a907e8bf60ac5a5a7ca609131bf1b24f3#9bd7d56a907e8bf60ac5a5a7ca609131bf1b24f3"
+source = "git+https://github.com/typedb/typeql?tag=3.12.2#7f4cac93fa8eee8643aa9f75eb60cacb5a454842"
 dependencies = [
  "chrono",
  "itertools 0.14.0",

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -161,8 +161,8 @@ use_repo(
 bazel_dep(name = "typedb_bazel_distribution", version = "0.0.0")
 git_override(
     module_name = "typedb_bazel_distribution",
-    remote = "https://github.com/krishnangovindraj/bazel-distribution",
-    commit = "f88143ac4b259d373508377268e4b8d146257b7f",
+    remote = "https://github.com/typedb/bazel-distribution",
+    commit = "ab5bfc90274e2d34569d5bc22558314b551cdecd",
 )
 
 bazel_dep(name = "typedb_dependencies", version = "0.0.0")

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -161,8 +161,8 @@ use_repo(
 bazel_dep(name = "typedb_bazel_distribution", version = "0.0.0")
 git_override(
     module_name = "typedb_bazel_distribution",
-    remote = "https://github.com/typedb/bazel-distribution",
-    commit = "8756119e8ad5cd52d8a25f0d0204d6ff29dccebf",
+    remote = "https://github.com/krishnangovindraj/bazel-distribution",
+    commit = "f88143ac4b259d373508377268e4b8d146257b7f",
 )
 
 bazel_dep(name = "typedb_dependencies", version = "0.0.0")

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -8410,7 +8410,7 @@
     },
     "@@typedb_dependencies+//distribution/artifact:rules.bzl%native_artifact_files": {
       "general": {
-        "bzlTransitiveDigest": "j3hx3mUtu6z2mFVqzO+QxuHlrl18RFJ+k2KdWIGo83o=",
+        "bzlTransitiveDigest": "Kb5QWQrUc0s27j+2UawgVDIuZeaZUkqrRVUHDu0Ao8s=",
         "usagesDigest": "IwxuSmZZ4PgoYNVioUdK3Gd/b2GVlohqGdv8E+JFtBk=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},


### PR DESCRIPTION
## Product change and motivation
To stop local `build //...` on mac failing because of the signing keychain not existing.
