### PR TITLE
Refactor how type-inference handles disjunctions

### DIFF
--- a/compiler/annotation/inference/match_inference.rs
+++ b/compiler/annotation/inference/match_inference.rs
@@ -1060,120 +1060,242 @@ pub mod tests {
         let (_tmp_dir, storage) = setup_storage();
         let (type_manager, thing_manager) = managers();
 
-        let ((_, type_cat, type_dog), (type_name, type_catname, type_dogname), _) =
+        let ((type_animal, type_cat, type_dog), (type_name, type_catname, type_dogname), _) =
             setup_types(storage.clone().open_snapshot_write(), &type_manager, &thing_manager);
+        {
+            let mut translation_context = PipelineTranslationContext::new();
+            let mut value_parameters = ParameterRegistry::new();
+            let mut builder = Block::builder(translation_context.new_block_builder_context(&mut value_parameters));
+            let mut conjunction = builder.conjunction_mut();
+            let (var_animal, var_name, var_name_type) = ["animal", "name", "name_type"]
+                .into_iter()
+                .map(|name| conjunction.constraints_mut().get_or_declare_variable(name, None).unwrap())
+                .collect_tuple()
+                .unwrap();
 
-        let mut translation_context = PipelineTranslationContext::new();
-        let mut value_parameters = ParameterRegistry::new();
-        let mut builder = Block::builder(translation_context.new_block_builder_context(&mut value_parameters));
-        let mut conjunction = builder.conjunction_mut();
-        let (var_animal, var_name, var_name_type) = ["animal", "name", "name_type"]
-            .into_iter()
-            .map(|name| conjunction.constraints_mut().get_or_declare_variable(name, None).unwrap())
-            .collect_tuple()
+            // Case 1: {$a isa cat;} or {$a isa dog;}; $a has name $n;
+            conjunction.constraints_mut().add_label(var_name_type, Label::build("name", None)).unwrap();
+            conjunction.constraints_mut().add_isa(IsaKind::Subtype, var_name, var_name_type.into(), None).unwrap();
+            conjunction.constraints_mut().add_has(var_animal, var_name, None).unwrap();
+
+            let mut disj = conjunction.add_disjunction(None);
+
+            let mut branch1 = disj.add_conjunction();
+            let b1_var_animal_type = branch1.constraints_mut().get_or_declare_variable("b1_animal_type", None).unwrap();
+            branch1.constraints_mut().add_isa(IsaKind::Subtype, var_animal, b1_var_animal_type.into(), None).unwrap();
+            branch1.constraints_mut().add_label(b1_var_animal_type, LABEL_CAT.clone()).unwrap();
+
+            let mut branch2 = disj.add_conjunction();
+            let b2_var_animal_type = branch2.constraints_mut().get_or_declare_variable("b2_animal_type", None).unwrap();
+            branch2.constraints_mut().add_isa(IsaKind::Subtype, var_animal, b2_var_animal_type.into(), None).unwrap();
+            branch2.constraints_mut().add_label(b2_var_animal_type, LABEL_DOG.clone()).unwrap();
+
+            let (b1_var_animal_type, b2_var_animal_type) = (b1_var_animal_type, b2_var_animal_type);
+
+            let block = builder.finish().unwrap();
+
+            let snapshot = storage.clone().open_snapshot_write();
+            let annotation_context =
+                AnnotationContext::new(&snapshot, &type_manager, &EmptyAnnotatedFunctionSignatures);
+            let parameters = ParameterRegistry::new();
+            let mut pipeline_annotation_context =
+                annotation_context.for_pipeline(&mut translation_context.variable_registry, &parameters);
+            let graph = compute_type_inference_graph(
+                &mut pipeline_annotation_context,
+                block.conjunction(),
+                &BTreeMap::new(),
+                TypeInferenceMode::ConcreteSubtypesOnly,
+            )
             .unwrap();
 
-        // Case 1: {$a isa cat;} or {$a isa dog;}; $a has name $n;
-        conjunction.constraints_mut().add_label(var_name_type, Label::build("name", None)).unwrap();
-        conjunction.constraints_mut().add_isa(IsaKind::Subtype, var_name, var_name_type.into(), None).unwrap();
-        conjunction.constraints_mut().add_has(var_animal, var_name, None).unwrap();
+            let conjunction = block.conjunction();
+            let disj = conjunction.nested_patterns()[0].as_disjunction().unwrap();
+            let [b1, b2] = disj.conjunctions() else { unreachable!() };
+            let b1_isa = &b1.constraints()[0];
+            let b2_isa = &b2.constraints()[0];
+            let expected_nested_graphs = vec![
+                TypeInferenceGraph {
+                    conjunction: b1,
+                    vertices: VertexAnnotations::from([
+                        (var_animal.into(), BTreeSet::from([type_cat])),
+                        (b1_var_animal_type.into(), BTreeSet::from([type_cat])),
+                        (Vertex::Label(LABEL_CAT), BTreeSet::from([type_cat])),
+                    ]),
+                    edges: vec![expected_edge(
+                        b1_isa,
+                        var_animal.into(),
+                        b1_var_animal_type.into(),
+                        vec![(type_cat, type_cat)],
+                    )],
+                    nested_disjunctions: Vec::new(),
+                },
+                TypeInferenceGraph {
+                    conjunction: b2,
+                    vertices: VertexAnnotations::from([
+                        (var_animal.into(), BTreeSet::from([type_dog])),
+                        (b2_var_animal_type.into(), BTreeSet::from([type_dog])),
+                        (Vertex::Label(LABEL_DOG), BTreeSet::from([type_dog])),
+                    ]),
+                    edges: vec![expected_edge(
+                        b2_isa,
+                        var_animal.into(),
+                        b2_var_animal_type.into(),
+                        vec![(type_dog, type_dog)],
+                    )],
+                    nested_disjunctions: Vec::new(),
+                },
+            ];
 
-        let mut disj = conjunction.add_disjunction(None);
-
-        let mut branch1 = disj.add_conjunction();
-        let b1_var_animal_type = branch1.constraints_mut().get_or_declare_variable("b1_animal_type", None).unwrap();
-        branch1.constraints_mut().add_isa(IsaKind::Subtype, var_animal, b1_var_animal_type.into(), None).unwrap();
-        branch1.constraints_mut().add_label(b1_var_animal_type, LABEL_CAT.clone()).unwrap();
-
-        let mut branch2 = disj.add_conjunction();
-        let b2_var_animal_type = branch2.constraints_mut().get_or_declare_variable("b2_animal_type", None).unwrap();
-        branch2.constraints_mut().add_isa(IsaKind::Subtype, var_animal, b2_var_animal_type.into(), None).unwrap();
-        branch2.constraints_mut().add_label(b2_var_animal_type, LABEL_DOG.clone()).unwrap();
-
-        let (b1_var_animal_type, b2_var_animal_type) = (b1_var_animal_type, b2_var_animal_type);
-
-        let block = builder.finish().unwrap();
-
-        let snapshot = storage.clone().open_snapshot_write();
-        let annotation_context = AnnotationContext::new(&snapshot, &type_manager, &EmptyAnnotatedFunctionSignatures);
-        let parameters = ParameterRegistry::new();
-        let mut pipeline_annotation_context =
-            annotation_context.for_pipeline(&mut translation_context.variable_registry, &parameters);
-        let graph = compute_type_inference_graph(
-            &mut pipeline_annotation_context,
-            block.conjunction(),
-            &BTreeMap::new(),
-            TypeInferenceMode::ConcreteSubtypesOnly,
-        )
-        .unwrap();
-
-        let conjunction = block.conjunction();
-        let disj = conjunction.nested_patterns()[0].as_disjunction().unwrap();
-        let [b1, b2] = disj.conjunctions() else { unreachable!() };
-        let b1_isa = &b1.constraints()[0];
-        let b2_isa = &b2.constraints()[0];
-        let expected_nested_graphs = vec![
-            TypeInferenceGraph {
-                conjunction: b1,
+            let expected_graph = TypeInferenceGraph {
+                conjunction,
                 vertices: VertexAnnotations::from([
-                    (var_animal.into(), BTreeSet::from([type_cat])),
-                    (b1_var_animal_type.into(), BTreeSet::from([type_cat])),
-                    (Vertex::Label(LABEL_CAT), BTreeSet::from([type_cat])),
+                    (var_animal.into(), BTreeSet::from([type_cat, type_dog])),
+                    (var_name.into(), BTreeSet::from([type_catname, type_dogname])),
+                    (var_name_type.into(), BTreeSet::from([type_name])),
+                    (Vertex::Label(LABEL_NAME), BTreeSet::from([type_name])),
+                ]),
+                edges: vec![
+                    expected_edge(
+                        &conjunction.constraints()[1],
+                        var_name.into(),
+                        var_name_type.into(),
+                        vec![(type_catname, type_name), (type_dogname, type_name)],
+                    ),
+                    expected_edge(
+                        &conjunction.constraints()[2],
+                        var_animal.into(),
+                        var_name.into(),
+                        vec![(type_cat, type_catname), (type_dog, type_dogname)],
+                    ),
+                ],
+                nested_disjunctions: vec![NestedTypeInferenceGraphDisjunction {
+                    disjunction_pattern: &disj,
+                    disjunction: expected_nested_graphs,
+                }],
+            };
+
+            assert_eq!(expected_graph, graph);
+        }
+
+        {
+            // Case 2: $a isa animal; {$a has cat-name;} or { $b isa catname; };
+            // Test that the second branch means `$a` retains dog
+            let mut translation_context = PipelineTranslationContext::new();
+            let mut value_parameters = ParameterRegistry::new();
+            let mut builder = Block::builder(translation_context.new_block_builder_context(&mut value_parameters));
+            let mut conjunction = builder.conjunction_mut();
+            let var_animal = conjunction.constraints_mut().get_or_declare_variable("animal", None).unwrap();
+
+            conjunction
+                .constraints_mut()
+                .add_isa(IsaKind::Subtype, var_animal, Vertex::Label(LABEL_ANIMAL), None)
+                .unwrap();
+
+            let mut disj = conjunction.add_disjunction(None);
+
+            let mut branch1 = disj.add_conjunction();
+            let b1_var_name = branch1.constraints_mut().get_or_declare_variable("b1_name", None).unwrap();
+            branch1.constraints_mut().add_has(var_animal, b1_var_name, None).unwrap();
+            branch1
+                .constraints_mut()
+                .add_isa(IsaKind::Subtype, b1_var_name, Vertex::Label(LABEL_CATNAME), None)
+                .unwrap();
+
+            let mut branch2 = disj.add_conjunction();
+            let b2_var_catname_other =
+                branch2.constraints_mut().get_or_declare_variable("b2_catname_other", None).unwrap();
+            branch2
+                .constraints_mut()
+                .add_isa(IsaKind::Subtype, b2_var_catname_other, Vertex::Label(LABEL_CATNAME), None)
+                .unwrap();
+            let block = builder.finish().unwrap();
+
+            let snapshot = storage.clone().open_snapshot_write();
+            let annotation_context =
+                AnnotationContext::new(&snapshot, &type_manager, &EmptyAnnotatedFunctionSignatures);
+            let parameters = ParameterRegistry::new();
+            let mut pipeline_annotation_context =
+                annotation_context.for_pipeline(&mut translation_context.variable_registry, &parameters);
+            let graph = compute_type_inference_graph(
+                &mut pipeline_annotation_context,
+                block.conjunction(),
+                &BTreeMap::new(),
+                TypeInferenceMode::ConcreteSubtypesOnly,
+            )
+            .unwrap();
+
+            let conjunction = block.conjunction();
+            let disj = conjunction.nested_patterns()[0].as_disjunction().unwrap();
+            let [b1, b2] = disj.conjunctions() else { unreachable!() };
+            let b1_has = &b1.constraints()[0];
+            let b1_isa = &b1.constraints()[1];
+            let b2_isa = &b2.constraints()[0];
+            let expected_nested_graphs = vec![
+                TypeInferenceGraph {
+                    conjunction: b1,
+                    vertices: VertexAnnotations::from([
+                        (var_animal.into(), BTreeSet::from([type_cat])),
+                        (b1_var_name.into(), BTreeSet::from([type_catname])),
+                        (Vertex::Label(LABEL_CATNAME), BTreeSet::from([type_catname])),
+                    ]),
+                    edges: vec![
+                        expected_edge(b1_has, var_animal.into(), b1_var_name.into(), vec![(type_cat, type_catname)]),
+                        expected_edge(
+                            b1_isa,
+                            b1_var_name.into(),
+                            Vertex::Label(LABEL_CATNAME),
+                            vec![(type_catname, type_catname)],
+                        ),
+                    ],
+                    nested_disjunctions: Vec::new(),
+                },
+                TypeInferenceGraph {
+                    conjunction: b2,
+                    vertices: VertexAnnotations::from([
+                        (b2_var_catname_other.into(), BTreeSet::from([type_catname])),
+                        (Vertex::Label(LABEL_CATNAME), BTreeSet::from([type_catname])),
+                    ]),
+                    edges: vec![expected_edge(
+                        b2_isa,
+                        b2_var_catname_other.into(),
+                        Vertex::Label(LABEL_CATNAME),
+                        vec![(type_catname, type_catname)],
+                    )],
+                    nested_disjunctions: Vec::new(),
+                },
+            ];
+
+            let expected_graph = TypeInferenceGraph {
+                conjunction,
+                vertices: VertexAnnotations::from([
+                    (var_animal.into(), BTreeSet::from([type_cat, type_dog])),
+                    (Vertex::Label(LABEL_ANIMAL), BTreeSet::from([type_animal])),
                 ]),
                 edges: vec![expected_edge(
-                    b1_isa,
+                    &conjunction.constraints()[0],
                     var_animal.into(),
-                    b1_var_animal_type.into(),
-                    vec![(type_cat, type_cat)],
+                    Vertex::Label(LABEL_ANIMAL),
+                    vec![(type_cat, type_animal), (type_dog, type_animal)],
                 )],
-                nested_disjunctions: Vec::new(),
-            },
-            TypeInferenceGraph {
-                conjunction: b2,
-                vertices: VertexAnnotations::from([
-                    (var_animal.into(), BTreeSet::from([type_dog])),
-                    (b2_var_animal_type.into(), BTreeSet::from([type_dog])),
-                    (Vertex::Label(LABEL_DOG), BTreeSet::from([type_dog])),
-                ]),
-                edges: vec![expected_edge(
-                    b2_isa,
-                    var_animal.into(),
-                    b2_var_animal_type.into(),
-                    vec![(type_dog, type_dog)],
-                )],
-                nested_disjunctions: Vec::new(),
-            },
-        ];
+                nested_disjunctions: vec![NestedTypeInferenceGraphDisjunction {
+                    disjunction_pattern: &disj,
+                    disjunction: expected_nested_graphs,
+                }],
+            };
 
-        let expected_graph = TypeInferenceGraph {
-            conjunction,
-            vertices: VertexAnnotations::from([
-                (var_animal.into(), BTreeSet::from([type_cat, type_dog])),
-                (var_name.into(), BTreeSet::from([type_catname, type_dogname])),
-                (var_name_type.into(), BTreeSet::from([type_name])),
-                (Vertex::Label(LABEL_NAME), BTreeSet::from([type_name])),
-            ]),
-            edges: vec![
-                expected_edge(
-                    &conjunction.constraints()[1],
-                    var_name.into(),
-                    var_name_type.into(),
-                    vec![(type_catname, type_name), (type_dogname, type_name)],
-                ),
-                expected_edge(
-                    &conjunction.constraints()[2],
-                    var_animal.into(),
-                    var_name.into(),
-                    vec![(type_cat, type_catname), (type_dog, type_dogname)],
-                ),
-            ],
-            nested_disjunctions: vec![NestedTypeInferenceGraphDisjunction {
-                disjunction_pattern: &disj,
-                disjunction: expected_nested_graphs,
-            }],
-        };
+            assert_eq!(expected_graph.vertices, graph.vertices);
+            assert_eq!(expected_graph.edges, graph.edges);
+            assert_eq!(
+                expected_graph.nested_disjunctions[0].disjunction[0],
+                graph.nested_disjunctions[0].disjunction[0],
+            );
+            assert_eq!(
+                expected_graph.nested_disjunctions[0].disjunction[1].vertices,
+                graph.nested_disjunctions[0].disjunction[1].vertices,
+            );
 
-        assert_eq!(expected_graph, graph);
+            assert_eq!(expected_graph, graph);
+        }
     }
 
     #[test]

--- a/compiler/annotation/inference/match_inference.rs
+++ b/compiler/annotation/inference/match_inference.rs
@@ -84,7 +84,7 @@ fn infer_types_in_negations_and_optionals_and_complete<'conj>(
             }
             NestedPattern::Optional(optional) => {
                 let optional_graph = infer_types_impl(ctx, optional.conjunction(), &vertices, type_inference_mode)?;
-                for optional_var in optional.optionally_bound_in_pattern() {
+                for optional_var in optional.optionally_bound_by_pattern() {
                     let optional_vertex = Vertex::Variable(optional_var);
                     needs_value_type_inference!("Remove the cagtegory check");
                     debug_assert!(
@@ -109,7 +109,7 @@ fn infer_types_in_negations_and_optionals_and_complete<'conj>(
             .into_iter()
             .map(|d| infer_types_in_negations_and_optionals_and_complete(ctx, d, type_inference_mode))
             .collect::<Result<Vec<_>, _>>()?;
-        for optional_var in nested_disjunction.disjunction_pattern.optionally_bound_in_pattern() {
+        for optional_var in nested_disjunction.disjunction_pattern.optionally_bound_by_pattern() {
             let optional_vertex = Vertex::Variable(optional_var);
             debug_assert!(
                 branches.iter().all(|b| b.vertices.contains_key(&optional_vertex))

--- a/compiler/annotation/inference/match_inference.rs
+++ b/compiler/annotation/inference/match_inference.rs
@@ -5,7 +5,7 @@
  */
 
 use std::{
-    collections::{BTreeMap, BTreeSet, HashMap, HashSet},
+    collections::{BTreeMap, BTreeSet, HashMap},
     sync::Arc,
 };
 
@@ -63,7 +63,7 @@ fn infer_types_impl<'conj>(
 
 fn infer_types_in_negations_and_optionals_and_complete<'conj>(
     ctx: &mut PipelineAnnotationContext<'_, impl ReadableSnapshot>,
-    mut graph: TypeInferenceGraph<'conj>,
+    graph: TypeInferenceGraph<'conj>,
     type_inference_mode: TypeInferenceMode,
 ) -> Result<FullTypeInferenceGraph<'conj>, TypeInferenceError> {
     // Add the negations & optionals to TypeInferenceGraph to get FullTypeInferenceGraph.
@@ -375,42 +375,58 @@ impl<'this> TypeInferenceEdge<'this> {
 pub(crate) struct NestedTypeInferenceGraphDisjunction<'this> {
     pub(crate) disjunction_pattern: &'this Disjunction,
     pub(crate) disjunction: Vec<TypeInferenceGraph<'this>>,
-    pub(crate) shared_variables: BTreeSet<Variable>,
-    pub(crate) shared_vertex_annotations: VertexAnnotations,
 }
 
 impl NestedTypeInferenceGraphDisjunction<'_> {
     fn prune_self_from_vertices(&mut self, parent_vertices: &VertexAnnotations) {
-        for nested_graph in &mut self.disjunction {
-            for (vertex, vertex_types) in &mut nested_graph.vertices {
-                if let Some(parent_vertex_types) = parent_vertices.get(vertex) {
-                    vertex_types.retain(|type_| parent_vertex_types.contains(type_))
-                }
+        let Self { disjunction, disjunction_pattern } = self;
+        for nested_graph in disjunction {
+            let TypeInferenceGraph { conjunction, vertices: nested_vertices, .. } = nested_graph;
+            for vertex in Self::branch_variables_affected_by_parent(disjunction_pattern, conjunction) {
+                debug_assert!(parent_vertices.contains_key(&vertex) && nested_vertices.contains_key(&vertex));
+                nested_vertices.get_mut(&vertex).unwrap().retain(|type_| parent_vertices[&vertex].contains(type_))
             }
             nested_graph.prune_constraints_from_vertices();
         }
     }
 
     fn prune_vertices_from_self(&mut self, parent_vertices: &mut VertexAnnotations) -> bool {
+        debug_assert!(Self::variables_affecting_parent(self.disjunction_pattern).all(|vertex| {
+            self.disjunction.iter().all(|branch| branch.vertices.contains_key(&vertex))
+                && parent_vertices.contains_key(&vertex)
+        }));
+
         let mut is_modified = false;
         for nested_graph in &mut self.disjunction {
             is_modified |= nested_graph.prune_vertices_from_constraints();
         }
 
-        for (parent_vertex, parent_vertex_types) in parent_vertices {
+        for vertex in Self::variables_affecting_parent(self.disjunction_pattern) {
+            let parent_vertex_types = parent_vertices.get_mut(&vertex).unwrap();
             let size_before = parent_vertex_types.len();
             parent_vertex_types.retain(|type_| {
                 self.disjunction.iter().any(|nested_graph| {
-                    nested_graph
-                        .vertices
-                        .get(parent_vertex)
-                        .map(|nested_types| nested_types.contains(type_))
-                        .unwrap_or(true)
+                    nested_graph.vertices.get(&vertex).map(|nested_types| nested_types.contains(type_)).unwrap_or(true)
                 })
             });
             is_modified |= size_before != parent_vertex_types.len();
         }
         is_modified
+    }
+
+    pub(crate) fn variables_affecting_parent(disjunction: &Disjunction) -> impl Iterator<Item = Vertex<Variable>> {
+        // Are those in every branch. But simpler:
+        disjunction.always_bound_by_pattern().map(Vertex::Variable)
+    }
+
+    pub(crate) fn branch_variables_affected_by_parent(
+        disjunction: &Disjunction,
+        branch: &Conjunction,
+    ) -> impl Iterator<Item = Vertex<Variable>> {
+        disjunction
+            .visible_referenced_variables()
+            .filter(|variable| branch.is_variable_visible_referenced(variable))
+            .map(Vertex::Variable)
     }
 }
 
@@ -1142,8 +1158,6 @@ pub mod tests {
             nested_disjunctions: vec![NestedTypeInferenceGraphDisjunction {
                 disjunction_pattern: &disj,
                 disjunction: expected_nested_graphs,
-                shared_variables: BTreeSet::new(),
-                shared_vertex_annotations: VertexAnnotations::default(),
             }],
         };
 

--- a/compiler/annotation/inference/match_inference.rs
+++ b/compiler/annotation/inference/match_inference.rs
@@ -33,6 +33,10 @@ use crate::annotation::{
     type_inference::TypeInferenceMode,
 };
 
+macro_rules! needs_value_type_inference {
+    ($_message:literal) => {};
+}
+
 pub fn infer_types_for_block(
     ctx: &mut PipelineAnnotationContext<'_, impl ReadableSnapshot>,
     previous_stage_annotations: &RunningVariableAnnotations,
@@ -82,6 +86,7 @@ fn infer_types_in_negations_and_optionals_and_complete<'conj>(
                 let optional_graph = infer_types_impl(ctx, optional.conjunction(), &vertices, type_inference_mode)?;
                 for optional_var in optional.optionally_bound_in_pattern() {
                     let optional_vertex = Vertex::Variable(optional_var);
+                    needs_value_type_inference!("Remove the cagtegory check");
                     debug_assert!(
                         optional_graph.vertices.contains_key(&optional_vertex)
                             || ctx.variable_registry.get_variable_category(optional_var)
@@ -391,10 +396,12 @@ impl NestedTypeInferenceGraphDisjunction<'_> {
     }
 
     fn prune_vertices_from_self(&mut self, parent_vertices: &mut VertexAnnotations) -> bool {
-        debug_assert!(Self::variables_affecting_parent(self.disjunction_pattern).all(|vertex| {
-            self.disjunction.iter().all(|branch| branch.vertices.contains_key(&vertex))
-                && parent_vertices.contains_key(&vertex)
-        }));
+        // TODO: Re-enable when we have value-type inference
+        needs_value_type_inference!("Uncomment debug_assert");
+        // debug_assert!(Self::variables_affecting_parent(self.disjunction_pattern).all(|vertex| {
+        //     self.disjunction.iter().all(|branch| branch.vertices.contains_key(&vertex))
+        //         && parent_vertices.contains_key(&vertex)
+        // }));
 
         let mut is_modified = false;
         for nested_graph in &mut self.disjunction {
@@ -402,6 +409,10 @@ impl NestedTypeInferenceGraphDisjunction<'_> {
         }
 
         for vertex in Self::variables_affecting_parent(self.disjunction_pattern) {
+            if !parent_vertices.contains_key(&vertex) {
+                needs_value_type_inference!("condition goes away");
+                continue;
+            }
             let parent_vertex_types = parent_vertices.get_mut(&vertex).unwrap();
             let size_before = parent_vertex_types.len();
             parent_vertex_types.retain(|type_| {

--- a/compiler/annotation/inference/match_inference.rs
+++ b/compiler/annotation/inference/match_inference.rs
@@ -434,9 +434,10 @@ impl NestedTypeInferenceGraphDisjunction<'_> {
         disjunction: &Disjunction,
         branch: &Conjunction,
     ) -> impl Iterator<Item = Vertex<Variable>> {
+        // Must exclude OptionallyBinding
         disjunction
-            .visible_referenced_variables()
-            .filter(|variable| branch.is_variable_visible_referenced(variable))
+            .always_bound_by_pattern()
+            .chain(disjunction.required_inputs().filter(|variable| branch.is_variable_visible_referenced(variable)))
             .map(Vertex::Variable)
     }
 }

--- a/compiler/annotation/inference/mod.rs
+++ b/compiler/annotation/inference/mod.rs
@@ -29,7 +29,7 @@ impl VertexAnnotations {
         if let Some(existing_annotations) = self.get_mut(vertex) {
             let size_before = existing_annotations.len();
             existing_annotations.retain(|x| new_annotations.contains(x));
-            existing_annotations.len() == size_before
+            existing_annotations.len() != size_before
         } else {
             self.insert(vertex.clone(), new_annotations.into_owned());
             true

--- a/compiler/annotation/inference/type_seeder.rs
+++ b/compiler/annotation/inference/type_seeder.rs
@@ -442,8 +442,7 @@ impl<'this, Snapshot: ReadableSnapshot> TypeGraphSeedingContext<'this, Snapshot>
         for nested_graph in &mut nested.disjunction {
             let TypeInferenceGraph { conjunction: branch_pattern, vertices: nested_vertices, .. } = nested_graph;
             for vertex in NestedGraphDisj::branch_variables_affected_by_parent(&disjunction_pattern, &branch_pattern) {
-                debug_assert!(parent_vertices.get_mut(&vertex).is_some());
-                if let Some(parent_annotations) = parent_vertices.get_mut(&vertex) {
+                if let Some(parent_annotations) = parent_vertices.get(&vertex) {
                     something_changed |= nested_vertices.add_or_intersect(&vertex, Cow::Borrowed(parent_annotations));
                 }
             }
@@ -456,12 +455,12 @@ impl<'this, Snapshot: ReadableSnapshot> TypeGraphSeedingContext<'this, Snapshot>
 
         // Update parent from the shared variables
         for vertex in NestedGraphDisj::variables_affecting_parent(disjunction_pattern) {
-            let union = nested
-                .disjunction
-                .iter()
-                .flat_map(|nested_graph| nested_graph.vertices[&vertex].iter().copied())
-                .collect();
-            parent_vertices.add_or_intersect(&vertex, Cow::Owned(union));
+            // If they haven't been seeded yet (?), don't wrongly restrict the parent.
+            if nested.disjunction.iter().all(|branch| branch.vertices.contains_key(&vertex)) {
+                let union =
+                    nested.disjunction.iter().flat_map(|branch| branch.vertices[&vertex].iter().copied()).collect();
+                parent_vertices.add_or_intersect(&vertex, Cow::Owned(union));
+            }
         }
 
         Ok(something_changed)

--- a/compiler/annotation/inference/type_seeder.rs
+++ b/compiler/annotation/inference/type_seeder.rs
@@ -438,8 +438,8 @@ impl<'this, Snapshot: ReadableSnapshot> TypeGraphSeedingContext<'this, Snapshot>
         use NestedTypeInferenceGraphDisjunction as NestedGraphDisj;
         let mut something_changed = false;
         // Apply annotations of the parent on the nested
-        let NestedGraphDisj { disjunction_pattern, disjunction: nested_graph_disjunction } = nested;
-        for nested_graph in &mut *nested_graph_disjunction {
+        let disjunction_pattern = nested.disjunction_pattern;
+        for nested_graph in &mut nested.disjunction {
             let TypeInferenceGraph { conjunction: branch_pattern, vertices: nested_vertices, .. } = nested_graph;
             for vertex in NestedGraphDisj::branch_variables_affected_by_parent(&disjunction_pattern, &branch_pattern) {
                 debug_assert!(parent_vertices.get_mut(&vertex).is_some());
@@ -450,39 +450,21 @@ impl<'this, Snapshot: ReadableSnapshot> TypeGraphSeedingContext<'this, Snapshot>
         }
 
         // Propagate it within the child & recursively into nested
-        for nested_graph in &mut *nested_graph_disjunction {
+        for nested_graph in &mut nested.disjunction {
             something_changed |= self.propagate_vertex_annotations(nested_graph)?;
         }
 
         // Update parent from the shared variables
         for vertex in NestedGraphDisj::variables_affecting_parent(disjunction_pattern) {
-            // TODO: Can this #[allow(clippy::map_entry, reason = "false positive")] go?
-            #[allow(clippy::map_entry, reason = "false positive")]
-            if let Some(types_from_branches) =
-                self.try_union_annotations_across_all_branches(&nested_graph_disjunction, &vertex)
-            {
-                parent_vertices.add_or_intersect(&vertex, Cow::Owned(types_from_branches));
-            }
+            let union = nested
+                .disjunction
+                .iter()
+                .flat_map(|nested_graph| nested_graph.vertices[&vertex].iter().copied())
+                .collect();
+            parent_vertices.add_or_intersect(&vertex, Cow::Owned(union));
         }
 
         Ok(something_changed)
-    }
-
-    fn try_union_annotations_across_all_branches(
-        &self,
-        disjunction: &[TypeInferenceGraph<'_>],
-        vertex: &Vertex<Variable>,
-    ) -> Option<BTreeSet<TypeAnnotation>> {
-        if disjunction.iter().all(|nested_graph| nested_graph.vertices.contains_key(vertex)) {
-            Some(
-                disjunction
-                    .iter()
-                    .flat_map(|nested_graph| nested_graph.vertices.get(vertex).unwrap().iter().cloned())
-                    .collect(),
-            )
-        } else {
-            None
-        }
     }
 
     // Phase 3: seed edges

--- a/compiler/annotation/inference/type_seeder.rs
+++ b/compiler/annotation/inference/type_seeder.rs
@@ -180,13 +180,7 @@ impl<'this, Snapshot: ReadableSnapshot> TypeGraphSeedingContext<'this, Snapshot>
         disjunction: &'conj Disjunction,
     ) -> NestedTypeInferenceGraphDisjunction<'conj> {
         let nested_graphs = disjunction.conjunctions().iter().map(|conj| self.build_recursive(conj)).collect_vec();
-        let shared_variables = disjunction.visible_referenced_variables().collect();
-        NestedTypeInferenceGraphDisjunction {
-            disjunction_pattern: disjunction,
-            disjunction: nested_graphs,
-            shared_variables,
-            shared_vertex_annotations: VertexAnnotations::default(),
-        }
+        NestedTypeInferenceGraphDisjunction { disjunction_pattern: disjunction, disjunction: nested_graphs }
     }
 
     // Phase 1: Collect all type & function return annotations
@@ -441,50 +435,36 @@ impl<'this, Snapshot: ReadableSnapshot> TypeGraphSeedingContext<'this, Snapshot>
         nested: &mut NestedTypeInferenceGraphDisjunction<'_>,
         parent_vertices: &mut VertexAnnotations,
     ) -> Result<bool, Box<ConceptReadError>> {
+        use NestedTypeInferenceGraphDisjunction as NestedGraphDisj;
         let mut something_changed = false;
-        // Apply annotations ot the parent on the nested
-        for &variable in nested.shared_variables.iter() {
-            let vertex = Vertex::Variable(variable);
-            if let Some(parent_annotations) = parent_vertices.get_mut(&vertex) {
-                for nested_graph in &mut nested.disjunction {
-                    // Note: This adds a vertex annotation even if this branch does not reference the variable
-                    // This is needed to prevent one branch from narrowing the parent's annotations
-                    nested_graph.vertices.add_or_intersect(&vertex, Cow::Borrowed(parent_annotations));
+        // Apply annotations of the parent on the nested
+        let NestedGraphDisj { disjunction_pattern, disjunction: nested_graph_disjunction } = nested;
+        for nested_graph in &mut *nested_graph_disjunction {
+            let TypeInferenceGraph { conjunction: branch_pattern, vertices: nested_vertices, .. } = nested_graph;
+            for vertex in NestedGraphDisj::branch_variables_affected_by_parent(&disjunction_pattern, &branch_pattern) {
+                debug_assert!(parent_vertices.get_mut(&vertex).is_some());
+                if let Some(parent_annotations) = parent_vertices.get_mut(&vertex) {
+                    something_changed |= nested_vertices.add_or_intersect(&vertex, Cow::Borrowed(parent_annotations));
                 }
             }
         }
 
         // Propagate it within the child & recursively into nested
-        for nested_graph in &mut nested.disjunction {
+        for nested_graph in &mut *nested_graph_disjunction {
             something_changed |= self.propagate_vertex_annotations(nested_graph)?;
         }
 
-        // Update shared variables of the disjunction
-        let NestedTypeInferenceGraphDisjunction {
-            disjunction_pattern: _,
-            shared_vertex_annotations,
-            disjunction: nested_graph_disjunction,
-            shared_variables,
-        } = nested;
-        for &variable in shared_variables.iter() {
-            let vertex = Vertex::Variable(variable);
+        // Update parent from the shared variables
+        for vertex in NestedGraphDisj::variables_affecting_parent(disjunction_pattern) {
+            // TODO: Can this #[allow(clippy::map_entry, reason = "false positive")] go?
             #[allow(clippy::map_entry, reason = "false positive")]
-            if !shared_vertex_annotations.contains_key(&vertex) {
-                if let Some(types_from_branches) =
-                    self.try_union_annotations_across_all_branches(nested_graph_disjunction, &vertex)
-                {
-                    shared_vertex_annotations.insert(vertex, types_from_branches);
-                }
+            if let Some(types_from_branches) =
+                self.try_union_annotations_across_all_branches(&nested_graph_disjunction, &vertex)
+            {
+                parent_vertices.add_or_intersect(&vertex, Cow::Owned(types_from_branches));
             }
         }
 
-        // Update parent from the shared variables
-        for (vertex, types) in shared_vertex_annotations.iter() {
-            if !parent_vertices.contains_key(vertex) {
-                parent_vertices.insert(vertex.clone(), types.clone());
-                something_changed = true;
-            }
-        }
         Ok(something_changed)
     }
 

--- a/ir/pattern/mod.rs
+++ b/ir/pattern/mod.rs
@@ -72,18 +72,25 @@ pub trait Pattern {
         self.visible_referenced_variables().filter(Variable::is_named)
     }
 
+    fn is_variable_visible_referenced(&self, variable: &Variable) -> bool;
     // A referenced variable is "visible" if it's not local to some subpattern.
     // includes all variables from constraints and subpatterns. Does not include stage inputs if unused.
     fn visible_referenced_variables(&self) -> impl Iterator<Item = Variable> + '_;
 
+    fn always_bound_by_pattern(&self) -> impl Iterator<Item = Variable> + '_;
+
     fn required_inputs(&self) -> impl Iterator<Item = Variable> + '_;
 
-    fn optionally_bound_in_pattern(&self) -> impl Iterator<Item = Variable> + '_;
+    fn optionally_bound_by_pattern(&self) -> impl Iterator<Item = Variable> + '_;
 }
 
 macro_rules! impl_pattern_from_pattern_variables {
     ($pattern:ty) => {
         impl Pattern for $pattern {
+            fn is_variable_visible_referenced(&self, variable: &Variable) -> bool {
+                self.pattern_variables.is_variable_visible_referenced(variable)
+            }
+
             fn visible_referenced_variables(&self) -> impl Iterator<Item = Variable> + '_ {
                 self.pattern_variables.visible_referenced_variables()
             }
@@ -92,8 +99,12 @@ macro_rules! impl_pattern_from_pattern_variables {
                 self.pattern_variables.required_inputs()
             }
 
-            fn optionally_bound_in_pattern(&self) -> impl Iterator<Item = Variable> + '_ {
-                self.pattern_variables.optionally_bound_in_pattern()
+            fn always_bound_by_pattern(&self) -> impl Iterator<Item = Variable> + '_ {
+                self.pattern_variables.always_bound_by_pattern()
+            }
+
+            fn optionally_bound_by_pattern(&self) -> impl Iterator<Item = Variable> + '_ {
+                self.pattern_variables.optionally_bound_by_pattern()
             }
         }
     };
@@ -385,7 +396,7 @@ impl fmt::Display for ValueType {
 }
 
 #[derive(Copy, Clone, Debug, Default, PartialEq, Eq)]
-pub enum BindingMode {
+pub(crate) enum BindingMode {
     RequirePrebound,
     AlwaysBinding,
     LocallyBindingInChild,
@@ -395,19 +406,19 @@ pub enum BindingMode {
 }
 
 impl BindingMode {
-    pub fn is_require_prebound(&self) -> bool {
+    pub(crate) fn is_require_prebound(&self) -> bool {
         *self == BindingMode::RequirePrebound
     }
 
-    pub fn is_always_binding(&self) -> bool {
+    pub(crate) fn is_always_binding(&self) -> bool {
         *self == BindingMode::AlwaysBinding
     }
 
-    pub fn is_locally_binding_in_child(&self) -> bool {
+    pub(crate) fn is_locally_binding_in_child(&self) -> bool {
         *self == BindingMode::LocallyBindingInChild
     }
 
-    pub fn is_optionally_binding(&self) -> bool {
+    pub(crate) fn is_optionally_binding(&self) -> bool {
         *self == BindingMode::OptionallyBinding
     }
 }
@@ -505,6 +516,10 @@ impl PatternVariables {
         )
     }
 
+    pub(crate) fn is_variable_visible_referenced(&self, variable: &Variable) -> bool {
+        self.0.contains_key(variable)
+    }
+
     pub(crate) fn visible_referenced_variables(&self) -> impl Iterator<Item = Variable> + '_ {
         self.0.keys().copied()
     }
@@ -513,7 +528,11 @@ impl PatternVariables {
         self.0.iter().filter_map(|(v, required)| (*required == PatternVariableMode::RequiredInput).then_some(*v))
     }
 
-    pub(crate) fn optionally_bound_in_pattern(&self) -> impl Iterator<Item = Variable> + '_ {
+    pub(crate) fn always_bound_by_pattern(&self) -> impl Iterator<Item = Variable> + '_ {
+        self.0.iter().filter_map(|(v, required)| (*required == PatternVariableMode::Binding).then_some(*v))
+    }
+
+    pub(crate) fn optionally_bound_by_pattern(&self) -> impl Iterator<Item = Variable> + '_ {
         self.0.iter().filter_map(|(v, required)| (*required == PatternVariableMode::OptionallyBinding).then_some(*v))
     }
 }


### PR DESCRIPTION
## Product change and motivation
We leverage the "variable binding mode" information to compute the set of variable annotations to be synced from the parent to each branch of the disjunction, and vice-versa.
