### PR TITLE
Validate assignments through IR

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -192,8 +192,8 @@ git_override(
 bazel_dep(name = "typedb_behaviour", version = "0.0.0")
 git_override(
     module_name = "typedb_behaviour",
-    remote = "https://github.com/typedb/typedb-behaviour",
-    commit = "7d35851bffeabd642b7288dea82eb63852f3c191",
+    remote = "https://github.com/krishnangovindraj/typedb-behaviour",
+    commit = "e010ced66331dac9320c959ae9be085608702d67",
 )
 
 http_file = use_repo_rule("@bazel_tools//tools/build_defs/repo:http.bzl", "http_file")

--- a/ir/pattern/mod.rs
+++ b/ir/pattern/mod.rs
@@ -575,14 +575,14 @@ impl PatternVariableModes {
     }
 }
 
-pub(crate) type LocationNote = Option<Span>;
+type Source = Option<Span>;
 
 #[derive(Copy, Clone, Debug, Default, PartialEq, Eq)]
 pub(crate) enum AssignmentStatus {
     #[default]
     NotAssigned,
-    AtMostOncePerBranch(LocationNote),
-    ErrorMultipleAssignments(LocationNote, LocationNote),
+    AtMostOncePerBranch(Source),
+    MultipleAssignmentsInBranch(Source, Source),
 }
 
 impl AssignmentStatus {
@@ -631,10 +631,10 @@ impl BitAnd for AssignmentStatus {
     fn bitand(self, rhs: Self) -> Self {
         match (self, rhs) {
             (Self::NotAssigned, x) | (x, Self::NotAssigned) => x,
-            (Self::ErrorMultipleAssignments(s1, s2), _) | (_, Self::ErrorMultipleAssignments(s1, s2)) => {
-                Self::ErrorMultipleAssignments(s1, s2)
+            (Self::MultipleAssignmentsInBranch(s1, s2), _) | (_, Self::MultipleAssignmentsInBranch(s1, s2)) => {
+                Self::MultipleAssignmentsInBranch(s1, s2)
             }
-            (Self::AtMostOncePerBranch(s1), Self::AtMostOncePerBranch(s2)) => Self::ErrorMultipleAssignments(s1, s2),
+            (Self::AtMostOncePerBranch(s1), Self::AtMostOncePerBranch(s2)) => Self::MultipleAssignmentsInBranch(s1, s2),
         }
     }
 }
@@ -645,8 +645,8 @@ impl BitOr for AssignmentStatus {
     fn bitor(self, rhs: Self) -> Self {
         match (self, rhs) {
             (Self::NotAssigned, x) | (x, Self::NotAssigned) => x,
-            (Self::ErrorMultipleAssignments(s1, s2), _) | (_, Self::ErrorMultipleAssignments(s1, s2)) => {
-                Self::ErrorMultipleAssignments(s1, s2)
+            (Self::MultipleAssignmentsInBranch(s1, s2), _) | (_, Self::MultipleAssignmentsInBranch(s1, s2)) => {
+                Self::MultipleAssignmentsInBranch(s1, s2)
             }
             (Self::AtMostOncePerBranch(s), Self::AtMostOncePerBranch(_)) => Self::AtMostOncePerBranch(s),
         }

--- a/ir/pattern/mod.rs
+++ b/ir/pattern/mod.rs
@@ -10,7 +10,7 @@ use std::{
     fmt,
     hash::{Hash, Hasher},
     mem,
-    ops::{BitAnd, BitAndAssign, BitOr, BitXor},
+    ops::{BitAnd, BitAndAssign, BitOr, BitOrAssign, BitXor},
 };
 
 use answer::variable::Variable;
@@ -116,6 +116,12 @@ macro_rules! impl_pattern_from_pattern_variables {
     };
 }
 pub(self) use impl_pattern_from_pattern_variables;
+
+use crate::pattern::{
+    conjunction::{ConjunctionBuilder, NestedPatternBuilder},
+    constraint::Constraint,
+    disjunction::DisjunctionBuilder,
+};
 
 // TODO: rename to 'Identifier' in lieu of a better name
 #[derive(Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
@@ -566,6 +572,96 @@ impl PatternVariableModes {
 
     pub(crate) fn optionally_bound_by_pattern(&self) -> impl Iterator<Item = Variable> + '_ {
         self.0.iter().filter_map(|(v, required)| (*required == PatternVariableMode::OptionallyBinding).then_some(*v))
+    }
+}
+
+pub(crate) type LocationNote = Option<Span>;
+
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq)]
+pub(crate) enum AssignmentStatus {
+    #[default]
+    NotAssigned,
+    AtMostOncePerBranch(LocationNote),
+    ErrorMultipleAssignments(LocationNote, LocationNote),
+}
+
+impl AssignmentStatus {
+    pub(crate) fn for_conjunction(conjunction: &ConjunctionBuilder) -> HashMap<Variable, AssignmentStatus> {
+        let mut assignment_statuses = HashMap::new();
+        conjunction.constraints().iter().for_each(|constraint| {
+            let assigned_ids = match constraint {
+                Constraint::FunctionCallBinding(binding) => binding.ids_assigned().for_each(|id| {
+                    *assignment_statuses.entry(id).or_default() &=
+                        AssignmentStatus::AtMostOncePerBranch(constraint.source_span());
+                }),
+                Constraint::ExpressionBinding(binding) => binding.ids_assigned().for_each(|id| {
+                    *assignment_statuses.entry(id).or_default() &=
+                        AssignmentStatus::AtMostOncePerBranch(constraint.source_span());
+                }),
+                _ => return,
+            };
+        });
+        for nested in conjunction.nested_patterns() {
+            let nested_statuses = match nested {
+                NestedPatternBuilder::Negation(negation) => Self::for_conjunction(negation.conjunction()),
+                NestedPatternBuilder::Optional(optional) => Self::for_conjunction(optional.conjunction()),
+                NestedPatternBuilder::Disjunction(disjunction) => Self::for_disjunction(disjunction),
+            };
+            for (id, status) in nested_statuses {
+                *assignment_statuses.entry(id).or_default() &= status;
+            }
+        }
+        assignment_statuses
+    }
+
+    pub(crate) fn for_disjunction(disjunction: &DisjunctionBuilder) -> HashMap<Variable, AssignmentStatus> {
+        let mut assignment_statuses = HashMap::new();
+        for conjunction in disjunction.conjunctions() {
+            for (id, status) in Self::for_conjunction(conjunction) {
+                *assignment_statuses.entry(id).or_default() |= status;
+            }
+        }
+        assignment_statuses
+    }
+}
+
+impl BitAnd for AssignmentStatus {
+    type Output = Self;
+
+    fn bitand(self, rhs: Self) -> Self {
+        match (self, rhs) {
+            (Self::NotAssigned, x) | (x, Self::NotAssigned) => x,
+            (Self::ErrorMultipleAssignments(s1, s2), _) | (_, Self::ErrorMultipleAssignments(s1, s2)) => {
+                Self::ErrorMultipleAssignments(s1, s2)
+            }
+            (Self::AtMostOncePerBranch(s1), Self::AtMostOncePerBranch(s2)) => Self::ErrorMultipleAssignments(s1, s2),
+        }
+    }
+}
+
+impl BitOr for AssignmentStatus {
+    type Output = Self;
+
+    fn bitor(self, rhs: Self) -> Self {
+        match (self, rhs) {
+            (Self::NotAssigned, x) | (x, Self::NotAssigned) => x,
+            (Self::ErrorMultipleAssignments(s1, s2), _) | (_, Self::ErrorMultipleAssignments(s1, s2)) => {
+                Self::ErrorMultipleAssignments(s1, s2)
+            }
+            (Self::AtMostOncePerBranch(s), Self::AtMostOncePerBranch(_)) => Self::AtMostOncePerBranch(s),
+        }
+    }
+}
+
+impl BitAndAssign for AssignmentStatus {
+    fn bitand_assign(&mut self, rhs: Self) {
+        *self = *self & rhs;
+    }
+}
+
+impl BitOrAssign for AssignmentStatus {
+    fn bitor_assign(&mut self, rhs: Self) {
+        *self = *self | rhs;
     }
 }
 

--- a/ir/pipeline/block.rs
+++ b/ir/pipeline/block.rs
@@ -298,9 +298,13 @@ fn validate_expressions_assignments_are_unique(
 ) -> Result<(), Box<RepresentationError>> {
     let assignment_statuses = AssignmentStatus::for_conjunction(conjunction);
     for id in context.input_variables() {
-        if let Some(AssignmentStatus::AtMostOncePerBranch(source_span)) = assignment_statuses.get(&id).copied() {
-            let variable = context.get_variable_name_or_unnamed(id).to_owned();
-            return Err(Box::new(RepresentationError::AssigningToInputVariable { variable, source_span }));
+        match assignment_statuses.get(&id).copied() {
+            Some(AssignmentStatus::AtMostOncePerBranch(source_span))
+            | Some(AssignmentStatus::MultipleAssignmentsInBranch(source_span, _)) => {
+                let variable = context.get_variable_name_or_unnamed(id).to_owned();
+                return Err(Box::new(RepresentationError::AssigningToInputVariable { variable, source_span }));
+            }
+            Some(AssignmentStatus::NotAssigned) | None => (),
         }
     }
 

--- a/ir/pipeline/block.rs
+++ b/ir/pipeline/block.rs
@@ -305,7 +305,7 @@ fn validate_expressions_assignments_are_unique(
     }
 
     for (id, mode) in assignment_statuses {
-        if let AssignmentStatus::ErrorMultipleAssignments(source_span, other_span) = mode {
+        if let AssignmentStatus::MultipleAssignmentsInBranch(source_span, other_span) = mode {
             let variable = context.get_variable_name_or_unnamed(id).to_owned();
             return Err(Box::new(RepresentationError::MultipleAssignmentsForVariable {
                 variable,

--- a/ir/pipeline/block.rs
+++ b/ir/pipeline/block.rs
@@ -17,7 +17,7 @@ use typeql::common::Span;
 use crate::{
     RepresentationError,
     pattern::{
-        BindingMode, BranchID, Pattern, PatternVariableModes, ScopeId,
+        AssignmentStatus, BindingMode, BranchID, Pattern, PatternVariableModes, ScopeId,
         conjunction::{Conjunction, ConjunctionBuilder, ConjunctionBuilderWithContext, NestedPatternBuilder},
         constraint::Constraint,
         nested_pattern::NestedPattern,
@@ -78,6 +78,7 @@ impl<'reg> BlockBuilder<'reg> {
         validate_all_required_variables_can_be_bound(&self, &block_binding_modes, &self.context.variable_registry)?;
         validate_no_unbound_variable_categories(&self.conjunction, &self.context)?;
         validate_is_variables_have_same_category(&self.conjunction, &self.context.variable_registry)?;
+        validate_expressions_assignments_are_unique(&self.conjunction, &self.context)?;
 
         // Update
         block_binding_modes
@@ -93,7 +94,7 @@ impl<'reg> BlockBuilder<'reg> {
 
         let input_variables = self.context.input_variables().collect();
         validate_is_plannable(&conjunction, &input_variables, &self.context.variable_registry)?;
-        validate_expressions_assignments_are_unique(&conjunction, &input_variables, &self.context.variable_registry)?;
+
         let block_context = self.context.block_context;
         Ok(Block { conjunction, block_context })
     }
@@ -292,73 +293,25 @@ fn validate_optional_returns_recursive(
 }
 
 fn validate_expressions_assignments_are_unique(
-    conjunction: &Conjunction,
-    input_variables: &BTreeSet<Variable>,
-    variable_registry: &VariableRegistry,
+    conjunction: &ConjunctionBuilder,
+    context: &BlockBuilderContext<'_>,
 ) -> Result<(), Box<RepresentationError>> {
-    let mut assigned_in_block = BTreeMap::new();
-    validate_expressions_assignments_are_unique_impl(conjunction, &mut assigned_in_block, variable_registry)?;
-
-    if let Some((&variable, &source_span)) = assigned_in_block.iter().find(|(var, _)| input_variables.contains(var)) {
-        let variable = variable_registry.get_variable_name_or_unnamed(variable).to_owned();
-        Err(Box::new(RepresentationError::AssigningToInputVariable { variable, source_span }))
-    } else {
-        Ok(())
-    }
-}
-fn validate_expressions_assignments_are_unique_impl(
-    conjunction: &Conjunction,
-    assigned: &mut BTreeMap<Variable, Option<Span>>,
-    variable_registry: &VariableRegistry,
-) -> Result<(), Box<RepresentationError>> {
-    // TODO: Can we absorb this change into BindingModes if we introduce an "Assigned" variant?
-    fn add_or_error(
-        variable_registry: &VariableRegistry,
-        assigned: &mut BTreeMap<Variable, Option<Span>>,
-        (id, source_span): (Variable, Option<Span>),
-    ) -> Result<(), Box<RepresentationError>> {
-        if let Some(other_span) = assigned.insert(id, source_span) {
-            let variable = variable_registry.get_variable_name_or_unnamed(id).to_owned();
-            Err(Box::new(RepresentationError::MultipleAssignmentsForVariable { variable, source_span, other_span }))
-        } else {
-            Ok(())
+    let assignment_statuses = AssignmentStatus::for_conjunction(conjunction);
+    for id in context.input_variables() {
+        if let Some(AssignmentStatus::AtMostOncePerBranch(source_span)) = assignment_statuses.get(&id).copied() {
+            let variable = context.get_variable_name_or_unnamed(id).to_owned();
+            return Err(Box::new(RepresentationError::AssigningToInputVariable { variable, source_span }));
         }
     }
 
-    conjunction
-        .constraints()
-        .iter()
-        .filter_map(|constraint| constraint.as_expression_binding())
-        .flat_map(|expr| expr.ids_assigned().map(|id| (id, expr.source_span())))
-        .try_for_each(|id_span| add_or_error(variable_registry, assigned, id_span))?;
-
-    conjunction
-        .constraints()
-        .iter()
-        .filter_map(|constraint| constraint.as_function_call_binding())
-        .flat_map(|func_call| func_call.ids_assigned().map(|id| (id, func_call.source_span())))
-        .try_for_each(|id_span| add_or_error(variable_registry, assigned, id_span))?;
-
-    for nested in conjunction.nested_patterns() {
-        match nested {
-            NestedPattern::Optional(optional) => {
-                validate_expressions_assignments_are_unique_impl(optional.conjunction(), assigned, variable_registry)?;
-            }
-            NestedPattern::Negation(negation) => {
-                validate_expressions_assignments_are_unique_impl(negation.conjunction(), assigned, variable_registry)?;
-            }
-            NestedPattern::Disjunction(disjunction) => {
-                let mut disjunction_assigned = BTreeMap::new();
-                disjunction.conjunctions().iter().try_for_each(|branch| {
-                    let mut branch_assigned = BTreeMap::new();
-                    validate_expressions_assignments_are_unique_impl(branch, &mut branch_assigned, variable_registry)?;
-                    disjunction_assigned.extend(branch_assigned);
-                    Ok::<_, Box<RepresentationError>>(())
-                })?;
-                disjunction_assigned
-                    .into_iter()
-                    .try_for_each(|id_span| add_or_error(variable_registry, assigned, id_span))?;
-            }
+    for (id, mode) in assignment_statuses {
+        if let AssignmentStatus::ErrorMultipleAssignments(source_span, other_span) = mode {
+            let variable = context.get_variable_name_or_unnamed(id).to_owned();
+            return Err(Box::new(RepresentationError::MultipleAssignmentsForVariable {
+                variable,
+                source_span,
+                other_span,
+            }));
         }
     }
     Ok(())


### PR DESCRIPTION
## Product change and motivation
Validates that no variable is assigned to more than once in the same branch. Validating there are no circular assignments is done by the more general `validate_is_plannable` method.
