### PR TITLE
Refactor vertex annotations during type-inference to be an enum over sets of types

### DIFF
--- a/answer/lib.rs
+++ b/answer/lib.rs
@@ -236,22 +236,6 @@ impl Type {
             Type::RoleType(role) => role.is_abstract(snapshot, type_manager),
         }
     }
-
-    pub fn try_retain(
-        annotations: &mut BTreeSet<Self>,
-        predicate: impl Fn(&Self) -> Result<bool, Box<ConceptReadError>>,
-    ) -> Result<(), Box<ConceptReadError>> {
-        let mut to_be_removed = Vec::new();
-        for annotation in annotations.iter() {
-            if !predicate(annotation)? {
-                to_be_removed.push(*annotation);
-            }
-        }
-        for annotation in to_be_removed.iter() {
-            annotations.remove(annotation);
-        }
-        Ok(())
-    }
 }
 
 impl Hkt for Type {

--- a/compiler/annotation/inference/match_inference.rs
+++ b/compiler/annotation/inference/match_inference.rs
@@ -25,7 +25,10 @@ use storage::snapshot::ReadableSnapshot;
 
 use crate::annotation::{
     PipelineAnnotationContext, TypeInferenceError,
-    inference::{RetainAndContainExt, VertexAnnotations, type_seeder::TypeGraphSeedingContext},
+    inference::{
+        ConceptVertexTypes, TypeAnnotationSetEntry, TypeAnnotationSetTrait, VertexAnnotations, VertexTypeAnnotations,
+        type_seeder::TypeGraphSeedingContext,
+    },
     pipeline::RunningVariableAnnotations,
     type_annotations::{
         BlockAnnotations, ConstraintTypeAnnotations, LeftRightAnnotations, LinksAnnotations, TypeAnnotations,
@@ -46,7 +49,7 @@ pub fn infer_types_for_block(
     let input_annotations = previous_stage_annotations
         .concepts
         .iter()
-        .map(|(var, annotations)| (Vertex::Variable(*var), (**annotations).clone()))
+        .map(|(var, annotations)| (Vertex::Variable(*var), ConceptVertexTypes((**annotations).clone()).into()))
         .collect();
     let input_annotations = VertexAnnotations { annotations: input_annotations };
     let root_graph = infer_types_impl(ctx, block.conjunction(), &input_annotations, type_inference_mode)?;
@@ -119,7 +122,8 @@ fn infer_types_in_negations_and_optionals_and_complete<'conj>(
             if ctx.variable_registry.get_variable_category(optional_var) == Some(VariableCategory::Value) {
                 continue;
             }
-            let annotations = branches.iter().flat_map(|b| b.vertices[&optional_vertex].iter().copied()).collect();
+            let annotations = VertexAnnotations::try_union(branches.iter().map(|g| &vertices), &optional_vertex)?
+                .expect("Can't be None if there's atleast one branch");
             vertices.insert(optional_vertex, annotations);
         }
         disjunctions.push(branches);
@@ -188,16 +192,18 @@ fn construct_error_message_for_unsatisfiable_edge(
         Vertex::Label(label) => label.scoped_name().as_str().to_string(),
         Vertex::Parameter(_) => unreachable!("Parameters can't be involved in TypeInferenceEdges"),
     };
-    let resolve_type_label = |type_: &answer::Type| {
-        type_
+    let resolve_type_label = |type_: TypeAnnotationSetEntry| match type_ {
+        TypeAnnotationSetEntry::Concept(type_) => type_
             .get_label(ctx.snapshot, ctx.type_manager)
             .map(|label| label.scoped_name().to_string())
-            .unwrap_or_else(|_| "(Error while resolving label)".to_owned())
+            .unwrap_or_else(|_| "(Error while resolving label)".to_owned()),
     };
     let left_variable = resolve_vertex(&edge.left);
     let right_variable = resolve_vertex(&edge.right);
-    let left_types = graph.vertices.annotations.get(&edge.left).unwrap().iter().map(resolve_type_label).join(", ");
-    let right_types = graph.vertices.annotations.get(&edge.right).unwrap().iter().map(resolve_type_label).join(", ");
+    let left_types =
+        graph.vertices.annotations.get(&edge.left).unwrap().iter_types().map(resolve_type_label).join(", ");
+    let right_types =
+        graph.vertices.annotations.get(&edge.right).unwrap().iter_types().map(resolve_type_label).join(", ");
     TypeInferenceError::DetectedUnsatisfiableEdge {
         left_variable,
         right_variable,
@@ -300,8 +306,8 @@ impl<'this> TypeInferenceEdge<'this> {
         constraint: &'this Constraint<Variable>,
         left: Vertex<Variable>,
         right: Vertex<Variable>,
-        initial_left_to_right: BTreeMap<TypeAnnotation, BTreeSet<TypeAnnotation>>,
-        initial_right_to_left: BTreeMap<TypeAnnotation, BTreeSet<TypeAnnotation>>,
+        initial_left_to_right: BTreeMap<TypeAnnotation, ConceptVertexTypes>,
+        initial_right_to_left: BTreeMap<TypeAnnotation, ConceptVertexTypes>,
     ) -> TypeInferenceEdge<'this> {
         // The left_to_right & right_to_left sets must be consistent with each other. i.e.
         //   They must contain the same set of edges.
@@ -317,13 +323,9 @@ impl<'this> TypeInferenceEdge<'this> {
                 .iter()
                 .all(|(u, vs)| vs.iter().all(|v| initial_left_to_right.get(v).unwrap().contains(u)))
         );
-        TypeInferenceEdge {
-            constraint,
-            left,
-            right,
-            left_to_right: initial_left_to_right,
-            right_to_left: initial_right_to_left,
-        }
+        let left_to_right = initial_left_to_right.into_iter().map(|(k, v)| (k, v.0)).collect();
+        let right_to_left = initial_right_to_left.into_iter().map(|(k, v)| (k, v.0)).collect();
+        TypeInferenceEdge { constraint, left, right, left_to_right, right_to_left }
     }
 
     fn remove_type_from_values_of(
@@ -360,16 +362,19 @@ impl<'this> TypeInferenceEdge<'this> {
         let TypeInferenceEdge { left_to_right, right_to_left, .. } = self;
         {
             let left_vertex_annotations = vertices.get(&self.left).unwrap();
-            left_to_right.iter().filter(|(left_type, _)| !left_vertex_annotations.contains(*left_type)).for_each(
+            left_to_right.iter().filter(|(left_type, _)| !left_vertex_annotations.contains_type(*left_type)).for_each(
                 |(left_type, right_keys)| Self::remove_type_from_values_of(left_type, right_keys, right_to_left),
             );
             left_to_right.retain_intersection(left_vertex_annotations);
         };
         {
             let right_vertex_annotations = vertices.get(&self.right).unwrap();
-            right_to_left.iter().filter(|(right_type, _)| !right_vertex_annotations.contains(*right_type)).for_each(
-                |(right_type, left_keys)| Self::remove_type_from_values_of(right_type, left_keys, left_to_right),
-            );
+            right_to_left
+                .iter()
+                .filter(|(right_type, _)| !right_vertex_annotations.contains_type(*right_type))
+                .for_each(|(right_type, left_keys)| {
+                    Self::remove_type_from_values_of(right_type, left_keys, left_to_right)
+                });
             right_to_left.retain_intersection(right_vertex_annotations);
         };
     }
@@ -414,9 +419,13 @@ impl NestedTypeInferenceGraphDisjunction<'_> {
             }
             let parent_vertex_types = parent_vertices.get_mut(&vertex).unwrap();
             let size_before = parent_vertex_types.len();
-            parent_vertex_types.retain(|type_| {
+            parent_vertex_types.retain_types(|type_| {
                 self.disjunction.iter().any(|nested_graph| {
-                    nested_graph.vertices.get(&vertex).map(|nested_types| nested_types.contains(type_)).unwrap_or(true)
+                    nested_graph
+                        .vertices
+                        .get(&vertex)
+                        .map(|nested_types| nested_types.contains_type(type_))
+                        .unwrap_or(true)
                 })
             });
             is_modified |= size_before != parent_vertex_types.len();
@@ -484,11 +493,13 @@ impl FullTypeInferenceGraph<'_> {
             }
         }
 
-        let vertex_annotations = vertices
+        let concept_vertex_annotations = vertices
             .into_iter()
-            .map(|(variable, types)| (variable.into(), Arc::new(types)))
+            .filter_map(|(variable, types)| match types {
+                VertexTypeAnnotations::Concept(types) => Some((variable.into(), Arc::new(types.0))),
+            })
             .collect::<BTreeMap<_, _>>();
-        TypeAnnotations::new(vertex_annotations, constraint_annotations)
+        TypeAnnotations::new(concept_vertex_annotations, constraint_annotations)
     }
 }
 
@@ -543,6 +554,7 @@ pub mod tests {
                 annotate_named_function,
             },
             inference::{
+                VertexTypeAnnotations,
                 match_inference::{
                     NestedTypeInferenceGraphDisjunction, TypeInferenceEdge, TypeInferenceGraph, VertexAnnotations,
                     compute_type_inference_graph, infer_types_for_block, prune_types,
@@ -843,7 +855,7 @@ pub mod tests {
 
             let expected_graph = TypeInferenceGraph {
                 conjunction: block.conjunction(),
-                vertices: VertexAnnotations::from([
+                vertices: VertexAnnotations::from_iter([
                     (var_animal.into(), BTreeSet::from([type_cat])),
                     (var_name.into(), BTreeSet::from([type_catname])),
                     (var_animal_type.into(), BTreeSet::from([type_cat])),
@@ -911,7 +923,7 @@ pub mod tests {
 
             let expected_graph = TypeInferenceGraph {
                 conjunction: block.conjunction(),
-                vertices: VertexAnnotations::from([
+                vertices: VertexAnnotations::from_iter([
                     (var_animal.into(), BTreeSet::from([type_cat])),
                     (var_name.into(), BTreeSet::from([type_catname])),
                     (var_animal_type.into(), BTreeSet::from([type_animal])),
@@ -1018,7 +1030,7 @@ pub mod tests {
 
             let expected_graph = TypeInferenceGraph {
                 conjunction: block.conjunction(),
-                vertices: VertexAnnotations::from([
+                vertices: VertexAnnotations::from_iter([
                     (var_animal.into(), types_a),
                     (var_name.into(), types_n),
                     (var_animal_type.into(), BTreeSet::from([type_animal])),
@@ -1115,7 +1127,7 @@ pub mod tests {
             let expected_nested_graphs = vec![
                 TypeInferenceGraph {
                     conjunction: b1,
-                    vertices: VertexAnnotations::from([
+                    vertices: VertexAnnotations::from_iter([
                         (var_animal.into(), BTreeSet::from([type_cat])),
                         (b1_var_animal_type.into(), BTreeSet::from([type_cat])),
                         (Vertex::Label(LABEL_CAT), BTreeSet::from([type_cat])),
@@ -1130,7 +1142,7 @@ pub mod tests {
                 },
                 TypeInferenceGraph {
                     conjunction: b2,
-                    vertices: VertexAnnotations::from([
+                    vertices: VertexAnnotations::from_iter([
                         (var_animal.into(), BTreeSet::from([type_dog])),
                         (b2_var_animal_type.into(), BTreeSet::from([type_dog])),
                         (Vertex::Label(LABEL_DOG), BTreeSet::from([type_dog])),
@@ -1147,7 +1159,7 @@ pub mod tests {
 
             let expected_graph = TypeInferenceGraph {
                 conjunction,
-                vertices: VertexAnnotations::from([
+                vertices: VertexAnnotations::from_iter([
                     (var_animal.into(), BTreeSet::from([type_cat, type_dog])),
                     (var_name.into(), BTreeSet::from([type_catname, type_dogname])),
                     (var_name_type.into(), BTreeSet::from([type_name])),
@@ -1232,7 +1244,7 @@ pub mod tests {
             let expected_nested_graphs = vec![
                 TypeInferenceGraph {
                     conjunction: b1,
-                    vertices: VertexAnnotations::from([
+                    vertices: VertexAnnotations::from_iter([
                         (var_animal.into(), BTreeSet::from([type_cat])),
                         (b1_var_name.into(), BTreeSet::from([type_catname])),
                         (Vertex::Label(LABEL_CATNAME), BTreeSet::from([type_catname])),
@@ -1250,7 +1262,7 @@ pub mod tests {
                 },
                 TypeInferenceGraph {
                     conjunction: b2,
-                    vertices: VertexAnnotations::from([
+                    vertices: VertexAnnotations::from_iter([
                         (b2_var_catname_other.into(), BTreeSet::from([type_catname])),
                         (Vertex::Label(LABEL_CATNAME), BTreeSet::from([type_catname])),
                     ]),
@@ -1266,7 +1278,7 @@ pub mod tests {
 
             let expected_graph = TypeInferenceGraph {
                 conjunction,
-                vertices: VertexAnnotations::from([
+                vertices: VertexAnnotations::from_iter([
                     (var_animal.into(), BTreeSet::from([type_cat, type_dog])),
                     (Vertex::Label(LABEL_ANIMAL), BTreeSet::from([type_animal])),
                 ]),
@@ -1336,7 +1348,7 @@ pub mod tests {
 
         let expected_graph = TypeInferenceGraph {
             conjunction,
-            vertices: VertexAnnotations::from([
+            vertices: VertexAnnotations::from_iter([
                 (var_animal.into(), BTreeSet::from([type_cat, type_dog])),
                 (var_name.into(), BTreeSet::from([type_catname, type_dogname])),
             ]),
@@ -1423,7 +1435,7 @@ pub mod tests {
 
         let expected_graph = TypeInferenceGraph {
             conjunction,
-            vertices: VertexAnnotations::from([
+            vertices: VertexAnnotations::from_iter([
                 (var_has_fear.into(), BTreeSet::from([type_cat])),
                 (var_is_feared.into(), BTreeSet::from([type_dog])),
                 (var_fears_type.into(), BTreeSet::from([type_fears])),
@@ -1537,7 +1549,7 @@ pub mod tests {
 
             let expected_graph = TypeInferenceGraph {
                 conjunction: block.conjunction(),
-                vertices: VertexAnnotations::from([
+                vertices: VertexAnnotations::from_iter([
                     (var_animal.into(), BTreeSet::from([type_cat])),
                     (var_name.into(), BTreeSet::from([type_catname])),
                     (var_animal_type.into(), BTreeSet::from([type_cat])),
@@ -1607,7 +1619,7 @@ pub mod tests {
 
             let expected_graph = TypeInferenceGraph {
                 conjunction: block.conjunction(),
-                vertices: VertexAnnotations::from([
+                vertices: VertexAnnotations::from_iter([
                     (var_animal.into(), BTreeSet::from([type_cat])),
                     (var_name.into(), BTreeSet::from([type_catname])),
                     (var_owner_type.into(), BTreeSet::from([type_cat])),
@@ -1674,7 +1686,7 @@ pub mod tests {
 
             let expected_graph = TypeInferenceGraph {
                 conjunction: block.conjunction(),
-                vertices: VertexAnnotations::from([
+                vertices: VertexAnnotations::from_iter([
                     (var_animal.into(), BTreeSet::new()),
                     (var_name.into(), BTreeSet::new()),
                     (var_animal_type.into(), BTreeSet::new()),
@@ -1728,7 +1740,7 @@ pub mod tests {
 
             let expected_graph = TypeInferenceGraph {
                 conjunction: block.conjunction(),
-                vertices: VertexAnnotations::from([
+                vertices: VertexAnnotations::from_iter([
                     (var_animal.into(), types_a.clone()),
                     (var_name.into(), types_n.clone()),
                     (var_animal_type.into(), types_a.clone()),
@@ -1807,7 +1819,7 @@ pub mod tests {
 
             let expected_graph = TypeInferenceGraph {
                 conjunction: block.conjunction(),
-                vertices: VertexAnnotations::from([
+                vertices: VertexAnnotations::from_iter([
                     (var_animal.into(), BTreeSet::from([type_cat])),
                     (var_name.into(), BTreeSet::from([type_catname])),
                     (Vertex::Label(LABEL_CAT), BTreeSet::from([type_cat])),
@@ -1874,7 +1886,7 @@ pub mod tests {
 
             let expected_graph = TypeInferenceGraph {
                 conjunction: block.conjunction(),
-                vertices: VertexAnnotations::from([
+                vertices: VertexAnnotations::from_iter([
                     (var_animal.into(), BTreeSet::from([type_cat])),
                     (var_name.into(), BTreeSet::from([type_catname])),
                     (Vertex::Label(LABEL_ANIMAL), BTreeSet::from([type_animal])),
@@ -1977,7 +1989,7 @@ pub mod tests {
 
             let expected_graph = TypeInferenceGraph {
                 conjunction: block.conjunction(),
-                vertices: VertexAnnotations::from([
+                vertices: VertexAnnotations::from_iter([
                     (var_animal.into(), types_a),
                     (var_name.into(), types_n),
                     (Vertex::Label(LABEL_ANIMAL), BTreeSet::from([type_animal])),
@@ -2037,7 +2049,7 @@ pub mod tests {
         let constraints = conjunction.constraints();
         let mut expected_graph = TypeInferenceGraph {
             conjunction,
-            vertices: VertexAnnotations::from([
+            vertices: VertexAnnotations::from_iter([
                 (var_animal.into(), BTreeSet::from([type_cat, type_dog])),
                 (var_name.into(), BTreeSet::from([type_catname, type_dogname])),
             ]),
@@ -2063,7 +2075,12 @@ pub mod tests {
         prune_types(&mut graph);
         if expected_graph != graph {
             // We need this because of non-determinism
-            expected_graph.vertices.get_mut(&var_animal.into()).unwrap().insert(type_fears);
+            let Some(VertexTypeAnnotations::Concept(expected_animal_types)) =
+                expected_graph.vertices.get_mut(&var_animal.into())
+            else {
+                unreachable!()
+            };
+            expected_animal_types.insert(type_fears);
             assert_eq!(expected_graph, graph)
         }
     }

--- a/compiler/annotation/inference/mod.rs
+++ b/compiler/annotation/inference/mod.rs
@@ -9,15 +9,97 @@ use std::{
     ops::{Deref, DerefMut},
 };
 
-use answer::{Type as TypeAnnotation, variable::Variable};
+use answer::variable::Variable;
+// use encoding::value::value_type::ValueType;
 use ir::pattern::Vertex;
+
+use crate::annotation::TypeInferenceError;
 
 pub mod match_inference;
 pub mod type_seeder;
 
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum VertexTypeAnnotations {
+    Concept(ConceptVertexTypes),
+}
+
+impl VertexTypeAnnotations {
+    fn concept_from(iter: impl IntoIterator<Item = answer::Type>) -> Self {
+        Self::Concept(ConceptVertexTypes(BTreeSet::from_iter(iter)))
+    }
+
+    fn len(&self) -> usize {
+        match self {
+            VertexTypeAnnotations::Concept(type_set) => type_set.len(),
+        }
+    }
+
+    fn is_empty(&self) -> bool {
+        match self {
+            VertexTypeAnnotations::Concept(type_set) => type_set.is_empty(),
+        }
+    }
+
+    pub(crate) fn retain_types(&mut self, f: impl Fn(&TypeAnnotationSetEntry) -> bool) {
+        match self {
+            VertexTypeAnnotations::Concept(type_set) => type_set.retain(|t| f(&((*t).into()))),
+        }
+    }
+
+    pub(crate) fn extend_to_union(&mut self, other: &Self) -> Result<(), TypeInferenceError> {
+        match (self, other) {
+            (Self::Concept(inner), Self::Concept(other)) => inner.extend(other),
+        }
+        Ok(())
+    }
+}
+
+impl From<ConceptVertexTypes> for VertexTypeAnnotations {
+    fn from(value: ConceptVertexTypes) -> Self {
+        Self::Concept(value)
+    }
+}
+
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub(super) struct ConceptVertexTypes(BTreeSet<answer::Type>);
+//
+// impl FromIterator<answer::Type> for ConceptVertexTypes {
+//     fn from_iter<T: IntoIterator<Item=TypeAnnotation>>(iter: T) -> Self {
+//         Self(BTreeSet::from_iter(iter))
+//     }
+// }
+
+impl Deref for ConceptVertexTypes {
+    type Target = BTreeSet<answer::Type>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl DerefMut for ConceptVertexTypes {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+impl From<BTreeSet<answer::Type>> for ConceptVertexTypes {
+    fn from(value: BTreeSet<answer::Type>) -> Self {
+        Self(value)
+    }
+}
+
+impl<'a> IntoIterator for &'a ConceptVertexTypes {
+    type Item = <&'a BTreeSet<answer::Type> as IntoIterator>::Item;
+    type IntoIter = <&'a BTreeSet<answer::Type> as IntoIterator>::IntoIter;
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.iter()
+    }
+}
+
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
 pub(crate) struct VertexAnnotations {
-    annotations: BTreeMap<Vertex<Variable>, BTreeSet<TypeAnnotation>>,
+    annotations: BTreeMap<Vertex<Variable>, VertexTypeAnnotations>,
 }
 
 impl VertexAnnotations {
@@ -25,22 +107,39 @@ impl VertexAnnotations {
         Self { annotations: BTreeMap::new() }
     }
 
-    pub(crate) fn add_or_intersect(
+    pub(crate) fn add_or_intersect<OTHER: TypeAnnotationSetTrait + Into<VertexTypeAnnotations> + Clone>(
         &mut self,
         vertex: &Vertex<Variable>,
-        new_annotations: Cow<'_, BTreeSet<TypeAnnotation>>,
+        new_annotations: Cow<'_, OTHER>,
     ) -> bool {
         if let Some(existing_annotations) = self.get_mut(vertex) {
             existing_annotations.retain_intersection(&*new_annotations)
         } else {
-            self.insert(vertex.clone(), new_annotations.into_owned());
+            self.insert(vertex.clone(), new_annotations.into_owned().into());
             true
         }
+    }
+
+    pub(super) fn try_union<'a>(
+        mut sets_of_annotations: impl Iterator<Item = &'a VertexAnnotations>,
+        vertex: &Vertex<Variable>,
+    ) -> Result<Option<VertexTypeAnnotations>, TypeInferenceError> {
+        let mut union: Option<VertexTypeAnnotations> = None;
+        sets_of_annotations.try_for_each(|annotations| {
+            let branch_annotations = annotations.get(vertex).unwrap();
+            if let Some(inner) = &mut union {
+                inner.extend_to_union(branch_annotations)?;
+            } else {
+                union = Some(branch_annotations.clone())
+            }
+            Ok::<(), TypeInferenceError>(())
+        })?;
+        Ok(union)
     }
 }
 
 impl Deref for VertexAnnotations {
-    type Target = BTreeMap<Vertex<Variable>, BTreeSet<TypeAnnotation>>;
+    type Target = BTreeMap<Vertex<Variable>, VertexTypeAnnotations>;
 
     fn deref(&self) -> &Self::Target {
         &self.annotations
@@ -54,24 +153,24 @@ impl DerefMut for VertexAnnotations {
 }
 
 impl IntoIterator for VertexAnnotations {
-    type Item = <BTreeMap<Vertex<Variable>, BTreeSet<TypeAnnotation>> as IntoIterator>::Item;
-    type IntoIter = <BTreeMap<Vertex<Variable>, BTreeSet<TypeAnnotation>> as IntoIterator>::IntoIter;
+    type Item = <BTreeMap<Vertex<Variable>, VertexTypeAnnotations> as IntoIterator>::Item;
+    type IntoIter = <BTreeMap<Vertex<Variable>, VertexTypeAnnotations> as IntoIterator>::IntoIter;
     fn into_iter(self) -> Self::IntoIter {
         self.annotations.into_iter()
     }
 }
 
 impl<'a> IntoIterator for &'a VertexAnnotations {
-    type Item = <&'a BTreeMap<Vertex<Variable>, BTreeSet<TypeAnnotation>> as IntoIterator>::Item;
-    type IntoIter = <&'a BTreeMap<Vertex<Variable>, BTreeSet<TypeAnnotation>> as IntoIterator>::IntoIter;
+    type Item = <&'a BTreeMap<Vertex<Variable>, VertexTypeAnnotations> as IntoIterator>::Item;
+    type IntoIter = <&'a BTreeMap<Vertex<Variable>, VertexTypeAnnotations> as IntoIterator>::IntoIter;
     fn into_iter(self) -> Self::IntoIter {
         self.annotations.iter()
     }
 }
 
 impl<'a> IntoIterator for &'a mut VertexAnnotations {
-    type Item = <&'a mut BTreeMap<Vertex<Variable>, BTreeSet<TypeAnnotation>> as IntoIterator>::Item;
-    type IntoIter = <&'a mut BTreeMap<Vertex<Variable>, BTreeSet<TypeAnnotation>> as IntoIterator>::IntoIter;
+    type Item = <&'a mut BTreeMap<Vertex<Variable>, VertexTypeAnnotations> as IntoIterator>::Item;
+    type IntoIter = <&'a mut BTreeMap<Vertex<Variable>, VertexTypeAnnotations> as IntoIterator>::IntoIter;
     fn into_iter(self) -> Self::IntoIter {
         self.annotations.iter_mut()
     }
@@ -79,7 +178,7 @@ impl<'a> IntoIterator for &'a mut VertexAnnotations {
 
 impl<T> From<T> for VertexAnnotations
 where
-    BTreeMap<Vertex<Variable>, BTreeSet<TypeAnnotation>>: From<T>,
+    BTreeMap<Vertex<Variable>, VertexTypeAnnotations>: From<T>,
 {
     fn from(t: T) -> Self {
         Self { annotations: t.into() }
@@ -147,31 +246,106 @@ impl<T: Ord> ExtendMappedOperations<T> for BTreeSet<T> {}
 impl<T> FromIteratorMappedOperations<T> for Vec<T> {}
 impl<T> ExtendMappedOperations<T> for Vec<T> {}
 
-pub(crate) trait RetainAndContainExt<T> {
-    fn contains_ext(&self, item: &T) -> bool;
-    fn retain_intersection<S: RetainAndContainExt<T>>(&mut self, other: &S) -> bool;
+#[derive(Debug, Clone, Copy)]
+pub(crate) enum TypeAnnotationSetEntry {
+    Concept(answer::Type),
+    // Value(ValueType),
 }
 
-impl<K: Ord, V> RetainAndContainExt<K> for BTreeMap<K, V> {
-    fn contains_ext(&self, item: &K) -> bool {
-        self.contains_key(item)
+impl From<answer::Type> for TypeAnnotationSetEntry {
+    fn from(value: answer::Type) -> Self {
+        Self::Concept(value)
+    }
+}
+
+pub(crate) trait TypeAnnotationSetTrait {
+    type NativeItem;
+
+    fn contains_type<T: Into<TypeAnnotationSetEntry> + Copy>(&self, type_: &T) -> bool;
+    fn iter_types(&self) -> impl Iterator<Item = TypeAnnotationSetEntry>;
+    fn retain_intersection<OTHER: TypeAnnotationSetTrait>(&mut self, other: &OTHER) -> bool;
+}
+
+impl TypeAnnotationSetTrait for VertexTypeAnnotations {
+    type NativeItem = TypeAnnotationSetEntry;
+
+    fn contains_type<T: Into<TypeAnnotationSetEntry> + Copy>(&self, type_: &T) -> bool {
+        match self {
+            VertexTypeAnnotations::Concept(type_set) => type_set.contains_type(type_),
+        }
     }
 
-    fn retain_intersection<S: RetainAndContainExt<K>>(&mut self, other: &S) -> bool {
+    fn iter_types(&self) -> impl Iterator<Item = TypeAnnotationSetEntry> {
+        match self {
+            VertexTypeAnnotations::Concept(type_set) => type_set.iter_types(),
+        }
+    }
+
+    fn retain_intersection<OTHER: TypeAnnotationSetTrait>(&mut self, other: &OTHER) -> bool {
+        match self {
+            VertexTypeAnnotations::Concept(type_set) => type_set.retain_intersection(other),
+        }
+    }
+}
+
+impl TypeAnnotationSetTrait for ConceptVertexTypes {
+    type NativeItem = answer::Type;
+
+    fn contains_type<T: Into<TypeAnnotationSetEntry> + Copy>(&self, type_: &T) -> bool {
+        match (*type_).into() {
+            TypeAnnotationSetEntry::Concept(type_) => self.contains(&type_),
+            // TypeAnnotationSetEntry::Value(_) => false,
+        }
+    }
+
+    fn iter_types(&self) -> impl Iterator<Item = TypeAnnotationSetEntry> {
+        self.iter().map(|t| TypeAnnotationSetEntry::Concept(*t))
+    }
+
+    fn retain_intersection<OTHER: TypeAnnotationSetTrait>(&mut self, other: &OTHER) -> bool {
         let size_before = self.len();
-        self.retain(|x, _| other.contains_ext(x));
+        self.retain(|type_| other.contains_type(type_));
         self.len() != size_before
     }
 }
 
-impl<K: Ord> RetainAndContainExt<K> for BTreeSet<K> {
-    fn contains_ext(&self, item: &K) -> bool {
-        self.contains(item)
+impl TypeAnnotationSetTrait for BTreeMap<answer::Type, BTreeSet<answer::Type>> {
+    type NativeItem = answer::Type;
+
+    fn contains_type<T: Into<TypeAnnotationSetEntry> + Copy>(&self, type_: &T) -> bool {
+        match (*type_).into() {
+            TypeAnnotationSetEntry::Concept(type_) => self.contains_key(&type_),
+            // TypeAnnotationSetEntry::Value(_) => false,
+        }
     }
 
-    fn retain_intersection<S: RetainAndContainExt<K>>(&mut self, other: &S) -> bool {
+    fn iter_types(&self) -> impl Iterator<Item = TypeAnnotationSetEntry> {
+        self.keys().map(|type_| TypeAnnotationSetEntry::Concept(*type_))
+    }
+
+    fn retain_intersection<OTHER: TypeAnnotationSetTrait>(&mut self, other: &OTHER) -> bool {
         let size_before = self.len();
-        self.retain(|x| other.contains_ext(x));
+        self.retain(|type_, _| other.contains_type(type_));
         self.len() != size_before
+    }
+}
+
+#[cfg(debug_assertions)]
+pub mod tests {
+    use std::collections::BTreeSet;
+
+    use answer::{Type, variable::Variable};
+    use ir::pattern::Vertex;
+
+    use crate::annotation::inference::{ConceptVertexTypes, VertexAnnotations, VertexTypeAnnotations};
+
+    impl FromIterator<(Vertex<Variable>, BTreeSet<answer::Type>)> for VertexAnnotations {
+        fn from_iter<T: IntoIterator<Item = (Vertex<Variable>, BTreeSet<Type>)>>(iter: T) -> Self {
+            let annotations = iter
+                .into_iter()
+                .map(|(v, types)| (v, VertexTypeAnnotations::Concept(ConceptVertexTypes(types))))
+                .collect();
+            Self { annotations }
+        }
     }
 }

--- a/compiler/annotation/inference/type_seeder.rs
+++ b/compiler/annotation/inference/type_seeder.rs
@@ -38,7 +38,8 @@ use crate::annotation::{
     TypeInferenceError,
     function::{AnnotatedFunctionSignatures, FunctionParameterAnnotation},
     inference::{
-        ExtendMappedOperations, FromIteratorMappedOperations, RetainAndContainExt, VertexAnnotations,
+        ConceptVertexTypes, ExtendMappedOperations, FromIteratorMappedOperations, TypeAnnotationSetTrait,
+        VertexAnnotations, VertexTypeAnnotations,
         match_inference::{NestedTypeInferenceGraphDisjunction, TypeInferenceEdge, TypeInferenceGraph},
     },
     type_inference::{TypeInferenceMode, get_type_annotation_from_label},
@@ -61,7 +62,7 @@ impl<'this, Snapshot: ReadableSnapshot> TypeGraphSeedingContext<'this, Snapshot>
         self.stage_type != TypeInferenceMode::IncludeAbstractSubtypes
     }
 
-    fn may_assert_no_abstract(&self, variable: &Vertex<Variable>, types: &BTreeSet<Type>) {
+    fn may_assert_no_abstract(&self, variable: &Vertex<Variable>, types: &ConceptVertexTypes) {
         #[cfg(debug_assertions)]
         if self.stage_type != TypeInferenceMode::IncludeAbstractSubtypes {
             let is_thing = matches!(variable, Vertex::Variable(var) if {
@@ -235,7 +236,7 @@ impl<'this, Snapshot: ReadableSnapshot> TypeGraphSeedingContext<'this, Snapshot>
                     if !graph.vertices.contains_key(vertex) {
                         let annotation_opt = get_type_annotation_from_label(self.snapshot, self.type_manager, label)?;
                         if let Some(annotation) = annotation_opt {
-                            graph.vertices.insert(vertex.clone(), BTreeSet::from([annotation]));
+                            graph.vertices.insert(vertex.clone(), VertexTypeAnnotations::concept_from([annotation]));
                         } else {
                             return Err(TypeInferenceError::LabelNotResolved {
                                 name: label.to_string(),
@@ -248,7 +249,10 @@ impl<'this, Snapshot: ReadableSnapshot> TypeGraphSeedingContext<'this, Snapshot>
                             let annotation_opt =
                                 get_type_annotation_from_label(self.snapshot, self.type_manager, label)?;
                             debug_assert_ne!(annotation_opt, None);
-                            debug_assert_eq!(graph.vertices[vertex], BTreeSet::from([annotation_opt.unwrap()]));
+                            debug_assert_eq!(
+                                graph.vertices[vertex],
+                                VertexTypeAnnotations::concept_from([annotation_opt.unwrap()])
+                            );
                         }
                     }
                 }
@@ -308,7 +312,7 @@ impl<'this, Snapshot: ReadableSnapshot> TypeGraphSeedingContext<'this, Snapshot>
     fn get_unbounded_type_annotations(
         &self,
         category: VariableCategory,
-    ) -> Result<BTreeSet<TypeAnnotation>, Box<ConceptReadError>> {
+    ) -> Result<VertexTypeAnnotations, Box<ConceptReadError>> {
         // We can't refine based on categories since categories are global.
         // Had categories been per scope, we could indeed have been more specific.
         let (include_thing_types, include_role_types) = match category {
@@ -325,7 +329,7 @@ impl<'this, Snapshot: ReadableSnapshot> TypeGraphSeedingContext<'this, Snapshot>
             | VariableCategory::Attribute => (true, false),
             VariableCategory::AttributeOrValue => unreachable!("Insufficiently bound variable!"),
         };
-        let mut annotations: BTreeSet<TypeAnnotation> = BTreeSet::new();
+        let mut annotations = ConceptVertexTypes(BTreeSet::new());
 
         let snapshot = self.snapshot;
         let type_manager = self.type_manager;
@@ -337,11 +341,11 @@ impl<'this, Snapshot: ReadableSnapshot> TypeGraphSeedingContext<'this, Snapshot>
         if include_role_types {
             annotations.extend_into(type_manager.get_role_types(snapshot)?);
         }
-        Ok(annotations)
+        Ok(VertexTypeAnnotations::Concept(annotations))
     }
 
     // Phase 2: Use constraints to infer annotations on other vertices
-    fn propagate_vertex_annotations(&self, graph: &mut TypeInferenceGraph<'_>) -> Result<bool, Box<ConceptReadError>> {
+    fn propagate_vertex_annotations(&self, graph: &mut TypeInferenceGraph<'_>) -> Result<bool, TypeInferenceError> {
         let mut is_modified = false;
         // Prioritise `isa` constraints
         for c in graph.conjunction.constraints().iter().filter(|c| matches!(c, Constraint::Isa(_))) {
@@ -403,20 +407,20 @@ impl<'this, Snapshot: ReadableSnapshot> TypeGraphSeedingContext<'this, Snapshot>
         let any_modified = match (vertices.get(left), vertices.get(right)) {
             (None, None) => false,
             (Some(_), Some(_)) => false,
-            (Some(left_types), None) => {
-                let mut right_types = BTreeSet::new();
+            (Some(VertexTypeAnnotations::Concept(left_types)), None) => {
+                let mut right_types = ConceptVertexTypes(BTreeSet::new());
                 for type_ in left_types {
                     inner.annotate_left_to_right_for_type(self, type_, &mut right_types)?;
                 }
-                vertices.insert(right.clone(), right_types);
+                vertices.insert(right.clone(), VertexTypeAnnotations::Concept(right_types.into()));
                 true
             }
-            (None, Some(right_types)) => {
-                let mut left_types = BTreeSet::new();
+            (None, Some(VertexTypeAnnotations::Concept(right_types))) => {
+                let mut left_types = ConceptVertexTypes(BTreeSet::new());
                 for type_ in right_types {
                     inner.annotate_right_to_left_for_type(self, type_, &mut left_types)?;
                 }
-                vertices.insert(left.clone(), left_types);
+                vertices.insert(left.clone(), VertexTypeAnnotations::Concept(left_types.into()));
                 true
             }
         };
@@ -427,7 +431,7 @@ impl<'this, Snapshot: ReadableSnapshot> TypeGraphSeedingContext<'this, Snapshot>
         &self,
         nested: &mut NestedTypeInferenceGraphDisjunction<'_>,
         parent_vertices: &mut VertexAnnotations,
-    ) -> Result<bool, Box<ConceptReadError>> {
+    ) -> Result<bool, TypeInferenceError> {
         use NestedTypeInferenceGraphDisjunction as NestedGraphDisj;
         let mut something_changed = false;
         // Apply annotations of the parent on the nested
@@ -450,9 +454,9 @@ impl<'this, Snapshot: ReadableSnapshot> TypeGraphSeedingContext<'this, Snapshot>
         for vertex in NestedGraphDisj::variables_affecting_parent(disjunction_pattern) {
             // If they haven't been seeded yet (?), don't wrongly restrict the parent.
             if nested.disjunction.iter().all(|branch| branch.vertices.contains_key(&vertex)) {
-                let union =
-                    nested.disjunction.iter().flat_map(|branch| branch.vertices[&vertex].iter().copied()).collect();
-                parent_vertices.add_or_intersect(&vertex, Cow::Owned(union));
+                let union = VertexAnnotations::try_union(nested.disjunction.iter().map(|b| &b.vertices), &vertex)?
+                    .expect("Won't be null if there's at least one branch");
+                parent_vertices.add_or_intersect(&vertex, Cow::Owned::<VertexTypeAnnotations>(union));
             }
         }
 
@@ -464,9 +468,11 @@ impl<'this, Snapshot: ReadableSnapshot> TypeGraphSeedingContext<'this, Snapshot>
         &self,
         graph: &mut TypeInferenceGraph<'_>,
         stage_type: TypeInferenceMode,
-    ) -> Result<(), Box<ConceptReadError>> {
+    ) -> Result<(), TypeInferenceError> {
         #[cfg(debug_assertions)]
-        graph.vertices.iter().for_each(|(variable, types)| self.may_assert_no_abstract(variable, types));
+        graph.vertices.iter().for_each(|(variable, types)| match types {
+            VertexTypeAnnotations::Concept(types) => self.may_assert_no_abstract(variable, types),
+        });
         let TypeInferenceGraph { conjunction, edges, vertices, .. } = graph;
         for constraint in conjunction.constraints() {
             match constraint {
@@ -518,13 +524,16 @@ impl<'this, Snapshot: ReadableSnapshot> TypeGraphSeedingContext<'this, Snapshot>
         constraint: &'conj Constraint<Variable>,
         inner: &impl BinaryConstraint,
         vertices: &VertexAnnotations,
-    ) -> Result<TypeInferenceEdge<'conj>, Box<ConceptReadError>> {
+    ) -> Result<TypeInferenceEdge<'conj>, TypeInferenceError> {
         let (left, right) = (inner.left().clone(), inner.right().clone());
-        debug_assert!(vertices.contains_key(&left) && vertices.contains_key(&right));
-        let left_to_right =
-            inner.annotate_left_to_right(self, vertices.get(&left).unwrap(), vertices.get(&right).unwrap())?;
-        let right_to_left =
-            inner.annotate_right_to_left(self, vertices.get(&right).unwrap(), vertices.get(&left).unwrap())?;
+        let Some(VertexTypeAnnotations::Concept(left_vertex_types)) = vertices.get(&left) else {
+            return Err(TypeInferenceError::InternalVertexTypesMismatch { expected: "concept".to_owned() });
+        };
+        let Some(VertexTypeAnnotations::Concept(right_vertex_types)) = vertices.get(&right) else {
+            return Err(TypeInferenceError::InternalVertexTypesMismatch { expected: "concept".to_owned() });
+        };
+        let left_to_right = inner.annotate_left_to_right(self, left_vertex_types, right_vertex_types)?;
+        let right_to_left = inner.annotate_right_to_left(self, right_vertex_types, left_vertex_types)?;
         debug_assert!(left_to_right.values().all(|v| !v.is_empty()));
         debug_assert!(right_to_left.values().all(|v| !v.is_empty()));
         Ok(TypeInferenceEdge::build(constraint, left, right, left_to_right, right_to_left))
@@ -539,11 +548,11 @@ impl<'this, Snapshot: ReadableSnapshot> TypeGraphSeedingContext<'this, Snapshot>
         graph: &mut TypeInferenceGraph<'_>,
     ) -> Result<(), TypeInferenceError> {
         for annotated_vertex in &mut graph.vertices {
-            let (Vertex::Variable(id), annotations) = annotated_vertex else {
+            let (Vertex::Variable(id), VertexTypeAnnotations::Concept(annotations)) = annotated_vertex else {
                 continue;
             };
             if self.variable_registry.get_variable_category(*id).is_some_and(|cat| cat.is_category_thing()) {
-                TypeAnnotation::try_retain(annotations, |type_| self.is_not_abstract(type_))?;
+                try_retain(annotations, |type_| self.is_not_abstract(type_))?;
             }
         }
         for nested in graph.nested_disjunctions.iter_mut().flat_map(|nested| nested.disjunction.iter_mut()) {
@@ -551,6 +560,19 @@ impl<'this, Snapshot: ReadableSnapshot> TypeGraphSeedingContext<'this, Snapshot>
         }
         Ok(())
     }
+}
+
+fn try_retain<T: Ord + Copy, E>(set: &mut BTreeSet<T>, predicate: impl Fn(&T) -> Result<bool, E>) -> Result<(), E> {
+    let mut to_be_removed = Vec::new();
+    for item in set.iter() {
+        if !predicate(item)? {
+            to_be_removed.push(*item);
+        }
+    }
+    for annotation in to_be_removed.iter() {
+        set.remove(annotation);
+    }
+    Ok(())
 }
 
 trait UnaryConstraint {
@@ -605,7 +627,8 @@ impl UnaryConstraint for Kind<Variable> {
             EncodingKind::Attribute => BTreeSet::from_into(type_manager.get_attribute_types(context.snapshot)?),
             EncodingKind::Role => BTreeSet::from_into(type_manager.get_role_types(context.snapshot)?),
         };
-        graph_vertices.add_or_intersect(self.type_(), Cow::Owned(annotations));
+        graph_vertices
+            .add_or_intersect::<ConceptVertexTypes>(self.type_(), Cow::Owned(ConceptVertexTypes(annotations)));
         Ok(())
     }
 }
@@ -613,12 +636,12 @@ impl UnaryConstraint for Kind<Variable> {
 impl UnaryConstraint for Label<Variable> {
     fn apply<Snapshot: ReadableSnapshot>(
         &self,
-        _seeder: &TypeGraphSeedingContext<'_, Snapshot>,
+        _context: &TypeGraphSeedingContext<'_, Snapshot>,
         graph_vertices: &mut VertexAnnotations,
     ) -> Result<(), TypeInferenceError> {
         let annotation_opt = graph_vertices.get(self.type_label());
         if let Some(annotation) = annotation_opt {
-            graph_vertices.add_or_intersect(self.type_(), Cow::Owned(annotation.clone()));
+            graph_vertices.add_or_intersect::<VertexTypeAnnotations>(self.type_(), Cow::Owned(annotation.clone()));
             Ok(())
         } else {
             Err(TypeInferenceError::LabelNotResolved {
@@ -637,7 +660,7 @@ impl UnaryConstraint for RoleName<Variable> {
     ) -> Result<(), TypeInferenceError> {
         let role_types_opt = context.type_manager.get_roles_by_name(context.snapshot, self.name())?;
         if let Some(role_types) = role_types_opt {
-            let mut annotations = BTreeSet::new();
+            let mut annotations = ConceptVertexTypes(BTreeSet::new());
             for &role_type in &*role_types {
                 annotations.insert(role_type.into());
                 if !context.is_write_stage() {
@@ -645,7 +668,7 @@ impl UnaryConstraint for RoleName<Variable> {
                         .extend_into_ref(&role_type.get_subtypes_transitive(context.snapshot, context.type_manager)?);
                 }
             }
-            graph_vertices.add_or_intersect(self.type_(), Cow::Owned(annotations));
+            graph_vertices.add_or_intersect::<ConceptVertexTypes>(self.type_(), Cow::Owned(annotations));
             Ok(())
         } else {
             Err(TypeInferenceError::RoleNameNotResolved {
@@ -677,7 +700,7 @@ impl UnaryConstraint for Value<Variable> {
             }
         }?;
 
-        let mut annotations = BTreeSet::new();
+        let mut annotations = ConceptVertexTypes(BTreeSet::new());
         let attribute_types = context.type_manager.get_attribute_types(context.snapshot)?;
         for attribute_type in attribute_types {
             let attribute_value_type_opt =
@@ -689,7 +712,7 @@ impl UnaryConstraint for Value<Variable> {
             }
         }
 
-        graph_vertices.add_or_intersect(self.attribute_type(), Cow::Owned(annotations));
+        graph_vertices.add_or_intersect::<ConceptVertexTypes>(self.attribute_type(), Cow::Owned(annotations));
         Ok(())
     }
 }
@@ -707,13 +730,19 @@ impl UnaryConstraint for FunctionCallBinding<Variable> {
                 zip(self.assigned(), annotated_function_signature.returns.iter())
             {
                 if let FunctionParameterAnnotation::Concept(types) = return_annotation {
-                    graph_vertices.add_or_intersect(assigned_variable, Cow::Borrowed(types));
+                    graph_vertices.add_or_intersect::<ConceptVertexTypes>(
+                        assigned_variable,
+                        Cow::Owned(ConceptVertexTypes(types.clone())),
+                    );
                 }
             }
             let args = self.function_call().argument_ids();
             for (arg_var, arg_annotations) in zip(args, &annotated_function_signature.arguments) {
                 if let FunctionParameterAnnotation::Concept(types) = arg_annotations {
-                    graph_vertices.add_or_intersect(&Vertex::Variable(arg_var), Cow::Borrowed(types));
+                    graph_vertices.add_or_intersect::<ConceptVertexTypes>(
+                        &Vertex::Variable(arg_var),
+                        Cow::Owned(ConceptVertexTypes(types.clone())),
+                    );
                 }
             }
         }
@@ -727,18 +756,20 @@ impl UnaryConstraint for Comparison<Variable> {
         context: &TypeGraphSeedingContext<'_, Snapshot>,
         graph_vertices: &mut VertexAnnotations,
     ) -> Result<(), TypeInferenceError> {
-        let attributes_lazy =
-            LazyCell::new(|| Ok(BTreeSet::from_into(context.type_manager.get_attribute_types(context.snapshot)?)));
+        let attributes_lazy = LazyCell::new(|| {
+            let types = BTreeSet::from_into(context.type_manager.get_attribute_types(context.snapshot)?);
+            Ok(ConceptVertexTypes(types))
+        });
         if let Vertex::Variable(var) = self.lhs() {
             if context.variable_registry.get_variable_category(*var).map_or(false, |cat| cat.is_category_thing()) {
                 let attributes = (*attributes_lazy).as_ref().map_err(TypeInferenceError::clone)?;
-                graph_vertices.add_or_intersect(self.lhs(), Cow::Borrowed(&attributes));
+                graph_vertices.add_or_intersect(self.lhs(), Cow::Borrowed(attributes));
             }
         }
         if let Vertex::Variable(var) = self.rhs() {
             if context.variable_registry.get_variable_category(*var).map_or(false, |cat| cat.is_category_thing()) {
                 let attributes = (*attributes_lazy).as_ref().map_err(TypeInferenceError::clone)?;
-                graph_vertices.add_or_intersect(self.rhs(), Cow::Borrowed(&attributes));
+                graph_vertices.add_or_intersect(self.rhs(), Cow::Borrowed(attributes));
             }
         }
         Ok(())
@@ -752,14 +783,14 @@ trait BinaryConstraint {
     fn annotate_left_to_right(
         &self,
         context: &TypeGraphSeedingContext<'_, impl ReadableSnapshot>,
-        left_types: &BTreeSet<TypeAnnotation>,
-        allowed_right_types: &BTreeSet<TypeAnnotation>,
-    ) -> Result<BTreeMap<TypeAnnotation, BTreeSet<TypeAnnotation>>, Box<ConceptReadError>> {
+        left_types: &ConceptVertexTypes,
+        allowed_right_types: &ConceptVertexTypes,
+    ) -> Result<BTreeMap<TypeAnnotation, ConceptVertexTypes>, Box<ConceptReadError>> {
         let mut left_to_right = BTreeMap::new();
         context.may_assert_no_abstract(self.left(), &left_types);
         context.may_assert_no_abstract(self.right(), &allowed_right_types);
         for left_type in left_types {
-            let mut right_annotations = BTreeSet::new();
+            let mut right_annotations = ConceptVertexTypes(BTreeSet::new());
             self.annotate_left_to_right_for_type(context, left_type, &mut right_annotations)?;
             right_annotations.retain_intersection(allowed_right_types);
             context.may_assert_no_abstract(self.right(), &right_annotations);
@@ -773,14 +804,14 @@ trait BinaryConstraint {
     fn annotate_right_to_left(
         &self,
         context: &TypeGraphSeedingContext<'_, impl ReadableSnapshot>,
-        right_types: &BTreeSet<TypeAnnotation>,
-        allowed_left_types: &BTreeSet<TypeAnnotation>,
-    ) -> Result<BTreeMap<TypeAnnotation, BTreeSet<TypeAnnotation>>, Box<ConceptReadError>> {
+        right_types: &ConceptVertexTypes,
+        allowed_left_types: &ConceptVertexTypes,
+    ) -> Result<BTreeMap<TypeAnnotation, ConceptVertexTypes>, Box<ConceptReadError>> {
         let mut right_to_left = BTreeMap::new();
         context.may_assert_no_abstract(self.left(), &allowed_left_types);
         context.may_assert_no_abstract(self.right(), &right_types);
         for right_type in right_types {
-            let mut left_annotations = BTreeSet::new();
+            let mut left_annotations = ConceptVertexTypes(BTreeSet::new());
             self.annotate_right_to_left_for_type(context, right_type, &mut left_annotations)?;
             left_annotations.retain_intersection(allowed_left_types);
             context.may_assert_no_abstract(self.left(), &left_annotations);
@@ -795,14 +826,14 @@ trait BinaryConstraint {
         &self,
         context: &TypeGraphSeedingContext<'_, impl ReadableSnapshot>,
         left_type: &TypeAnnotation,
-        collector: &mut BTreeSet<TypeAnnotation>,
+        collector: &mut ConceptVertexTypes,
     ) -> Result<(), Box<ConceptReadError>>;
 
     fn annotate_right_to_left_for_type(
         &self,
         context: &TypeGraphSeedingContext<'_, impl ReadableSnapshot>,
         right_type: &TypeAnnotation,
-        collector: &mut BTreeSet<TypeAnnotation>,
+        collector: &mut ConceptVertexTypes,
     ) -> Result<(), Box<ConceptReadError>>;
 }
 
@@ -820,7 +851,7 @@ impl BinaryConstraint for Has<Variable> {
         &self,
         context: &TypeGraphSeedingContext<'_, impl ReadableSnapshot>,
         left_type: &TypeAnnotation,
-        collector: &mut BTreeSet<TypeAnnotation>,
+        collector: &mut ConceptVertexTypes,
     ) -> Result<(), Box<ConceptReadError>> {
         let Some(owner) = left_type.try_as_object_type() else {
             return Ok(()); // It can't be another type => Do nothing and let type-inference clean it up
@@ -835,7 +866,7 @@ impl BinaryConstraint for Has<Variable> {
         &self,
         context: &TypeGraphSeedingContext<'_, impl ReadableSnapshot>,
         right_type: &TypeAnnotation,
-        collector: &mut BTreeSet<TypeAnnotation>,
+        collector: &mut ConceptVertexTypes,
     ) -> Result<(), Box<ConceptReadError>> {
         let TypeAnnotation::Attribute(attribute) = right_type else {
             return Ok(()); // It can't be another type => Do nothing and let type-inference clean it up
@@ -858,7 +889,7 @@ impl BinaryConstraint for Owns<Variable> {
         &self,
         context: &TypeGraphSeedingContext<'_, impl ReadableSnapshot>,
         left_type: &TypeAnnotation,
-        collector: &mut BTreeSet<TypeAnnotation>,
+        collector: &mut ConceptVertexTypes,
     ) -> Result<(), Box<ConceptReadError>> {
         let Some(owner) = left_type.try_as_object_type() else {
             // It can't be another type => Do nothing and let type-inference clean it up
@@ -874,7 +905,7 @@ impl BinaryConstraint for Owns<Variable> {
         &self,
         context: &TypeGraphSeedingContext<'_, impl ReadableSnapshot>,
         right_type: &TypeAnnotation,
-        collector: &mut BTreeSet<TypeAnnotation>,
+        collector: &mut ConceptVertexTypes,
     ) -> Result<(), Box<ConceptReadError>> {
         let TypeAnnotation::Attribute(attribute) = right_type else {
             // It can't be another type => Do nothing and let type-inference clean it up
@@ -898,7 +929,7 @@ impl BinaryConstraint for Isa<Variable> {
         &self,
         context: &TypeGraphSeedingContext<'_, impl ReadableSnapshot>,
         left_type: &TypeAnnotation,
-        collector: &mut BTreeSet<TypeAnnotation>,
+        collector: &mut ConceptVertexTypes,
     ) -> Result<(), Box<ConceptReadError>> {
         if !context.is_write_stage() && self.isa_kind() == IsaKind::Subtype {
             match left_type {
@@ -921,7 +952,7 @@ impl BinaryConstraint for Isa<Variable> {
         &self,
         context: &TypeGraphSeedingContext<'_, impl ReadableSnapshot>,
         right_type: &TypeAnnotation,
-        collector: &mut BTreeSet<TypeAnnotation>,
+        collector: &mut ConceptVertexTypes,
     ) -> Result<(), Box<ConceptReadError>> {
         if !context.is_write_stage() && self.isa_kind() == IsaKind::Subtype {
             match right_type {
@@ -955,7 +986,7 @@ impl BinaryConstraint for Sub<Variable> {
         &self,
         context: &TypeGraphSeedingContext<'_, impl ReadableSnapshot>,
         left_type: &TypeAnnotation,
-        collector: &mut BTreeSet<TypeAnnotation>,
+        collector: &mut ConceptVertexTypes,
     ) -> Result<(), Box<ConceptReadError>> {
         if self.sub_kind() == SubKind::Subtype {
             match left_type {
@@ -1000,7 +1031,7 @@ impl BinaryConstraint for Sub<Variable> {
         &self,
         context: &TypeGraphSeedingContext<'_, impl ReadableSnapshot>,
         right_type: &TypeAnnotation,
-        collector: &mut BTreeSet<TypeAnnotation>,
+        collector: &mut ConceptVertexTypes,
     ) -> Result<(), Box<ConceptReadError>> {
         if self.sub_kind() == SubKind::Subtype {
             match right_type {
@@ -1046,9 +1077,9 @@ impl BinaryConstraint for Is<Variable> {
 
     fn annotate_left_to_right_for_type(
         &self,
-        _seeder: &TypeGraphSeedingContext<'_, impl ReadableSnapshot>,
+        _context: &TypeGraphSeedingContext<'_, impl ReadableSnapshot>,
         left_type: &TypeAnnotation,
-        collector: &mut BTreeSet<TypeAnnotation>,
+        collector: &mut ConceptVertexTypes,
     ) -> Result<(), Box<ConceptReadError>> {
         collector.insert(*left_type);
         Ok(())
@@ -1056,9 +1087,9 @@ impl BinaryConstraint for Is<Variable> {
 
     fn annotate_right_to_left_for_type(
         &self,
-        _seeder: &TypeGraphSeedingContext<'_, impl ReadableSnapshot>,
+        _context: &TypeGraphSeedingContext<'_, impl ReadableSnapshot>,
         right_type: &TypeAnnotation,
-        collector: &mut BTreeSet<TypeAnnotation>,
+        collector: &mut ConceptVertexTypes,
     ) -> Result<(), Box<ConceptReadError>> {
         collector.insert(*right_type);
         Ok(())
@@ -1078,15 +1109,15 @@ impl BinaryConstraint for Comparison<Variable> {
     fn annotate_left_to_right(
         &self,
         context: &TypeGraphSeedingContext<'_, impl ReadableSnapshot>,
-        left_types: &BTreeSet<Type>,
-        allowed_right_types: &BTreeSet<Type>,
-    ) -> Result<BTreeMap<Type, BTreeSet<Type>>, Box<ConceptReadError>> {
+        left_types: &ConceptVertexTypes,
+        allowed_right_types: &ConceptVertexTypes,
+    ) -> Result<BTreeMap<TypeAnnotation, ConceptVertexTypes>, Box<ConceptReadError>> {
         let mut left_to_right = BTreeMap::new();
         context.may_assert_no_abstract(self.left(), &left_types);
         context.may_assert_no_abstract(self.right(), &allowed_right_types);
         // TODO: Optimise?
         for left_type in left_types {
-            let mut right_annotations = BTreeSet::new();
+            let mut right_annotations = ConceptVertexTypes(BTreeSet::new());
             let left_value_type = match left_type {
                 TypeAnnotation::Attribute(attribute) => {
                     attribute.get_value_type_without_source(context.snapshot, context.type_manager)?
@@ -1117,16 +1148,16 @@ impl BinaryConstraint for Comparison<Variable> {
     fn annotate_right_to_left(
         &self,
         context: &TypeGraphSeedingContext<'_, impl ReadableSnapshot>,
-        right_types: &BTreeSet<Type>,
-        allowed_left_types: &BTreeSet<Type>,
-    ) -> Result<BTreeMap<Type, BTreeSet<Type>>, Box<ConceptReadError>> {
+        right_types: &ConceptVertexTypes,
+        allowed_left_types: &ConceptVertexTypes,
+    ) -> Result<BTreeMap<TypeAnnotation, ConceptVertexTypes>, Box<ConceptReadError>> {
         let mut right_to_left = BTreeMap::new();
         #[cfg(debug_assertions)]
         context.may_assert_no_abstract(self.left(), &allowed_left_types);
         context.may_assert_no_abstract(self.right(), &right_types);
         // TODO: Optimise?
         for right_type in right_types {
-            let mut left_annotations = BTreeSet::new();
+            let mut left_annotations = ConceptVertexTypes(BTreeSet::new());
             let right_value_type = match right_type {
                 TypeAnnotation::Attribute(attribute) => {
                     attribute.get_value_type_without_source(context.snapshot, context.type_manager)?
@@ -1156,18 +1187,18 @@ impl BinaryConstraint for Comparison<Variable> {
 
     fn annotate_left_to_right_for_type(
         &self,
-        _seeder: &TypeGraphSeedingContext<'_, impl ReadableSnapshot>,
+        _context: &TypeGraphSeedingContext<'_, impl ReadableSnapshot>,
         _left_type: &TypeAnnotation,
-        _collector: &mut BTreeSet<TypeAnnotation>,
+        _collector: &mut ConceptVertexTypes,
     ) -> Result<(), Box<ConceptReadError>> {
         unreachable!()
     }
 
     fn annotate_right_to_left_for_type(
         &self,
-        _seeder: &TypeGraphSeedingContext<'_, impl ReadableSnapshot>,
-        _right_type: &TypeAnnotation,
-        _collector: &mut BTreeSet<TypeAnnotation>,
+        _context: &TypeGraphSeedingContext<'_, impl ReadableSnapshot>,
+        _left_type: &TypeAnnotation,
+        _collector: &mut ConceptVertexTypes,
     ) -> Result<(), Box<ConceptReadError>> {
         unreachable!()
     }
@@ -1194,7 +1225,7 @@ impl BinaryConstraint for PlayerRoleEdge<'_> {
         &self,
         context: &TypeGraphSeedingContext<'_, impl ReadableSnapshot>,
         left_type: &TypeAnnotation,
-        collector: &mut BTreeSet<TypeAnnotation>,
+        collector: &mut ConceptVertexTypes,
     ) -> Result<(), Box<ConceptReadError>> {
         let Some(player) = left_type.try_as_object_type() else {
             // It can't be another type => Do nothing and let type-inference clean it up
@@ -1210,7 +1241,7 @@ impl BinaryConstraint for PlayerRoleEdge<'_> {
         &self,
         context: &TypeGraphSeedingContext<'_, impl ReadableSnapshot>,
         right_type: &TypeAnnotation,
-        collector: &mut BTreeSet<TypeAnnotation>,
+        collector: &mut ConceptVertexTypes,
     ) -> Result<(), Box<ConceptReadError>> {
         let TypeAnnotation::RoleType(role_type) = right_type else {
             return Ok(());
@@ -1234,7 +1265,7 @@ impl BinaryConstraint for Plays<Variable> {
         &self,
         context: &TypeGraphSeedingContext<'_, impl ReadableSnapshot>,
         left_type: &TypeAnnotation,
-        collector: &mut BTreeSet<TypeAnnotation>,
+        collector: &mut ConceptVertexTypes,
     ) -> Result<(), Box<ConceptReadError>> {
         let Some(player) = left_type.try_as_object_type() else {
             // It can't be another type => Do nothing and let type-inference clean it up
@@ -1250,7 +1281,7 @@ impl BinaryConstraint for Plays<Variable> {
         &self,
         context: &TypeGraphSeedingContext<'_, impl ReadableSnapshot>,
         right_type: &TypeAnnotation,
-        collector: &mut BTreeSet<TypeAnnotation>,
+        collector: &mut ConceptVertexTypes,
     ) -> Result<(), Box<ConceptReadError>> {
         let TypeAnnotation::RoleType(role_type) = right_type else {
             // It can't be another type => Do nothing and let type-inference clean it up
@@ -1274,7 +1305,7 @@ impl BinaryConstraint for RelationRoleEdge<'_> {
         &self,
         context: &TypeGraphSeedingContext<'_, impl ReadableSnapshot>,
         left_type: &TypeAnnotation,
-        collector: &mut BTreeSet<TypeAnnotation>,
+        collector: &mut ConceptVertexTypes,
     ) -> Result<(), Box<ConceptReadError>> {
         let TypeAnnotation::Relation(relation) = left_type else {
             // It can't be another type => Do nothing and let type-inference clean it up
@@ -1294,7 +1325,7 @@ impl BinaryConstraint for RelationRoleEdge<'_> {
         &self,
         context: &TypeGraphSeedingContext<'_, impl ReadableSnapshot>,
         right_type: &TypeAnnotation,
-        collector: &mut BTreeSet<TypeAnnotation>,
+        collector: &mut ConceptVertexTypes,
     ) -> Result<(), Box<ConceptReadError>> {
         let TypeAnnotation::RoleType(role) = right_type else {
             // It can't be another type => Do nothing and let type-inference clean it up
@@ -1324,7 +1355,7 @@ impl BinaryConstraint for Relates<Variable> {
         &self,
         context: &TypeGraphSeedingContext<'_, impl ReadableSnapshot>,
         left_type: &TypeAnnotation,
-        collector: &mut BTreeSet<TypeAnnotation>,
+        collector: &mut ConceptVertexTypes,
     ) -> Result<(), Box<ConceptReadError>> {
         let TypeAnnotation::Relation(relation) = left_type else {
             // It can't be another type => Do nothing and let type-inference clean it up
@@ -1340,7 +1371,7 @@ impl BinaryConstraint for Relates<Variable> {
         &self,
         context: &TypeGraphSeedingContext<'_, impl ReadableSnapshot>,
         right_type: &TypeAnnotation,
-        collector: &mut BTreeSet<TypeAnnotation>,
+        collector: &mut ConceptVertexTypes,
     ) -> Result<(), Box<ConceptReadError>> {
         let TypeAnnotation::RoleType(role_type) = right_type else {
             // It can't be another type => Do nothing and let type-inference clean it up
@@ -1418,7 +1449,7 @@ pub mod tests {
         let constraints = conjunction.constraints();
         let expected_graph = TypeInferenceGraph {
             conjunction,
-            vertices: VertexAnnotations::from([
+            vertices: VertexAnnotations::from_iter([
                 (var_animal.into(), BTreeSet::from([type_cat])),
                 (var_name.into(), BTreeSet::from([type_catname, type_dogname])),
                 (var_animal_type.into(), BTreeSet::from([type_cat])),
@@ -1532,7 +1563,7 @@ pub mod tests {
             let constraints = conjunction.constraints();
             let expected_graph = TypeInferenceGraph {
                 conjunction,
-                vertices: VertexAnnotations::from([
+                vertices: VertexAnnotations::from_iter([
                     (Vertex::Label(label_owner.clone()), types_x.clone()),
                     (var_x.into(), types_x),
                     (var_a.into(), types_a),
@@ -1613,7 +1644,7 @@ pub mod tests {
             let constraints = conjunction.constraints();
             let expected_graph = TypeInferenceGraph {
                 conjunction,
-                vertices: VertexAnnotations::from([(var_x.into(), types_x), (var_t.into(), types_t)]),
+                vertices: VertexAnnotations::from_iter([(var_x.into(), types_x), (var_t.into(), types_t)]),
                 edges: vec![expected_edge(
                     &constraints[0],
                     var_x.into(),

--- a/compiler/annotation/mod.rs
+++ b/compiler/annotation/mod.rs
@@ -244,6 +244,11 @@ typedb_error!(
             constraint_type: String,
             source_span: Option<Span>,
         ),
+        InternalVertexTypesMismatch(
+            254,
+            "Expected vertex to have annotations of kind: {expected} but it wasn't.",
+            expected: String,
+        ),
         OptionalTypesUnsupported(255, "Optional types are not yet supported."),
         ListTypesUnsupported(256, "List types are not yet supported."),
     }

--- a/encoding/graph/definition/definition_key.rs
+++ b/encoding/graph/definition/definition_key.rs
@@ -19,7 +19,7 @@ use crate::{
     layout::prefix::{Prefix, PrefixID},
 };
 
-#[derive(Clone, Debug, PartialEq, Eq, Hash, Ord, PartialOrd)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Ord, PartialOrd)]
 pub struct DefinitionKey {
     prefix: Prefix,
     definition_id: DefinitionID,

--- a/encoding/value/value_type.rs
+++ b/encoding/value/value_type.rs
@@ -21,7 +21,7 @@ use crate::{
 };
 
 // We can support Prefix::ATTRIBUTE_MAX - Prefix::ATTRIBUTE_MIN different built-in value types
-#[derive(Clone, Eq, PartialEq, Hash, Ord, PartialOrd)]
+#[derive(Clone, Copy, Eq, PartialEq, Hash, Ord, PartialOrd)]
 pub enum ValueType {
     Boolean,
     Integer,

--- a/query/given_rows.rs
+++ b/query/given_rows.rs
@@ -81,7 +81,7 @@ impl GivenRowEntry {
         let make_err = {
             let actual_type = value.value_type().to_string();
             let expected_type = expected_type.clone();
-            |value: String| GivenRowDecodeError::ValueTypeMismatch { expected_type, actual_type, value }
+            move |value: String| GivenRowDecodeError::ValueTypeMismatch { expected_type, actual_type, value }
         };
 
         if value.value_type().is_trivially_castable_to(expected_type.category()) {


### PR DESCRIPTION
## Product change and motivation
In preparation of supporting value types in the normal type inference procedure, a vertex annotation is now an enum with a single variant holding a set of concept-types.