### PR TITLE
Simplify type inference of negations & optionals, conversion to TypeAnnotations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5872,7 +5872,7 @@ checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 [[package]]
 name = "typeql"
 version = "0.0.0"
-source = "git+https://github.com/typedb/typeql?rev=9bd7d56a907e8bf60ac5a5a7ca609131bf1b24f3#9bd7d56a907e8bf60ac5a5a7ca609131bf1b24f3"
+source = "git+https://github.com/typedb/typeql?tag=3.12.2#7f4cac93fa8eee8643aa9f75eb60cacb5a454842"
 dependencies = [
  "chrono",
  "itertools 0.14.0",

--- a/compiler/annotation/inference/match_inference.rs
+++ b/compiler/annotation/inference/match_inference.rs
@@ -12,7 +12,7 @@ use std::{
 use answer::{Type as TypeAnnotation, variable::Variable};
 use ir::{
     pattern::{
-        Pattern, Scope, ScopeId, Vertex, conjunction::Conjunction, constraint::Constraint,
+        Pattern, Scope, ScopeId, Vertex, conjunction::Conjunction, constraint::Constraint, disjunction::Disjunction,
         nested_pattern::NestedPattern,
     },
     pipeline::{
@@ -39,25 +39,14 @@ pub fn infer_types_for_block(
     block: &Block,
     type_inference_mode: TypeInferenceMode,
 ) -> Result<BlockAnnotations, TypeInferenceError> {
-    let mut flattened_graphs = HashMap::new();
     let input_annotations = previous_stage_annotations
         .concepts
         .iter()
         .map(|(var, annotations)| (Vertex::Variable(*var), (**annotations).clone()))
         .collect();
-    infer_types_impl(ctx, block.conjunction(), &input_annotations, type_inference_mode, &mut flattened_graphs)?;
-
-    let type_annotations_by_scope = flattened_graphs
-        .into_iter()
-        .map(|(scope_id, flattened_graph)| (scope_id, flattened_graph.into_type_annotations()))
-        .collect();
-    debug_assert!(all_vertex_annotations_available(
-        block.block_context(),
-        ctx.variable_registry,
-        block.conjunction(),
-        &type_annotations_by_scope
-    ));
-
+    let root_graph = infer_types_impl(ctx, block.conjunction(), &input_annotations, type_inference_mode)?;
+    let mut type_annotations_by_scope = HashMap::new();
+    root_graph.into_type_annotations_by_scope(&mut type_annotations_by_scope);
     Ok(BlockAnnotations::new(type_annotations_by_scope))
 }
 
@@ -66,47 +55,52 @@ fn infer_types_impl<'conj>(
     conjunction: &'conj Conjunction,
     input_annotations: &BTreeMap<Vertex<Variable>, BTreeSet<TypeAnnotation>>,
     type_inference_mode: TypeInferenceMode,
-    flattened_graphs: &mut HashMap<ScopeId, FlattenedTypeInferenceGraph<'conj>>,
-) -> Result<(), TypeInferenceError> {
+) -> Result<FullTypeInferenceGraph<'conj>, TypeInferenceError> {
     let graph = compute_type_inference_graph(ctx, conjunction, input_annotations, type_inference_mode)?;
-    infer_types_in_negations_and_optionals_then_flatten(ctx, graph, type_inference_mode, flattened_graphs)?;
-    Ok(())
+    infer_types_in_negations_and_optionals_and_complete(ctx, graph, type_inference_mode)
 }
 
-fn infer_types_in_negations_and_optionals_then_flatten<'conj>(
+fn infer_types_in_negations_and_optionals_and_complete<'conj>(
     ctx: &mut PipelineAnnotationContext<'_, impl ReadableSnapshot>,
     mut graph: TypeInferenceGraph<'conj>,
     type_inference_mode: TypeInferenceMode,
-    flattened_graphs: &mut HashMap<ScopeId, FlattenedTypeInferenceGraph<'conj>>,
-) -> Result<(), TypeInferenceError> {
-    for nested in graph.conjunction.nested_patterns() {
+) -> Result<FullTypeInferenceGraph<'conj>, TypeInferenceError> {
+    let TypeInferenceGraph { conjunction, mut vertices, edges, nested_disjunctions } = graph;
+    let mut negations = Vec::new();
+    let mut optionals = Vec::new();
+    for nested in conjunction.nested_patterns() {
         match nested {
             NestedPattern::Disjunction(_) => {} // Done above
             NestedPattern::Negation(negation) => {
-                infer_types_impl(ctx, negation.conjunction(), &graph.vertices, type_inference_mode, flattened_graphs)?;
+                // No variables can escape a negation => Nothing to update
+                negations.push(infer_types_impl(ctx, negation.conjunction(), &vertices, type_inference_mode)?);
             }
             NestedPattern::Optional(optional) => {
-                infer_types_impl(ctx, optional.conjunction(), &graph.vertices, type_inference_mode, flattened_graphs)?;
-                let optional_root_annotations =
-                    &flattened_graphs.get(&optional.conjunction().scope_id()).unwrap().vertices;
-                let required_inputs = optional.required_inputs().collect::<HashSet<_>>();
-                optional_root_annotations
-                    .iter()
-                    .filter(|(vertex, _)| vertex.as_variable().map_or(false, |v| !required_inputs.contains(&v)))
-                    .for_each(|(var, annotations)| {
-                        debug_assert!(!graph.vertices.annotations.contains_key(var));
-                        graph.vertices.annotations.insert(var.clone(), annotations.clone());
-                    });
+                let optional_graph = infer_types_impl(ctx, optional.conjunction(), &vertices, type_inference_mode)?;
+                optional.optionally_bound_in_pattern().for_each(|optional_var| {
+                    let optional_vertex = Vertex::Variable(optional_var);
+                    let annotations = optional_graph.vertices[&optional_vertex].clone();
+                    vertices.insert(optional_vertex, annotations);
+                });
+                optionals.push(optional_graph)
             }
         }
     }
-    let (flattened_graph, disjunctions) = graph.flatten_graph();
-    disjunctions.into_iter().flat_map(|disjunction| disjunction.disjunction.into_iter()).try_for_each(|nested| {
-        infer_types_in_negations_and_optionals_then_flatten(ctx, nested, type_inference_mode, flattened_graphs)?;
-        Ok(())
-    })?;
-    flattened_graphs.insert(flattened_graph.conjunction.scope_id(), flattened_graph);
-    Ok(())
+    let mut disjunctions = Vec::new();
+    for nested_disjunction in nested_disjunctions {
+        let branches = nested_disjunction
+            .disjunction
+            .into_iter()
+            .map(|d| infer_types_in_negations_and_optionals_and_complete(ctx, d, type_inference_mode))
+            .collect::<Result<Vec<_>, _>>()?;
+        nested_disjunction.disjunction_pattern.optionally_bound_in_pattern().for_each(|optional_var| {
+            let optional_vertex = Vertex::Variable(optional_var);
+            let annotations = branches.iter().flat_map(|b| b.vertices[&optional_vertex].iter().copied()).collect();
+            vertices.insert(optional_vertex, annotations);
+        });
+        disjunctions.push(branches);
+    }
+    Ok(FullTypeInferenceGraph { conjunction, vertices, edges, disjunctions, optionals, negations })
 }
 
 fn all_vertex_annotations_available(
@@ -223,13 +217,6 @@ pub(crate) struct TypeInferenceGraph<'this> {
 }
 
 impl<'this> TypeInferenceGraph<'this> {
-    pub(crate) fn flatten_graph(
-        self,
-    ) -> (FlattenedTypeInferenceGraph<'this>, Vec<NestedTypeInferenceGraphDisjunction<'this>>) {
-        let Self { conjunction, vertices, edges, nested_disjunctions } = self;
-        (FlattenedTypeInferenceGraph { conjunction, vertices, edges }, nested_disjunctions)
-    }
-
     fn prune_constraints_from_vertices(&mut self) {
         for edge in &mut self.edges {
             edge.prune_self_from_vertices(&self.vertices)
@@ -368,6 +355,7 @@ impl<'this> TypeInferenceEdge<'this> {
 
 #[derive(Debug)]
 pub(crate) struct NestedTypeInferenceGraphDisjunction<'this> {
+    pub(crate) disjunction_pattern: &'this Disjunction,
     pub(crate) disjunction: Vec<TypeInferenceGraph<'this>>,
     pub(crate) shared_variables: BTreeSet<Variable>,
     pub(crate) shared_vertex_annotations: VertexAnnotations,
@@ -409,15 +397,29 @@ impl NestedTypeInferenceGraphDisjunction<'_> {
 }
 
 #[derive(Debug)]
-struct FlattenedTypeInferenceGraph<'this> {
+struct FullTypeInferenceGraph<'this> {
     conjunction: &'this Conjunction,
     vertices: VertexAnnotations,
     edges: Vec<TypeInferenceEdge<'this>>,
+    disjunctions: Vec<Vec<FullTypeInferenceGraph<'this>>>,
+    optionals: Vec<FullTypeInferenceGraph<'this>>,
+    negations: Vec<FullTypeInferenceGraph<'this>>,
 }
 
-impl FlattenedTypeInferenceGraph<'_> {
-    fn into_type_annotations(self) -> TypeAnnotations {
-        let Self { vertices, edges, .. } = self;
+impl FullTypeInferenceGraph<'_> {
+    fn into_type_annotations_by_scope(self, by_scope: &mut HashMap<ScopeId, TypeAnnotations>) {
+        let Self { conjunction, vertices, edges, disjunctions, negations, optionals } = self;
+        let type_annotations = Self::build_type_annotations(vertices, edges);
+        by_scope.insert(conjunction.scope_id(), type_annotations);
+        let all_nested = disjunctions
+            .into_iter()
+            .flat_map(|disjunction| disjunction.into_iter())
+            .chain(negations.into_iter())
+            .chain(optionals.into_iter());
+        all_nested.for_each(|nested| nested.into_type_annotations_by_scope(by_scope));
+    }
+
+    fn build_type_annotations(vertices: VertexAnnotations, edges: Vec<TypeInferenceEdge<'_>>) -> TypeAnnotations {
         let mut constraint_annotations = HashMap::new();
         let mut combine_links_edges = HashMap::new();
         edges.into_iter().for_each(|edge| {
@@ -445,7 +447,6 @@ impl FlattenedTypeInferenceGraph<'_> {
             .into_iter()
             .map(|(variable, types)| (variable.into(), Arc::new(types)))
             .collect::<BTreeMap<_, _>>();
-
         TypeAnnotations::new(vertex_annotations, constraint_annotations)
     }
 }

--- a/compiler/annotation/inference/match_inference.rs
+++ b/compiler/annotation/inference/match_inference.rs
@@ -66,6 +66,8 @@ fn infer_types_in_negations_and_optionals_and_complete<'conj>(
     mut graph: TypeInferenceGraph<'conj>,
     type_inference_mode: TypeInferenceMode,
 ) -> Result<FullTypeInferenceGraph<'conj>, TypeInferenceError> {
+    // Add the negations & optionals to TypeInferenceGraph to get FullTypeInferenceGraph.
+    // Copy over the optional variable annotations from optionals & disjunctions.
     let TypeInferenceGraph { conjunction, mut vertices, edges, nested_disjunctions } = graph;
     let mut negations = Vec::new();
     let mut optionals = Vec::new();

--- a/compiler/annotation/inference/match_inference.rs
+++ b/compiler/annotation/inference/match_inference.rs
@@ -1127,6 +1127,7 @@ pub mod tests {
                 ),
             ],
             nested_disjunctions: vec![NestedTypeInferenceGraphDisjunction {
+                disjunction_pattern: &disj,
                 disjunction: expected_nested_graphs,
                 shared_variables: BTreeSet::new(),
                 shared_vertex_annotations: VertexAnnotations::default(),

--- a/compiler/annotation/inference/match_inference.rs
+++ b/compiler/annotation/inference/match_inference.rs
@@ -80,7 +80,7 @@ fn infer_types_in_negations_and_optionals_and_complete<'conj>(
             }
             NestedPattern::Optional(optional) => {
                 let optional_graph = infer_types_impl(ctx, optional.conjunction(), &vertices, type_inference_mode)?;
-                optional.optionally_bound_in_pattern().for_each(|optional_var| {
+                for optional_var in optional.optionally_bound_in_pattern() {
                     let optional_vertex = Vertex::Variable(optional_var);
                     debug_assert!(
                         optional_graph.vertices.contains_key(&optional_vertex)
@@ -88,11 +88,11 @@ fn infer_types_in_negations_and_optionals_and_complete<'conj>(
                                 == Some(VariableCategory::Value)
                     );
                     if ctx.variable_registry.get_variable_category(optional_var) == Some(VariableCategory::Value) {
-                        return;
+                        continue;
                     }
                     let annotations = optional_graph.vertices[&optional_vertex].clone();
                     vertices.insert(optional_vertex, annotations);
-                });
+                }
                 optionals.push(optional_graph)
             }
         }
@@ -104,18 +104,18 @@ fn infer_types_in_negations_and_optionals_and_complete<'conj>(
             .into_iter()
             .map(|d| infer_types_in_negations_and_optionals_and_complete(ctx, d, type_inference_mode))
             .collect::<Result<Vec<_>, _>>()?;
-        nested_disjunction.disjunction_pattern.optionally_bound_in_pattern().for_each(|optional_var| {
+        for optional_var in nested_disjunction.disjunction_pattern.optionally_bound_in_pattern() {
             let optional_vertex = Vertex::Variable(optional_var);
             debug_assert!(
                 branches.iter().all(|b| b.vertices.contains_key(&optional_vertex))
                     || ctx.variable_registry.get_variable_category(optional_var) == Some(VariableCategory::Value)
             );
             if ctx.variable_registry.get_variable_category(optional_var) == Some(VariableCategory::Value) {
-                return;
+                continue;
             }
             let annotations = branches.iter().flat_map(|b| b.vertices[&optional_vertex].iter().copied()).collect();
             vertices.insert(optional_vertex, annotations);
-        });
+        }
         disjunctions.push(branches);
     }
     Ok(FullTypeInferenceGraph { conjunction, vertices, edges, disjunctions, optionals, negations })
@@ -215,7 +215,7 @@ fn pre_check_edges_for_trivial_unsatisfiability<'a>(
     graph
         .nested_disjunctions
         .iter()
-        .flat_map(|d| d.disjunction.iter())
+        .flatten()
         .try_for_each(|nested| pre_check_edges_for_trivial_unsatisfiability(nested))?;
     Ok(())
 }
@@ -272,7 +272,7 @@ impl<'this> TypeInferenceGraph<'this> {
         }
         self.nested_disjunctions
             .iter()
-            .flat_map(|d| d.disjunction.iter())
+            .flatten()
             .try_for_each(|graph| graph.check_thing_constraints_satisfiable(variable_registry))?;
         Ok(())
     }
@@ -429,18 +429,14 @@ impl FullTypeInferenceGraph<'_> {
         let Self { conjunction, vertices, edges, disjunctions, negations, optionals } = self;
         let type_annotations = Self::build_type_annotations(vertices, edges);
         by_scope.insert(conjunction.scope_id(), type_annotations);
-        let all_nested = disjunctions
-            .into_iter()
-            .flat_map(|disjunction| disjunction.into_iter())
-            .chain(negations.into_iter())
-            .chain(optionals.into_iter());
+        let all_nested = disjunctions.into_iter().flatten().chain(negations.into_iter()).chain(optionals.into_iter());
         all_nested.for_each(|nested| nested.into_type_annotations_by_scope(by_scope));
     }
 
     fn build_type_annotations(vertices: VertexAnnotations, edges: Vec<TypeInferenceEdge<'_>>) -> TypeAnnotations {
         let mut constraint_annotations = HashMap::new();
         let mut combine_links_edges = HashMap::new();
-        edges.into_iter().for_each(|edge| {
+        for edge in edges {
             let TypeInferenceEdge { constraint, left_to_right, right_to_left, .. } = edge;
             if let Constraint::Links(links) = edge.constraint {
                 if let Some((other_left_right, other_right_left)) = combine_links_edges.remove(&edge.right) {
@@ -459,7 +455,7 @@ impl FullTypeInferenceGraph<'_> {
                 let lr_annotations = LeftRightAnnotations::build(left_to_right, right_to_left);
                 constraint_annotations.insert(constraint.clone(), ConstraintTypeAnnotations::LeftRight(lr_annotations));
             }
-        });
+        }
 
         let vertex_annotations = vertices
             .into_iter()

--- a/compiler/annotation/inference/match_inference.rs
+++ b/compiler/annotation/inference/match_inference.rs
@@ -215,7 +215,7 @@ fn pre_check_edges_for_trivial_unsatisfiability<'a>(
     graph
         .nested_disjunctions
         .iter()
-        .flatten()
+        .flat_map(|d| d.disjunction.iter())
         .try_for_each(|nested| pre_check_edges_for_trivial_unsatisfiability(nested))?;
     Ok(())
 }
@@ -272,7 +272,7 @@ impl<'this> TypeInferenceGraph<'this> {
         }
         self.nested_disjunctions
             .iter()
-            .flatten()
+            .flat_map(|d| d.disjunction.iter())
             .try_for_each(|graph| graph.check_thing_constraints_satisfiable(variable_registry))?;
         Ok(())
     }

--- a/compiler/annotation/inference/match_inference.rs
+++ b/compiler/annotation/inference/match_inference.rs
@@ -57,7 +57,8 @@ fn infer_types_impl<'conj>(
     type_inference_mode: TypeInferenceMode,
 ) -> Result<FullTypeInferenceGraph<'conj>, TypeInferenceError> {
     let graph = compute_type_inference_graph(ctx, conjunction, input_annotations, type_inference_mode)?;
-    infer_types_in_negations_and_optionals_and_complete(ctx, graph, type_inference_mode)
+    let full_graph = infer_types_in_negations_and_optionals_and_complete(ctx, graph, type_inference_mode)?;
+    Ok(full_graph)
 }
 
 fn infer_types_in_negations_and_optionals_and_complete<'conj>(

--- a/compiler/annotation/inference/match_inference.rs
+++ b/compiler/annotation/inference/match_inference.rs
@@ -13,7 +13,7 @@ use answer::{Type as TypeAnnotation, variable::Variable};
 use ir::{
     pattern::{
         Pattern, Scope, ScopeId, Vertex, conjunction::Conjunction, constraint::Constraint, disjunction::Disjunction,
-        nested_pattern::NestedPattern,
+        nested_pattern::NestedPattern, variable_category::VariableCategory,
     },
     pipeline::{
         VariableRegistry,
@@ -82,6 +82,14 @@ fn infer_types_in_negations_and_optionals_and_complete<'conj>(
                 let optional_graph = infer_types_impl(ctx, optional.conjunction(), &vertices, type_inference_mode)?;
                 optional.optionally_bound_in_pattern().for_each(|optional_var| {
                     let optional_vertex = Vertex::Variable(optional_var);
+                    debug_assert!(
+                        optional_graph.vertices.contains_key(&optional_vertex)
+                            || ctx.variable_registry.get_variable_category(optional_var)
+                                == Some(VariableCategory::Value)
+                    );
+                    if ctx.variable_registry.get_variable_category(optional_var) == Some(VariableCategory::Value) {
+                        return;
+                    }
                     let annotations = optional_graph.vertices[&optional_vertex].clone();
                     vertices.insert(optional_vertex, annotations);
                 });
@@ -98,6 +106,13 @@ fn infer_types_in_negations_and_optionals_and_complete<'conj>(
             .collect::<Result<Vec<_>, _>>()?;
         nested_disjunction.disjunction_pattern.optionally_bound_in_pattern().for_each(|optional_var| {
             let optional_vertex = Vertex::Variable(optional_var);
+            debug_assert!(
+                branches.iter().all(|b| b.vertices.contains_key(&optional_vertex))
+                    || ctx.variable_registry.get_variable_category(optional_var) == Some(VariableCategory::Value)
+            );
+            if ctx.variable_registry.get_variable_category(optional_var) == Some(VariableCategory::Value) {
+                return;
+            }
             let annotations = branches.iter().flat_map(|b| b.vertices[&optional_vertex].iter().copied()).collect();
             vertices.insert(optional_vertex, annotations);
         });

--- a/compiler/annotation/inference/match_inference.rs
+++ b/compiler/annotation/inference/match_inference.rs
@@ -5,9 +5,7 @@
  */
 
 use std::{
-    borrow::Cow,
     collections::{BTreeMap, BTreeSet, HashMap, HashSet},
-    ops::{Deref, DerefMut},
     sync::Arc,
 };
 
@@ -27,7 +25,7 @@ use storage::snapshot::ReadableSnapshot;
 
 use crate::annotation::{
     PipelineAnnotationContext, TypeInferenceError,
-    inference::type_seeder::TypeGraphSeedingContext,
+    inference::{VertexAnnotations, type_seeder::TypeGraphSeedingContext},
     pipeline::RunningVariableAnnotations,
     type_annotations::{
         BlockAnnotations, ConstraintTypeAnnotations, LeftRightAnnotations, LinksAnnotations, TypeAnnotations,
@@ -35,95 +33,24 @@ use crate::annotation::{
     type_inference::TypeInferenceMode,
 };
 
-#[derive(Clone, Debug, Default, Eq, PartialEq)]
-pub(crate) struct VertexAnnotations {
-    annotations: BTreeMap<Vertex<Variable>, BTreeSet<TypeAnnotation>>,
-}
-
-impl VertexAnnotations {
-    pub(crate) fn add_or_intersect(
-        &mut self,
-        vertex: &Vertex<Variable>,
-        new_annotations: Cow<'_, BTreeSet<TypeAnnotation>>,
-    ) -> bool {
-        if let Some(existing_annotations) = self.get_mut(vertex) {
-            let size_before = existing_annotations.len();
-            existing_annotations.retain(|x| new_annotations.contains(x));
-            existing_annotations.len() == size_before
-        } else {
-            self.insert(vertex.clone(), new_annotations.into_owned());
-            true
-        }
-    }
-}
-
-impl Deref for VertexAnnotations {
-    type Target = BTreeMap<Vertex<Variable>, BTreeSet<TypeAnnotation>>;
-
-    fn deref(&self) -> &Self::Target {
-        &self.annotations
-    }
-}
-
-impl DerefMut for VertexAnnotations {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.annotations
-    }
-}
-
-impl IntoIterator for VertexAnnotations {
-    type Item = <BTreeMap<Vertex<Variable>, BTreeSet<TypeAnnotation>> as IntoIterator>::Item;
-    type IntoIter = <BTreeMap<Vertex<Variable>, BTreeSet<TypeAnnotation>> as IntoIterator>::IntoIter;
-    fn into_iter(self) -> Self::IntoIter {
-        self.annotations.into_iter()
-    }
-}
-
-impl<'a> IntoIterator for &'a VertexAnnotations {
-    type Item = <&'a BTreeMap<Vertex<Variable>, BTreeSet<TypeAnnotation>> as IntoIterator>::Item;
-    type IntoIter = <&'a BTreeMap<Vertex<Variable>, BTreeSet<TypeAnnotation>> as IntoIterator>::IntoIter;
-    fn into_iter(self) -> Self::IntoIter {
-        self.annotations.iter()
-    }
-}
-
-impl<'a> IntoIterator for &'a mut VertexAnnotations {
-    type Item = <&'a mut BTreeMap<Vertex<Variable>, BTreeSet<TypeAnnotation>> as IntoIterator>::Item;
-    type IntoIter = <&'a mut BTreeMap<Vertex<Variable>, BTreeSet<TypeAnnotation>> as IntoIterator>::IntoIter;
-    fn into_iter(self) -> Self::IntoIter {
-        self.annotations.iter_mut()
-    }
-}
-
-impl<T> From<T> for VertexAnnotations
-where
-    BTreeMap<Vertex<Variable>, BTreeSet<TypeAnnotation>>: From<T>,
-{
-    fn from(t: T) -> Self {
-        Self { annotations: t.into() }
-    }
-}
-
 pub fn infer_types_for_block(
     ctx: &mut PipelineAnnotationContext<'_, impl ReadableSnapshot>,
     previous_stage_annotations: &RunningVariableAnnotations,
     block: &Block,
     type_inference_mode: TypeInferenceMode,
 ) -> Result<BlockAnnotations, TypeInferenceError> {
-    let mut type_annotations_by_scope = HashMap::new();
+    let mut flattened_graphs = HashMap::new();
     let input_annotations = previous_stage_annotations
         .concepts
         .iter()
         .map(|(var, annotations)| (Vertex::Variable(*var), (**annotations).clone()))
         .collect();
-    infer_types_impl(
-        ctx,
-        block.conjunction(),
-        &input_annotations,
-        type_inference_mode,
-        &mut type_annotations_by_scope,
-    )?;
+    infer_types_impl(ctx, block.conjunction(), &input_annotations, type_inference_mode, &mut flattened_graphs)?;
 
+    let type_annotations_by_scope = flattened_graphs
+        .into_iter()
+        .map(|(scope_id, flattened_graph)| (scope_id, flattened_graph.into_type_annotations()))
+        .collect();
     debug_assert!(all_vertex_annotations_available(
         block.block_context(),
         ctx.variable_registry,
@@ -134,64 +61,51 @@ pub fn infer_types_for_block(
     Ok(BlockAnnotations::new(type_annotations_by_scope))
 }
 
-fn infer_types_impl(
+fn infer_types_impl<'conj>(
     ctx: &mut PipelineAnnotationContext<'_, impl ReadableSnapshot>,
-    conjunction: &Conjunction,
+    conjunction: &'conj Conjunction,
     input_annotations: &BTreeMap<Vertex<Variable>, BTreeSet<TypeAnnotation>>,
     type_inference_mode: TypeInferenceMode,
-    type_annotations_by_scope: &mut HashMap<ScopeId, TypeAnnotations>,
+    flattened_graphs: &mut HashMap<ScopeId, FlattenedTypeInferenceGraph<'conj>>,
 ) -> Result<(), TypeInferenceError> {
-    let mut graph = compute_type_inference_graph(ctx, conjunction, input_annotations, type_inference_mode)?;
-
-    infer_types_in_negations_and_conjunctions(ctx, &mut graph, type_inference_mode, type_annotations_by_scope)?;
-
-    graph.collect_type_annotations(type_annotations_by_scope);
+    let graph = compute_type_inference_graph(ctx, conjunction, input_annotations, type_inference_mode)?;
+    infer_types_in_negations_and_optionals_then_flatten(ctx, graph, type_inference_mode, flattened_graphs)?;
     Ok(())
 }
 
-fn infer_types_in_negations_and_conjunctions(
+fn infer_types_in_negations_and_optionals_then_flatten<'conj>(
     ctx: &mut PipelineAnnotationContext<'_, impl ReadableSnapshot>,
-    parent_conjunction_graph: &mut TypeInferenceGraph<'_>,
+    mut graph: TypeInferenceGraph<'conj>,
     type_inference_mode: TypeInferenceMode,
-    type_annotations_by_scope: &mut HashMap<ScopeId, TypeAnnotations>,
+    flattened_graphs: &mut HashMap<ScopeId, FlattenedTypeInferenceGraph<'conj>>,
 ) -> Result<(), TypeInferenceError> {
-    let TypeInferenceGraph { conjunction, vertices, nested_disjunctions, .. } = parent_conjunction_graph;
-    nested_disjunctions.iter_mut().flat_map(|disjunction| disjunction.disjunction.iter_mut()).try_for_each(
-        |nested| infer_types_in_negations_and_conjunctions(ctx, nested, type_inference_mode, type_annotations_by_scope),
-    )?;
-    for nested in conjunction.nested_patterns() {
+    for nested in graph.conjunction.nested_patterns() {
         match nested {
             NestedPattern::Disjunction(_) => {} // Done above
             NestedPattern::Negation(negation) => {
-                infer_types_impl(
-                    ctx,
-                    negation.conjunction(),
-                    &vertices,
-                    type_inference_mode,
-                    type_annotations_by_scope,
-                )?;
+                infer_types_impl(ctx, negation.conjunction(), &graph.vertices, type_inference_mode, flattened_graphs)?;
             }
             NestedPattern::Optional(optional) => {
-                infer_types_impl(
-                    ctx,
-                    optional.conjunction(),
-                    &vertices,
-                    type_inference_mode,
-                    type_annotations_by_scope,
-                )?;
+                infer_types_impl(ctx, optional.conjunction(), &graph.vertices, type_inference_mode, flattened_graphs)?;
                 let optional_root_annotations =
-                    type_annotations_by_scope.get(&optional.conjunction().scope_id()).unwrap().vertex_annotations();
+                    &flattened_graphs.get(&optional.conjunction().scope_id()).unwrap().vertices;
                 let required_inputs = optional.required_inputs().collect::<HashSet<_>>();
                 optional_root_annotations
                     .iter()
                     .filter(|(vertex, _)| vertex.as_variable().map_or(false, |v| !required_inputs.contains(&v)))
                     .for_each(|(var, annotations)| {
-                        debug_assert!(!vertices.annotations.contains_key(var));
-                        vertices.annotations.insert(var.clone(), (**annotations).clone());
+                        debug_assert!(!graph.vertices.annotations.contains_key(var));
+                        graph.vertices.annotations.insert(var.clone(), annotations.clone());
                     });
             }
         }
     }
+    let (flattened_graph, disjunctions) = graph.flatten_graph();
+    disjunctions.into_iter().flat_map(|disjunction| disjunction.disjunction.into_iter()).try_for_each(|nested| {
+        infer_types_in_negations_and_optionals_then_flatten(ctx, nested, type_inference_mode, flattened_graphs)?;
+        Ok(())
+    })?;
+    flattened_graphs.insert(flattened_graph.conjunction.scope_id(), flattened_graph);
     Ok(())
 }
 
@@ -308,7 +222,14 @@ pub(crate) struct TypeInferenceGraph<'this> {
     pub(crate) nested_disjunctions: Vec<NestedTypeInferenceGraphDisjunction<'this>>,
 }
 
-impl TypeInferenceGraph<'_> {
+impl<'this> TypeInferenceGraph<'this> {
+    pub(crate) fn flatten_graph(
+        self,
+    ) -> (FlattenedTypeInferenceGraph<'this>, Vec<NestedTypeInferenceGraphDisjunction<'this>>) {
+        let Self { conjunction, vertices, edges, nested_disjunctions } = self;
+        (FlattenedTypeInferenceGraph { conjunction, vertices, edges }, nested_disjunctions)
+    }
+
     fn prune_constraints_from_vertices(&mut self) {
         for edge in &mut self.edges {
             edge.prune_self_from_vertices(&self.vertices)
@@ -327,45 +248,6 @@ impl TypeInferenceGraph<'_> {
             is_modified |= nested_graph.prune_vertices_from_self(&mut self.vertices);
         }
         is_modified
-    }
-
-    pub(crate) fn collect_type_annotations(self, type_annotations_by_scope: &mut HashMap<ScopeId, TypeAnnotations>) {
-        let TypeInferenceGraph { vertices, edges, nested_disjunctions, conjunction } = self;
-        let mut constraint_annotations = HashMap::new();
-        let mut combine_links_edges = HashMap::new();
-        edges.into_iter().for_each(|edge| {
-            let TypeInferenceEdge { constraint, left_to_right, right_to_left, .. } = edge;
-            if let Constraint::Links(links) = edge.constraint {
-                if let Some((other_left_right, other_right_left)) = combine_links_edges.remove(&edge.right) {
-                    let lrf_annotation = {
-                        if &edge.left == links.relation() {
-                            LinksAnnotations::build(left_to_right, right_to_left, other_left_right, other_right_left)
-                        } else {
-                            LinksAnnotations::build(other_left_right, other_right_left, left_to_right, right_to_left)
-                        }
-                    };
-                    constraint_annotations.insert(constraint.clone(), ConstraintTypeAnnotations::Links(lrf_annotation));
-                } else {
-                    combine_links_edges.insert(edge.right, (left_to_right, right_to_left));
-                }
-            } else {
-                let lr_annotations = LeftRightAnnotations::build(left_to_right, right_to_left);
-                constraint_annotations.insert(constraint.clone(), ConstraintTypeAnnotations::LeftRight(lr_annotations));
-            }
-        });
-
-        let vertex_annotations = vertices
-            .into_iter()
-            .map(|(variable, types)| (variable.into(), Arc::new(types)))
-            .collect::<BTreeMap<_, _>>();
-
-        let type_annotations = TypeAnnotations::new(vertex_annotations, constraint_annotations);
-        type_annotations_by_scope.insert(conjunction.scope_id(), type_annotations);
-
-        nested_disjunctions
-            .into_iter()
-            .flat_map(|disjunction| disjunction.disjunction)
-            .for_each(|nested| nested.collect_type_annotations(type_annotations_by_scope));
     }
 
     fn check_thing_constraints_satisfiable(
@@ -523,6 +405,48 @@ impl NestedTypeInferenceGraphDisjunction<'_> {
             is_modified |= size_before != parent_vertex_types.len();
         }
         is_modified
+    }
+}
+
+#[derive(Debug)]
+struct FlattenedTypeInferenceGraph<'this> {
+    conjunction: &'this Conjunction,
+    vertices: VertexAnnotations,
+    edges: Vec<TypeInferenceEdge<'this>>,
+}
+
+impl FlattenedTypeInferenceGraph<'_> {
+    fn into_type_annotations(self) -> TypeAnnotations {
+        let Self { vertices, edges, .. } = self;
+        let mut constraint_annotations = HashMap::new();
+        let mut combine_links_edges = HashMap::new();
+        edges.into_iter().for_each(|edge| {
+            let TypeInferenceEdge { constraint, left_to_right, right_to_left, .. } = edge;
+            if let Constraint::Links(links) = edge.constraint {
+                if let Some((other_left_right, other_right_left)) = combine_links_edges.remove(&edge.right) {
+                    let lrf_annotation = {
+                        if &edge.left == links.relation() {
+                            LinksAnnotations::build(left_to_right, right_to_left, other_left_right, other_right_left)
+                        } else {
+                            LinksAnnotations::build(other_left_right, other_right_left, left_to_right, right_to_left)
+                        }
+                    };
+                    constraint_annotations.insert(constraint.clone(), ConstraintTypeAnnotations::Links(lrf_annotation));
+                } else {
+                    combine_links_edges.insert(edge.right, (left_to_right, right_to_left));
+                }
+            } else {
+                let lr_annotations = LeftRightAnnotations::build(left_to_right, right_to_left);
+                constraint_annotations.insert(constraint.clone(), ConstraintTypeAnnotations::LeftRight(lr_annotations));
+            }
+        });
+
+        let vertex_annotations = vertices
+            .into_iter()
+            .map(|(variable, types)| (variable.into(), Arc::new(types)))
+            .collect::<BTreeMap<_, _>>();
+
+        TypeAnnotations::new(vertex_annotations, constraint_annotations)
     }
 }
 
@@ -1583,7 +1507,7 @@ pub mod tests {
             )
             .create_graph(&BTreeMap::new(), block.conjunction())
             .unwrap();
-            crate::annotation::inference::match_inference::prune_types(&mut graph);
+            prune_types(&mut graph);
 
             let expected_graph = TypeInferenceGraph {
                 conjunction: block.conjunction(),

--- a/compiler/annotation/inference/mod.rs
+++ b/compiler/annotation/inference/mod.rs
@@ -3,6 +3,83 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
+use std::{
+    borrow::Cow,
+    collections::{BTreeMap, BTreeSet},
+    ops::{Deref, DerefMut},
+};
+
+use answer::{Type as TypeAnnotation, variable::Variable};
+use ir::pattern::Vertex;
 
 pub mod match_inference;
 pub mod type_seeder;
+
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub(crate) struct VertexAnnotations {
+    annotations: BTreeMap<Vertex<Variable>, BTreeSet<TypeAnnotation>>,
+}
+
+impl VertexAnnotations {
+    pub(crate) fn add_or_intersect(
+        &mut self,
+        vertex: &Vertex<Variable>,
+        new_annotations: Cow<'_, BTreeSet<TypeAnnotation>>,
+    ) -> bool {
+        if let Some(existing_annotations) = self.get_mut(vertex) {
+            let size_before = existing_annotations.len();
+            existing_annotations.retain(|x| new_annotations.contains(x));
+            existing_annotations.len() == size_before
+        } else {
+            self.insert(vertex.clone(), new_annotations.into_owned());
+            true
+        }
+    }
+}
+
+impl Deref for VertexAnnotations {
+    type Target = BTreeMap<Vertex<Variable>, BTreeSet<TypeAnnotation>>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.annotations
+    }
+}
+
+impl DerefMut for VertexAnnotations {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.annotations
+    }
+}
+
+impl IntoIterator for VertexAnnotations {
+    type Item = <BTreeMap<Vertex<Variable>, BTreeSet<TypeAnnotation>> as IntoIterator>::Item;
+    type IntoIter = <BTreeMap<Vertex<Variable>, BTreeSet<TypeAnnotation>> as IntoIterator>::IntoIter;
+    fn into_iter(self) -> Self::IntoIter {
+        self.annotations.into_iter()
+    }
+}
+
+impl<'a> IntoIterator for &'a VertexAnnotations {
+    type Item = <&'a BTreeMap<Vertex<Variable>, BTreeSet<TypeAnnotation>> as IntoIterator>::Item;
+    type IntoIter = <&'a BTreeMap<Vertex<Variable>, BTreeSet<TypeAnnotation>> as IntoIterator>::IntoIter;
+    fn into_iter(self) -> Self::IntoIter {
+        self.annotations.iter()
+    }
+}
+
+impl<'a> IntoIterator for &'a mut VertexAnnotations {
+    type Item = <&'a mut BTreeMap<Vertex<Variable>, BTreeSet<TypeAnnotation>> as IntoIterator>::Item;
+    type IntoIter = <&'a mut BTreeMap<Vertex<Variable>, BTreeSet<TypeAnnotation>> as IntoIterator>::IntoIter;
+    fn into_iter(self) -> Self::IntoIter {
+        self.annotations.iter_mut()
+    }
+}
+
+impl<T> From<T> for VertexAnnotations
+where
+    BTreeMap<Vertex<Variable>, BTreeSet<TypeAnnotation>>: From<T>,
+{
+    fn from(t: T) -> Self {
+        Self { annotations: t.into() }
+    }
+}

--- a/compiler/annotation/inference/type_seeder.rs
+++ b/compiler/annotation/inference/type_seeder.rs
@@ -232,7 +232,7 @@ impl<'this, Snapshot: ReadableSnapshot> TypeGraphSeedingContext<'this, Snapshot>
         for c in graph.conjunction.constraints().iter().filter_map(|c| c.as_comparison()) {
             c.apply(self, vertices)?;
         }
-        for nested_graph in graph.nested_disjunctions.iter_mut().flatten() {
+        for nested_graph in graph.nested_disjunctions.iter_mut().flat_map(|nested| nested.disjunction.iter_mut()) {
             self.seed_vertex_annotations_from_type_and_called_function_signatures(nested_graph)?;
         }
         Ok(())
@@ -427,7 +427,7 @@ impl<'this, Snapshot: ReadableSnapshot> TypeGraphSeedingContext<'this, Snapshot>
             (None, Some(right_types)) => {
                 let mut left_types = BTreeSet::new();
                 for type_ in right_types {
-                    inner.annotate_right_to_left_for_type(self, type_, &mut left_types)
+                    inner.annotate_right_to_left_for_type(self, type_, &mut left_types)?;
                 }
                 vertices.insert(left.clone(), left_types);
                 true
@@ -593,7 +593,7 @@ impl<'this, Snapshot: ReadableSnapshot> TypeGraphSeedingContext<'this, Snapshot>
                     .map_err(|source| TypeInferenceError::ConceptRead { typedb_source: source })?;
             }
         }
-        for nested in graph.nested_disjunctions.iter_mut().flatten() {
+        for nested in graph.nested_disjunctions.iter_mut().flat_map(|nested| nested.disjunction.iter_mut()) {
             self.prune_abstract_types_from_thing_vertex_annotations_recursive(nested)?;
         }
         Ok(())

--- a/compiler/annotation/inference/type_seeder.rs
+++ b/compiler/annotation/inference/type_seeder.rs
@@ -232,7 +232,7 @@ impl<'this, Snapshot: ReadableSnapshot> TypeGraphSeedingContext<'this, Snapshot>
         for c in graph.conjunction.constraints().iter().filter_map(|c| c.as_comparison()) {
             c.apply(self, vertices)?;
         }
-        for nested_graph in graph.nested_disjunctions.iter_mut().flat_map(|nested| &mut nested.disjunction) {
+        for nested_graph in graph.nested_disjunctions.iter_mut().flatten() {
             self.seed_vertex_annotations_from_type_and_called_function_signatures(nested_graph)?;
         }
         Ok(())
@@ -418,17 +418,17 @@ impl<'this, Snapshot: ReadableSnapshot> TypeGraphSeedingContext<'this, Snapshot>
             (Some(_), Some(_)) => false,
             (Some(left_types), None) => {
                 let mut right_types = BTreeSet::new();
-                left_types
-                    .iter()
-                    .try_for_each(|type_| inner.annotate_left_to_right_for_type(self, type_, &mut right_types))?;
+                for type_ in left_types {
+                    inner.annotate_left_to_right_for_type(self, type_, &mut right_types)?;
+                }
                 vertices.insert(right.clone(), right_types);
                 true
             }
             (None, Some(right_types)) => {
                 let mut left_types = BTreeSet::new();
-                right_types
-                    .iter()
-                    .try_for_each(|type_| inner.annotate_right_to_left_for_type(self, type_, &mut left_types))?;
+                for type_ in right_types {
+                    inner.annotate_right_to_left_for_type(self, type_, &mut left_types)
+                }
                 vertices.insert(left.clone(), left_types);
                 true
             }
@@ -593,7 +593,7 @@ impl<'this, Snapshot: ReadableSnapshot> TypeGraphSeedingContext<'this, Snapshot>
                     .map_err(|source| TypeInferenceError::ConceptRead { typedb_source: source })?;
             }
         }
-        for nested in graph.nested_disjunctions.iter_mut().flat_map(|nested| nested.disjunction.iter_mut()) {
+        for nested in graph.nested_disjunctions.iter_mut().flatten() {
             self.prune_abstract_types_from_thing_vertex_annotations_recursive(nested)?;
         }
         Ok(())

--- a/compiler/annotation/inference/type_seeder.rs
+++ b/compiler/annotation/inference/type_seeder.rs
@@ -37,8 +37,9 @@ use storage::snapshot::ReadableSnapshot;
 use crate::annotation::{
     TypeInferenceError,
     function::{AnnotatedFunctionSignatures, FunctionParameterAnnotation},
-    inference::match_inference::{
-        NestedTypeInferenceGraphDisjunction, TypeInferenceEdge, TypeInferenceGraph, VertexAnnotations,
+    inference::{
+        VertexAnnotations,
+        match_inference::{NestedTypeInferenceGraphDisjunction, TypeInferenceEdge, TypeInferenceGraph},
     },
     type_inference::{TypeInferenceMode, get_type_annotation_from_label},
 };
@@ -1663,7 +1664,8 @@ pub mod tests {
     use crate::annotation::{
         function::EmptyAnnotatedFunctionSignatures,
         inference::{
-            match_inference::{TypeInferenceGraph, VertexAnnotations, tests::expected_edge},
+            VertexAnnotations,
+            match_inference::{TypeInferenceGraph, tests::expected_edge},
             type_seeder::{TypeGraphSeedingContext, TypeInferenceMode},
         },
         tests::{

--- a/compiler/annotation/inference/type_seeder.rs
+++ b/compiler/annotation/inference/type_seeder.rs
@@ -182,6 +182,7 @@ impl<'this, Snapshot: ReadableSnapshot> TypeGraphSeedingContext<'this, Snapshot>
         let nested_graphs = disjunction.conjunctions().iter().map(|conj| self.build_recursive(conj)).collect_vec();
         let shared_variables = disjunction.visible_referenced_variables().collect();
         NestedTypeInferenceGraphDisjunction {
+            disjunction_pattern: disjunction,
             disjunction: nested_graphs,
             shared_variables,
             shared_vertex_annotations: VertexAnnotations::default(),
@@ -460,6 +461,7 @@ impl<'this, Snapshot: ReadableSnapshot> TypeGraphSeedingContext<'this, Snapshot>
 
         // Update shared variables of the disjunction
         let NestedTypeInferenceGraphDisjunction {
+            disjunction_pattern: _,
             shared_vertex_annotations,
             disjunction: nested_graph_disjunction,
             shared_variables,

--- a/ir/pattern/mod.rs
+++ b/ir/pattern/mod.rs
@@ -77,6 +77,8 @@ pub trait Pattern {
     fn visible_referenced_variables(&self) -> impl Iterator<Item = Variable> + '_;
 
     fn required_inputs(&self) -> impl Iterator<Item = Variable> + '_;
+
+    fn optionally_bound_in_pattern(&self) -> impl Iterator<Item = Variable> + '_;
 }
 
 macro_rules! impl_pattern_from_pattern_variables {
@@ -88,6 +90,10 @@ macro_rules! impl_pattern_from_pattern_variables {
 
             fn required_inputs(&self) -> impl Iterator<Item = Variable> + '_ {
                 self.pattern_variables.required_inputs()
+            }
+
+            fn optionally_bound_in_pattern(&self) -> impl Iterator<Item = Variable> + '_ {
+                self.pattern_variables.optionally_bound_in_pattern()
             }
         }
     };
@@ -475,13 +481,14 @@ impl ContextualisedBindingMode {
 }
 
 #[derive(Debug, Clone, PartialEq)]
-pub(crate) enum IsRequired {
-    Required,
-    NotRequired,
+pub(crate) enum PatternVariableMode {
+    RequiredInput,
+    Binding,
+    OptionallyBinding,
 }
 
 #[derive(Debug, Clone)]
-pub(crate) struct PatternVariables(HashMap<Variable, IsRequired>);
+pub(crate) struct PatternVariables(HashMap<Variable, PatternVariableMode>);
 impl PatternVariables {
     fn from(modes: &ContextualisedBindingMode) -> Self {
         Self(
@@ -489,10 +496,9 @@ impl PatternVariables {
                 .0
                 .iter()
                 .filter_map(|(var, mode)| match mode {
-                    BindingMode::RequirePrebound => Some((*var, IsRequired::Required)),
-                    BindingMode::AlwaysBinding | BindingMode::OptionallyBinding => {
-                        Some((*var, IsRequired::NotRequired))
-                    }
+                    BindingMode::RequirePrebound => Some((*var, PatternVariableMode::RequiredInput)),
+                    BindingMode::AlwaysBinding => Some((*var, PatternVariableMode::Binding)),
+                    BindingMode::OptionallyBinding => Some((*var, PatternVariableMode::OptionallyBinding)),
                     BindingMode::LocallyBindingInChild | BindingMode::Absent => None,
                 })
                 .collect(),
@@ -504,7 +510,11 @@ impl PatternVariables {
     }
 
     pub(crate) fn required_inputs(&self) -> impl Iterator<Item = Variable> + '_ {
-        self.0.iter().filter_map(|(v, required)| (*required == IsRequired::Required).then_some(*v))
+        self.0.iter().filter_map(|(v, required)| (*required == PatternVariableMode::RequiredInput).then_some(*v))
+    }
+
+    pub(crate) fn optionally_bound_in_pattern(&self) -> impl Iterator<Item = Variable> + '_ {
+        self.0.iter().filter_map(|(v, required)| (*required == PatternVariableMode::OptionallyBinding).then_some(*v))
     }
 }
 


### PR DESCRIPTION
## Product change and motivation
Refactors the type-inference package in preparation for more refactors

## Implementation
* Moves the logic of type-inference into a module of its own to k from the entry methods 
* Tweaks how we convert TypeInferenceGraphs to TypeAnnotations to a simpler system.
