### PR TITLE
Cleanup record carries its commit's sequence number

### DIFF
--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -4351,7 +4351,7 @@
     },
     "@@rules_rust+//crate_universe/private:internal_extensions.bzl%cu": {
       "general": {
-        "bzlTransitiveDigest": "XH8HAZa70v86XA5UWxDe/y5nwwtCwLSPWywsmY0i7Zw=",
+        "bzlTransitiveDigest": "FycwLplphqB6c90uV4ihzHoc22Z7neESpQvd2zRTk8g=",
         "usagesDigest": "cZ+ECJwGd7BJK/WUN0WIFhTQlfl/eawnUc90nVO6Ghc=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},

--- a/common/primitive/Cargo.toml
+++ b/common/primitive/Cargo.toml
@@ -3,6 +3,7 @@
 # Do not modify this file.
 
 features = {}
+dev-dependencies = {}
 
 [package]
 	name = "primitive"

--- a/concept/thing/cleanup.rs
+++ b/concept/thing/cleanup.rs
@@ -22,14 +22,21 @@ use storage::{
     key_range::{KeyRange, RangeEnd, RangeStart},
     key_value::StorageKey,
     keyspace::KeyspaceSet,
+    sequence_number::SequenceNumber,
 };
 
-type CleanupRecordKey = StorageKey<'static, BUFFER_KEY_INLINE>;
+type CleanupKey = StorageKey<'static, BUFFER_KEY_INLINE>;
 
 #[derive(Debug)]
+pub struct CleanupRecord {
+    pub sequence_number: SequenceNumber,
+    pub cleanup_intervals: CleanupIntervals,
+}
+
+#[derive(Debug, Clone)]
 struct KeyRangeInclusive {
-    start: CleanupRecordKey,
-    end: CleanupRecordKey,
+    start: CleanupKey,
+    end: CleanupKey,
     fixed_width: bool,
 }
 
@@ -37,26 +44,26 @@ impl KeyRangeInclusive {
     fn merge(self, other: Self) -> Self {
         debug_assert_eq!(self.fixed_width, other.fixed_width);
         Self {
-            start: CleanupRecordKey::min(self.start, other.start),
-            end: CleanupRecordKey::max(self.end, other.end),
+            start: CleanupKey::min(self.start, other.start),
+            end: CleanupKey::max(self.end, other.end),
             fixed_width: self.fixed_width,
         }
     }
 }
 
-impl From<KeyRangeInclusive> for KeyRange<CleanupRecordKey> {
+impl From<KeyRangeInclusive> for KeyRange<CleanupKey> {
     fn from(value: KeyRangeInclusive) -> Self {
         let KeyRangeInclusive { start, end, fixed_width } = value;
         Self::new(RangeStart::Inclusive(start), RangeEnd::EndPrefixInclusive(end), fixed_width)
     }
 }
 
-#[derive(Debug, Default)]
-pub struct CleanupRecord {
-    intervals: BTreeMap<CleanupRecordKey, KeyRangeInclusive>,
+#[derive(Debug, Default, Clone)]
+pub struct CleanupIntervals {
+    intervals: BTreeMap<CleanupKey, KeyRangeInclusive>,
 }
 
-impl CleanupRecord {
+impl CleanupIntervals {
     pub fn new() -> Self {
         Self { intervals: BTreeMap::new() }
     }
@@ -65,14 +72,14 @@ impl CleanupRecord {
         Self {
             intervals: KS::iter()
                 .map(|ks| {
-                    let empty_key = || CleanupRecordKey::new(ks, Bytes::copy(&[]));
+                    let empty_key = || CleanupKey::new(ks, Bytes::copy(&[]));
                     (empty_key(), KeyRangeInclusive { start: empty_key(), end: empty_key(), fixed_width: false })
                 })
                 .collect(),
         }
     }
 
-    pub fn insert(&mut self, prefix: CleanupRecordKey, key: CleanupRecordKey, fixed_width_keys: bool) {
+    pub fn insert(&mut self, prefix: CleanupKey, key: CleanupKey, fixed_width_keys: bool) {
         debug_assert!(key.starts_with(&prefix));
         match self.intervals.entry(prefix) {
             Entry::Vacant(vacant_entry) => {
@@ -90,23 +97,26 @@ impl CleanupRecord {
     }
 
     pub fn merge(a: Self, b: Self) -> Self {
-        let intervals = itertools::merge_join_by(a.intervals, b.intervals, |(apfx, _), (bpfx, _)| {
-            CleanupRecordKey::cmp(apfx, bpfx)
-        })
-        .map(|x| match x {
-            EitherOrBoth::Left(kv) | EitherOrBoth::Right(kv) => kv,
-            EitherOrBoth::Both((pfx, range_a), (_pfx, range_b)) => {
-                debug_assert_eq!(pfx, _pfx);
-                (pfx, range_a.merge(range_b))
-            }
-        })
-        .collect();
+        let intervals =
+            itertools::merge_join_by(a.intervals, b.intervals, |(apfx, _), (bpfx, _)| CleanupKey::cmp(apfx, bpfx))
+                .map(|x| match x {
+                    EitherOrBoth::Left(kv) | EitherOrBoth::Right(kv) => kv,
+                    EitherOrBoth::Both((pfx, range_a), (_pfx, range_b)) => {
+                        debug_assert_eq!(pfx, _pfx);
+                        (pfx, range_a.merge(range_b))
+                    }
+                })
+                .collect();
         Self { intervals }
+    }
+
+    pub fn into_record(self, sequence_number: SequenceNumber) -> CleanupRecord {
+        CleanupRecord { sequence_number, cleanup_intervals: self }
     }
 }
 
-impl IntoIterator for CleanupRecord {
-    type Item = (CleanupRecordKey, KeyRange<CleanupRecordKey>);
+impl IntoIterator for CleanupIntervals {
+    type Item = (CleanupKey, KeyRange<CleanupKey>);
 
     type IntoIter = IntoIter;
 
@@ -117,13 +127,13 @@ impl IntoIterator for CleanupRecord {
 
 pub struct IntoIter(
     Map<
-        btree_map::IntoIter<CleanupRecordKey, KeyRangeInclusive>,
-        fn((CleanupRecordKey, KeyRangeInclusive)) -> (CleanupRecordKey, KeyRange<CleanupRecordKey>),
+        btree_map::IntoIter<CleanupKey, KeyRangeInclusive>,
+        fn((CleanupKey, KeyRangeInclusive)) -> (CleanupKey, KeyRange<CleanupKey>),
     >,
 );
 
 impl Iterator for IntoIter {
-    type Item = (CleanupRecordKey, KeyRange<CleanupRecordKey>);
+    type Item = (CleanupKey, KeyRange<CleanupKey>);
 
     fn next(&mut self) -> Option<Self::Item> {
         self.0.next()
@@ -132,7 +142,7 @@ impl Iterator for IntoIter {
 
 impl DurabilityRecord for CleanupRecord {
     const RECORD_TYPE: DurabilityRecordType = 11;
-    const RECORD_NAME: &'static str = "";
+    const RECORD_NAME: &'static str = "cleanup_record";
 
     fn serialise_into(&self, writer: &mut impl std::io::Write) -> bincode::Result<()> {
         bincode::serialize_into(writer, self)
@@ -151,12 +161,56 @@ mod serialise {
     use serde::{
         Deserialize, Serialize,
         de::{self, Visitor},
-        ser::SerializeMap,
+        ser::{SerializeMap, SerializeSeq},
     };
 
-    use super::{CleanupRecord, CleanupRecordKey, KeyRangeInclusive};
+    use super::{CleanupIntervals, CleanupKey, CleanupRecord, KeyRangeInclusive};
 
     impl Serialize for CleanupRecord {
+        fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            let mut seq = serializer.serialize_seq(Some(2))?;
+            seq.serialize_element(&self.sequence_number)?;
+            seq.serialize_element(&self.cleanup_intervals)?;
+            seq.end()
+        }
+    }
+
+    impl<'de> Deserialize<'de> for CleanupRecord {
+        fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            struct CleanupRecordVisitor;
+
+            impl<'de> Visitor<'de> for CleanupRecordVisitor {
+                type Value = CleanupRecord;
+
+                fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+                    formatter.write_str("a sequence of two elements")
+                }
+
+                fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
+                where
+                    A: serde::de::SeqAccess<'de>,
+                {
+                    let sequence_number = seq
+                        .next_element()?
+                        .ok_or_else(|| de::Error::invalid_length(0, &"a sequence of two elements"))?;
+                    let cleanup_intervals = seq
+                        .next_element()?
+                        .ok_or_else(|| de::Error::invalid_length(1, &"a sequence of two elements"))?;
+                    Ok(CleanupRecord { sequence_number, cleanup_intervals })
+                }
+            }
+
+            deserializer.deserialize_seq(CleanupRecordVisitor)
+        }
+    }
+
+    impl Serialize for CleanupIntervals {
         fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
         where
             S: serde::Serializer,
@@ -169,7 +223,7 @@ mod serialise {
         }
     }
 
-    impl<'de> Deserialize<'de> for CleanupRecord {
+    impl<'de> Deserialize<'de> for CleanupIntervals {
         fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
         where
             D: serde::Deserializer<'de>,
@@ -177,7 +231,7 @@ mod serialise {
             struct KeyRangeMapVisitor;
 
             impl<'de> Visitor<'de> for KeyRangeMapVisitor {
-                type Value = BTreeMap<CleanupRecordKey, KeyRangeInclusive>;
+                type Value = BTreeMap<CleanupKey, KeyRangeInclusive>;
 
                 fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
                     formatter.write_str(type_name::<Self>())
@@ -189,13 +243,13 @@ mod serialise {
                 {
                     let mut intervals = BTreeMap::new();
                     while let Some((prefix, range)) = map.next_entry()? {
-                        intervals.insert(CleanupRecordKey::Array(prefix), range);
+                        intervals.insert(CleanupKey::Array(prefix), range);
                     }
                     Ok(intervals)
                 }
             }
 
-            Ok(CleanupRecord { intervals: deserializer.deserialize_map(KeyRangeMapVisitor)? })
+            Ok(CleanupIntervals { intervals: deserializer.deserialize_map(KeyRangeMapVisitor)? })
         }
     }
 
@@ -244,8 +298,8 @@ mod serialise {
                     }
 
                     Ok(KeyRangeInclusive {
-                        start: CleanupRecordKey::Array(start.ok_or_else(|| de::Error::missing_field("start"))?),
-                        end: CleanupRecordKey::Array(end.ok_or_else(|| de::Error::missing_field("end"))?),
+                        start: CleanupKey::Array(start.ok_or_else(|| de::Error::missing_field("start"))?),
+                        end: CleanupKey::Array(end.ok_or_else(|| de::Error::missing_field("end"))?),
                         fixed_width: fixed_width.ok_or_else(|| de::Error::missing_field("fixed_width"))?,
                     })
                 }

--- a/concept/thing/thing_manager.rs
+++ b/concept/thing/thing_manager.rs
@@ -77,7 +77,7 @@ use crate::{
     thing::{
         ThingAPI,
         attribute::{Attribute, AttributeIterator},
-        cleanup::CleanupRecord,
+        cleanup::CleanupIntervals,
         decode_attribute_ids, decode_role_players, encode_attribute_ids, encode_role_players,
         entity::Entity,
         has::Has,
@@ -1797,7 +1797,7 @@ impl ThingManager {
         &self,
         snapshot: &mut Snapshot,
         storage_counters: StorageCounters,
-    ) -> Result<CleanupRecord, Vec<ConceptWriteError>> {
+    ) -> Result<CleanupIntervals, Vec<ConceptWriteError>> {
         let cardinality_change_tracker =
             CardinalityChangeTracker::build(snapshot, self.type_manager(), self, storage_counters.clone())
                 .map_err(|typedb_source| vec![ConceptWriteError::ConceptRead { typedb_source }])?;
@@ -1826,19 +1826,19 @@ impl ThingManager {
     fn finalise_storage_writes(
         &self,
         snapshot: &mut impl WritableSnapshot,
-    ) -> Result<CleanupRecord, Box<ConceptReadError>> {
-        let mut cleanup_record = CleanupRecord::new();
+    ) -> Result<CleanupIntervals, Box<ConceptReadError>> {
+        let mut cleanup_intervals = CleanupIntervals::new();
 
         // TODO: Should not collect here (iterate_writes() already copies)
         for (key, write) in snapshot.iterate_writes().collect_vec() {
             self.create_commit_locks(snapshot, &key)?;
 
             if let Write::Delete = write {
-                register_delete_in_cleanup_record(&mut cleanup_record, key);
+                register_delete_in_cleanup_intervals(&mut cleanup_intervals, key);
             }
         }
 
-        Ok(cleanup_record)
+        Ok(cleanup_intervals)
     }
 
     fn create_commit_locks(
@@ -3025,24 +3025,27 @@ impl ThingManager {
     }
 }
 
-fn register_delete_in_cleanup_record(cleanup_record: &mut CleanupRecord, key: StorageKeyArray<BUFFER_KEY_INLINE>) {
+fn register_delete_in_cleanup_intervals(
+    cleanup_intervals: &mut CleanupIntervals,
+    key: StorageKeyArray<BUFFER_KEY_INLINE>,
+) {
     if let Some(object) = ObjectVertex::try_decode(key.bytes()) {
         let prefix = ObjectVertex::build_prefix_type(object.prefix(), object.type_id_(), object.keyspace());
-        cleanup_record.insert(
+        cleanup_intervals.insert(
             prefix.resize_to(),
             StorageKey::Array(key).resize_to(),
             ObjectVertex::FIXED_WIDTH_ENCODING,
         );
     } else if let Some(attr) = AttributeVertex::try_decode(key.bytes()) {
         let prefix = AttributeVertex::build_prefix_type(attr.prefix(), attr.type_id_(), attr.keyspace());
-        cleanup_record.insert(
+        cleanup_intervals.insert(
             prefix.resize_to(),
             StorageKey::Array(key).resize_to(),
             AttributeVertex::FIXED_WIDTH_ENCODING,
         );
     } else if let Some(has) = ThingEdgeHas::try_decode(key.bytes()) {
         let prefix = ThingEdgeHas::prefix_from_type(Object::new(has.from()).type_().vertex());
-        cleanup_record.insert(
+        cleanup_intervals.insert(
             prefix.resize_to(),
             StorageKey::Array(key).resize_to(),
             ThingEdgeHas::FIXED_WIDTH_ENCODING,
@@ -3052,7 +3055,7 @@ fn register_delete_in_cleanup_record(cleanup_record: &mut CleanupRecord, key: St
             reverse_has.from().value_type_category(),
             reverse_has.from().type_id_(),
         );
-        cleanup_record.insert(
+        cleanup_intervals.insert(
             prefix.resize_to(),
             StorageKey::Array(key).resize_to(),
             ThingEdgeHasReverse::FIXED_WIDTH_ENCODING,
@@ -3066,7 +3069,7 @@ fn register_delete_in_cleanup_record(cleanup_record: &mut CleanupRecord, key: St
         } else {
             ThingEdgeLinks::prefix_from_relation_type(links.from().type_id_())
         };
-        cleanup_record.insert(
+        cleanup_intervals.insert(
             prefix.resize_to(),
             StorageKey::Array(key).resize_to(),
             ThingEdgeLinks::FIXED_WIDTH_ENCODING,
@@ -3077,7 +3080,7 @@ fn register_delete_in_cleanup_record(cleanup_record: &mut CleanupRecord, key: St
             Object::new(links_index.from()).type_().vertex().prefix(),
             links_index.from().type_id_(),
         );
-        cleanup_record.insert(
+        cleanup_intervals.insert(
             prefix.resize_to(),
             StorageKey::Array(key).resize_to(),
             ThingEdgeIndexedRelation::FIXED_WIDTH_ENCODING,

--- a/database/Cargo.toml
+++ b/database/Cargo.toml
@@ -111,6 +111,10 @@ features = {}
 	name = "test_transaction"
 
 [[test]]
+	path = "tests/cleanup_records.rs"
+	name = "test_cleanup_records"
+
+[[test]]
 	path = "tests/migration.rs"
 	name = "test_migration"
 

--- a/database/database.rs
+++ b/database/database.rs
@@ -18,7 +18,7 @@ use std::{
 
 use concept::{
     thing::{
-        cleanup::CleanupRecord,
+        cleanup::{CleanupIntervals, CleanupRecord},
         statistics::{Statistics, StatisticsError},
     },
     type_::type_manager::{
@@ -94,7 +94,7 @@ pub struct Database<D> {
 
     pub(super) schema: Arc<RwLock<Schema>>,
     pub(super) query_cache: Arc<QueryCache>,
-    pub(super) _cleanup_queue: Arc<RwLock<BTreeMap<SequenceNumber, CleanupRecord>>>,
+    pub(super) _cleanup_queue: Arc<RwLock<BTreeMap<SequenceNumber, CleanupIntervals>>>,
 
     schema_write_transaction_exclusivity: Mutex<SchemaWriteTransactionState>,
     _statistics_updater: IntervalRunner,
@@ -340,7 +340,7 @@ impl Database<WALClient> {
 
         let checkpoint_fn = make_checkpoint_fn(name.to_owned(), path.to_owned(), SequenceNumber::MIN, storage.clone());
 
-        let cleanup_queue = Arc::<RwLock<BTreeMap<SequenceNumber, CleanupRecord>>>::default();
+        let cleanup_queue = Arc::<RwLock<BTreeMap<SequenceNumber, CleanupIntervals>>>::default();
         let cleanup_fn =
             make_cleanup_fn(name.to_owned(), storage.clone(), schema.clone(), cleanup_queue.clone(), cleanup_strategy);
 
@@ -474,8 +474,10 @@ impl Database<WALClient> {
             Arc::new(RwLock::new(
                 storage
                     .durability()
-                    .iter_type_from(earliest_uncleaned)
-                    .and_then(Itertools::try_collect)
+                    .iter_type_from::<CleanupRecord>(earliest_uncleaned)
+                    .and_then(|iter| {
+                        iter.map_ok(|(_, record)| (record.sequence_number, record.cleanup_intervals)).try_collect()
+                    })
                     .map_err(|typedb_source| DatabaseOpenError::DurabilityClientRead { typedb_source })?,
             ))
         };
@@ -650,11 +652,11 @@ fn make_cleanup_fn(
     database_name: String,
     storage: Arc<MVCCStorage<WALClient>>,
     schema: Arc<RwLock<Schema>>,
-    cleanup_queue: Arc<RwLock<BTreeMap<SequenceNumber, CleanupRecord>>>,
+    cleanup_queue: Arc<RwLock<BTreeMap<SequenceNumber, CleanupIntervals>>>,
     cleanup_strategy: MvccCleanupStrategy,
 ) -> impl Fn() {
     fn make_disabled_cleanup_fn(
-        cleanup_queue: Arc<RwLock<BTreeMap<SequenceNumber, CleanupRecord>>>,
+        cleanup_queue: Arc<RwLock<BTreeMap<SequenceNumber, CleanupIntervals>>>,
     ) -> Box<dyn Fn() + Send + Sync> {
         Box::new(move || {
             cleanup_queue.write().unwrap().clear();
@@ -665,7 +667,7 @@ fn make_cleanup_fn(
         database_name: String,
         storage: Arc<MVCCStorage<WALClient>>,
         schema: Arc<RwLock<Schema>>,
-        cleanup_queue: Arc<RwLock<BTreeMap<SequenceNumber, CleanupRecord>>>,
+        cleanup_queue: Arc<RwLock<BTreeMap<SequenceNumber, CleanupIntervals>>>,
     ) -> Box<dyn Fn() + Send + Sync> {
         Box::new(move || {
             debug!("Running cleanup for database {}", database_name);
@@ -685,10 +687,10 @@ fn make_cleanup_fn(
                 let contains_end = range.contains_key(&watermark.previous());
                 let all_consecutive = range.keys().tuple_windows().all(|(a, &b)| a.next() == b);
                 if contains_start && contains_end && all_consecutive {
-                    range.into_values().fold(CleanupRecord::default(), CleanupRecord::merge)
+                    range.into_values().fold(CleanupIntervals::default(), CleanupIntervals::merge)
                 } else {
                     info!("Missing delta records during cleanup; scanning database for dead keys.");
-                    CleanupRecord::everything::<EncodingKeyspace>()
+                    CleanupIntervals::everything::<EncodingKeyspace>()
                 }
             };
 

--- a/database/tests/BUILD
+++ b/database/tests/BUILD
@@ -107,6 +107,7 @@ rust_test(
         "//common/options",
         "//database",
         "//diagnostics",
+        "//durability",
         "//executor",
         "//query",
         "//storage",

--- a/database/tests/BUILD
+++ b/database/tests/BUILD
@@ -99,6 +99,24 @@ rust_test(
 )
 
 rust_test(
+    name = "test_cleanup_records",
+    srcs = glob([
+        "cleanup_records.rs",
+    ]),
+    deps = [
+        "//common/options",
+        "//database",
+        "//diagnostics",
+        "//executor",
+        "//query",
+        "//storage",
+        "//util/test:test_utils",
+
+        "@typeql//rust:typeql",
+    ]
+)
+
+rust_test(
     name = "test_transaction_isolation",
     srcs = glob([
         "test_transaction_isolation.rs",

--- a/database/tests/cleanup_records.rs
+++ b/database/tests/cleanup_records.rs
@@ -89,6 +89,7 @@ fn statistics_synchronization_under_concurrent_load() {
                 panic!("Saw a commit record {} twice", sequence_number.number())
             }
         } else if raw_record.record_type == CleanupRecord::RECORD_TYPE {
+            let sequence_number = CleanupRecord::deserialise_from(&mut &*raw_record.bytes).unwrap().sequence_number;
             if let Some(flag) = scratch.get_mut(&sequence_number) {
                 assert_eq!(*flag, Flag::SeenCommit, "Saw a cleanup record for {} twice", sequence_number.number());
                 *flag = Flag::SeenBoth;

--- a/database/tests/cleanup_records.rs
+++ b/database/tests/cleanup_records.rs
@@ -1,0 +1,118 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+use std::{collections::HashMap, sync::Arc, thread};
+
+use database::{
+    Database,
+    database_manager::DatabaseManager,
+    query::{execute_schema_query, execute_write_query_in_write},
+    transaction::{CleanupRecord, CommitIntent, TransactionSchema, TransactionWrite},
+};
+use diagnostics::{diagnostics_manager::DiagnosticsManager, metrics::FsyncMetrics};
+use durability::{DurabilityService, wal::WAL};
+use executor::ExecutionInterrupt;
+use options::{MvccCleanupStrategy, QueryOptions, TransactionOptions, byte_size::ByteSize};
+use query::given_rows::GivenRowsSimple;
+use storage::{
+    durability_client::{DurabilityRecord, WALClient},
+    record::CommitRecord,
+    sequence_number::SequenceNumber,
+};
+use test_utils::{create_tmp_storage_dir, init_logging};
+
+const DB_NAME: &str = "cleanup-records";
+const SCHEMA: &str = r#"define
+    attribute name value string;
+    attribute age value integer;
+    entity person owns name @key, owns age;
+"#;
+
+const NUM_THREADS: u32 = 20;
+const WRITES_PER_THREAD: u32 = 20;
+
+#[test]
+fn statistics_synchronization_under_concurrent_load() {
+    init_logging();
+    let tmp_dir = create_tmp_storage_dir();
+    {
+        let dbm = DatabaseManager::new(
+            &tmp_dir,
+            Arc::new(DiagnosticsManager::new_disabled()),
+            ByteSize::mb(64),
+            ByteSize::mb(64),
+            database::database_manager::ImportOwnership::Exclusive,
+            MvccCleanupStrategy::Disabled,
+        )
+        .unwrap();
+        dbm.put_database(DB_NAME).unwrap();
+        let database = dbm.database(DB_NAME).unwrap();
+
+        let schema_query = typeql::parse_query(SCHEMA).unwrap().into_structure().into_schema();
+        let tx = TransactionSchema::open(database.clone(), TransactionOptions::default()).unwrap();
+        let (tx, result) = execute_schema_query(tx, schema_query, SCHEMA.to_string());
+        result.unwrap();
+        let (mut profile, intent) = tx.finalise();
+        intent.unwrap().commit(profile.commit_profile()).unwrap();
+
+        let mut handles = Vec::new();
+        for thread_id in 0..NUM_THREADS {
+            let database = database.clone();
+            let handle = thread::spawn(move || {
+                for write in 0..WRITES_PER_THREAD {
+                    let id = thread_id * WRITES_PER_THREAD + write;
+                    run_insert(&database, id);
+                }
+            });
+            handles.push(handle);
+        }
+        for h in handles {
+            h.join().unwrap();
+        }
+    }
+
+    #[derive(Debug, PartialEq, Eq)]
+    enum Flag {
+        SeenCommit,
+        SeenBoth,
+    }
+    let wal = WAL::load(tmp_dir.join(DB_NAME), FsyncMetrics::new()).unwrap();
+    let mut scratch = HashMap::new();
+    for item in wal.iter_any_from(SequenceNumber::MIN).unwrap() {
+        let raw_record = item.unwrap();
+        let sequence_number = raw_record.sequence_number;
+        if raw_record.record_type == CommitRecord::RECORD_TYPE {
+            if scratch.insert(sequence_number, Flag::SeenCommit).is_some() {
+                panic!("Saw a commit record {} twice", sequence_number.number())
+            }
+        } else if raw_record.record_type == CleanupRecord::RECORD_TYPE {
+            if let Some(flag) = scratch.get_mut(&sequence_number) {
+                assert_eq!(*flag, Flag::SeenCommit, "Saw a cleanup record for {} twice", sequence_number.number());
+                *flag = Flag::SeenBoth;
+            } else {
+                panic!("Saw a cleanup record for {} before its commit record", sequence_number.number())
+            }
+        }
+    }
+}
+
+fn run_insert(database: &Arc<Database<WALClient>>, id: u32) {
+    let mut tx = TransactionWrite::open(database.clone(), TransactionOptions::default()).unwrap();
+    let query_str = format!(r#"insert $p isa person, has name "person_{id}", has age {id};"#);
+    let pipeline = typeql::parse_query(&query_str).unwrap().into_structure().into_pipeline();
+    let (returned_tx, result) = execute_write_query_in_write(
+        tx,
+        QueryOptions::default_grpc(),
+        Arc::new(pipeline),
+        None::<GivenRowsSimple>,
+        query_str,
+        ExecutionInterrupt::new_uninterruptible(),
+    );
+    result.unwrap();
+    tx = returned_tx;
+    let (mut profile, intent) = tx.finalise();
+    intent.unwrap().commit(profile.commit_profile()).unwrap();
+}

--- a/database/tests/cleanup_records.rs
+++ b/database/tests/cleanup_records.rs
@@ -75,9 +75,9 @@ fn statistics_synchronization_under_concurrent_load() {
     }
 
     #[derive(Debug, PartialEq, Eq)]
-    enum Flag {
-        SeenCommit,
-        SeenBoth,
+    enum Seen {
+        Commit,
+        Both,
     }
     let wal = WAL::load(tmp_dir.join(DB_NAME), FsyncMetrics::new()).unwrap();
     let mut scratch = HashMap::new();
@@ -85,14 +85,14 @@ fn statistics_synchronization_under_concurrent_load() {
         let raw_record = item.unwrap();
         let sequence_number = raw_record.sequence_number;
         if raw_record.record_type == CommitRecord::RECORD_TYPE {
-            if scratch.insert(sequence_number, Flag::SeenCommit).is_some() {
+            if scratch.insert(sequence_number, Seen::Commit).is_some() {
                 panic!("Saw a commit record {} twice", sequence_number.number())
             }
         } else if raw_record.record_type == CleanupRecord::RECORD_TYPE {
             let sequence_number = CleanupRecord::deserialise_from(&mut &*raw_record.bytes).unwrap().sequence_number;
             if let Some(flag) = scratch.get_mut(&sequence_number) {
-                assert_eq!(*flag, Flag::SeenCommit, "Saw a cleanup record for {} twice", sequence_number.number());
-                *flag = Flag::SeenBoth;
+                assert_eq!(*flag, Seen::Commit, "Saw a cleanup record for {} twice", sequence_number.number());
+                *flag = Seen::Both;
             } else {
                 panic!("Saw a cleanup record for {} before its commit record", sequence_number.number())
             }

--- a/database/transaction.rs
+++ b/database/transaction.rs
@@ -12,7 +12,7 @@ use std::{
 pub use concept::thing::cleanup::CleanupRecord;
 use concept::{
     error::{ConceptReadError, ConceptWriteError},
-    thing::{statistics::StatisticsError, thing_manager::ThingManager},
+    thing::{cleanup::CleanupIntervals, statistics::StatisticsError, thing_manager::ThingManager},
     type_::type_manager::{
         TypeManager,
         type_cache::{TypeCache, TypeCacheCreateError},
@@ -200,7 +200,7 @@ impl<D: DurabilityClient> TransactionWrite<D> {
             Ok(snapshot) => snapshot,
         };
 
-        let cleanup_record = match self.thing_manager.finalise(&mut snapshot, commit_profile.storage_counters()) {
+        let cleanup_intervals = match self.thing_manager.finalise(&mut snapshot, commit_profile.storage_counters()) {
             Ok(compaction) => compaction,
             Err(errs) => {
                 // TODO: send all the errors, not just the first,
@@ -210,7 +210,10 @@ impl<D: DurabilityClient> TransactionWrite<D> {
             }
         };
         commit_profile.things_finalised();
-        (profile, Ok(DataCommitIntent { database_drop_guard: self.database, write_snapshot: snapshot, cleanup_record }))
+        (
+            profile,
+            Ok(DataCommitIntent { database_drop_guard: self.database, write_snapshot: snapshot, cleanup_intervals }),
+        )
     }
 
     pub fn rollback(&mut self) {
@@ -319,7 +322,7 @@ impl<D: DurabilityClient> TransactionSchema<D> {
         };
         commit_profile.types_validated();
 
-        let cleanup_record = match self.thing_manager.finalise(&mut snapshot, commit_profile.storage_counters()) {
+        let cleanup_intervals = match self.thing_manager.finalise(&mut snapshot, commit_profile.storage_counters()) {
             Ok(compaction) => compaction,
             Err(errs) => {
                 // TODO: send all the errors, not just the first,
@@ -340,7 +343,7 @@ impl<D: DurabilityClient> TransactionSchema<D> {
         let _type_manager = Arc::into_inner(self.type_manager).expect("Failed to unwrap Arc<TypeManager>");
         (
             profile,
-            Ok(SchemaCommitIntent { database_drop_guard: self.database, schema_snapshot: snapshot, cleanup_record }),
+            Ok(SchemaCommitIntent { database_drop_guard: self.database, schema_snapshot: snapshot, cleanup_intervals }),
         )
     }
 
@@ -449,31 +452,35 @@ macro_rules! with_transaction_parts {
 #[derive(Debug, Serialize, Deserialize)]
 pub struct CommitInfo {
     pub commit_record: CommitRecord,
-    pub cleanup_record: CleanupRecord,
+    pub cleanup_intervals: CleanupIntervals,
 }
 
 pub struct DataCommitIntent<D> {
     database_drop_guard: DatabaseDropGuard<D>,
     write_snapshot: WriteSnapshot<D>,
-    cleanup_record: CleanupRecord,
+    cleanup_intervals: CleanupIntervals,
 }
 
 impl<D: DurabilityClient> DataCommitIntent<D> {
-    pub fn new(database: Arc<Database<D>>, write_snapshot: WriteSnapshot<D>, cleanup_record: CleanupRecord) -> Self {
-        Self { database_drop_guard: DatabaseDropGuard::new(database), write_snapshot, cleanup_record }
+    pub fn new(
+        database: Arc<Database<D>>,
+        write_snapshot: WriteSnapshot<D>,
+        cleanup_intervals: CleanupIntervals,
+    ) -> Self {
+        Self { database_drop_guard: DatabaseDropGuard::new(database), write_snapshot, cleanup_intervals }
     }
 
     /// Rebuilds an intent from a commit's portable form.
     pub fn from_commit_info(database: Arc<Database<D>>, commit_info: CommitInfo) -> Self {
-        let CommitInfo { commit_record, cleanup_record } = commit_info;
+        let CommitInfo { commit_record, cleanup_intervals } = commit_info;
         let snapshot = WriteSnapshot::new_with_commit_record(database.storage.clone(), commit_record);
-        Self::new(database, snapshot, cleanup_record)
+        Self::new(database, snapshot, cleanup_intervals)
     }
 
     /// Splits an intent into its portable form with MVCC timeline guards.
     pub fn into_commit_info(self) -> (DatabaseDropGuard<D>, WriteSnapshotDropGuard, CommitInfo) {
         let (reader_guard, commit_record) = self.write_snapshot.into_commit_record();
-        let commit_info = CommitInfo { commit_record, cleanup_record: self.cleanup_record };
+        let commit_info = CommitInfo { commit_record, cleanup_intervals: self.cleanup_intervals };
         (self.database_drop_guard, reader_guard, commit_info)
     }
 }
@@ -499,9 +506,9 @@ impl<D: DurabilityClient> CommitIntent for DataCommitIntent<D> {
             database
                 .storage
                 .durability()
-                .unsequenced_write(&self.cleanup_record)
+                .unsequenced_write(&self.cleanup_intervals.clone().into_record(sequence_number))
                 .map_err(|typedb_source| DataCommitError::DurabilityError { typedb_source })?;
-            database._cleanup_queue.write().unwrap().insert(sequence_number, self.cleanup_record);
+            database._cleanup_queue.write().unwrap().insert(sequence_number, self.cleanup_intervals);
         }
         Ok(())
     }
@@ -510,25 +517,29 @@ impl<D: DurabilityClient> CommitIntent for DataCommitIntent<D> {
 pub struct SchemaCommitIntent<D> {
     database_drop_guard: DatabaseDropGuard<D>,
     schema_snapshot: SchemaSnapshot<D>,
-    cleanup_record: CleanupRecord,
+    cleanup_intervals: CleanupIntervals,
 }
 
 impl<D: DurabilityClient> SchemaCommitIntent<D> {
-    pub fn new(database: Arc<Database<D>>, schema_snapshot: SchemaSnapshot<D>, cleanup_record: CleanupRecord) -> Self {
-        Self { database_drop_guard: DatabaseDropGuard::new(database), schema_snapshot, cleanup_record }
+    pub fn new(
+        database: Arc<Database<D>>,
+        schema_snapshot: SchemaSnapshot<D>,
+        cleanup_intervals: CleanupIntervals,
+    ) -> Self {
+        Self { database_drop_guard: DatabaseDropGuard::new(database), schema_snapshot, cleanup_intervals }
     }
 
     /// Rebuilds an intent from a commit's portable form.
     pub fn from_commit_info(database: Arc<Database<D>>, commit_info: CommitInfo) -> Self {
-        let CommitInfo { commit_record, cleanup_record } = commit_info;
+        let CommitInfo { commit_record, cleanup_intervals } = commit_info;
         let snapshot = SchemaSnapshot::new_with_commit_record(database.storage.clone(), commit_record);
-        Self::new(database, snapshot, cleanup_record)
+        Self::new(database, snapshot, cleanup_intervals)
     }
 
     /// Splits an intent into its portable form with MVCC timeline guards.
     pub fn into_commit_info(self) -> (DatabaseDropGuard<D>, WriteSnapshotDropGuard, CommitInfo) {
         let (reader_guard, commit_record) = self.schema_snapshot.into_commit_record();
-        let commit_info = CommitInfo { commit_record, cleanup_record: self.cleanup_record };
+        let commit_info = CommitInfo { commit_record, cleanup_intervals: self.cleanup_intervals };
         (self.database_drop_guard, reader_guard, commit_info)
     }
 }
@@ -575,9 +586,9 @@ impl<D: DurabilityClient> CommitIntent for SchemaCommitIntent<D> {
             database
                 .storage
                 .durability()
-                .unsequenced_write(&self.cleanup_record)
+                .unsequenced_write(&self.cleanup_intervals.clone().into_record(sequence_number))
                 .map_err(|typedb_source| SchemaCommitError::DurabilityError { typedb_source })?;
-            database._cleanup_queue.write().unwrap().insert(sequence_number, self.cleanup_record);
+            database._cleanup_queue.write().unwrap().insert(sequence_number, self.cleanup_intervals);
 
             // replace schema cache
             let type_cache = match TypeCache::new(database.storage.clone(), sequence_number) {


### PR DESCRIPTION
## Product change and motivation

Fix bug where a cleanup record would inherit the sequence number of the previous commit record in the WAL, rather than track the sequence number of the commit that it is associated with. This could lead to multiple cleanup records with the same sequence number, and conversely to some commit records lacking a corresponding cleanup record.

## Implementation
