### PR TITLE
Allow evicting commits in isolation manager - Arc/Weak version

### DIFF
--- a/storage/isolation_manager.rs
+++ b/storage/isolation_manager.rs
@@ -370,10 +370,10 @@ impl Timeline {
     fn may_free_windows(&self) {
         let watermark = self.watermark();
         let can_free_some =
-            self.windows.read().unwrap_or_log().front().is_some_and(|f| f.get_readers() == 0 && watermark >= f.end());
+            self.windows.read().unwrap_or_log().front().is_some_and(|f| f.get_readers() == 1 && watermark >= f.end());
         if can_free_some {
             let windows = &mut *self.windows.write().unwrap_or_log();
-            while watermark >= windows.front().unwrap().end() && windows.front().unwrap().get_readers() == 0 {
+            while watermark >= windows.front().unwrap().end() && windows.front().unwrap().get_readers() == 1 {
                 windows.pop_front();
             }
         }
@@ -427,7 +427,7 @@ impl Timeline {
 
     fn earliest_reader(&self) -> Option<SequenceNumber> {
         for window in &*self.windows.read().unwrap() {
-            if window.readers.load(Ordering::Relaxed) > 0 {
+            if window.get_readers() > 1 {
                 return Some(window.start());
             }
         }
@@ -436,11 +436,10 @@ impl Timeline {
 
     fn record_reader(&self, sequence_number: SequenceNumber) -> ReaderDropGuard {
         if let Some(window) = self.try_get_window(sequence_number) {
-            window.increment_readers();
-            ReaderDropGuard { window: Some(window) }
+            ReaderDropGuard { _window: Some(window) }
         } else {
             // we only need to record readers against the timeline for windows that are still in-memory
-            ReaderDropGuard { window: None }
+            ReaderDropGuard { _window: None }
         }
     }
 
@@ -512,15 +511,7 @@ impl Timeline {
 }
 
 pub struct ReaderDropGuard {
-    window: Option<Arc<TimelineWindow<TIMELINE_WINDOW_SIZE>>>,
-}
-
-impl Drop for ReaderDropGuard {
-    fn drop(&mut self) {
-        if let Some(window) = self.window.as_ref() {
-            window.decrement_readers();
-        }
-    }
+    _window: Option<Arc<TimelineWindow<TIMELINE_WINDOW_SIZE>>>,
 }
 
 #[derive(Debug)]
@@ -528,7 +519,6 @@ struct TimelineWindow<const SIZE: usize> {
     start: SequenceNumber,
     slot_status: [AtomicU8; SIZE],
     commit_records: [OnceLock<CommitRecord>; SIZE],
-    readers: AtomicU64,
 }
 
 impl<const SIZE: usize> TimelineWindow<SIZE> {
@@ -537,7 +527,7 @@ impl<const SIZE: usize> TimelineWindow<SIZE> {
         let slot_status = [const { AtomicU8::new(0) }; SIZE];
         debug_assert_eq!(slot_status[0].load(Ordering::SeqCst), SlotMarker::Empty.as_u8());
 
-        TimelineWindow { start, slot_status, commit_records, readers: AtomicU64::new(0) }
+        TimelineWindow { start, slot_status, commit_records }
     }
 
     fn start(&self) -> SequenceNumber {
@@ -599,16 +589,8 @@ impl<const SIZE: usize> TimelineWindow<SIZE> {
         }
     }
 
-    fn get_readers(&self) -> u64 {
-        self.readers.load(Ordering::Relaxed)
-    }
-
-    fn increment_readers(&self) {
-        self.readers.fetch_add(1, Ordering::Relaxed);
-    }
-
-    fn decrement_readers(&self) -> u64 {
-        self.readers.fetch_sub(1, Ordering::Relaxed) - 1 // Return the resulting number of readers
+    fn get_readers(self: &Arc<Self>) -> usize {
+        Arc::strong_count(self) + Arc::weak_count(self)
     }
 }
 
@@ -819,7 +801,7 @@ mod tests {
         }
 
         match timeline.try_get_window(timeline.watermark()) {
-            Some(window) => assert_eq!(0, window.get_readers()),
+            Some(window) => assert_eq!(2, window.get_readers()), // 1 in the timeline, 1 not yet dropped here
             None => panic!(),
         };
     }

--- a/storage/isolation_manager.rs
+++ b/storage/isolation_manager.rs
@@ -367,6 +367,13 @@ impl<T> ArcOrWeak<T> {
         }
     }
 
+    fn downgrade(&self) -> Weak<T> {
+        match self {
+            ArcOrWeak::Arc(arc) => Arc::downgrade(arc),
+            ArcOrWeak::Weak(weak) => weak.clone(),
+        }
+    }
+
     fn get_readers(&self) -> usize {
         self.strong_count() + self.weak_count()
     }
@@ -387,6 +394,10 @@ impl<T> ArcOrWeak<T> {
             ArcOrWeak::Arc(arc) => Arc::weak_count(arc),
             ArcOrWeak::Weak(weak) => Weak::weak_count(weak),
         }
+    }
+
+    fn evict(&mut self) {
+        *self = Self::Weak(self.downgrade())
     }
 }
 
@@ -448,6 +459,12 @@ impl Timeline {
                 && window.get_readers() <= 1
             {
                 windows.pop_first();
+            }
+            while let mut entry = windows.first_entry().unwrap()
+                && watermark >= entry.key().end()
+                && entry.get().get_writing_readers() <= 1
+            {
+                entry.get_mut().evict();
             }
         }
     }

--- a/storage/isolation_manager.rs
+++ b/storage/isolation_manager.rs
@@ -922,4 +922,34 @@ mod tests {
 
         assert_eq!(timeline.window_count(), 1);
     }
+
+    #[test]
+    fn windows_are_evicted() {
+        let timeline = create_timeline();
+
+        let _guard = timeline.record_read_snapshot_reader(SequenceNumber::new(1));
+        _guard._window.as_ref().unwrap().weak_count();
+
+        for i in 1..TIMELINE_WINDOW_SIZE * 2 {
+            let tx = MockTransaction::new(&timeline, _seq(i as u64));
+            tx_start_commit(&timeline, &tx);
+            tx_finalise_commit_status(&timeline, tx, true);
+        }
+
+        _guard._window.as_ref().unwrap().weak_count();
+        timeline.may_free_windows();
+        assert_eq!(timeline.window_count(), 2);
+
+        for i in 1..2 {
+            assert!(
+                timeline.try_get_window(_seq(TIMELINE_WINDOW_SIZE as u64 * i)).is_none(),
+                "Window {i} was not evicted",
+            )
+        }
+
+        drop(_guard);
+        // after the read transaction closes
+        timeline.may_free_windows();
+        assert_eq!(timeline.window_count(), 1);
+    }
 }

--- a/storage/isolation_manager.rs
+++ b/storage/isolation_manager.rs
@@ -9,11 +9,11 @@
 
 use std::{
     cmp::max,
-    collections::{HashMap, VecDeque},
+    collections::{BTreeMap, HashMap},
     error::Error,
     fmt,
     sync::{
-        Arc, OnceLock, RwLock,
+        Arc, OnceLock, RwLock, Weak,
         atomic::{AtomicBool, AtomicU8, AtomicU64, Ordering},
     },
 };
@@ -49,7 +49,7 @@ impl IsolationManager {
         }
     }
 
-    pub(crate) fn opened_for_read(&self, sequence_number: SequenceNumber) -> ReaderDropGuard {
+    pub(crate) fn opened_for_read_by_reader(&self, sequence_number: SequenceNumber) -> ReadingReaderDropGuard {
         debug_assert!(
             sequence_number <= self.watermark(),
             "assertion `{} <= {}` failed",
@@ -57,6 +57,16 @@ impl IsolationManager {
             self.watermark()
         );
         self.timeline.record_reader(sequence_number)
+    }
+
+    pub(crate) fn opened_for_read_by_writer(&self, sequence_number: SequenceNumber) -> WritingReaderDropGuard {
+        debug_assert!(
+            sequence_number <= self.watermark(),
+            "assertion `{} <= {}` failed",
+            sequence_number,
+            self.watermark()
+        );
+        self.timeline.record_writing_reader(sequence_number)
     }
 
     pub(crate) fn applied(&self, sequence_number: SequenceNumber) -> Result<(), ExpectedWindowError> {
@@ -339,6 +349,62 @@ impl fmt::Display for ExpectedWindowError {
 
 impl Error for ExpectedWindowError {}
 
+#[derive(Debug)]
+enum ArcOrWeak<T> {
+    Arc(Arc<T>),
+    Weak(Weak<T>),
+}
+
+impl<T> ArcOrWeak<T> {
+    fn new_arc(value: T) -> Self {
+        Self::Arc(Arc::new(value))
+    }
+
+    fn upgrade(&self) -> Option<Arc<T>> {
+        match self {
+            ArcOrWeak::Arc(arc) => Some(arc.clone()),
+            ArcOrWeak::Weak(weak) => weak.upgrade(),
+        }
+    }
+
+    fn get_readers(&self) -> usize {
+        self.strong_count() + self.weak_count()
+    }
+
+    fn get_writing_readers(&self) -> usize {
+        self.strong_count()
+    }
+
+    fn strong_count(&self) -> usize {
+        match self {
+            ArcOrWeak::Arc(arc) => Arc::strong_count(arc),
+            ArcOrWeak::Weak(weak) => Weak::strong_count(weak),
+        }
+    }
+
+    fn weak_count(&self) -> usize {
+        match self {
+            ArcOrWeak::Arc(arc) => Arc::weak_count(arc),
+            ArcOrWeak::Weak(weak) => Weak::weak_count(weak),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+struct WindowRange {
+    start: SequenceNumber,
+}
+
+impl WindowRange {
+    fn starting_at(start: SequenceNumber) -> Self {
+        Self { start }
+    }
+
+    fn end(self) -> SequenceNumber {
+        self.start + TIMELINE_WINDOW_SIZE
+    }
+}
+
 /// Timeline concept:
 ///   Timeline is made of Windows. Each Window stores a number of Slots.
 ///   Conceptually the timeline is one sequence of Slots, but we cut it into Windows for more efficient allocation/clean up/search.
@@ -353,25 +419,35 @@ impl Error for ExpectedWindowError {}
 #[derive(Debug)]
 struct Timeline {
     // We can adjust the Window size to amortise the cost of the read-write locks to maintain the timeline
-    windows: RwLock<VecDeque<Arc<TimelineWindow<TIMELINE_WINDOW_SIZE>>>>,
+    windows: RwLock<BTreeMap<WindowRange, ArcOrWeak<TimelineWindow<TIMELINE_WINDOW_SIZE>>>>,
     watermark: AtomicU64,
 }
 
 impl Timeline {
     // The whole of the timeline uses the underlying u64
     fn new(next_sequence_number: SequenceNumber) -> Timeline {
-        let windows = VecDeque::from([Arc::new(TimelineWindow::new(next_sequence_number))]);
+        let windows = BTreeMap::from([(
+            WindowRange::starting_at(next_sequence_number),
+            ArcOrWeak::new_arc(TimelineWindow::new(next_sequence_number)),
+        )]);
         Timeline { windows: RwLock::new(windows), watermark: AtomicU64::new(next_sequence_number.number() - 1) }
     }
 
     fn may_free_windows(&self) {
         let watermark = self.watermark();
-        let can_free_some =
-            self.windows.read().unwrap_or_log().front().is_some_and(|f| f.get_readers() == 1 && watermark >= f.end());
+        let can_free_some = self
+            .windows
+            .read()
+            .unwrap_or_log()
+            .first_key_value()
+            .is_some_and(|(s, w)| w.get_readers() <= 1 && watermark >= s.end());
         if can_free_some {
             let windows = &mut *self.windows.write().unwrap_or_log();
-            while watermark >= windows.front().unwrap().end() && windows.front().unwrap().get_readers() == 1 {
-                windows.pop_front();
+            while let (range, window) = windows.first_key_value().unwrap()
+                && watermark >= range.end()
+                && window.get_readers() <= 1
+            {
+                windows.pop_first();
             }
         }
     }
@@ -423,21 +499,25 @@ impl Timeline {
     }
 
     fn earliest_reader(&self) -> Option<SequenceNumber> {
-        for window in &*self.windows.read().unwrap() {
+        for (range, window) in &*self.windows.read().unwrap() {
             if window.get_readers() > 1 {
-                return Some(window.start());
+                return Some(range.start);
             }
         }
         None
     }
 
-    fn record_reader(&self, sequence_number: SequenceNumber) -> ReaderDropGuard {
+    fn record_reader(&self, sequence_number: SequenceNumber) -> ReadingReaderDropGuard {
         if let Some(window) = self.try_get_window(sequence_number) {
-            ReaderDropGuard { _window: Some(window) }
+            ReadingReaderDropGuard { _window: Some(Arc::downgrade(&window)) }
         } else {
             // we only need to record readers against the timeline for windows that are still in-memory
-            ReaderDropGuard { _window: None }
+            ReadingReaderDropGuard { _window: None }
         }
+    }
+
+    fn record_writing_reader(&self, sequence_number: SequenceNumber) -> WritingReaderDropGuard {
+        WritingReaderDropGuard { _window: self.try_get_window(sequence_number) }
     }
 
     fn collect_concurrent_windows(
@@ -446,25 +526,26 @@ impl Timeline {
         commit_sequence_number: SequenceNumber,
     ) -> (Vec<Arc<TimelineWindow<TIMELINE_WINDOW_SIZE>>>, SequenceNumber) {
         let windows = &*self.windows.read().unwrap_or_log();
-        let first_concurrent_window_index = Self::resolve_window(windows, open_sequence_number.next()).unwrap_or(0);
-        let last_concurrent_window_index =
-            Self::resolve_window(windows, commit_sequence_number.previous()).unwrap_or(0);
+        let first_concurrent_window_index =
+            Self::resolve_window(windows, open_sequence_number.next()).unwrap_or(*windows.first_key_value().unwrap().0);
+        let last_concurrent_window_index = Self::resolve_window(windows, commit_sequence_number.previous())
+            .unwrap_or(*windows.first_key_value().unwrap().0);
         let mut concurrent_windows: Vec<Arc<TimelineWindow<TIMELINE_WINDOW_SIZE>>> = Vec::new();
-        (first_concurrent_window_index..=last_concurrent_window_index).for_each(|window_index| {
-            concurrent_windows.push(windows.get(window_index).unwrap().clone());
+        windows.range(first_concurrent_window_index..=last_concurrent_window_index).for_each(|(_, window)| {
+            concurrent_windows.push(window.upgrade().unwrap());
         });
-        let start_index_of_first_concurrent_window = windows.get(first_concurrent_window_index).unwrap().start();
+        let start_index_of_first_concurrent_window = first_concurrent_window_index.start;
         (concurrent_windows, start_index_of_first_concurrent_window)
     }
 
     fn try_get_window(&self, sequence_number: SequenceNumber) -> Option<Arc<TimelineWindow<TIMELINE_WINDOW_SIZE>>> {
         let windows = self.windows.read().unwrap_or_log();
         let window_index = Self::resolve_window(&windows, sequence_number)?;
-        Some(windows.get(window_index).unwrap().clone())
+        windows.get(&window_index).and_then(ArcOrWeak::upgrade)
     }
 
     fn get_or_create_window(&self, sequence_number: SequenceNumber) -> Arc<TimelineWindow<TIMELINE_WINDOW_SIZE>> {
-        let end = self.windows.read().unwrap_or_log().back().unwrap().end();
+        let end = self.windows.read().unwrap_or_log().last_key_value().unwrap().0.end();
         if sequence_number >= end {
             self.create_windows_to(sequence_number);
         }
@@ -477,14 +558,10 @@ impl Timeline {
 
     fn create_windows_to(&self, sequence_number: SequenceNumber) {
         let windows = &mut *self.windows.write().unwrap_or_log();
-        loop {
-            let end = windows.back().unwrap().end();
-            if sequence_number >= end {
-                let shared_new_window = Arc::new(TimelineWindow::new(end));
-                windows.push_back(shared_new_window.clone());
-            } else {
-                break;
-            }
+        while let end = windows.last_key_value().unwrap().0.end()
+            && end <= sequence_number
+        {
+            windows.insert(WindowRange::starting_at(end), ArcOrWeak::new_arc(TimelineWindow::new(end)));
         }
     }
 
@@ -493,21 +570,26 @@ impl Timeline {
     }
 
     fn resolve_window(
-        windows: &VecDeque<Arc<TimelineWindow<TIMELINE_WINDOW_SIZE>>>,
+        windows: &BTreeMap<WindowRange, ArcOrWeak<TimelineWindow<TIMELINE_WINDOW_SIZE>>>,
         to_resolve: SequenceNumber,
-    ) -> Option<usize> {
-        let start = windows.front().unwrap().start();
-        let end = windows.back().unwrap().end();
+    ) -> Option<WindowRange> {
+        let start = windows.first_key_value().unwrap().0.start;
+        let end = windows.last_key_value().unwrap().0.end();
         if to_resolve >= start && to_resolve < end {
-            let offset = to_resolve - start;
-            Some(offset / TIMELINE_WINDOW_SIZE)
+            let mut offset = to_resolve - start;
+            offset -= offset % TIMELINE_WINDOW_SIZE;
+            Some(WindowRange::starting_at(start + offset))
         } else {
             None
         }
     }
 }
 
-pub struct ReaderDropGuard {
+pub struct ReadingReaderDropGuard {
+    _window: Option<Weak<TimelineWindow<TIMELINE_WINDOW_SIZE>>>,
+}
+
+pub struct WritingReaderDropGuard {
     _window: Option<Arc<TimelineWindow<TIMELINE_WINDOW_SIZE>>>,
 }
 
@@ -525,10 +607,6 @@ impl<const SIZE: usize> TimelineWindow<SIZE> {
         debug_assert_eq!(slot_status[0].load(Ordering::SeqCst), SlotMarker::Empty.as_u8());
 
         TimelineWindow { start, slot_status, commit_records }
-    }
-
-    fn start(&self) -> SequenceNumber {
-        self.start
     }
 
     fn end(&self) -> SequenceNumber {
@@ -584,10 +662,6 @@ impl<const SIZE: usize> TimelineWindow<SIZE> {
                 CommitStatus::Aborted => return false,
             }
         }
-    }
-
-    fn get_readers(self: &Arc<Self>) -> usize {
-        Arc::strong_count(self) + Arc::weak_count(self)
     }
 }
 
@@ -646,7 +720,7 @@ mod tests {
     use assert as assert_true;
 
     use crate::{
-        isolation_manager::{CommitStatus, ReaderDropGuard, TIMELINE_WINDOW_SIZE, Timeline},
+        isolation_manager::{CommitStatus, TIMELINE_WINDOW_SIZE, Timeline, WritingReaderDropGuard},
         keyspace::{KeyspaceId, KeyspaceSet},
         record::{CommitRecord, CommitType},
         sequence_number::SequenceNumber,
@@ -679,13 +753,13 @@ mod tests {
     struct MockTransaction {
         read_sequence_number: SequenceNumber,
         commit_sequence_number: SequenceNumber,
-        reader_drop_guard: ReaderDropGuard,
+        reader_drop_guard: WritingReaderDropGuard,
     }
 
     impl MockTransaction {
         fn new(timeline: &Timeline, commit_sequence_number: SequenceNumber) -> MockTransaction {
             let read_sequence_number = timeline.watermark();
-            let reader_drop_guard = timeline.record_reader(read_sequence_number);
+            let reader_drop_guard = timeline.record_writing_reader(read_sequence_number);
             MockTransaction { read_sequence_number, commit_sequence_number, reader_drop_guard }
         }
     }
@@ -798,7 +872,7 @@ mod tests {
         }
 
         match timeline.try_get_window(timeline.watermark()) {
-            Some(window) => assert_eq!(2, window.get_readers()), // 1 in the timeline, 1 not yet dropped here
+            Some(window) => assert_eq!(2, Arc::strong_count(&window)), // 1 in the timeline, 1 not yet dropped here
             None => panic!(),
         };
     }

--- a/storage/isolation_manager.rs
+++ b/storage/isolation_manager.rs
@@ -350,54 +350,56 @@ impl fmt::Display for ExpectedWindowError {
 impl Error for ExpectedWindowError {}
 
 #[derive(Debug)]
-enum ArcOrWeak<T> {
+enum EvictableArc<T> {
     Arc(Arc<T>),
     Weak(Weak<T>),
 }
 
-impl<T> ArcOrWeak<T> {
+impl<T> EvictableArc<T> {
     fn new_arc(value: T) -> Self {
         Self::Arc(Arc::new(value))
     }
 
     fn upgrade(&self) -> Option<Arc<T>> {
         match self {
-            ArcOrWeak::Arc(arc) => Some(arc.clone()),
-            ArcOrWeak::Weak(weak) => weak.upgrade(),
+            Self::Arc(arc) => Some(arc.clone()),
+            Self::Weak(weak) => weak.upgrade(),
         }
     }
 
     fn downgrade(&self) -> Weak<T> {
         match self {
-            ArcOrWeak::Arc(arc) => Arc::downgrade(arc),
-            ArcOrWeak::Weak(weak) => weak.clone(),
+            Self::Arc(arc) => Arc::downgrade(arc),
+            Self::Weak(weak) => weak.clone(),
         }
     }
 
-    fn get_readers(&self) -> usize {
+    fn get_read_snapshot_readers(&self) -> usize {
         self.strong_count() + self.weak_count()
     }
 
-    fn get_writing_readers(&self) -> usize {
+    fn get_write_snapshot_readers(&self) -> usize {
         self.strong_count()
     }
 
     fn strong_count(&self) -> usize {
         match self {
-            ArcOrWeak::Arc(arc) => Arc::strong_count(arc),
-            ArcOrWeak::Weak(weak) => Weak::strong_count(weak),
+            Self::Arc(arc) => Arc::strong_count(arc),
+            Self::Weak(weak) => Weak::strong_count(weak),
         }
     }
 
     fn weak_count(&self) -> usize {
         match self {
-            ArcOrWeak::Arc(arc) => Arc::weak_count(arc),
-            ArcOrWeak::Weak(weak) => Weak::weak_count(weak),
+            Self::Arc(arc) => Arc::weak_count(arc),
+            Self::Weak(weak) => Weak::weak_count(weak),
         }
     }
 
     fn evict(&mut self) {
-        *self = Self::Weak(self.downgrade())
+        if let Self::Arc(_) = self {
+            *self = Self::Weak(self.downgrade())
+        }
     }
 }
 
@@ -430,7 +432,7 @@ impl WindowRange {
 #[derive(Debug)]
 struct Timeline {
     // We can adjust the Window size to amortise the cost of the read-write locks to maintain the timeline
-    windows: RwLock<BTreeMap<WindowRange, ArcOrWeak<TimelineWindow<TIMELINE_WINDOW_SIZE>>>>,
+    windows: RwLock<BTreeMap<WindowRange, EvictableArc<TimelineWindow<TIMELINE_WINDOW_SIZE>>>>,
     watermark: AtomicU64,
 }
 
@@ -439,7 +441,7 @@ impl Timeline {
     fn new(next_sequence_number: SequenceNumber) -> Timeline {
         let windows = BTreeMap::from([(
             WindowRange::starting_at(next_sequence_number),
-            ArcOrWeak::new_arc(TimelineWindow::new(next_sequence_number)),
+            EvictableArc::new_arc(TimelineWindow::new(next_sequence_number)),
         )]);
         Timeline { windows: RwLock::new(windows), watermark: AtomicU64::new(next_sequence_number.number() - 1) }
     }
@@ -451,20 +453,20 @@ impl Timeline {
             .read()
             .unwrap_or_log()
             .first_key_value()
-            .is_some_and(|(s, w)| w.get_readers() <= 1 && watermark >= s.end());
+            .is_some_and(|(s, w)| w.get_write_snapshot_readers() <= 1 && watermark >= s.end());
         if can_free_some {
             let windows = &mut *self.windows.write().unwrap_or_log();
             while let (range, window) = windows.first_key_value().unwrap()
-                && watermark >= range.end()
-                && window.get_readers() <= 1
+                && range.end() <= watermark
+                && window.get_read_snapshot_readers() <= 1
             {
                 windows.pop_first();
             }
-            while let mut entry = windows.first_entry().unwrap()
-                && watermark >= entry.key().end()
-                && entry.get().get_writing_readers() <= 1
-            {
-                entry.get_mut().evict();
+            for (range, window) in windows {
+                if range.end() > watermark || window.get_write_snapshot_readers() > 1 {
+                    break;
+                }
+                window.evict();
             }
         }
     }
@@ -517,7 +519,7 @@ impl Timeline {
 
     fn earliest_reader(&self) -> Option<SequenceNumber> {
         for (range, window) in &*self.windows.read().unwrap() {
-            if window.get_readers() > 1 {
+            if window.get_read_snapshot_readers() > 1 {
                 return Some(range.start);
             }
         }
@@ -564,7 +566,7 @@ impl Timeline {
     fn try_get_window(&self, sequence_number: SequenceNumber) -> Option<Arc<TimelineWindow<TIMELINE_WINDOW_SIZE>>> {
         let windows = self.windows.read().unwrap_or_log();
         let window_index = Self::resolve_window(&windows, sequence_number)?;
-        windows.get(&window_index).and_then(ArcOrWeak::upgrade)
+        windows.get(&window_index).and_then(EvictableArc::upgrade)
     }
 
     fn get_or_create_window(&self, sequence_number: SequenceNumber) -> Arc<TimelineWindow<TIMELINE_WINDOW_SIZE>> {
@@ -584,7 +586,7 @@ impl Timeline {
         while let end = windows.last_key_value().unwrap().0.end()
             && end <= sequence_number
         {
-            windows.insert(WindowRange::starting_at(end), ArcOrWeak::new_arc(TimelineWindow::new(end)));
+            windows.insert(WindowRange::starting_at(end), EvictableArc::new_arc(TimelineWindow::new(end)));
         }
     }
 
@@ -593,7 +595,7 @@ impl Timeline {
     }
 
     fn resolve_window(
-        windows: &BTreeMap<WindowRange, ArcOrWeak<TimelineWindow<TIMELINE_WINDOW_SIZE>>>,
+        windows: &BTreeMap<WindowRange, EvictableArc<TimelineWindow<TIMELINE_WINDOW_SIZE>>>,
         to_resolve: SequenceNumber,
     ) -> Option<WindowRange> {
         let start = windows.first_key_value().unwrap().0.start;

--- a/storage/isolation_manager.rs
+++ b/storage/isolation_manager.rs
@@ -543,10 +543,16 @@ impl Timeline {
         commit_sequence_number: SequenceNumber,
     ) -> (Vec<Arc<TimelineWindow<TIMELINE_WINDOW_SIZE>>>, SequenceNumber) {
         let windows = &*self.windows.read().unwrap_or_log();
-        let first_concurrent_window_index =
-            Self::resolve_window(windows, open_sequence_number.next()).unwrap_or(*windows.first_key_value().unwrap().0);
-        let last_concurrent_window_index = Self::resolve_window(windows, commit_sequence_number.previous())
+
+        let first_concurrent_sequence_number = open_sequence_number.next();
+        let last_concurrent_sequence_number =
+            SequenceNumber::max(first_concurrent_sequence_number, commit_sequence_number.previous());
+
+        let first_concurrent_window_index = Self::resolve_window(windows, first_concurrent_sequence_number)
             .unwrap_or(*windows.first_key_value().unwrap().0);
+        let last_concurrent_window_index =
+            Self::resolve_window(windows, last_concurrent_sequence_number).unwrap_or(first_concurrent_window_index);
+
         let mut concurrent_windows: Vec<Arc<TimelineWindow<TIMELINE_WINDOW_SIZE>>> = Vec::new();
         windows.range(first_concurrent_window_index..=last_concurrent_window_index).for_each(|(_, window)| {
             concurrent_windows.push(window.upgrade().unwrap());

--- a/storage/isolation_manager.rs
+++ b/storage/isolation_manager.rs
@@ -49,24 +49,24 @@ impl IsolationManager {
         }
     }
 
-    pub(crate) fn opened_for_read_by_reader(&self, sequence_number: SequenceNumber) -> ReadingReaderDropGuard {
+    pub(crate) fn opened_for_read_by_reader(&self, sequence_number: SequenceNumber) -> ReadSnapshotDropGuard {
         debug_assert!(
             sequence_number <= self.watermark(),
             "assertion `{} <= {}` failed",
             sequence_number,
             self.watermark()
         );
-        self.timeline.record_reader(sequence_number)
+        self.timeline.record_read_snapshot_reader(sequence_number)
     }
 
-    pub(crate) fn opened_for_read_by_writer(&self, sequence_number: SequenceNumber) -> WritingReaderDropGuard {
+    pub(crate) fn opened_for_read_by_writer(&self, sequence_number: SequenceNumber) -> WriteSnapshotDropGuard {
         debug_assert!(
             sequence_number <= self.watermark(),
             "assertion `{} <= {}` failed",
             sequence_number,
             self.watermark()
         );
-        self.timeline.record_writing_reader(sequence_number)
+        self.timeline.record_write_snapshot_reader(sequence_number)
     }
 
     pub(crate) fn applied(&self, sequence_number: SequenceNumber) -> Result<(), ExpectedWindowError> {
@@ -524,17 +524,17 @@ impl Timeline {
         None
     }
 
-    fn record_reader(&self, sequence_number: SequenceNumber) -> ReadingReaderDropGuard {
+    fn record_read_snapshot_reader(&self, sequence_number: SequenceNumber) -> ReadSnapshotDropGuard {
         if let Some(window) = self.try_get_window(sequence_number) {
-            ReadingReaderDropGuard { _window: Some(Arc::downgrade(&window)) }
+            ReadSnapshotDropGuard { _window: Some(Arc::downgrade(&window)) }
         } else {
             // we only need to record readers against the timeline for windows that are still in-memory
-            ReadingReaderDropGuard { _window: None }
+            ReadSnapshotDropGuard { _window: None }
         }
     }
 
-    fn record_writing_reader(&self, sequence_number: SequenceNumber) -> WritingReaderDropGuard {
-        WritingReaderDropGuard { _window: self.try_get_window(sequence_number) }
+    fn record_write_snapshot_reader(&self, sequence_number: SequenceNumber) -> WriteSnapshotDropGuard {
+        WriteSnapshotDropGuard { _window: self.try_get_window(sequence_number) }
     }
 
     fn collect_concurrent_windows(
@@ -608,11 +608,11 @@ impl Timeline {
     }
 }
 
-pub struct ReadingReaderDropGuard {
+pub struct ReadSnapshotDropGuard {
     _window: Option<Weak<TimelineWindow<TIMELINE_WINDOW_SIZE>>>,
 }
 
-pub struct WritingReaderDropGuard {
+pub struct WriteSnapshotDropGuard {
     _window: Option<Arc<TimelineWindow<TIMELINE_WINDOW_SIZE>>>,
 }
 
@@ -743,7 +743,7 @@ mod tests {
     use assert as assert_true;
 
     use crate::{
-        isolation_manager::{CommitStatus, TIMELINE_WINDOW_SIZE, Timeline, WritingReaderDropGuard},
+        isolation_manager::{CommitStatus, TIMELINE_WINDOW_SIZE, Timeline, WriteSnapshotDropGuard},
         keyspace::{KeyspaceId, KeyspaceSet},
         record::{CommitRecord, CommitType},
         sequence_number::SequenceNumber,
@@ -776,13 +776,13 @@ mod tests {
     struct MockTransaction {
         read_sequence_number: SequenceNumber,
         commit_sequence_number: SequenceNumber,
-        reader_drop_guard: WritingReaderDropGuard,
+        reader_drop_guard: WriteSnapshotDropGuard,
     }
 
     impl MockTransaction {
         fn new(timeline: &Timeline, commit_sequence_number: SequenceNumber) -> MockTransaction {
             let read_sequence_number = timeline.watermark();
-            let reader_drop_guard = timeline.record_writing_reader(read_sequence_number);
+            let reader_drop_guard = timeline.record_write_snapshot_reader(read_sequence_number);
             MockTransaction { read_sequence_number, commit_sequence_number, reader_drop_guard }
         }
     }

--- a/storage/isolation_manager.rs
+++ b/storage/isolation_manager.rs
@@ -151,20 +151,17 @@ impl IsolationManager {
             commit_record.open_sequence_number().next(),
             stop_sequence_number,
         )? {
-            if let Ok((_, commit_status)) = commit_status_result {
-                let commit_dependency = match commit_status {
-                    CommitStatus::Aborted => CommitDependency::Independent,
-                    CommitStatus::Applied(predecessor_record) => commit_record.compute_dependency(&predecessor_record),
-                    CommitStatus::Pending(_) => {
-                        unreachable!("Evicted records cannot be pending")
-                    }
-                    CommitStatus::Empty | CommitStatus::Validated(_) => unreachable!(),
-                };
-                if let Some(conflict) = handle_dependency(commit_dependency) {
-                    return Ok(Some(conflict));
+            let (_, commit_status) = commit_status_result?;
+            let commit_dependency = match commit_status {
+                CommitStatus::Aborted => CommitDependency::Independent,
+                CommitStatus::Applied(predecessor_record) => commit_record.compute_dependency(&predecessor_record),
+                CommitStatus::Pending(_) => {
+                    unreachable!("Evicted records cannot be pending")
                 }
-            } else if let Err(err) = commit_status_result {
-                return Err(err);
+                CommitStatus::Empty | CommitStatus::Validated(_) => unreachable!(),
+            };
+            if let Some(conflict) = handle_dependency(commit_dependency) {
+                return Ok(Some(conflict));
             }
         }
         Ok(None)

--- a/storage/isolation_manager.rs
+++ b/storage/isolation_manager.rs
@@ -744,34 +744,10 @@ mod tests {
 
     use crate::{
         isolation_manager::{CommitStatus, TIMELINE_WINDOW_SIZE, Timeline, WriteSnapshotDropGuard},
-        keyspace::{KeyspaceId, KeyspaceSet},
         record::{CommitRecord, CommitType},
         sequence_number::SequenceNumber,
         snapshot::{buffer::OperationsBuffer, snapshot_id::SnapshotId},
     };
-
-    macro_rules! test_keyspace_set {
-        {$($variant:ident => $id:literal : $name: literal),* $(,)?} => {
-            #[derive(Clone, Copy)]
-            enum TestKeyspaceSet { $($variant),* }
-            impl KeyspaceSet for TestKeyspaceSet {
-                fn iter() -> impl Iterator<Item = Self> { [$(Self::$variant),*].into_iter() }
-                fn id(&self) -> KeyspaceId {
-                    match *self { $(Self::$variant => KeyspaceId($id)),* }
-                }
-                fn name(&self) -> &'static str {
-                    match *self { $(Self::$variant => $name),* }
-                }
-                fn prefix_length(&self) -> Option<usize> {
-                    None
-                }
-            }
-        };
-    }
-
-    test_keyspace_set! {
-        Keyspace => 0: "keyspace",
-    }
 
     struct MockTransaction {
         read_sequence_number: SequenceNumber,
@@ -826,22 +802,22 @@ mod tests {
     #[test]
     fn watermark_is_updated() {
         let timeline = &create_timeline();
-        let tx1 = MockTransaction::new(&timeline, _seq(1));
+        let tx1 = MockTransaction::new(timeline, _seq(1));
 
         tx_start_commit(timeline, &tx1);
         let tx1_commit_sequence_number = tx1.commit_sequence_number;
         tx_finalise_commit_status(timeline, tx1, true);
         assert_eq!(tx1_commit_sequence_number, timeline.watermark());
 
-        let tx2 = MockTransaction::new(&timeline, _seq(2));
+        let tx2 = MockTransaction::new(timeline, _seq(2));
 
         tx_start_commit(timeline, &tx2);
         let tx2_commit_sequence_number = tx2.commit_sequence_number;
         tx_finalise_commit_status(timeline, tx2, false);
         assert_eq!(tx2_commit_sequence_number, timeline.watermark());
 
-        let tx3 = MockTransaction::new(&timeline, _seq(3));
-        let tx4 = MockTransaction::new(&timeline, _seq(4));
+        let tx3 = MockTransaction::new(timeline, _seq(3));
+        let tx4 = MockTransaction::new(timeline, _seq(4));
         tx_start_commit(timeline, &tx3);
         tx_start_commit(timeline, &tx4);
         let tx4_commit_sequence_number = tx4.commit_sequence_number;
@@ -857,18 +833,18 @@ mod tests {
 
         let tx_count = TIMELINE_WINDOW_SIZE + 2;
         for i in 1..tx_count {
-            let tx = MockTransaction::new(&timeline, _seq(i as u64));
+            let tx = MockTransaction::new(timeline, _seq(i as u64));
             tx_start_commit(timeline, &tx);
         }
 
         let stop_at = tx_count - 2;
         for i in 1..stop_at {
-            let tx = MockTransaction::new(&timeline, _seq(i as u64));
+            let tx = MockTransaction::new(timeline, _seq(i as u64));
             tx_finalise_commit_status(timeline, tx, true);
         }
         assert_true!(timeline.try_get_window(_seq(1)).is_some());
         for i in stop_at..tx_count {
-            let tx = MockTransaction::new(&timeline, _seq(i as u64));
+            let tx = MockTransaction::new(timeline, _seq(i as u64));
             tx_finalise_commit_status(timeline, tx, true);
         }
         assert_true!(timeline.try_get_window(_seq(1)).is_none());
@@ -912,7 +888,7 @@ mod tests {
                 for _ in 0..TRANSACTIONS_PER_THREAD {
                     let (timeline, commit_sequence_number_counter) = &*timeline_and_counter;
                     let index = commit_sequence_number_counter.fetch_add(1, Ordering::SeqCst);
-                    let tx = MockTransaction::new(&timeline, _seq(index));
+                    let tx = MockTransaction::new(timeline, _seq(index));
                     tx_start_commit(timeline, &tx);
                     tx_finalise_commit_status(timeline, tx, true);
                 }

--- a/storage/recovery/commit_recovery.rs
+++ b/storage/recovery/commit_recovery.rs
@@ -172,7 +172,7 @@ pub(crate) fn apply_recovered(
             }
             RecoveryCommitStatus::Rejected => isolation_manager.load_aborted(commit_sequence_number),
             RecoveryCommitStatus::Pending(commit_record) => {
-                let read_guard = isolation_manager.opened_for_read(commit_record.open_sequence_number());
+                let read_guard = isolation_manager.opened_for_read_by_writer(commit_record.open_sequence_number());
                 let validated_commit = isolation_manager
                     .validate_commit(commit_sequence_number, commit_record, durability_client)
                     .map_err(|error| DurabilityClientRead { typedb_source: error })?;

--- a/storage/snapshot/snapshot.rs
+++ b/storage/snapshot/snapshot.rs
@@ -25,7 +25,7 @@ use resource::{
 use crate::{
     MVCCStorage, StorageCommitError,
     durability_client::DurabilityClient,
-    isolation_manager::ReaderDropGuard,
+    isolation_manager::{ReadingReaderDropGuard, WritingReaderDropGuard},
     iterator::MVCCReadError,
     key_range::{KeyRange, RangeEnd, RangeStart},
     key_value::{StorageKey, StorageKeyArray, StorageKeyReference},
@@ -216,7 +216,7 @@ where
 {
     fn commit(self, commit_profile: &mut CommitProfile) -> Result<Option<SequenceNumber>, SnapshotError>;
 
-    fn into_commit_record(self) -> (ReaderDropGuard, CommitRecord);
+    fn into_commit_record(self) -> (WritingReaderDropGuard, CommitRecord);
 
     fn has_changes(&self) -> bool {
         !self.operations().is_writes_empty() || !self.operations().locks_empty()
@@ -228,7 +228,7 @@ pub struct ReadSnapshot<D> {
     id: SnapshotId,
     iterator_pool: IteratorPool, // Must be declared & dropped before storage
     storage: Arc<MVCCStorage<D>>,
-    reader_guard: ReaderDropGuard,
+    _reader_guard: ReadingReaderDropGuard,
 }
 
 impl<D: fmt::Debug> fmt::Debug for ReadSnapshot<D> {
@@ -239,14 +239,14 @@ impl<D: fmt::Debug> fmt::Debug for ReadSnapshot<D> {
 
 impl<D> ReadSnapshot<D> {
     pub(crate) fn new(storage: Arc<MVCCStorage<D>>, open_sequence_number: SequenceNumber) -> Self {
-        let reader_guard = storage.isolation_manager.opened_for_read(open_sequence_number);
+        let _reader_guard = storage.isolation_manager.opened_for_read_by_reader(open_sequence_number);
         // Note: for serialisability, we would need to register the open transaction to the IsolationManager
         ReadSnapshot {
             open_sequence_number,
             id: SnapshotId::new(),
             iterator_pool: IteratorPool::new(),
             storage,
-            reader_guard,
+            _reader_guard,
         }
     }
 }
@@ -332,7 +332,7 @@ pub struct WriteSnapshot<D> {
     operations: OperationsBuffer,
     iterator_pool: IteratorPool, // Pool must be declared & dropped before storage
     storage: Arc<MVCCStorage<D>>,
-    reader_guard: ReaderDropGuard,
+    reader_guard: WritingReaderDropGuard,
 }
 
 impl<D: fmt::Debug> fmt::Debug for WriteSnapshot<D> {
@@ -364,7 +364,7 @@ impl<D> WriteSnapshot<D> {
         open_sequence_number: SequenceNumber,
         id: Option<SnapshotId>,
     ) -> Self {
-        let reader_guard = storage.isolation_manager.opened_for_read(open_sequence_number);
+        let reader_guard = storage.isolation_manager.opened_for_read_by_writer(open_sequence_number);
         WriteSnapshot {
             storage,
             operations,
@@ -499,7 +499,7 @@ impl<D: DurabilityClient> CommittableSnapshot<D> for WriteSnapshot<D> {
         }
     }
 
-    fn into_commit_record(self) -> (ReaderDropGuard, CommitRecord) {
+    fn into_commit_record(self) -> (WritingReaderDropGuard, CommitRecord) {
         let Self { operations, open_sequence_number, id, reader_guard, iterator_pool: _, storage: _ } = self;
         (reader_guard, CommitRecord::new(operations, open_sequence_number, CommitType::Data, id))
     }
@@ -511,7 +511,7 @@ pub struct SchemaSnapshot<D> {
     operations: OperationsBuffer,
     iterator_pool: IteratorPool, // Must be declared & dropped before storage
     storage: Arc<MVCCStorage<D>>,
-    reader_guard: ReaderDropGuard,
+    reader_guard: WritingReaderDropGuard,
 }
 
 impl<D: fmt::Debug> fmt::Debug for SchemaSnapshot<D> {
@@ -543,7 +543,7 @@ impl<D> SchemaSnapshot<D> {
         open_sequence_number: SequenceNumber,
         id: Option<SnapshotId>,
     ) -> Self {
-        let reader_guard = storage.isolation_manager.opened_for_read(open_sequence_number);
+        let reader_guard = storage.isolation_manager.opened_for_read_by_writer(open_sequence_number);
         SchemaSnapshot {
             storage,
             operations,
@@ -678,7 +678,7 @@ impl<D: DurabilityClient> CommittableSnapshot<D> for SchemaSnapshot<D> {
         }
     }
 
-    fn into_commit_record(self) -> (ReaderDropGuard, CommitRecord) {
+    fn into_commit_record(self) -> (WritingReaderDropGuard, CommitRecord) {
         let Self { operations, open_sequence_number, reader_guard, id, iterator_pool: _, storage: _ } = self;
         (reader_guard, CommitRecord::new(operations, open_sequence_number, CommitType::Schema, id))
     }

--- a/storage/snapshot/snapshot.rs
+++ b/storage/snapshot/snapshot.rs
@@ -25,7 +25,7 @@ use resource::{
 use crate::{
     MVCCStorage, StorageCommitError,
     durability_client::DurabilityClient,
-    isolation_manager::{ReadingReaderDropGuard, WritingReaderDropGuard},
+    isolation_manager::{ReadSnapshotDropGuard, WriteSnapshotDropGuard},
     iterator::MVCCReadError,
     key_range::{KeyRange, RangeEnd, RangeStart},
     key_value::{StorageKey, StorageKeyArray, StorageKeyReference},
@@ -216,7 +216,7 @@ where
 {
     fn commit(self, commit_profile: &mut CommitProfile) -> Result<Option<SequenceNumber>, SnapshotError>;
 
-    fn into_commit_record(self) -> (WritingReaderDropGuard, CommitRecord);
+    fn into_commit_record(self) -> (WriteSnapshotDropGuard, CommitRecord);
 
     fn has_changes(&self) -> bool {
         !self.operations().is_writes_empty() || !self.operations().locks_empty()
@@ -228,7 +228,7 @@ pub struct ReadSnapshot<D> {
     id: SnapshotId,
     iterator_pool: IteratorPool, // Must be declared & dropped before storage
     storage: Arc<MVCCStorage<D>>,
-    _reader_guard: ReadingReaderDropGuard,
+    _reader_guard: ReadSnapshotDropGuard,
 }
 
 impl<D: fmt::Debug> fmt::Debug for ReadSnapshot<D> {
@@ -332,7 +332,7 @@ pub struct WriteSnapshot<D> {
     operations: OperationsBuffer,
     iterator_pool: IteratorPool, // Pool must be declared & dropped before storage
     storage: Arc<MVCCStorage<D>>,
-    reader_guard: WritingReaderDropGuard,
+    reader_guard: WriteSnapshotDropGuard,
 }
 
 impl<D: fmt::Debug> fmt::Debug for WriteSnapshot<D> {
@@ -499,7 +499,7 @@ impl<D: DurabilityClient> CommittableSnapshot<D> for WriteSnapshot<D> {
         }
     }
 
-    fn into_commit_record(self) -> (WritingReaderDropGuard, CommitRecord) {
+    fn into_commit_record(self) -> (WriteSnapshotDropGuard, CommitRecord) {
         let Self { operations, open_sequence_number, id, reader_guard, iterator_pool: _, storage: _ } = self;
         (reader_guard, CommitRecord::new(operations, open_sequence_number, CommitType::Data, id))
     }
@@ -511,7 +511,7 @@ pub struct SchemaSnapshot<D> {
     operations: OperationsBuffer,
     iterator_pool: IteratorPool, // Must be declared & dropped before storage
     storage: Arc<MVCCStorage<D>>,
-    reader_guard: WritingReaderDropGuard,
+    reader_guard: WriteSnapshotDropGuard,
 }
 
 impl<D: fmt::Debug> fmt::Debug for SchemaSnapshot<D> {
@@ -678,7 +678,7 @@ impl<D: DurabilityClient> CommittableSnapshot<D> for SchemaSnapshot<D> {
         }
     }
 
-    fn into_commit_record(self) -> (WritingReaderDropGuard, CommitRecord) {
+    fn into_commit_record(self) -> (WriteSnapshotDropGuard, CommitRecord) {
         let Self { operations, open_sequence_number, reader_guard, id, iterator_pool: _, storage: _ } = self;
         (reader_guard, CommitRecord::new(operations, open_sequence_number, CommitType::Schema, id))
     }

--- a/storage/storage.rs
+++ b/storage/storage.rs
@@ -7,6 +7,7 @@
 #![deny(unused_must_use)]
 #![deny(elided_lifetimes_in_paths)]
 #![allow(clippy::module_inception)]
+#![allow(clippy::collapsible_if, reason = "usually false positives that would hurt readability")]
 
 use std::{
     collections::BTreeMap,


### PR DESCRIPTION
## Product change and motivation

Allow freeing memory held by old commits that are still being read, but cannot cause a conflict.

## Implementation
