### PR TITLE
Reset database by delete and recreate

### DIFF
--- a/concept/thing/statistics.rs
+++ b/concept/thing/statistics.rs
@@ -514,26 +514,6 @@ impl Statistics {
         }
         largest
     }
-
-    pub fn reset(&mut self, sequence_number: SequenceNumber) {
-        self.sequence_number = sequence_number;
-        self.total_count = 0;
-        self.total_thing_count = 0;
-        self.total_entity_count = 0;
-        self.total_relation_count = 0;
-        self.total_attribute_count = 0;
-        self.total_role_count = 0;
-        self.total_has_count = 0;
-        self.entity_counts.clear();
-        self.relation_counts.clear();
-        self.attribute_counts.clear();
-        self.role_counts.clear();
-        self.has_attribute_counts.clear();
-        self.attribute_owner_counts.clear();
-        self.role_player_counts.clear();
-        self.relation_role_counts.clear();
-        self.links_index_counts.clear();
-    }
 }
 
 fn write_to_delta<D>(

--- a/database/database.rs
+++ b/database/database.rs
@@ -46,7 +46,7 @@ use function::{FunctionError, function_cache::FunctionCache};
 use query::query_cache::QueryCache;
 use resource::constants::database::{CHECKPOINT_INTERVAL, STATISTICS_UPDATE_INTERVAL};
 use storage::{
-    MVCCStorage, StorageDeleteError, StorageOpenError, StorageResetError,
+    MVCCStorage, StorageDeleteError, StorageOpenError,
     durability_client::{DurabilityClient, DurabilityClientError, WALClient},
     keyspace::rocks_resources::RocksResources,
     recovery::checkpoint::{CheckpointCreateError, CheckpointLoadError, CheckpointReader, CheckpointWriter},
@@ -56,13 +56,7 @@ use storage::{
 use tracing::{Level, debug, event, trace};
 
 use crate::{
-    DatabaseOpenError::FunctionCacheInitialise,
-    DatabaseResetError::{
-        CorruptionPartialResetKeyGeneratorInUse, CorruptionPartialResetThingVertexGeneratorInUse,
-        CorruptionPartialResetTypeVertexGeneratorInUse,
-    },
-    database_manager::DatabaseManager,
-    transaction::TransactionError,
+    DatabaseOpenError::FunctionCacheInitialise, database_manager::DatabaseManager, transaction::TransactionError,
 };
 
 #[derive(Debug, Clone)]
@@ -503,41 +497,6 @@ impl Database<WALClient> {
         Ok(())
     }
 
-    pub fn reset(&mut self) -> Result<(), DatabaseResetError> {
-        use DatabaseResetError::CorruptionPartialResetStorageInUse;
-
-        self.reserve_schema_transaction(Duration::from_secs(60).as_millis() as u64)
-            .map_err(|typedb_source| DatabaseResetError::Transaction { typedb_source })?; // exclusively lock out other write or schema transactions;
-        let mut locked_schema = self.schema.write().unwrap();
-
-        match Arc::get_mut(&mut self.storage) {
-            None => return Err(DatabaseResetError::StorageInUse {}),
-            Some(storage) => {
-                storage.reset().map_err(|err| CorruptionPartialResetStorageInUse { typedb_source: err })?
-            }
-        }
-        match Arc::get_mut(&mut self.definition_key_generator) {
-            None => return Err(CorruptionPartialResetKeyGeneratorInUse {}),
-            Some(definition_key_generator) => definition_key_generator.reset(),
-        }
-        match Arc::get_mut(&mut self.type_vertex_generator) {
-            None => return Err(CorruptionPartialResetTypeVertexGeneratorInUse {}),
-            Some(type_vertex_generator) => type_vertex_generator.reset(),
-        }
-        match Arc::get_mut(&mut self.thing_vertex_generator) {
-            None => return Err(CorruptionPartialResetThingVertexGeneratorInUse {}),
-            Some(thing_vertex_generator) => thing_vertex_generator.reset(),
-        }
-
-        let thing_statistics = Arc::get_mut(&mut locked_schema.thing_statistics).unwrap();
-        thing_statistics.reset(self.storage.snapshot_watermark());
-
-        self.query_cache.force_reset(&Statistics::new(SequenceNumber::MIN));
-
-        self.release_schema_transaction();
-        Ok(())
-    }
-
     pub fn get_metrics(&self) -> DatabaseMetricsSnapshot {
         let schema = self.schema.read().expect("Expected database schema lock acquisition");
         DatabaseMetricsSnapshot {
@@ -659,29 +618,5 @@ typedb_error! {
     pub DatabaseResetError(component = "Database reset", prefix = "DBR") {
         DatabaseDelete(1, "Cannot delete database.", typedb_source: DatabaseDeleteError),
         DatabaseCreate(2, "Cannot create database.", typedb_source: DatabaseCreateError),
-        Transaction(3, "Transaction error.", typedb_source: TransactionError),
-        InUse(4, "Database cannot be reset since it is in use."),
-        StorageInUse(5, "Database cannot be reset since the storage is in use."),
-        CorruptionPartialResetStorageInUse(
-            6,
-            "Corruption warning: database reset failed partway because the storage is still in use.",
-            typedb_source: StorageResetError
-        ),
-        CorruptionPartialResetKeyGeneratorInUse(
-            7,
-            "Corruption warning: Database reset failed partway because the schema key generator is still in use."
-        ),
-        CorruptionPartialResetTypeVertexGeneratorInUse(
-            8,
-            "Corruption warning: Database reset failed partway because the type key generator is still in use."
-        ),
-        CorruptionPartialResetThingVertexGeneratorInUse(
-            9,
-            "Corruption warning: Database reset failed partway because the instance key generator is still in use."
-        ),
-        CorruptionPartialResetQuertyCacheInUse(
-            10,
-            "Corruption warning: Database reset failed partway because the query cache is still in use."
-        ),
     }
 }

--- a/database/database_manager.rs
+++ b/database/database_manager.rs
@@ -255,40 +255,14 @@ impl DatabaseManager {
         database.delete()
     }
 
-    pub fn reset_else_recreate_database(&self, name: impl AsRef<str>) -> Result<(), DatabaseResetError> {
-        // TODO: this is a partial implementation, only single threaded and without cooperative transaction shutdown
-        // remove from map to make DB unavailable
-        let mut databases = self.databases.write().unwrap();
-        let db = databases.remove(name.as_ref());
-        let result = if let Some(db) = db {
-            match Arc::try_unwrap(db) {
-                Ok(mut unwrapped) => {
-                    let reset_result = unwrapped.reset();
-                    databases.insert(name.as_ref().to_owned(), Arc::new(unwrapped));
-                    reset_result
-                }
-                Err(arc) => {
-                    // failed to reset since it's in use - let's re-insert for now instead of losing the reference
-                    databases.insert(name.as_ref().to_owned(), arc);
-                    Err(DatabaseResetError::InUse {})
-                }
-            }
-        } else {
-            drop(databases);
-            self.put_database(name).map_err(|typedb_source| DatabaseResetError::DatabaseCreate { typedb_source })?;
-            return Ok(());
-        };
-
-        drop(databases);
-        match result {
-            Ok(_) => (),
-            Err(_) => {
-                self.delete_database(name.as_ref())
-                    .map_err(|typedb_source| DatabaseResetError::DatabaseDelete { typedb_source })?;
-                self.put_database(name).map_err(|typedb_source| DatabaseResetError::DatabaseCreate { typedb_source })?
-            }
-        };
-        Ok(())
+    /// Resets a database to a freshly created state by deleting and recreating it, or creates it if it does not exist.
+    pub fn reset_database(&self, name: impl AsRef<str>) -> Result<(), DatabaseResetError> {
+        let name = name.as_ref();
+        match self.delete_database(name) {
+            Ok(()) | Err(DatabaseDeleteError::DoesNotExist {}) => (),
+            Err(typedb_source) => return Err(DatabaseResetError::DatabaseDelete { typedb_source }),
+        }
+        self.put_database(name).map_err(|typedb_source| DatabaseResetError::DatabaseCreate { typedb_source })
     }
 
     pub fn rocks_resources(&self) -> &Arc<RocksResources> {

--- a/database/tests/test_transaction_isolation.rs
+++ b/database/tests/test_transaction_isolation.rs
@@ -24,7 +24,7 @@ use test_utils::{TempDir, init_logging};
 
 const DB_NAME: &str = "isolation-test";
 
-fn create_reset_database() -> (TempDir, Arc<Database<WALClient>>) {
+fn create_database() -> (TempDir, Arc<Database<WALClient>>) {
     init_logging();
     let tmp_dir = test_utils::create_tmp_storage_dir();
     let dbm = DatabaseManager::new(
@@ -104,7 +104,7 @@ fn get_isolation_conflict(err: &DataCommitError) -> &IsolationConflict {
 
 #[test]
 fn concurrent_inserts_of_new_entity_and_relation_both_succeed() {
-    let (_tmp, database) = create_reset_database();
+    let (_tmp, database) = create_database();
     commit_schema(
         database.clone(),
         r#"define
@@ -124,7 +124,7 @@ fn concurrent_inserts_of_new_entity_and_relation_both_succeed() {
 
 #[test]
 fn concurrent_deletes_of_identical_entity_one_fails() {
-    let (_tmp, database) = create_reset_database();
+    let (_tmp, database) = create_database();
     commit_schema(database.clone(), "define entity person, owns id @key; attribute id, value integer;");
     commit_write_query(database.clone(), r#"insert $p isa person, has id 1;"#);
 
@@ -139,7 +139,7 @@ fn concurrent_deletes_of_identical_entity_one_fails() {
 
 #[test]
 fn concurrent_deletes_of_identical_relation_one_fails() {
-    let (_tmp, database) = create_reset_database();
+    let (_tmp, database) = create_database();
     commit_schema(
         database.clone(),
         r#"define
@@ -173,7 +173,7 @@ fn concurrent_deletes_of_identical_relation_one_fails() {
 
 #[test]
 fn concurrent_has_writes_with_owns_cardinality_one_fails() {
-    let (_tmp, database) = create_reset_database();
+    let (_tmp, database) = create_database();
     commit_schema(
         database.clone(),
         r#"define
@@ -200,7 +200,7 @@ fn concurrent_has_deletes_violating_owns_cardinality_lower_bound_one_fails() {
     // with two names. Two concurrent has-deletes from different snapshots, each removing one of
     // them, would drop the owner to 0 names if both committed - falling below the lower bound.
     // The cardinality commit lock must serialise them and reject one.
-    let (_tmp, database) = create_reset_database();
+    let (_tmp, database) = create_database();
     commit_schema(
         database.clone(),
         r#"define
@@ -228,7 +228,7 @@ fn concurrent_has_writes_with_bounded_owns_cardinality_always_contend_even_when_
     // transaction validates against its own snapshot and would otherwise both pass through and
     // commit a sum that violates the bound. So both writes contend on the same lock and one is
     // rejected as an isolation conflict, even though the resulting state would be valid.
-    let (_tmp, database) = create_reset_database();
+    let (_tmp, database) = create_database();
     commit_schema(
         database.clone(),
         r#"define
@@ -250,7 +250,7 @@ fn concurrent_has_writes_with_bounded_owns_cardinality_always_contend_even_when_
 
 #[test]
 fn concurrent_has_writes_to_different_owners_with_bounded_cardinality_both_succeed() {
-    let (_tmp, database) = create_reset_database();
+    let (_tmp, database) = create_database();
     commit_schema(
         database.clone(),
         r#"define
@@ -282,7 +282,7 @@ fn concurrent_has_writes_violating_inherited_owns_cardinality_one_fails() {
     // type's instance must still serialise on the (instance, owns) commit lock - the constraint
     // is sourced from the parent owns and the lock-key composition uses the constraint's source
     // attribute type, so subtypes inherit both the constraint and the lock identity.
-    let (_tmp, database) = create_reset_database();
+    let (_tmp, database) = create_database();
     commit_schema(
         database.clone(),
         r#"define
@@ -305,7 +305,7 @@ fn concurrent_has_writes_violating_inherited_owns_cardinality_one_fails() {
 
 #[test]
 fn concurrent_has_writes_with_unlimited_cardinality_both_succeed() {
-    let (_tmp, database) = create_reset_database();
+    let (_tmp, database) = create_database();
     commit_schema(
         database.clone(),
         r#"define
@@ -331,7 +331,7 @@ fn concurrent_has_writes_with_unlimited_cardinality_both_succeed() {
 
 #[test]
 fn concurrent_has_writes_violating_unique_one_fails() {
-    let (_tmp, database) = create_reset_database();
+    let (_tmp, database) = create_database();
     commit_schema(
         database.clone(),
         r#"define
@@ -364,7 +364,7 @@ fn concurrent_has_writes_violating_inherited_unique_across_subtypes_one_fails() 
     // The unique commit lock is keyed by `unique_constraint.source().owner().vertex()` and
     // `source().attribute().vertex()` - both resolve to the parent's owns - so the lock key is
     // identical regardless of which subtype the runtime instance has. One transaction must fail.
-    let (_tmp, database) = create_reset_database();
+    let (_tmp, database) = create_database();
     commit_schema(
         database.clone(),
         r#"define
@@ -398,7 +398,7 @@ fn concurrent_has_writes_violating_inherited_unique_across_subtypes_one_fails() 
 
 #[test]
 fn concurrent_has_writes_violating_inline_key_one_fails() {
-    let (_tmp, database) = create_reset_database();
+    let (_tmp, database) = create_database();
     commit_schema(
         database.clone(),
         r#"define
@@ -419,7 +419,7 @@ fn concurrent_has_writes_violating_inline_key_one_fails() {
 #[test]
 fn concurrent_has_writes_violating_hashed_string_key_one_fails() {
     // String @key with a value longer than the inline threshold (16 bytes)
-    let (_tmp, database) = create_reset_database();
+    let (_tmp, database) = create_database();
     commit_schema(
         database.clone(),
         r#"define
@@ -450,7 +450,7 @@ fn concurrent_has_writes_violating_inherited_key_across_subtypes_one_fails() {
     // Two concurrent inserts each create a different subtype (student, teacher) but with the
     // same key value. The conflict is on the parent type's interpretation of (type + key value):
     // the unique commit lock keyed by the source Owns serialises them and rejects one.
-    let (_tmp, database) = create_reset_database();
+    let (_tmp, database) = create_database();
     commit_schema(
         database.clone(),
         r#"define
@@ -478,7 +478,7 @@ fn concurrent_has_writes_violating_inherited_key_across_subtypes_one_fails() {
 fn concurrent_player_links_with_bounded_relates_cardinality_one_fails() {
     // The padding player is needed so `cleanup_relations` doesn't auto-delete an empty
     // friendship at setup-commit time
-    let (_tmp, database) = create_reset_database();
+    let (_tmp, database) = create_database();
     commit_schema(
         database.clone(),
         r#"define
@@ -515,7 +515,7 @@ fn concurrent_player_links_with_bounded_relates_cardinality_one_fails() {
 
 #[test]
 fn concurrent_player_links_with_bounded_plays_cardinality_one_fails() {
-    let (_tmp, database) = create_reset_database();
+    let (_tmp, database) = create_database();
     commit_schema(
         database.clone(),
         r#"define
@@ -553,7 +553,7 @@ fn concurrent_player_links_with_bounded_plays_cardinality_one_fails() {
 
 #[test]
 fn concurrent_player_links_via_super_and_specialised_sub_role_one_fails() {
-    let (_tmp, database) = create_reset_database();
+    let (_tmp, database) = create_database();
     commit_schema(
         database.clone(),
         r#"define
@@ -581,7 +581,7 @@ fn concurrent_player_links_via_super_and_specialised_sub_role_one_fails() {
 
 #[test]
 fn concurrent_has_write_and_owner_delete_one_fails() {
-    let (_tmp, database) = create_reset_database();
+    let (_tmp, database) = create_database();
     commit_schema(
         database.clone(),
         r#"define
@@ -603,7 +603,7 @@ fn concurrent_has_write_and_owner_delete_one_fails() {
 
 #[test]
 fn concurrent_has_write_and_attribute_delete_one_fails() {
-    let (_tmp, database) = create_reset_database();
+    let (_tmp, database) = create_database();
     commit_schema(
         database.clone(),
         r#"define
@@ -632,7 +632,7 @@ fn concurrent_has_write_and_attribute_delete_one_fails() {
 // TODO: We in the past used to have this be allowed? Slightly more lax - not a large difference
 #[test]
 fn concurrent_has_insert_new_attribute_deleting_attribute() {
-    let (_tmp, database) = create_reset_database();
+    let (_tmp, database) = create_database();
     commit_schema(
         database.clone(),
         r#"define
@@ -660,7 +660,7 @@ fn concurrent_has_insert_new_attribute_deleting_attribute() {
 
 #[test]
 fn concurrent_player_link_and_relation_delete_one_fails() {
-    let (_tmp, database) = create_reset_database();
+    let (_tmp, database) = create_database();
     commit_schema(
         database.clone(),
         r#"define
@@ -693,7 +693,7 @@ fn concurrent_player_link_and_relation_delete_one_fails() {
 
 #[test]
 fn concurrent_player_link_and_player_delete_one_fails() {
-    let (_tmp, database) = create_reset_database();
+    let (_tmp, database) = create_database();
     commit_schema(
         database.clone(),
         r#"define

--- a/durability/durability.rs
+++ b/durability/durability.rs
@@ -51,8 +51,6 @@ pub trait DurabilityService {
     fn truncate_from(&self, sequence_number: DurabilitySequenceNumber) -> Result<(), DurabilityServiceError>;
 
     fn delete_durability(self) -> Result<(), DurabilityServiceError>;
-
-    fn reset(&mut self) -> Result<(), DurabilityServiceError>;
 }
 
 pub type DurabilityRecordType = u8;

--- a/durability/wal.rs
+++ b/durability/wal.rs
@@ -220,11 +220,6 @@ impl DurabilityService for WAL {
             .unwrap();
         files.delete()
     }
-
-    fn reset(&mut self) -> Result<(), DurabilityServiceError> {
-        self.next_sequence_number.store(DurabilitySequenceNumber::MIN.next().number(), Ordering::SeqCst);
-        self.files.write().unwrap().reset()
-    }
 }
 
 #[derive(Debug, Clone)]
@@ -397,16 +392,6 @@ impl Files {
     fn delete(self) -> Result<(), DurabilityServiceError> {
         drop(self.files);
         fs::remove_dir_all(&self.directory).map_err(|source| source.into())
-    }
-
-    fn reset(&mut self) -> Result<(), DurabilityServiceError> {
-        fs::remove_dir_all(&self.directory)?;
-        fs::create_dir(&self.directory)?;
-        self.files.clear();
-        let (files, writer) = Self::init_files_writer(&self.directory)?;
-        self.files = files;
-        self.writer = writer;
-        Ok(())
     }
 }
 

--- a/encoding/graph/common/schema_id_allocator.rs
+++ b/encoding/graph/common/schema_id_allocator.rs
@@ -6,7 +6,7 @@
 
 use std::{
     marker::PhantomData,
-    sync::atomic::{AtomicU64, Ordering, Ordering::Relaxed},
+    sync::atomic::{AtomicU64, Ordering::Relaxed},
 };
 
 use bytes::Bytes;
@@ -102,10 +102,6 @@ impl<T: SchemaID + Keyable<BUFFER_KEY_INLINE>> SchemaIDAllocator<T> {
                 }
             }
         }
-    }
-
-    pub fn reset(&mut self) {
-        self.last_allocated_type_id.store(0, Ordering::SeqCst)
     }
 }
 

--- a/encoding/graph/definition/definition_key_generator.rs
+++ b/encoding/graph/definition/definition_key_generator.rs
@@ -41,10 +41,6 @@ impl DefinitionKeyGenerator {
         Ok(definition_key)
     }
 
-    pub fn reset(&mut self) {
-        self.next_struct.reset()
-    }
-
     pub fn create_function<Snapshot: WritableSnapshot>(
         &self,
         snapshot: &mut Snapshot,

--- a/encoding/graph/thing/vertex_generator.rs
+++ b/encoding/graph/thing/vertex_generator.rs
@@ -435,9 +435,4 @@ impl ThingVertexGenerator {
     {
         StructAttributeID::find_hashed_id(type_id, struct_bytes, snapshot, &self.large_value_hasher)
     }
-
-    pub fn reset(&mut self) {
-        self.entity_ids.iter().for_each(|id| id.store(0, Ordering::SeqCst));
-        self.relation_ids.iter().for_each(|id| id.store(0, Ordering::SeqCst));
-    }
 }

--- a/encoding/graph/type_/vertex_generator.rs
+++ b/encoding/graph/type_/vertex_generator.rs
@@ -72,11 +72,4 @@ impl TypeVertexGenerator {
         snapshot.put(vertex.into_storage_key().into_owned_array());
         Ok(vertex)
     }
-
-    pub fn reset(&mut self) {
-        self.next_entity.reset();
-        self.next_relation.reset();
-        self.next_attribute.reset();
-        self.next_role.reset();
-    }
 }

--- a/storage/durability_client.rs
+++ b/storage/durability_client.rs
@@ -98,8 +98,6 @@ pub trait DurabilityClient {
     fn truncate_from(&self, sequence_number: SequenceNumber) -> Result<(), DurabilityClientError>;
 
     fn delete_durability(self) -> Result<(), DurabilityClientError>;
-
-    fn reset(&mut self) -> Result<(), DurabilityClientError>;
 }
 
 #[derive(Debug)]
@@ -209,10 +207,6 @@ impl DurabilityClient for WALClient {
 
     fn delete_durability(self) -> Result<(), DurabilityClientError> {
         self.wal.delete_durability().map_err(|err| DurabilityClientError::ServiceError { source: err })
-    }
-
-    fn reset(&mut self) -> Result<(), DurabilityClientError> {
-        self.wal.reset().map_err(|err| DurabilityClientError::ServiceError { source: err })
     }
 }
 

--- a/storage/isolation_manager.rs
+++ b/storage/isolation_manager.rs
@@ -31,7 +31,6 @@ use crate::{
 
 #[derive(Debug)]
 pub(crate) struct IsolationManager {
-    initial_sequence_number: SequenceNumber,
     timeline: Timeline,
 }
 
@@ -43,10 +42,7 @@ impl fmt::Display for IsolationManager {
 
 impl IsolationManager {
     pub(crate) fn new(next_sequence_number: SequenceNumber) -> IsolationManager {
-        IsolationManager {
-            initial_sequence_number: next_sequence_number,
-            timeline: Timeline::new(next_sequence_number),
-        }
+        IsolationManager { timeline: Timeline::new(next_sequence_number) }
     }
 
     pub(crate) fn opened_for_read(&self, sequence_number: SequenceNumber) -> ReaderDropGuard {
@@ -230,10 +226,6 @@ impl IsolationManager {
 
     pub(crate) fn watermark(&self) -> SequenceNumber {
         self.timeline.watermark()
-    }
-
-    pub fn reset(&mut self) {
-        self.timeline = Timeline::new(self.initial_sequence_number);
     }
 }
 

--- a/storage/keyspace/keyspace.rs
+++ b/storage/keyspace/keyspace.rs
@@ -15,7 +15,7 @@ use bytes::Bytes;
 use fail_point::{KEYSPACE_CHECKPOINT_FAIL, KEYSPACE_DELETE_FAIL, KEYSPACE_OPEN_FAIL, fail_point};
 use itertools::Itertools;
 use resource::profile::StorageCounters;
-use rocksdb::{DB, IteratorMode, Options, ReadOptions, WriteBatch, WriteOptions, checkpoint::Checkpoint};
+use rocksdb::{DB, Options, ReadOptions, WriteBatch, WriteOptions, checkpoint::Checkpoint};
 use serde::{Deserialize, Serialize};
 
 use super::{IteratorPool, constants, iterator};
@@ -143,13 +143,6 @@ impl Keyspaces {
             .collect_vec();
         if !errors.is_empty() {
             return Err(errors);
-        }
-        Ok(())
-    }
-
-    pub(crate) fn reset(&mut self) -> Result<(), KeyspaceError> {
-        for keyspace in self.keyspaces.iter_mut() {
-            keyspace.reset()?
         }
         Ok(())
     }
@@ -309,15 +302,6 @@ impl Keyspace {
         drop(self.kv_storage);
         fs::remove_dir_all(self.path.clone())
             .map_err(|error| KeyspaceDeleteError::DirectoryRemove { name: self.name, source: Arc::new(error) })?;
-        Ok(())
-    }
-
-    pub(crate) fn reset(&mut self) -> Result<(), KeyspaceError> {
-        let iterator = self.kv_storage.iterator(IteratorMode::Start);
-        for entry in iterator {
-            let (key, _) = entry.map_err(|err| KeyspaceError::Iterate { name: self.name, source: err })?;
-            self.kv_storage.delete(key).map_err(|err| KeyspaceError::Iterate { name: self.name, source: err })?;
-        }
         Ok(())
     }
 

--- a/storage/storage.rs
+++ b/storage/storage.rs
@@ -566,20 +566,6 @@ impl<Durability> MVCCStorage<Durability> {
         )
     }
 
-    pub fn reset(&mut self) -> Result<(), StorageResetError>
-    where
-        Durability: DurabilityClient,
-    {
-        self.isolation_manager.reset();
-        self.keyspaces
-            .reset()
-            .map_err(|err| StorageResetError::KeyspaceError { name: self.name.clone(), source: err })?;
-        self.durability_client
-            .reset()
-            .map_err(|err| StorageResetError::Durability { name: self.name.clone(), typedb_source: err })?;
-        Ok(())
-    }
-
     pub fn estimate_size_in_bytes(&self) -> Result<u64, StorageOpenError> {
         self.keyspaces.estimate_size_in_bytes().map_err(|source| StorageOpenError::Keyspace { source })
     }
@@ -625,13 +611,6 @@ typedb_error! {
         DurabilityDelete(1, "Deleting storage of database '{name}' failed partway while deleting durability records.", name: Arc<str>, typedb_source: DurabilityClientError),
         KeyspaceDelete(2, "Deleting storage of database '{name}' failed partway while deleting keyspaces: {errors:?}", name: Arc<str>, errors: Vec<KeyspaceDeleteError>),
         DirectoryDelete(3, "Deleting storage of database '{name}' failed partway while deleting directory.", name: Arc<str>, source: Arc<io::Error>),
-    }
-}
-
-typedb_error! {
-    pub StorageResetError(component = "Storage reset", prefix = "STR") {
-        KeyspaceError(1, "Resetting storage of database '{name}' failed partway while resetting keyspace.", name: Arc<str>, source: KeyspaceError),
-        Durability(2, "Resetting storage of database '{name}' failed partway while resetting durability records.", name: Arc<str>, typedb_source: DurabilityClientError),
     }
 }
 

--- a/tests/behaviour/steps/connection/database.rs
+++ b/tests/behaviour/steps/connection/database.rs
@@ -58,7 +58,7 @@ pub async fn connection_reset_database(context: &mut Context, name: String) {
     if context.transaction().is_some() {
         context.close_active_transaction();
     }
-    context.server().unwrap().lock().unwrap().database_manager().reset_else_recreate_database(&name).unwrap();
+    context.server().unwrap().lock().unwrap().database_manager().reset_database(&name).unwrap();
 }
 
 #[cucumber::when(expr = "connection delete database: {word}{may_error}")]


### PR DESCRIPTION
## Product change and motivation

`Database::reset` could never succeed: the checkpointer and statistics interval runners hold `Arc` clones of the storage, so `Arc::get_mut` always failed with `StorageInUse` and `reset_else_recreate_database` always fell back to delete + recreate. The unreachable in-place path also carried latent bugs (stale checkpoints left on disk after resetting the WAL; the isolation timeline rewound to the open-time sequence number while the WAL rewound to MIN). Make reset explicitly delete + recreate and remove the reset chain through storage, durability, keyspaces, generators and statistics.

## Implementation

Include architectural decisions, new assumptions, unimplemented paths/technical debt and tests written.
