### PR TITLE
Non IR changes isolated for review

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5891,7 +5891,7 @@ dependencies = [
 [[package]]
 name = "typedb-protocol"
 version = "0.0.0"
-source = "git+https://github.com/typedb/typedb-protocol?rev=310fef4e4ed2e735ed0fb2dc3248b4a35e604806#310fef4e4ed2e735ed0fb2dc3248b4a35e604806"
+source = "git+https://github.com/typedb/typedb-protocol?rev=856a6598867aeb24f0b2e538b8f2634d4b7391d0#856a6598867aeb24f0b2e538b8f2634d4b7391d0"
 dependencies = [
  "prost",
  "tonic",
@@ -5953,7 +5953,7 @@ checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 [[package]]
 name = "typeql"
 version = "0.0.0"
-source = "git+https://github.com/typedb/typeql?rev=5485e04a51c79ad1d29477db7532003c84983751#5485e04a51c79ad1d29477db7532003c84983751"
+source = "git+https://github.com/typedb/typeql?rev=991ce54cf1414ee77192beb1381d012d2da5cd32#991ce54cf1414ee77192beb1381d012d2da5cd32"
 dependencies = [
  "chrono",
  "itertools 0.14.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -222,7 +222,7 @@ features = {}
 
 		[workspace.dependencies.typeql]
 			features = []
-			rev = "5485e04a51c79ad1d29477db7532003c84983751"
+			rev = "991ce54cf1414ee77192beb1381d012d2da5cd32"
 			git = "https://github.com/typedb/typeql"
 			default-features = false
 
@@ -493,7 +493,7 @@ features = {}
 
 		[workspace.dependencies.typedb-protocol]
 			features = []
-			rev = "310fef4e4ed2e735ed0fb2dc3248b4a35e604806"
+			rev = "856a6598867aeb24f0b2e538b8f2634d4b7391d0"
 			git = "https://github.com/typedb/typedb-protocol"
 			default-features = false
 

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -109,8 +109,8 @@ workspace_refs = use_repo_rule("@typedb_bazel_distribution//common/workspace_ref
 workspace_refs(
     name = "typedb_workspace_refs",
     workspace_commit_dict = {
-        "typedb_protocol+": "310fef4e4ed2e735ed0fb2dc3248b4a35e604806",
-        "typeql+": "5485e04a51c79ad1d29477db7532003c84983751",
+        "typedb_protocol+": "856a6598867aeb24f0b2e538b8f2634d4b7391d0",
+        "typeql+": "991ce54cf1414ee77192beb1381d012d2da5cd32",
     },
     workspace_tag_dict = {
 #        "typedb_protocol+": "3.12.0",
@@ -178,15 +178,15 @@ git_override(
 bazel_dep(name = "typeql", version = "0.0.0")
 git_override(
     module_name = "typeql",
-    remote = "https://github.com/typedb/typeql",
-    commit = "5485e04a51c79ad1d29477db7532003c84983751",
+    remote = "https://github.com/krishnangovindraj/typeql",
+    commit = "991ce54cf1414ee77192beb1381d012d2da5cd32",
 )
 
 bazel_dep(name = "typedb_protocol", version = "0.0.0")
 git_override(
     module_name = "typedb_protocol",
     remote = "https://github.com/typedb/typedb-protocol",
-    commit = "310fef4e4ed2e735ed0fb2dc3248b4a35e604806",
+    commit = "856a6598867aeb24f0b2e538b8f2634d4b7391d0",
 )
 
 bazel_dep(name = "typedb_behaviour", version = "0.0.0")

--- a/common/error/error.rs
+++ b/common/error/error.rs
@@ -386,6 +386,7 @@ pub enum UnimplementedFeature {
     LetInBuiltinCall,
     Subkey,
     OptionalFunctions,
+    OptionalArguments,
 
     UnsortedJoin,
 
@@ -460,4 +461,14 @@ macro_rules! needs_update_when_feature_is_implemented {
     // Nothing, we just need the compile error when the feature is deleted
     ($feature:path) => {};
     ($feature:path, $msg:literal) => {};
+}
+
+#[macro_export]
+macro_rules! optional_usage_error {
+    ($err:expr) => {
+        tracing::warn!(
+            "Deprecated usage of optional variable. This will fail in the next version:\n{}",
+            <_ as error::TypeDBError>::format_description(&$err)
+        );
+    };
 }

--- a/compiler/annotation/inference/type_seeder.rs
+++ b/compiler/annotation/inference/type_seeder.rs
@@ -202,6 +202,7 @@ impl<'this, Snapshot: ReadableSnapshot> TypeGraphSeedingContext<'this, Snapshot>
                 Constraint::RoleName(c) => c.apply(self, vertices)?,
                 Constraint::Value(c) => c.apply(self, vertices)?,
                 | Constraint::Iid(_)
+                | Constraint::IsSet(_)
                 | Constraint::Is(_)
                 | Constraint::Sub(_)
                 | Constraint::Isa(_)
@@ -427,6 +428,7 @@ impl<'this, Snapshot: ReadableSnapshot> TypeGraphSeedingContext<'this, Snapshot>
             Constraint::Plays(plays) => self.try_propagating_vertex_annotation_impl(plays, vertices)?,
             Constraint::Comparison(_) // Unlike in 2.x, We don't use comparisons to propagate.
             | Constraint::DeleteConcepts(_)
+            | Constraint::IsSet(_)
             | Constraint::Iid(_)
             | Constraint::ExpressionBinding(_)
             | Constraint::FunctionCallBinding(_)
@@ -546,6 +548,7 @@ impl<'this, Snapshot: ReadableSnapshot> TypeGraphSeedingContext<'this, Snapshot>
                 Constraint::Plays(plays) => edges.push(self.seed_edge(constraint, plays, vertices)?),
                 Constraint::DeleteConcepts(_)
                 | Constraint::Iid(_)
+                | Constraint::IsSet(_)
                 | Constraint::RoleName(_)
                 | Constraint::Label(_)
                 | Constraint::Kind(_)

--- a/compiler/annotation/inference/validation.rs
+++ b/compiler/annotation/inference/validation.rs
@@ -94,7 +94,8 @@ fn check_non_type_constraints_satisfiable(
         | Constraint::DeleteConcepts(_)
         | Constraint::Comparison(_) => true,
 
-        Constraint::Kind(_)
+        Constraint::IsSet(_)
+        | Constraint::Kind(_)
         | Constraint::Label(_)
         | Constraint::RoleName(_)
         | Constraint::Sub(_)

--- a/compiler/annotation/pipeline.rs
+++ b/compiler/annotation/pipeline.rs
@@ -29,7 +29,7 @@ use ir::{
     translation::pipeline::{TranslatedGiven, TranslatedStage},
 };
 use storage::snapshot::ReadableSnapshot;
-use typeql::common::Span;
+use typeql::{common::Span, type_::NamedTypeAny};
 
 use crate::{
     PipelineOrigin,
@@ -154,8 +154,9 @@ fn annotate_given_stage(
     )?;
     let optionality = variables
         .iter()
-        .map(|&variable| {
-            if ctx.variable_registry.is_variable_optional(variable) {
+        .zip(labels.iter())
+        .map(|(&variable, label)| {
+            if matches!(label, NamedTypeAny::Optional(_)) {
                 VariableOptionality::Optional
             } else {
                 VariableOptionality::Required

--- a/compiler/annotation/write_type_check.rs
+++ b/compiler/annotation/write_type_check.rs
@@ -109,6 +109,7 @@ fn check_type_combinations_for_write_conjunction(
             | Constraint::FunctionCallBinding(_)
             | Constraint::Is(_)
             | Constraint::DeleteConcepts(_)
+            | Constraint::IsSet(_)
             | Constraint::Comparison(_)
             | Constraint::Owns(_)
             | Constraint::Relates(_)

--- a/compiler/executable/delete/executable.rs
+++ b/compiler/executable/delete/executable.rs
@@ -44,25 +44,12 @@ pub fn compile(
     block_annotations: &BlockAnnotations,
     variable_registry: &VariableRegistry,
     block: &Block,
-    source_span: Option<Span>,
 ) -> Result<DeleteExecutable, Box<WriteCompilationError>> {
     let mut deletes = Vec::with_capacity(1 + block.conjunction().nested_patterns().len());
 
     let root_delete =
         ConditionalDelete::new(block.conjunction(), block_annotations, variable_registry, input_variables)?;
     deletes.push(root_delete);
-
-    let unsafely_used_optional_variable = block
-        .conjunction()
-        .constraints()
-        .iter()
-        .flat_map(|constraint| constraint.ids())
-        .find(|var| variable_registry.is_variable_optional(*var));
-
-    if let Some(var) = unsafely_used_optional_variable {
-        let variable = variable_registry.get_variable_name_or_unnamed(var).to_owned();
-        return Err(Box::new(WriteCompilationError::OptionalVariableUsedOutsideTry { source_span, variable }));
-    }
 
     for nested_pattern in block.conjunction().nested_patterns() {
         let NestedPattern::Optional(optional) = nested_pattern else {
@@ -200,6 +187,7 @@ fn add_connection_deletes(
             }
             Constraint::LinksDeduplication(_) | Constraint::RoleName(_) => (), // Ignore. It will have done its job during type-inference
             Constraint::DeleteConcepts(_) => (),                               // Is a ConceptInstruction
+            Constraint::IsSet(_) => (),                                        // TODO: Do we want these or not?
             Constraint::Iid(_)
             | Constraint::Isa(_)
             | Constraint::Kind(_)

--- a/compiler/executable/insert/executable.rs
+++ b/compiler/executable/insert/executable.rs
@@ -80,18 +80,6 @@ pub fn compile(
         variable_registry,
         source_span,
     )?;
-
-    let unsafely_used_optional_variable = block
-        .conjunction()
-        .constraints()
-        .iter()
-        .flat_map(|constraint| constraint.ids())
-        .find(|var| variable_registry.is_variable_optional(*var));
-
-    if let Some(var) = unsafely_used_optional_variable {
-        let variable = variable_registry.get_variable_name_or_unnamed(var).to_owned();
-        return Err(Box::new(WriteCompilationError::OptionalVariableUsedOutsideTry { source_span, variable }));
-    }
     let mut inserts = Vec::with_capacity(1 + block.conjunction().nested_patterns().len());
     inserts.push(root_insert);
     for nested_pattern in block.conjunction().nested_patterns() {

--- a/compiler/executable/match_/instructions/mod.rs
+++ b/compiler/executable/match_/instructions/mod.rs
@@ -609,7 +609,7 @@ pub enum CheckInstruction<ID> {
         player2: ID,
     },
     NotNone {
-        variables: Vec<ID>,
+        variable: ID,
     },
     Comparison {
         lhs: CheckVertex<ID>,
@@ -668,9 +668,7 @@ impl<ID: IrID> CheckInstruction<ID> {
                 role2: mapping[&role2],
                 player2: mapping[&player2],
             },
-            Self::NotNone { variables } => {
-                CheckInstruction::NotNone { variables: variables.iter().map(|v| mapping[&v]).collect() }
-            }
+            Self::NotNone { variable } => CheckInstruction::NotNone { variable: variable.map(mapping) },
             Self::Comparison { lhs, rhs, comparator } => {
                 CheckInstruction::Comparison { lhs: lhs.map(mapping), rhs: rhs.map(mapping), comparator }
             }
@@ -721,7 +719,7 @@ impl<ID: IrID> CheckInstruction<ID> {
             CheckInstruction::LinksDeduplication { role1, player1, role2, player2 } => {
                 Box::new([*role1, *player1, *role2, *player2].into_iter())
             }
-            CheckInstruction::NotNone { variables } => Box::new(variables.iter().copied()),
+            CheckInstruction::NotNone { variable } => Box::new([*variable].into_iter()),
             CheckInstruction::Comparison { lhs, rhs, .. } => {
                 Box::new(lhs.as_variable().into_iter().chain(rhs.as_variable().into_iter()))
             }
@@ -778,8 +776,8 @@ impl<ID: IrID> fmt::Display for CheckInstruction<ID> {
                     "{start_player} indexed_relation(role {start_role}->{relation}->role {end_role}) {end_player}",
                 )?;
             }
-            Self::NotNone { variables } => {
-                write!(f, "[{variables:?}] not_none")?;
+            Self::NotNone { variable } => {
+                write!(f, "isset ({variable:?})")?;
             }
             Self::Is { lhs, rhs } => {
                 write!(f, "{lhs} {} {rhs}", typeql::token::Keyword::Is)?;

--- a/compiler/executable/match_/instructions/mod.rs
+++ b/compiler/executable/match_/instructions/mod.rs
@@ -608,7 +608,7 @@ pub enum CheckInstruction<ID> {
         role2: ID,
         player2: ID,
     },
-    NotNone {
+    IsSet {
         variable: ID,
     },
     Comparison {
@@ -668,7 +668,7 @@ impl<ID: IrID> CheckInstruction<ID> {
                 role2: mapping[&role2],
                 player2: mapping[&player2],
             },
-            Self::NotNone { variable } => CheckInstruction::NotNone { variable: variable.map(mapping) },
+            Self::IsSet { variable } => CheckInstruction::IsSet { variable: variable.map(mapping) },
             Self::Comparison { lhs, rhs, comparator } => {
                 CheckInstruction::Comparison { lhs: lhs.map(mapping), rhs: rhs.map(mapping), comparator }
             }
@@ -719,7 +719,7 @@ impl<ID: IrID> CheckInstruction<ID> {
             CheckInstruction::LinksDeduplication { role1, player1, role2, player2 } => {
                 Box::new([*role1, *player1, *role2, *player2].into_iter())
             }
-            CheckInstruction::NotNone { variable } => Box::new([*variable].into_iter()),
+            CheckInstruction::IsSet { variable } => Box::new([*variable].into_iter()),
             CheckInstruction::Comparison { lhs, rhs, .. } => {
                 Box::new(lhs.as_variable().into_iter().chain(rhs.as_variable().into_iter()))
             }
@@ -776,7 +776,7 @@ impl<ID: IrID> fmt::Display for CheckInstruction<ID> {
                     "{start_player} indexed_relation(role {start_role}->{relation}->role {end_role}) {end_player}",
                 )?;
             }
-            Self::NotNone { variable } => {
+            Self::IsSet { variable } => {
                 write!(f, "isset ({variable:?})")?;
             }
             Self::Is { lhs, rhs } => {

--- a/compiler/executable/match_/planner/mod.rs
+++ b/compiler/executable/match_/planner/mod.rs
@@ -302,6 +302,7 @@ impl StepBuilder {
 struct ConjunctionExecutableBuilder {
     selected_variables: HashSet<Variable>,
     input_variables: Vec<Variable>,
+    unwrapped_variables: HashSet<Variable>,
     constraint_variables: HashSet<Variable>,
 
     current_outputs: HashSet<Variable>,
@@ -324,6 +325,7 @@ impl ConjunctionExecutableBuilder {
         assigned_positions: &HashMap<Variable, ExecutorVariable>,
         selected_variables: HashSet<Variable>,
         input_variables: Vec<Variable>,
+        unwrapped_variables: HashSet<Variable>,
         constraint_variables: HashSet<Variable>,
         planner_statistics: PlannerStatistics,
     ) -> Self {
@@ -343,6 +345,7 @@ impl ConjunctionExecutableBuilder {
             branch_id,
             selected_variables,
             input_variables,
+            unwrapped_variables,
             constraint_variables,
             current_outputs,
             produced_so_far,

--- a/compiler/executable/match_/planner/plan.rs
+++ b/compiler/executable/match_/planner/plan.rs
@@ -1986,7 +1986,6 @@ impl ConjunctionPlan<'_> {
         if pushed_any {
             conjunction_builder.finish_one();
         }
-        // self.check_optional_inputs(conjunction_builder, input_variables, variable_registry);
     }
 
     fn may_make_not_none_check(&self, conjunction_builder: &mut ConjunctionExecutableBuilder, variable: Variable) {
@@ -1995,29 +1994,6 @@ impl ConjunctionPlan<'_> {
             conjunction_builder.push_check(CheckInstruction::NotNone { variable });
         }
     }
-
-    // fn check_optional_inputs(
-    //     &self,
-    //     conjunction_builder: &mut ConjunctionExecutableBuilder,
-    //     input_variables: impl IntoIterator<Item = Variable>,
-    //     variable_registry: &VariableRegistry,
-    // ) {
-    //     // TODO: Deprecate because all these variables should be in the unwrapped_variables (or in a parent)
-    //     let mut optional_inputs_in_constraints = input_variables
-    //         .into_iter()
-    //         .filter(|&var| variable_registry.is_variable_optional(var))
-    //         .filter(|var| conjunction_builder.constraint_variables.contains(var))
-    //         .collect::<Vec<_>>();
-    //     if !optional_inputs_in_constraints.is_empty() {
-    //         optional_inputs_in_constraints.into_iter().for_each(|var| {
-    //             let variable = conjunction_builder.position(var);
-    //             conjunction_builder.push_check(CheckInstruction::NotNone { variable });
-    //         });
-    //         conjunction_builder.finish_one();
-    //     } else {
-    //         drop(optional_inputs_in_constraints);
-    //     }
-    // }
 }
 
 #[derive(Clone, Debug)]

--- a/compiler/executable/match_/planner/plan.rs
+++ b/compiler/executable/match_/planner/plan.rs
@@ -22,7 +22,8 @@ use ir::{
         conjunction::Conjunction,
         constraint::{
             Comparator, Comparison, Constraint, ExpressionBinding, FunctionCallBinding, Has, Iid, IndexedRelation, Is,
-            Isa, Kind, Label, Links, LinksDeduplication, Owns, Plays, Relates, RoleName, Sub, Unsatisfiable, Value,
+            IsSet, Isa, Kind, Label, Links, LinksDeduplication, Owns, Plays, Relates, RoleName, Sub, Unsatisfiable,
+            Value,
         },
         nested_pattern::NestedPattern,
         variable_category::VariableCategory,
@@ -247,6 +248,7 @@ impl VertexId {
 #[derive(Clone)]
 pub(super) struct ConjunctionPlanBuilder<'a> {
     required_inputs: Vec<Variable>,
+    unwrapped_variables: HashSet<Variable>,
     graph: Graph<'a>,
     local_annotations: &'a TypeAnnotations,
     statistics: &'a Statistics,
@@ -267,6 +269,7 @@ impl<'a> ConjunctionPlanBuilder<'a> {
             statistics,
             planner_statistics: PlannerStatistics::new(),
             required_inputs,
+            unwrapped_variables: HashSet::new(),
         }
     }
 
@@ -394,6 +397,7 @@ impl<'a> ConjunctionPlanBuilder<'a> {
                 Constraint::DeleteConcepts(_) => {
                     debug_assert!(false, "DeleteConcepts can only appear in delete blocks")
                 }
+                Constraint::IsSet(is_set) => self.register_is_set(&is_set),
             }
         }
     }
@@ -527,6 +531,10 @@ impl<'a> ConjunctionPlanBuilder<'a> {
             self.local_annotations,
             self.statistics,
         ));
+    }
+
+    fn register_is_set(&mut self, is_set: &'a IsSet<Variable>) {
+        self.unwrapped_variables.extend(is_set.ids());
     }
 
     fn register_links_deduplication(&mut self, links_deduplication: &'a LinksDeduplication<Variable>) {
@@ -704,11 +712,12 @@ impl<'a> ConjunctionPlanBuilder<'a> {
 
         let element_to_order = ordering.iter().copied().enumerate().map(|(order, index)| (index, order)).collect();
 
-        let Self { graph, local_annotations: type_annotations, mut planner_statistics, .. } = self;
+        let Self { graph, unwrapped_variables, local_annotations: type_annotations, mut planner_statistics, .. } = self;
 
         planner_statistics.finalize(cost);
         Ok(ConjunctionPlan {
             graph,
+            unwrapped_variables,
             local_annotations: type_annotations,
             ordering,
             metadata,
@@ -1250,6 +1259,7 @@ pub(crate) struct ConjunctionPlan<'a> {
     metadata: HashMap<PatternVertexId, CostMetaData>,
     element_to_order: HashMap<VertexId, usize>,
     pub(crate) planner_statistics: PlannerStatistics,
+    unwrapped_variables: HashSet<Variable>,
 }
 
 impl fmt::Debug for ConjunctionPlan<'_> {
@@ -1273,6 +1283,7 @@ impl ConjunctionPlan<'_> {
             already_assigned_positions,
             selected_variables.clone(),
             input_variables.clone().into_iter().collect(),
+            self.unwrapped_variables.clone(),
             self.constraint_variables().collect(),
             self.planner_statistics,
         );
@@ -1286,6 +1297,7 @@ impl ConjunctionPlan<'_> {
             match index {
                 VertexId::Variable(var) => {
                     self.may_make_variable_producing_step(&mut conjunction_builder, var, variable_registry)?;
+                    self.may_make_not_none_check(&mut conjunction_builder, self.graph.index_to_variable[&var]);
                 }
                 VertexId::Pattern(pattern) => {
                     for input in self.inputs_of_pattern(pattern) {
@@ -1974,30 +1986,38 @@ impl ConjunctionPlan<'_> {
         if pushed_any {
             conjunction_builder.finish_one();
         }
-        self.check_optional_inputs(conjunction_builder, input_variables, variable_registry);
+        // self.check_optional_inputs(conjunction_builder, input_variables, variable_registry);
     }
 
-    fn check_optional_inputs(
-        &self,
-        conjunction_builder: &mut ConjunctionExecutableBuilder,
-        input_variables: impl IntoIterator<Item = Variable>,
-        variable_registry: &VariableRegistry,
-    ) {
-        let mut optional_inputs_in_constraints = input_variables
-            .into_iter()
-            .filter(|&var| variable_registry.is_variable_optional(var))
-            .filter(|var| conjunction_builder.constraint_variables.contains(var))
-            .peekable();
-        if optional_inputs_in_constraints.peek().is_some() {
-            let instruction = CheckInstruction::NotNone {
-                variables: optional_inputs_in_constraints.map(|var| conjunction_builder.position(var)).collect(),
-            };
-            conjunction_builder.push_check(instruction);
-            conjunction_builder.finish_one();
-        } else {
-            drop(optional_inputs_in_constraints);
+    fn may_make_not_none_check(&self, conjunction_builder: &mut ConjunctionExecutableBuilder, variable: Variable) {
+        if conjunction_builder.unwrapped_variables.contains(&variable) {
+            let variable = conjunction_builder.position(variable);
+            conjunction_builder.push_check(CheckInstruction::NotNone { variable });
         }
     }
+
+    // fn check_optional_inputs(
+    //     &self,
+    //     conjunction_builder: &mut ConjunctionExecutableBuilder,
+    //     input_variables: impl IntoIterator<Item = Variable>,
+    //     variable_registry: &VariableRegistry,
+    // ) {
+    //     // TODO: Deprecate because all these variables should be in the unwrapped_variables (or in a parent)
+    //     let mut optional_inputs_in_constraints = input_variables
+    //         .into_iter()
+    //         .filter(|&var| variable_registry.is_variable_optional(var))
+    //         .filter(|var| conjunction_builder.constraint_variables.contains(var))
+    //         .collect::<Vec<_>>();
+    //     if !optional_inputs_in_constraints.is_empty() {
+    //         optional_inputs_in_constraints.into_iter().for_each(|var| {
+    //             let variable = conjunction_builder.position(var);
+    //             conjunction_builder.push_check(CheckInstruction::NotNone { variable });
+    //         });
+    //         conjunction_builder.finish_one();
+    //     } else {
+    //         drop(optional_inputs_in_constraints);
+    //     }
+    // }
 }
 
 #[derive(Clone, Debug)]

--- a/compiler/executable/match_/planner/plan.rs
+++ b/compiler/executable/match_/planner/plan.rs
@@ -1297,7 +1297,7 @@ impl ConjunctionPlan<'_> {
             match index {
                 VertexId::Variable(var) => {
                     self.may_make_variable_producing_step(&mut conjunction_builder, var, variable_registry)?;
-                    self.may_make_not_none_check(&mut conjunction_builder, self.graph.index_to_variable[&var]);
+                    self.may_make_is_set_check(&mut conjunction_builder, self.graph.index_to_variable[&var]);
                 }
                 VertexId::Pattern(pattern) => {
                     for input in self.inputs_of_pattern(pattern) {
@@ -1988,10 +1988,10 @@ impl ConjunctionPlan<'_> {
         }
     }
 
-    fn may_make_not_none_check(&self, conjunction_builder: &mut ConjunctionExecutableBuilder, variable: Variable) {
+    fn may_make_is_set_check(&self, conjunction_builder: &mut ConjunctionExecutableBuilder, variable: Variable) {
         if conjunction_builder.unwrapped_variables.contains(&variable) {
             let variable = conjunction_builder.position(variable);
-            conjunction_builder.push_check(CheckInstruction::NotNone { variable });
+            conjunction_builder.push_check(CheckInstruction::IsSet { variable });
         }
     }
 }

--- a/compiler/executable/mod.rs
+++ b/compiler/executable/mod.rs
@@ -54,7 +54,7 @@ impl RequiredVariablesForWrite {
                 .constraints()
                 .iter()
                 .flat_map(|constraint| constraint.ids())
-                .filter(|id| conjunction.is_input(id) && variable_registry.is_variable_optional(*id))
+                .filter(|id| conjunction.is_input(id) && todo!("conjunction.is_optional(*id)"))
                 .filter_map(|id| variable_positions.get(&id).copied())
                 .collect(),
         )

--- a/compiler/executable/pipeline.rs
+++ b/compiler/executable/pipeline.rs
@@ -371,13 +371,12 @@ fn compile_stage(
                 match_annotations.referenced_types(),
             ))
         }
-        AnnotatedStage::Delete { block, annotations, source_span } => {
+        AnnotatedStage::Delete { block, annotations, .. } => {
             let plan = crate::executable::delete::executable::compile(
                 stage_input_positions,
                 annotations,
                 variable_registry,
                 block,
-                *source_span,
             )
             .map_err(|typedb_source| ExecutableCompilationError::DeleteExecutableCompilation { typedb_source })?;
             Ok((ExecutableStage::Delete(Arc::new(plan)), BTreeSet::new()))

--- a/compiler/executable/update/executable.rs
+++ b/compiler/executable/update/executable.rs
@@ -53,18 +53,6 @@ pub fn compile(
     variable_registry: &VariableRegistry,
     source_span: Option<Span>,
 ) -> Result<UpdateExecutable, Box<WriteCompilationError>> {
-    let unsafely_used_optional_variable = block
-        .conjunction()
-        .constraints()
-        .iter()
-        .flat_map(|constraint| constraint.ids())
-        .find(|var| variable_registry.is_variable_optional(*var));
-
-    if let Some(var) = unsafely_used_optional_variable {
-        let variable = variable_registry.get_variable_name_or_unnamed(var).to_owned();
-        return Err(Box::new(WriteCompilationError::OptionalVariableUsedOutsideTry { source_span, variable }));
-    }
-
     let mut variable_positions = input_variable_positions.clone();
     let root_update = ConditionalUpdate::new(
         block.conjunction(),

--- a/compiler/executable/update/type_check.rs
+++ b/compiler/executable/update/type_check.rs
@@ -53,6 +53,7 @@ pub fn check_annotations(
                 )?;
             }
             Constraint::DeleteConcepts(_)
+            | Constraint::IsSet(_)
             | Constraint::Isa(_)
             | Constraint::Is(_)
             | Constraint::Comparison(_)

--- a/executor/instruction/checker.rs
+++ b/executor/instruction/checker.rs
@@ -271,7 +271,7 @@ impl<T> Checker<T> {
                 &CheckInstruction::LinksDeduplication { role1, player1, role2, player2 } => {
                     self.filter_links_dedup_fn(row, role1, player1, role2, player2)
                 }
-                CheckInstruction::NotNone { variables } => self.filter_not_none_fn(context, row, variables),
+                CheckInstruction::NotNone { variable } => self.filter_not_none_fn(context, row, *variable),
                 &CheckInstruction::Is { lhs, rhs } => self.filter_is_fn(row, lhs, rhs),
                 CheckInstruction::Comparison { lhs, rhs, comparator } => {
                     self.filter_comparison_fn(context, row, lhs, rhs, *comparator, storage_counters.clone())
@@ -622,11 +622,10 @@ impl<T> Checker<T> {
         &self,
         context: &ExecutionContext<impl ReadableSnapshot + 'static>,
         row: &MaybeOwnedRow<'_>,
-        variables: &[ExecutorVariable],
+        variable: ExecutorVariable,
     ) -> Box<dyn Fn(&T) -> Result<bool, Box<ConceptReadError>>> {
-        let extractors: Vec<_> =
-            variables.iter().map(|var| self.make_extractor(&CheckVertex::Variable(*var), row, context)).collect();
-        Box::new(move |value: &T| Ok(extractors.iter().all(|extractor| !extractor(value).is_none())))
+        let extractor = self.make_extractor(&CheckVertex::Variable(variable), row, context);
+        Box::new(move |value: &T| Ok(!extractor(value).is_none()))
     }
 
     fn filter_comparison_fn(
@@ -745,7 +744,7 @@ impl Checker<()> {
                 CheckInstruction::Comparison { lhs, rhs, comparator } => {
                     Self::filter_comparison(context, row, lhs, rhs, *comparator, storage_counters.clone())?
                 }
-                CheckInstruction::NotNone { variables } => Self::filter_not_none(row, variables),
+                CheckInstruction::NotNone { variable } => Self::filter_not_none(row, *variable),
                 CheckInstruction::Unsatisfiable => false,
             };
             if !passes {
@@ -961,11 +960,10 @@ impl Checker<()> {
         !(role1 == role2 && player1 == player2)
     }
 
-    fn filter_not_none(row: &MaybeOwnedRow<'_>, variables: &[ExecutorVariable]) -> bool {
-        variables.iter().all(|var| {
-            let value = get_variable_value(Some(row), var);
-            !value.is_none()
-        })
+    fn filter_not_none(row: &MaybeOwnedRow<'_>, variable: ExecutorVariable) -> bool {
+        let ExecutorVariable::RowPosition(pos) = variable else { unreachable!() };
+        let value = row.get(pos);
+        !value.is_none()
     }
 
     fn filter_comparison(

--- a/executor/instruction/checker.rs
+++ b/executor/instruction/checker.rs
@@ -271,7 +271,7 @@ impl<T> Checker<T> {
                 &CheckInstruction::LinksDeduplication { role1, player1, role2, player2 } => {
                     self.filter_links_dedup_fn(row, role1, player1, role2, player2)
                 }
-                CheckInstruction::NotNone { variable } => self.filter_not_none_fn(context, row, *variable),
+                CheckInstruction::IsSet { variable } => self.filter_is_set_fn(context, row, *variable),
                 &CheckInstruction::Is { lhs, rhs } => self.filter_is_fn(row, lhs, rhs),
                 CheckInstruction::Comparison { lhs, rhs, comparator } => {
                     self.filter_comparison_fn(context, row, lhs, rhs, *comparator, storage_counters.clone())
@@ -618,7 +618,7 @@ impl<T> Checker<T> {
         Box::new(move |value: &T| Ok(!(role1(value) == role2(value) && player1(value) == player2(value))))
     }
 
-    fn filter_not_none_fn(
+    fn filter_is_set_fn(
         &self,
         context: &ExecutionContext<impl ReadableSnapshot + 'static>,
         row: &MaybeOwnedRow<'_>,
@@ -744,7 +744,7 @@ impl Checker<()> {
                 CheckInstruction::Comparison { lhs, rhs, comparator } => {
                     Self::filter_comparison(context, row, lhs, rhs, *comparator, storage_counters.clone())?
                 }
-                CheckInstruction::NotNone { variable } => Self::filter_not_none(row, *variable),
+                CheckInstruction::IsSet { variable } => Self::filter_is_set(row, *variable),
                 CheckInstruction::Unsatisfiable => false,
             };
             if !passes {
@@ -960,7 +960,7 @@ impl Checker<()> {
         !(role1 == role2 && player1 == player2)
     }
 
-    fn filter_not_none(row: &MaybeOwnedRow<'_>, variable: ExecutorVariable) -> bool {
+    fn filter_is_set(row: &MaybeOwnedRow<'_>, variable: ExecutorVariable) -> bool {
         let ExecutorVariable::RowPosition(pos) = variable else { unreachable!() };
         let value = row.get(pos);
         !value.is_none()

--- a/executor/tests/writes.rs
+++ b/executor/tests/writes.rs
@@ -288,7 +288,6 @@ fn execute_delete<Snapshot: WritableSnapshot + 'static>(
         &block_annotations,
         &translation_context.variable_registry,
         &block,
-        None,
     )
     .unwrap();
 

--- a/ir/lib.rs
+++ b/ir/lib.rs
@@ -233,6 +233,19 @@ typedb_error! {
             "The variable '{variable_name}' cannot be declared as both a 'Value' and as a 'Attribute'. Consider using '==' for a value-only comparison instead.",
             variable_name: String,
         ),
+        UnsafeOptionalDereference(
+            36,
+            "The optional variable '{variable}' was used in a context where it may fail the branch if unset. Please acknowledge the optionality.",
+            variable: String,
+            source_span: Option<Span>,
+        ),
+        MultipleAssignmentsForVariable(
+            37,
+            "Variable '{variable}' cannot be assigned to multiple times in the same branch.",
+            variable: String,
+            source_span: Option<Span>,
+            other_span: Option<Span>,
+        ),
         UpdateVariableUnavailable(
             39,
             "The variable '{variable}' referenced in the update stage is unavailable. It should be bound in the previous stage.",
@@ -270,7 +283,7 @@ typedb_error! {
         ),
         IllegalStatementForInsert(
             45,
-            "Illegal statement provided for an insert stage. Only 'has', 'links' and 'isa' constraints are allowed.",
+            "Illegal statement provided for an insert stage. Only 'has', 'links', 'isa' and 'isset' constraints are allowed.",
             source_span: Option<Span>,
         ),
         IllegalNestedPatternForInsert(
@@ -325,14 +338,6 @@ typedb_error! {
             unplannable_constraints: UnplannableConstraints,
             span: Option<Span>,
         ),
-        MultipleAssignmentsForVariable(
-            56,
-            "Variable '{variable}' cannot be assigned to multiple times in the same branch.",
-            variable: String,
-            source_span: Option<Span>,
-            other_span: Option<Span>,
-        ),
-
         InternalNotAValueBuiltin(
             100,
             "Attempted to translate function '{token}' as a builtin value function.",

--- a/ir/pattern/conjunction.rs
+++ b/ir/pattern/conjunction.rs
@@ -82,7 +82,7 @@ impl Conjunction {
         Box<RepresentationError>,
     > {
         let (new_checks, constraint_mapping, variable_mapping) =
-            self.constraints.make_variables_unique(variable_registry)?;
+            self.constraints.make_variables_unique(variable_registry, &mut self.pattern_variables)?;
         for (new_var, old_var) in &variable_mapping {
             if let Some(value) = self.pattern_variables.0.get(old_var).cloned() {
                 self.pattern_variables.0.insert(*new_var, value);
@@ -186,7 +186,10 @@ impl ConjunctionBuilder {
     }
 
     pub(crate) fn variable_binding_modes(&self) -> HashMap<Variable, BindingMode> {
-        let mut binding_modes = self.constraints.variable_binding_modes();
+        let mut binding_modes = HashMap::new();
+        self.constraints.variable_binding_modes().for_each(|(id, mode)| {
+            *binding_modes.entry(id).or_default() &= mode;
+        });
         for nested in self.nested_patterns.iter() {
             let nested_pattern_modes = nested.variable_binding_modes();
             for (var, mode) in nested_pattern_modes {

--- a/ir/pattern/constraint.rs
+++ b/ir/pattern/constraint.rs
@@ -14,6 +14,7 @@ use std::{
 };
 
 use answer::variable::Variable;
+use error::todo_must_implement;
 use itertools::Itertools;
 use structural_equality::StructuralEquality;
 use typeql::common::Span;
@@ -21,14 +22,12 @@ use typeql::common::Span;
 use crate::{
     LiteralParseError, RepresentationError,
     pattern::{
-        AssignedVariable, BindingMode, IrID, ParameterID, ScopeId, ValueType, Vertex,
+        AssignedVariable, BindingMode, IrID, ParameterID, PatternVariableMode, PatternVariableModes, ScopeId,
+        ValueType, Vertex,
         conjunction::Conjunction,
         expression::{ExpressionRepresentationError, ExpressionTree},
         function_call::FunctionCall,
-        variable_category::{
-            VariableCategory, VariableOptionality,
-            VariableOptionality::{Optional, Required},
-        },
+        variable_category::{VariableCategory, VariableOptionality},
     },
     pipeline::{
         ParameterRegistry, VariableRegistry, block::BlockBuilderContext, function_signature::FunctionSignature,
@@ -71,18 +70,14 @@ impl Constraints {
         self.constraints.last().unwrap()
     }
 
-    pub(crate) fn variable_binding_modes(&self) -> HashMap<Variable, BindingMode> {
-        self.constraints().iter().fold(HashMap::new(), |mut acc, constraint| {
-            constraint.binding_modes().for_each(|(var, mode)| {
-                *acc.entry(var).or_default() &= mode;
-            });
-            acc
-        })
+    pub(crate) fn variable_binding_modes(&self) -> impl Iterator<Item = (Variable, BindingMode)> + '_ {
+        self.constraints().iter().flat_map(|constraint| constraint.variable_binding_modes())
     }
 
     pub(super) fn make_variables_unique(
         &mut self,
         variable_registry: &mut VariableRegistry,
+        pattern_variables: &mut PatternVariableModes,
     ) -> Result<
         (Vec<Constraint<Variable>>, HashMap<Constraint<Variable>, Constraint<Variable>>, HashMap<Variable, Variable>),
         Box<RepresentationError>,
@@ -103,6 +98,7 @@ impl Constraints {
                     Is::new(old_var, *var, None).into()
                 };
                 variable_mapping.insert(*var, old_var);
+                pattern_variables.0.insert(*var, PatternVariableMode::Binding);
                 check_collector.push(check);
             }
             Ok::<(), Box<RepresentationError>>(())
@@ -177,6 +173,7 @@ impl Constraints {
                 | Constraint::Value(_)
                 | Constraint::Comparison(_)
                 | Constraint::DeleteConcepts(_)
+                | Constraint::IsSet(_)
                 | Constraint::LinksDeduplication(_)
                 | Constraint::Unsatisfiable(_) => {}
             }
@@ -300,6 +297,16 @@ impl<'cx, 'reg> ConstraintsBuilder<'cx, 'reg> {
         let delete_concepts = DeleteConcepts::new(variables, source_span);
         let constraint = self.constraints.add_constraint(delete_concepts);
         constraint.as_delete_concepts().unwrap()
+    }
+
+    pub fn add_is_set(
+        &mut self,
+        variables: Vec<Variable>,
+        source_span: Option<Span>,
+    ) -> Result<&IsSet<Variable>, Box<RepresentationError>> {
+        let is_set = IsSet::new(variables, source_span);
+        let constraint = self.constraints.add_constraint(is_set);
+        Ok(constraint.as_is_set().unwrap())
     }
 
     pub fn add_isa(
@@ -434,12 +441,7 @@ impl<'cx, 'reg> ConstraintsBuilder<'cx, 'reg> {
             },
         );
         if let Err(err) = mismatched_optionality_in_assignment {
-            // TODO: This has to wait till we finalize the spec
-            // use error::TypeDBError;
-            // tracing::warn!(
-            //     "The declared optionality of a variable assigned to by a function call did not match the optionality of the function return. This will fail in the next version:\n{}",
-            //     err.format_description()
-            // );
+            error::optional_usage_error!(err)
         }
 
         let function_call =
@@ -448,7 +450,6 @@ impl<'cx, 'reg> ConstraintsBuilder<'cx, 'reg> {
         for (index, var) in binding.ids_assigned().enumerate() {
             self.context.set_variable_category(var, callee_signature.returns[index].0, binding.clone().into())?;
         }
-        binding.optionally_assigned.iter().for_each(|var| self.context.set_variable_optionality(*var, true));
         for (callee_arg_index, caller_var) in binding.function_call.argument_ids().enumerate() {
             self.context.set_variable_category(
                 caller_var,
@@ -462,7 +463,7 @@ impl<'cx, 'reg> ConstraintsBuilder<'cx, 'reg> {
 
     pub fn add_function_binding(
         &mut self,
-        assigned: Vec<AssignedVariable>,
+        mut assigned: Vec<AssignedVariable>,
         callee_signature: &FunctionSignature,
         arguments: Vec<Variable>,
         function_name: &str,
@@ -489,20 +490,18 @@ impl<'cx, 'reg> ConstraintsBuilder<'cx, 'reg> {
             },
         );
         if let Err(err) = mismatched_optionality_in_assignment {
-            // TODO: This has to wait till we finalize the spec
-            // use error::TypeDBError;
-            // tracing::warn!(
-            //     "The declared optionality of a variable assigned to by a function call did not match the optionality of the function return. This will fail in the next version:\n{}",
-            //     err.format_description()
-            // );
-        }
+            // TODO Remove when we commit to erroring.
+            for (assigned_var, (_, optionality)) in assigned.iter_mut().zip(callee_signature.returns.iter()) {
+                assigned_var.optionality = *optionality;
+            }
+            error::optional_usage_error!(err)
+        };
         let function_call =
             self.create_function_call(&assigned, callee_signature, arguments, function_name, source_span)?;
         let binding = FunctionCallBinding::new(assigned, function_call, callee_signature.return_is_stream, source_span);
         for (index, var) in binding.ids_assigned().enumerate() {
             self.context.set_variable_category(var, callee_signature.returns[index].0, binding.clone().into())?;
         }
-        binding.optionally_assigned.iter().for_each(|var| self.context.set_variable_optionality(*var, true));
         for (callee_arg_index, caller_var) in binding.function_call.argument_ids().enumerate() {
             self.context.set_variable_category(
                 caller_var,
@@ -693,6 +692,7 @@ pub enum Constraint<ID> {
     Value(Value<ID>),
 
     DeleteConcepts(DeleteConcepts<ID>),
+    IsSet(IsSet<ID>),
     LinksDeduplication(LinksDeduplication<ID>),
     Unsatisfiable(Unsatisfiable),
 }
@@ -717,6 +717,7 @@ impl<ID: IrID> Constraint<ID> {
             Constraint::Plays(_) => typeql::token::Keyword::Plays.as_str(),
             Constraint::Value(_) => typeql::token::Keyword::Value.as_str(),
             Constraint::DeleteConcepts(_) => "delete-concepts",
+            Constraint::IsSet(_) => typeql::token::Keyword::IsSet.as_str(),
 
             Constraint::RoleName(_) => "role-name",
             Constraint::LinksDeduplication(_) => "links-deduplication",
@@ -744,22 +745,24 @@ impl<ID: IrID> Constraint<ID> {
             Constraint::Plays(plays) => Box::new(plays.ids()),
             Constraint::Value(value) => Box::new(value.ids()),
             Constraint::DeleteConcepts(inner) => Box::new(inner.ids()),
+            Constraint::IsSet(is_set) => Box::new(is_set.ids()),
             Constraint::LinksDeduplication(dedup) => Box::new(dedup.ids()),
             Constraint::Unsatisfiable(inner) => Box::new(inner.ids()),
         }
     }
 
-    pub fn binding_modes(&self) -> Box<dyn Iterator<Item = (ID, BindingMode)> + '_> {
+    pub fn variable_binding_modes(&self) -> Box<dyn Iterator<Item = (ID, BindingMode)> + '_> {
         fn _all_binding<'a, ID1>(
             it: impl Iterator<Item = ID1> + 'a,
         ) -> Box<dyn Iterator<Item = (ID1, BindingMode)> + 'a> {
-            Box::new(it.map(|id| (id, BindingMode::AlwaysBinding)))
+            Box::new(it.map(move |id| (id, BindingMode::AlwaysBinding)))
         }
         fn _all_required<'a, ID1>(
             it: impl Iterator<Item = ID1> + 'a,
         ) -> Box<dyn Iterator<Item = (ID1, BindingMode)> + 'a> {
-            Box::new(it.map(|id| (id, BindingMode::RequirePrebound)))
+            Box::new(it.map(move |id| (id, BindingMode::RequirePrebound)))
         }
+        let span = self.source_span();
         match self {
             Constraint::Kind(kind) => _all_binding(kind.ids()),
             Constraint::Label(label) => _all_binding(label.ids()),
@@ -777,6 +780,7 @@ impl<ID: IrID> Constraint<ID> {
 
             Constraint::Comparison(comparison) => _all_required(comparison.ids()),
             Constraint::Is(is) => _all_binding(is.ids()),
+            Constraint::IsSet(inner) => _all_required(inner.ids()),
 
             Constraint::DeleteConcepts(inner) => _all_required(inner.ids()),
             Constraint::Unsatisfiable(inner) => _all_binding(inner.ids()),
@@ -807,6 +811,7 @@ impl<ID: IrID> Constraint<ID> {
             Constraint::Plays(plays) => Box::new(plays.vertices()),
             Constraint::Value(value) => Box::new(value.vertices()),
             Constraint::DeleteConcepts(inner) => Box::new(inner.vertices()),
+            Constraint::IsSet(is_set) => Box::new(is_set.vertices()),
             Constraint::LinksDeduplication(dedup) => Box::new(dedup.vertices()),
             Constraint::Unsatisfiable(inner) => Box::new(inner.vertices()),
         }
@@ -835,6 +840,7 @@ impl<ID: IrID> Constraint<ID> {
             Self::Plays(plays) => plays.ids_foreach(function),
             Self::Value(value) => value.ids_foreach(function),
             Self::DeleteConcepts(inner) => inner.ids_foreach(function),
+            Self::IsSet(require) => require.ids_foreach(function),
             Self::LinksDeduplication(dedup) => dedup.ids_foreach(function),
             Self::Unsatisfiable(inner) => inner.ids_foreach(function),
         }
@@ -860,6 +866,7 @@ impl<ID: IrID> Constraint<ID> {
             Self::Plays(inner) => Constraint::Plays(inner.map(mapping)),
             Self::Value(inner) => Constraint::Value(inner.map(mapping)),
             Self::DeleteConcepts(inner) => Constraint::DeleteConcepts(inner.map(mapping)),
+            Self::IsSet(inner) => Constraint::IsSet(inner.map(mapping)),
             Self::LinksDeduplication(inner) => Constraint::LinksDeduplication(inner.map(mapping)),
             Self::Unsatisfiable(inner) => Constraint::Unsatisfiable(inner.map(mapping)),
         }
@@ -885,6 +892,7 @@ impl<ID: IrID> Constraint<ID> {
             Constraint::Plays(inner) => inner.source_span(),
             Constraint::Value(inner) => inner.source_span(),
             Constraint::DeleteConcepts(inner) => inner.source_span(),
+            Constraint::IsSet(inner) => inner.source_span(),
             Constraint::LinksDeduplication(inner) => None,
             Constraint::Unsatisfiable(inner) => None,
         }
@@ -928,6 +936,13 @@ impl<ID: IrID> Constraint<ID> {
     pub fn as_delete_concepts(&self) -> Option<&DeleteConcepts<ID>> {
         match self {
             Constraint::DeleteConcepts(inner) => Some(inner),
+            _ => None,
+        }
+    }
+
+    pub(crate) fn as_is_set(&self) -> Option<&IsSet<ID>> {
+        match self {
+            Constraint::IsSet(is_set) => Some(is_set),
             _ => None,
         }
     }
@@ -1046,6 +1061,7 @@ impl<ID: StructuralEquality + Ord> StructuralEquality for Constraint<ID> {
                 Self::Plays(inner) => inner.hash(),
                 Self::Value(inner) => inner.hash(),
                 Self::DeleteConcepts(inner) => inner.hash(),
+                Self::IsSet(inner) => inner.hash(),
                 Self::LinksDeduplication(inner) => inner.hash(),
                 Self::Unsatisfiable(inner) => StructuralEquality::hash(&inner),
             }
@@ -1071,6 +1087,7 @@ impl<ID: StructuralEquality + Ord> StructuralEquality for Constraint<ID> {
             (Self::Plays(inner), Self::Plays(other_inner)) => inner.equals(other_inner),
             (Self::Value(inner), Self::Value(other_inner)) => inner.equals(other_inner),
             (Self::DeleteConcepts(inner), Self::DeleteConcepts(other_inner)) => inner.equals(other_inner),
+            (Self::IsSet(inner), Self::IsSet(other_inner)) => inner.equals(other_inner),
             (Self::LinksDeduplication(inner), Self::LinksDeduplication(other_inner)) => inner.equals(other_inner),
             (Self::Unsatisfiable(inner), Self::Unsatisfiable(other_inner)) => inner.equals(other_inner),
             // note: this style forces updating the match when the variants change
@@ -1092,6 +1109,7 @@ impl<ID: StructuralEquality + Ord> StructuralEquality for Constraint<ID> {
             | (Self::Plays { .. }, _)
             | (Self::Value { .. }, _)
             | (Self::DeleteConcepts { .. }, _)
+            | (Self::IsSet { .. }, _)
             | (Self::LinksDeduplication { .. }, _)
             | (Self::Unsatisfiable(_), _) => false,
         }
@@ -1119,6 +1137,7 @@ impl<ID: IrID> fmt::Display for Constraint<ID> {
             Self::Plays(constraint) => fmt::Display::fmt(constraint, f),
             Self::Value(constraint) => fmt::Display::fmt(constraint, f),
             Self::DeleteConcepts(constraint) => fmt::Display::fmt(constraint, f),
+            Self::IsSet(constraint) => fmt::Display::fmt(constraint, f),
             Self::LinksDeduplication(constraint) => fmt::Display::fmt(constraint, f),
             Self::Unsatisfiable(constraint) => fmt::Display::fmt(constraint, f),
         }
@@ -2282,7 +2301,7 @@ impl<ID: IrID> fmt::Display for ExpressionBinding<ID> {
 #[derive(Debug, Clone, Eq, PartialEq, Hash)]
 pub struct FunctionCallBinding<ID> {
     assigned: Vec<Vertex<ID>>,
-    optionally_assigned: BTreeSet<ID>,
+    optionally_assigned: BTreeSet<ID>, // TODO: This might not be enough for `let $f, $f = one_opt_other_reqd()`;
     function_call: FunctionCall<ID>,
     is_stream: bool,
     source_span: Option<Span>,
@@ -2331,13 +2350,21 @@ impl<ID: IrID> FunctionCallBinding<ID> {
         self.assigned.iter().filter_map(Vertex::as_variable)
     }
 
+    pub fn assigned_optionalities(&self) -> impl Iterator<Item = (ID, VariableOptionality)> + '_ {
+        self.ids_assigned().map(|id| {
+            let optionality = if self.optionally_assigned.contains(&id) {
+                VariableOptionality::Optional
+            } else {
+                VariableOptionality::Required
+            };
+            (id, optionality)
+        })
+    }
+
     pub(crate) fn binding_modes(&self) -> impl Iterator<Item = (ID, BindingMode)> + '_ {
         self.ids_assigned()
             .filter(|id| !self.function_call.arguments().contains(id))
-            .map(|id| match self.optionally_assigned.contains(&id) {
-                true => (id, BindingMode::OptionallyBinding),
-                false => (id, BindingMode::AlwaysBinding),
-            })
+            .map(|id| (id, BindingMode::AlwaysBinding))
             .chain(self.function_call_arg_ids().map(|id| (id, BindingMode::RequirePrebound)))
     }
 
@@ -2957,6 +2984,12 @@ pub struct DeleteConcepts<ID> {
     source_span: Option<Span>,
 }
 
+#[derive(Debug, Clone, Eq, PartialEq, Hash)]
+pub struct IsSet<ID> {
+    variables: Vec<Vertex<ID>>,
+    source_span: Option<Span>,
+}
+
 impl<ID: IrID> DeleteConcepts<ID> {
     pub fn new(variables: Vec<ID>, source_span: Option<Span>) -> Self {
         let variables = variables.into_iter().map(Vertex::Variable).collect();
@@ -3005,6 +3038,58 @@ impl<ID: IrID> fmt::Display for DeleteConcepts<ID> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let vars = self.variables.iter().map(|id| id.to_string()).collect::<Vec<_>>().join(", ");
         write!(f, "delete {}", vars)
+    }
+}
+
+impl<ID: IrID> IsSet<ID> {
+    pub fn new(variables: Vec<ID>, source_span: Option<Span>) -> Self {
+        let variables = variables.into_iter().map(|id| Vertex::Variable(id)).collect();
+        Self { variables, source_span }
+    }
+
+    pub fn ids(&self) -> impl Iterator<Item = ID> + '_ {
+        self.variables.iter().map(|v| v.as_variable().unwrap())
+    }
+
+    pub fn vertices(&self) -> impl Iterator<Item = &Vertex<ID>> + Sized {
+        self.variables.iter()
+    }
+
+    pub fn ids_foreach<F: FnMut(ID)>(&self, mut function: F) {
+        self.ids().for_each(|id| function(id))
+    }
+
+    pub fn source_span(&self) -> Option<Span> {
+        self.source_span
+    }
+
+    pub fn map<T: Clone>(self, mapping: &HashMap<ID, T>) -> IsSet<T> {
+        let variables = self.variables.iter().map(|v| v.clone().map(mapping)).collect();
+        let source_span = self.source_span;
+        IsSet { variables, source_span }
+    }
+}
+
+impl<ID: IrID> From<IsSet<ID>> for Constraint<ID> {
+    fn from(val: IsSet<ID>) -> Self {
+        Constraint::IsSet(val)
+    }
+}
+
+impl<ID: StructuralEquality> StructuralEquality for IsSet<ID> {
+    fn hash(&self) -> u64 {
+        StructuralEquality::hash(&self.variables)
+    }
+
+    fn equals(&self, other: &Self) -> bool {
+        self.variables.equals(&other.variables)
+    }
+}
+
+impl<ID: IrID> fmt::Display for IsSet<ID> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let vars = self.variables.iter().map(|id| id.to_string()).collect::<Vec<_>>().join(", ");
+        write!(f, "{} {}", typeql::token::Keyword::IsSet, vars)
     }
 }
 

--- a/ir/pattern/mod.rs
+++ b/ir/pattern/mod.rs
@@ -118,9 +118,9 @@ macro_rules! impl_pattern_from_pattern_variables {
 pub(self) use impl_pattern_from_pattern_variables;
 
 use crate::pattern::{
-    conjunction::{ConjunctionBuilder, NestedPatternBuilder},
+    conjunction::{Conjunction, ConjunctionBuilder, NestedPatternBuilder},
     constraint::Constraint,
-    disjunction::DisjunctionBuilder,
+    disjunction::{Disjunction, DisjunctionBuilder},
 };
 
 // TODO: rename to 'Identifier' in lieu of a better name
@@ -407,78 +407,6 @@ impl fmt::Display for ValueType {
     }
 }
 
-#[derive(Copy, Clone, Debug, Default, PartialEq, Eq)]
-pub(super) enum BindingMode {
-    RequirePrebound,
-    AlwaysBinding,
-    LocallyBindingInChild,
-    OptionallyBinding,
-    #[default]
-    Absent,
-}
-
-impl BindingMode {
-    pub(super) fn is_require_prebound(&self) -> bool {
-        *self == BindingMode::RequirePrebound
-    }
-
-    pub(super) fn is_always_binding(&self) -> bool {
-        *self == BindingMode::AlwaysBinding
-    }
-
-    pub(super) fn is_locally_binding_in_child(&self) -> bool {
-        *self == BindingMode::LocallyBindingInChild
-    }
-
-    pub(super) fn is_optionally_binding(&self) -> bool {
-        *self == BindingMode::OptionallyBinding
-    }
-}
-
-impl BitAnd for BindingMode {
-    type Output = Self;
-
-    fn bitand(self, rhs: Self) -> Self {
-        // We upgrade (Optionally|LocallyBinding) & (Optionally|LocallyBinding) to RequirePrebound
-        match (self, rhs) {
-            (Self::Absent, x) | (x, Self::Absent) => x,
-            (Self::AlwaysBinding, _) | (_, Self::AlwaysBinding) => Self::AlwaysBinding,
-            (Self::RequirePrebound, _) | (_, Self::RequirePrebound) => Self::RequirePrebound,
-            (Self::LocallyBindingInChild, _) | (_, Self::LocallyBindingInChild) => Self::RequirePrebound,
-            (Self::OptionallyBinding, Self::OptionallyBinding) => Self::RequirePrebound,
-        }
-    }
-}
-
-impl BitAndAssign for BindingMode {
-    fn bitand_assign(&mut self, rhs: Self) {
-        *self = *self & rhs;
-    }
-}
-
-impl BitOr for BindingMode {
-    type Output = Self;
-    fn bitor(self, rhs: Self) -> Self {
-        match (self, rhs) {
-            (Self::OptionallyBinding, Self::OptionallyBinding) => Self::OptionallyBinding,
-            (Self::AlwaysBinding, Self::AlwaysBinding) => Self::AlwaysBinding,
-            (Self::Absent, Self::Absent) => Self::Absent,
-            (Self::Absent, Self::AlwaysBinding) | (Self::AlwaysBinding, Self::Absent) => Self::LocallyBindingInChild,
-            (Self::Absent, Self::LocallyBindingInChild) | (Self::LocallyBindingInChild, Self::Absent) => {
-                Self::LocallyBindingInChild
-            }
-            (Self::RequirePrebound, _) | (_, Self::RequirePrebound) => Self::RequirePrebound,
-            (Self::OptionallyBinding, _) | (_, Self::OptionallyBinding) => Self::RequirePrebound,
-            (Self::LocallyBindingInChild, _) | (_, Self::LocallyBindingInChild) => {
-                // This preserves associativity, but doesn't correctly escalate to RequirePrebound.
-                // ((AlwaysBinding | AlwaysBinding) | Absent) should be required
-                // That's corrected in disjunction
-                Self::LocallyBindingInChild
-            }
-        }
-    }
-}
-
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub(crate) enum PatternVariableMode {
     RequiredInput,
@@ -510,9 +438,7 @@ impl PatternVariableModes {
                         (_, BindingMode::Absent) => None?,
                         (PatternVariableMode::RequiredInput, _) => PatternVariableMode::RequiredInput,
                         (PatternVariableMode::Binding, BindingMode::LocallyBindingInChild)
-                        | (PatternVariableMode::Binding, BindingMode::OptionallyBinding) => {
-                            PatternVariableMode::RequiredInput
-                        }
+                        | (PatternVariableMode::Binding, BindingMode::BoundInTry) => PatternVariableMode::RequiredInput,
                         (PatternVariableMode::Binding, BindingMode::RequirePrebound) => {
                             PatternVariableMode::RequiredInput
                         }
@@ -526,7 +452,7 @@ impl PatternVariableModes {
                             // Happens in the transition from optional to inner
                             PatternVariableMode::Binding
                         }
-                        (PatternVariableMode::OptionallyBinding, BindingMode::OptionallyBinding) => {
+                        (PatternVariableMode::OptionallyBinding, BindingMode::BoundInTry) => {
                             // There's a nested optional even deeper.
                             PatternVariableMode::OptionallyBinding
                         }
@@ -538,7 +464,7 @@ impl PatternVariableModes {
                     );
                     match mode {
                         BindingMode::RequirePrebound => PatternVariableMode::RequiredInput,
-                        BindingMode::OptionallyBinding => PatternVariableMode::OptionallyBinding,
+                        BindingMode::BoundInTry => PatternVariableMode::OptionallyBinding,
                         BindingMode::AlwaysBinding => PatternVariableMode::Binding,
                         BindingMode::LocallyBindingInChild => None?,
                         BindingMode::Absent => None?,
@@ -572,6 +498,84 @@ impl PatternVariableModes {
 
     pub(crate) fn optionally_bound_by_pattern(&self) -> impl Iterator<Item = Variable> + '_ {
         self.0.iter().filter_map(|(v, required)| (*required == PatternVariableMode::OptionallyBinding).then_some(*v))
+    }
+}
+
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq)]
+pub(super) enum BindingMode {
+    RequirePrebound,
+    AlwaysBinding,
+    LocallyBindingInChild, // Bound in some, but not all branches
+    BoundInTry,            // Try blocks, but not assignments. Assignments are AlwaysBinding regardless.
+    #[default]
+    Absent,
+}
+
+impl BindingMode {
+    pub(super) fn is_require_prebound(&self) -> bool {
+        *self == BindingMode::RequirePrebound
+    }
+
+    pub(super) fn is_always_binding(&self) -> bool {
+        *self == BindingMode::AlwaysBinding
+    }
+
+    pub(super) fn is_locally_binding_in_child(&self) -> bool {
+        *self == BindingMode::LocallyBindingInChild
+    }
+
+    pub(super) fn is_bound_in_try(&self) -> bool {
+        *self == BindingMode::BoundInTry
+    }
+}
+
+impl BitAnd for BindingMode {
+    type Output = Self;
+
+    fn bitand(self, rhs: Self) -> Self {
+        // We upgrade (Optionally|LocallyBinding) & (Optionally|LocallyBinding) to RequirePrebound
+        match (self, rhs) {
+            (Self::Absent, x) | (x, Self::Absent) => x,
+            (Self::AlwaysBinding, _) | (_, Self::AlwaysBinding) => Self::AlwaysBinding,
+            (Self::RequirePrebound, _) | (_, Self::RequirePrebound) => Self::RequirePrebound,
+            (Self::LocallyBindingInChild, _) | (_, Self::LocallyBindingInChild) => Self::RequirePrebound,
+            (Self::BoundInTry, Self::BoundInTry) => Self::RequirePrebound,
+        }
+    }
+}
+
+impl BitOr for BindingMode {
+    type Output = Self;
+    fn bitor(self, rhs: Self) -> Self {
+        match (self, rhs) {
+            (Self::BoundInTry, Self::BoundInTry) => Self::BoundInTry,
+            (Self::AlwaysBinding, Self::AlwaysBinding) => Self::AlwaysBinding,
+            (Self::Absent, Self::Absent) => Self::Absent,
+            (Self::Absent, Self::AlwaysBinding) | (Self::AlwaysBinding, Self::Absent) => Self::LocallyBindingInChild,
+            (Self::Absent, Self::LocallyBindingInChild) | (Self::LocallyBindingInChild, Self::Absent) => {
+                Self::LocallyBindingInChild
+            }
+            (Self::RequirePrebound, _) | (_, Self::RequirePrebound) => Self::RequirePrebound,
+            (Self::BoundInTry, _) | (_, Self::BoundInTry) => Self::RequirePrebound,
+            (Self::LocallyBindingInChild, _) | (_, Self::LocallyBindingInChild) => {
+                // This preserves associativity, but doesn't correctly escalate to RequirePrebound.
+                // ((AlwaysBinding | AlwaysBinding) | Absent) should be required
+                // That's corrected in disjunction
+                Self::LocallyBindingInChild
+            }
+        }
+    }
+}
+
+impl BitAndAssign for BindingMode {
+    fn bitand_assign(&mut self, rhs: Self) {
+        *self = *self & rhs;
+    }
+}
+
+impl BitOrAssign for BindingMode {
+    fn bitor_assign(&mut self, rhs: Self) {
+        *self = *self | rhs;
     }
 }
 

--- a/ir/pattern/negation.rs
+++ b/ir/pattern/negation.rs
@@ -93,7 +93,7 @@ impl NegationBuilder {
             .variable_binding_modes()
             .into_iter()
             .map(|(var, mode)| {
-                if mode.is_always_binding() {
+                if mode.is_always_binding() || mode.is_bound_in_try() {
                     // if it is binding, we demote it to only locally binding (only relevant in the negation)
                     (var, BindingMode::LocallyBindingInChild)
                 } else {

--- a/ir/pattern/optional.rs
+++ b/ir/pattern/optional.rs
@@ -100,7 +100,7 @@ impl OptionalBuilder {
         self.conjunction
             .variable_binding_modes()
             .into_iter()
-            .map(|(v, mode)| if mode.is_always_binding() { (v, BindingMode::OptionallyBinding) } else { (v, mode) })
+            .map(|(v, mode)| if mode.is_always_binding() { (v, BindingMode::BoundInTry) } else { (v, mode) })
             .collect()
     }
 }

--- a/ir/pipeline/block.rs
+++ b/ir/pipeline/block.rs
@@ -21,7 +21,7 @@ use crate::{
         conjunction::{Conjunction, ConjunctionBuilder, ConjunctionBuilderWithContext, NestedPatternBuilder},
         constraint::Constraint,
         nested_pattern::NestedPattern,
-        variable_category::VariableCategory,
+        variable_category::{VariableCategory, VariableOptionality},
     },
     pipeline::{ParameterRegistry, VariableCategorySource, VariableRegistry},
 };
@@ -80,23 +80,31 @@ impl<'reg> BlockBuilder<'reg> {
         validate_is_variables_have_same_category(&self.conjunction, &self.context.variable_registry)?;
         validate_expressions_assignments_are_unique(&self.conjunction, &self.context)?;
 
-        // Update
-        block_binding_modes
-            .iter()
-            .filter(|(_, mode)| mode.is_optionally_binding())
-            .for_each(|(v, _)| self.context.set_variable_optionality(*v, true));
+        // Update names, optionalities get updated later.
+        // TODO: Try to move this down and use the pattern variables for the block.
+        // TODO: Actually, shouldn't the LocallyBinding be kept?
         self.context
             .variable_names_index
             .retain(|_, var| block_binding_modes.get(var).copied() != Some(BindingMode::LocallyBindingInChild));
-        let conjunction = self
+        let mut conjunction = self
             .conjunction
             .finish(&PatternVariableModes::for_block(block_binding_modes, self.context.input_variables()));
 
-        let input_variables = self.context.input_variables().collect();
-        validate_is_plannable(&conjunction, &input_variables, &self.context.variable_registry)?;
+        let optional_modes = validate_all_optional_dereferences_are_safe(&mut conjunction, &self.context)?;
 
-        let block_context = self.context.block_context;
-        Ok(Block { conjunction, block_context })
+        validate_is_plannable(
+            &conjunction,
+            &self.context.input_variables().collect(),
+            &self.context.variable_registry,
+        )?;
+
+        // Update
+        for (v, mode) in optional_modes {
+            let optionality = todo!("Omitted for diff / change of strategy downstream");
+            self.context.variable_optionalities.insert(v, optionality);
+        }
+
+        Ok(Block { conjunction, block_context: self.context.block_context })
     }
 
     pub fn conjunction_mut<'ctx>(&'ctx mut self) -> ConjunctionBuilderWithContext<'ctx, 'reg> {
@@ -108,9 +116,12 @@ impl<'reg> BlockBuilder<'reg> {
     }
 
     fn variable_binding_modes(&self) -> HashMap<Variable, BindingMode> {
-        let mut block_binding_modes = self.conjunction.variable_binding_modes();
-        block_binding_modes.extend(self.context.input_variables().map(|v| (v, BindingMode::AlwaysBinding)));
-        block_binding_modes
+        let mut variable_binding_modes = self.conjunction.variable_binding_modes();
+        for (id, optionality) in self.context.input_variable_optionalities() {
+            let mode = variable_binding_modes.entry(id).or_default();
+            *mode = BindingMode::AlwaysBinding;
+        }
+        variable_binding_modes
     }
 }
 
@@ -118,7 +129,8 @@ fn validate_no_unbound_variable_categories(
     conjunction: &ConjunctionBuilder,
     context: &BlockBuilderContext<'_>,
 ) -> Result<(), Box<RepresentationError>> {
-    let unbound = context.block_context.registered_variables().find(|&variable| {
+    // TODO: We need an intermediate ConjunctionBeingFinalized that stores these variable_usage_modes
+    let unbound = conjunction.variable_binding_modes().keys().copied().find(|&variable| {
         matches!(
             context.variable_registry.get_variable_category(variable),
             Some(VariableCategory::AttributeOrValue) | None
@@ -130,6 +142,17 @@ fn validate_no_unbound_variable_categories(
             source_span: context.variable_registry.source_span(variable),
         }))
     } else {
+        conjunction.nested_patterns().iter().try_for_each(|nested| match nested {
+            NestedPatternBuilder::Disjunction(disjunction) => {
+                disjunction.conjunctions().try_for_each(|c| validate_no_unbound_variable_categories(c, context))
+            }
+            NestedPatternBuilder::Negation(negation) => {
+                validate_no_unbound_variable_categories(negation.conjunction(), context)
+            }
+            NestedPatternBuilder::Optional(optional) => {
+                validate_no_unbound_variable_categories(optional.conjunction(), context)
+            }
+        })?;
         Ok(())
     }
 }
@@ -253,7 +276,6 @@ fn validate_optional_returns_recursive(
     conjunction: &ConjunctionBuilder,
     acc: &mut HashMap<Variable, Option<Span>>,
 ) -> Result<(), Box<RepresentationError>> {
-    let conjunction_binding_modes = conjunction.variable_binding_modes();
     conjunction.nested_patterns().iter().try_for_each(|nested| match nested {
         NestedPatternBuilder::Disjunction(disjunction) => {
             disjunction.conjunctions().try_for_each(|branch| validate_optional_returns_recursive(context, branch, acc))
@@ -267,29 +289,32 @@ fn validate_optional_returns_recursive(
     })?;
     conjunction.constraints().iter().filter_map(|c| c.as_function_call_binding()).for_each(|call| {
         for (var, mode) in call.binding_modes() {
-            if mode == BindingMode::OptionallyBinding {
+            if mode == BindingMode::BoundInTry {
                 acc.insert(var, call.source_span());
             }
         }
     });
     // Check at each level
+    let conjunction_binding_modes = conjunction.variable_binding_modes();
     let reused_optional_return_opt = acc.iter().find(|(var, _)| match conjunction_binding_modes.get(var) {
         None => false,
-        Some(mode) => *mode != BindingMode::OptionallyBinding,
+        Some(mode) => *mode != BindingMode::BoundInTry,
     });
     if let Some((var, &source_span)) = reused_optional_return_opt {
         let variable = context.get_variable_name_or_unnamed(*var).to_owned();
-        // TODO: This has to wait till we finalize the spec
-        // // Err(Box::new(RepresentationError::OptionalFunctionReturnReferenced { variable, source_span }))
-        // use error::TypeDBError;
-        // tracing::warn!(
-        //     "Function call reuses optionally assigned variable. This will fail in the next version:\n{}",
-        //     RepresentationError::OptionalFunctionReturnReferenced { variable, source_span }.format_description()
-        // );
+        error::optional_usage_error!(RepresentationError::OptionalFunctionReturnReferenced { variable, source_span });
         Ok(())
     } else {
         Ok(())
     }
+}
+
+type OptionalSafety = ();
+fn validate_all_optional_dereferences_are_safe(
+    conjunction: &mut Conjunction,
+    context: &BlockBuilderContext<'_>,
+) -> Result<HashMap<Variable, OptionalSafety>, Box<RepresentationError>> {
+    todo!("Not part of the diff for convenience")
 }
 
 fn validate_expressions_assignments_are_unique(
@@ -297,7 +322,7 @@ fn validate_expressions_assignments_are_unique(
     context: &BlockBuilderContext<'_>,
 ) -> Result<(), Box<RepresentationError>> {
     let assignment_statuses = AssignmentStatus::for_conjunction(conjunction);
-    for id in context.input_variables() {
+    for (id, _) in context.input_variable_optionalities() {
         match assignment_statuses.get(&id).copied() {
             Some(AssignmentStatus::AtMostOncePerBranch(source_span))
             | Some(AssignmentStatus::MultipleAssignmentsInBranch(source_span, _)) => {
@@ -370,8 +395,9 @@ fn validate_conjunction_has_valid_constraint_ordering(
             .iter()
             .copied()
             .filter(|i| {
-                let mut required_vars =
-                    constraint_at(*i).binding_modes().filter_map(|(id, mode)| mode.is_require_prebound().then_some(id));
+                let mut required_vars = constraint_at(*i)
+                    .variable_binding_modes()
+                    .filter_map(|(id, mode)| mode.is_require_prebound().then_some(id));
                 required_vars.all(|v| bound_variables.contains(&v))
             })
             .collect::<HashSet<usize>>();
@@ -456,7 +482,8 @@ impl UnplannableConstraints {
         }
         let mut constraints_and_requirements = Vec::new();
         constraints_and_requirements.extend(remaining_constraints.map(|c| {
-            let required_vars = c.binding_modes().filter_map(|(id, mode)| mode.is_require_prebound().then_some(id));
+            let required_vars =
+                c.variable_binding_modes().filter_map(|(id, mode)| mode.is_require_prebound().then_some(id));
             (c.name().to_owned(), unsatisfied_vars!(required_vars), c.source_span())
         }));
         constraints_and_requirements.extend(remaining_nested_patterns.map(|nested| {
@@ -482,30 +509,22 @@ impl fmt::Display for UnplannableConstraints {
 
 #[derive(Debug, Clone, Default, Eq, PartialEq)]
 pub struct BlockContext {
-    input_variables: HashSet<Variable>,
-    variable_declaration: HashSet<Variable>,
+    input_variable_optionalities: HashMap<Variable, VariableOptionality>,
+    // variable_declaration: HashSet<Variable>,
 }
 
+// TODO: All private? Can we inline BlockContext then?
 impl BlockContext {
-    fn new() -> Self {
-        Default::default()
+    fn new(input_variable_optionalities: HashMap<Variable, VariableOptionality>) -> Self {
+        Self { input_variable_optionalities }
     }
 
-    fn add_input_declaration(&mut self, var: Variable) {
-        self.add_variable_declaration(var);
-        self.input_variables.insert(var);
-    }
-
-    fn add_variable_declaration(&mut self, var: Variable) {
-        self.variable_declaration.insert(var);
+    fn input_variable_optionalities(&self) -> impl Iterator<Item = (Variable, VariableOptionality)> + '_ {
+        self.input_variable_optionalities.iter().map(|(&k, &v)| (k, v))
     }
 
     fn is_block_input_variable(&self, var: &Variable) -> bool {
-        self.input_variables.contains(var)
-    }
-
-    fn registered_variables(&self) -> impl Iterator<Item = Variable> + '_ {
-        self.variable_declaration.iter().copied()
+        self.input_variable_optionalities.contains_key(var)
     }
 }
 
@@ -513,28 +532,32 @@ impl BlockContext {
 pub struct BlockBuilderContext<'a> {
     variable_registry: &'a mut VariableRegistry,
     variable_names_index: &'a mut HashMap<String, Variable>,
+    variable_optionalities: &'a mut HashMap<Variable, VariableOptionality>,
     parameters: &'a mut ParameterRegistry,
 
     block_context: BlockContext,
     scope_id_allocator: u16,
+
+    pub is_write_stage: bool,
 }
 
 impl<'a> BlockBuilderContext<'a> {
     pub(crate) fn new(
         variable_registry: &'a mut VariableRegistry,
         available_input_names: &'a mut HashMap<String, Variable>,
+        variable_optionalities: &'a mut HashMap<Variable, VariableOptionality>,
         parameters: &'a mut ParameterRegistry,
     ) -> BlockBuilderContext<'a> {
-        let mut block_context = BlockContext::new();
-        available_input_names.values().for_each(|v| {
-            block_context.add_input_declaration(*v);
-        });
+        debug_assert!(available_input_names.values().all(|v| variable_optionalities.contains_key(v)));
+        let mut block_context = BlockContext::new(variable_optionalities.clone());
         Self {
             variable_registry,
             variable_names_index: available_input_names,
+            variable_optionalities,
             parameters,
             scope_id_allocator: 2, // `0`, `1` are reserved for INPUT, ROOT respectively.
             block_context,
+            is_write_stage: false,
         }
     }
 
@@ -558,7 +581,6 @@ impl<'a> BlockBuilderContext<'a> {
         match self.variable_names_index.get(name) {
             None => {
                 let variable = self.variable_registry.register_variable_named(name.to_string(), source_span)?;
-                self.block_context.add_variable_declaration(variable);
                 self.variable_names_index.insert(name.to_string(), variable);
                 Ok(variable)
             }
@@ -571,7 +593,6 @@ impl<'a> BlockBuilderContext<'a> {
         source_span: Option<Span>,
     ) -> Result<Variable, Box<RepresentationError>> {
         let variable = self.variable_registry.register_anonymous_variable(source_span)?;
-        self.block_context.add_variable_declaration(variable);
         Ok(variable)
     }
 
@@ -580,7 +601,12 @@ impl<'a> BlockBuilderContext<'a> {
     }
 
     pub(crate) fn input_variables(&self) -> impl Iterator<Item = Variable> + '_ {
-        self.block_context.registered_variables().filter(|var| self.is_block_input_variable(*var))
+        self.block_context.input_variable_optionalities.keys().copied()
+    }
+
+    pub(crate) fn input_variable_optionalities(&self) -> impl Iterator<Item = (Variable, VariableOptionality)> + '_ {
+        // TODO: Actually propagate per-stage optionality changes
+        self.block_context.input_variable_optionalities()
     }
 
     pub(crate) fn next_scope_id(&mut self) -> ScopeId {
@@ -597,10 +623,6 @@ impl<'a> BlockBuilderContext<'a> {
         source: Constraint<Variable>,
     ) -> Result<(), Box<RepresentationError>> {
         self.variable_registry.set_variable_category(variable, category, VariableCategorySource::Constraint(source))
-    }
-
-    pub(crate) fn set_variable_optionality(&mut self, variable: Variable, is_optional: bool) {
-        self.variable_registry.set_variable_is_optional(variable, is_optional);
     }
 
     pub(crate) fn parameters(&mut self) -> &mut ParameterRegistry {

--- a/ir/pipeline/mod.rs
+++ b/ir/pipeline/mod.rs
@@ -23,11 +23,7 @@ use typeql::{
 
 use crate::{
     LiteralParseError, RepresentationError,
-    pattern::{
-        BranchID, ParameterID, ValueType,
-        constraint::Constraint,
-        variable_category::{VariableCategory, VariableOptionality},
-    },
+    pattern::{BranchID, ParameterID, ValueType, constraint::Constraint, variable_category::VariableCategory},
     pipeline::{function_signature::FunctionID, reduce::Reducer},
 };
 
@@ -162,7 +158,6 @@ pub struct VariableRegistry {
     variable_names: HashMap<Variable, String>,
     variable_id_allocator: u16,
     variable_categories: HashMap<Variable, (VariableCategory, VariableCategorySource)>,
-    variable_optionality: HashMap<Variable, VariableOptionality>,
     variable_source_spans: HashMap<Variable, Span>,
 }
 
@@ -175,7 +170,6 @@ impl VariableRegistry {
             variable_names: HashMap::new(),
             variable_id_allocator: 0,
             variable_categories: HashMap::new(),
-            variable_optionality: HashMap::new(),
             variable_source_spans: HashMap::new(),
         }
     }
@@ -214,9 +208,6 @@ impl VariableRegistry {
         let new_var = self.register_anonymous_variable(None)?;
         if let Some(category) = self.get_variable_category(variable) {
             self.set_variable_category(new_var, category, VariableCategorySource::Variable(variable))?;
-        }
-        if let Some(optionality) = self.variable_optionality.get(&variable) {
-            self.set_variable_is_optional(new_var, *optionality == VariableOptionality::Optional);
         }
         Ok(new_var)
     }
@@ -320,20 +311,6 @@ impl VariableRegistry {
         self.variable_categories.get(&variable).map(|(category, _constraint)| *category)
     }
 
-    pub fn is_variable_optional(&self, variable: Variable) -> bool {
-        match self.variable_optionality.get(&variable).unwrap_or(&VariableOptionality::Required) {
-            VariableOptionality::Required => false,
-            VariableOptionality::Optional => true,
-        }
-    }
-
-    fn set_variable_is_optional(&mut self, variable: Variable, optional: bool) {
-        match optional {
-            true => self.variable_optionality.insert(variable, VariableOptionality::Optional),
-            false => self.variable_optionality.remove(&variable),
-        };
-    }
-
     pub fn has_variable_as_named(&self, variable: &Variable) -> bool {
         self.variable_names.contains_key(variable)
     }
@@ -346,13 +323,11 @@ impl VariableRegistry {
         &mut self,
         name: &str,
         category: VariableCategory,
-        optionality: VariableOptionality,
         source_span: Option<Span>,
     ) -> Result<Variable, Box<RepresentationError>> {
         let variable = self.register_variable_named(name.to_owned(), source_span)?;
         self.set_variable_category(variable, category, VariableCategorySource::ArgumentOrGiven)
             .expect("Expected a newly created variable");
-        self.set_variable_is_optional(variable, optionality == VariableOptionality::Optional);
         Ok(variable)
     }
 
@@ -360,14 +335,12 @@ impl VariableRegistry {
         &mut self,
         name: String,
         category: VariableCategory,
-        is_optional: bool,
         source_span: Option<Span>,
         reducer: Reducer,
     ) -> Result<Variable, Box<RepresentationError>> {
         let variable = self.register_variable_named(name, source_span)?;
         self.set_variable_category(variable, category, VariableCategorySource::Reduce(reducer))
             .expect("Expected a newly created variable");
-        self.set_variable_is_optional(variable, is_optional);
         Ok(variable)
     }
 }
@@ -381,10 +354,6 @@ impl fmt::Display for VariableRegistry {
         writeln!(f, "Variable categories:")?;
         for var in self.variable_categories.keys().sorted_unstable() {
             writeln!(f, "  {}: {}", var, self.variable_categories[var].0)?;
-        }
-        writeln!(f, "Optional variables:")?;
-        for var in self.variable_optionality.keys().sorted_unstable() {
-            writeln!(f, "  {}", var)?;
         }
         Ok(())
     }

--- a/ir/tests/binding_modes.rs
+++ b/ir/tests/binding_modes.rs
@@ -59,6 +59,8 @@ macro_rules! assert_optionals {
 }
 
 fn get_optionals(variable_registry: &VariableRegistry) -> Vec<&'_ str> {
+    todo!(
+        r#" // GETS FIXED IN NEXT PR
     variable_registry
         .variable_names()
         .iter()
@@ -66,6 +68,8 @@ fn get_optionals(variable_registry: &VariableRegistry) -> Vec<&'_ str> {
         .map(|(_, name)| name.as_str())
         .sorted()
         .collect()
+    "#
+    );
 }
 
 #[test]

--- a/ir/translation/constraints.rs
+++ b/ir/translation/constraints.rs
@@ -80,6 +80,11 @@ pub(super) fn add_statement(
                 constraints.add_assignment(assigned.variable, expression, *span)?;
             }
         }
+        typeql::Statement::IsSet(is_set) => {
+            let variables =
+                is_set.variables.iter().map(|v| register_typeql_var(constraints, v)).collect::<Result<Vec<_>, _>>()?;
+            constraints.add_is_set(variables, is_set.span())?;
+        }
         typeql::Statement::Thing(thing) => add_thing_statement(function_index, constraints, thing)?,
         typeql::Statement::Type(type_) => add_type_statement(constraints, type_)?,
     }

--- a/ir/translation/fetch.rs
+++ b/ir/translation/fetch.rs
@@ -315,6 +315,7 @@ fn translate_inline_expression_single(
     let builder_context = BlockBuilderContext::new(
         &mut local_context.variable_registry,
         &mut local_context.last_stage_visible_variables,
+        &mut local_context.variable_optionalities,
         value_parameters,
     );
     let mut builder = Block::builder(builder_context);
@@ -401,6 +402,7 @@ fn translate_inline_function_call<'a>(
     let builder_context = BlockBuilderContext::new(
         &mut local_context.variable_registry,
         &mut local_context.last_stage_visible_variables,
+        &mut local_context.variable_optionalities,
         value_parameters,
     );
     let mut builder = Block::builder(builder_context);

--- a/ir/translation/function.rs
+++ b/ir/translation/function.rs
@@ -111,12 +111,12 @@ fn translate_function_from(
     match (&signature.output, &body.return_operation) {
         (Output::Stream(declared_vars), ReturnOperation::Stream(defined_vars, _)) => {
             check_consistent_return(signature, block, &declared_vars.types, defined_vars, |v| {
-                context.variable_registry.is_variable_optional(*v)
+                context.is_variable_optional(*v)
             })?
         }
         (Output::Single(declared_vars), ReturnOperation::Single(_, defined_vars, _)) => {
             check_consistent_return(signature, block, &declared_vars.types, defined_vars, |v| {
-                context.variable_registry.is_variable_optional(*v)
+                context.is_variable_optional(*v)
             })?
         }
         (Output::Single(declared_vars), ReturnOperation::ReduceReducer(reducers, _)) => {
@@ -319,17 +319,11 @@ fn check_consistent_return<T>(
         .enumerate()
         .find_map(|(index, (declared, actual))| (declared != actual).then_some(index));
     if let Some(mismatch_index) = mismatching_index_opt {
-        // TODO: This has to wait till we finalize the spec
-        // use error::TypeDBError;
-        // tracing::warn!(
-        //     "Function has inconsistent return optionality. This will fail in the next version:\n{}",
-        //     FunctionRepresentationError::InconsistentReturnOptionality {
-        //         signature: signature.clone(),
-        //         return_: block.return_stmt.clone(),
-        //         mismatch_index,
-        //     }
-        //     .format_description()
-        // );
+        error::optional_usage_error!(FunctionRepresentationError::InconsistentReturnOptionality {
+            signature: signature.clone(),
+            return_: block.return_stmt.clone(),
+            mismatch_index,
+        });
     }
 
     Ok(())

--- a/ir/translation/match_.rs
+++ b/ir/translation/match_.rs
@@ -3,7 +3,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
-use typeql::common::Span;
 
 use crate::{
     RepresentationError,

--- a/ir/translation/mod.rs
+++ b/ir/translation/mod.rs
@@ -36,6 +36,7 @@ use crate::pattern::variable_category::VariableOptionality;
 pub struct PipelineTranslationContext {
     pub variable_registry: VariableRegistry, // TODO: Unpub
     last_stage_visible_variables: HashMap<String, Variable>,
+    variable_optionalities: HashMap<Variable, VariableOptionality>,
 }
 
 impl Default for PipelineTranslationContext {
@@ -46,7 +47,11 @@ impl Default for PipelineTranslationContext {
 
 impl PipelineTranslationContext {
     pub fn new() -> Self {
-        Self { variable_registry: VariableRegistry::new(), last_stage_visible_variables: HashMap::new() }
+        Self {
+            variable_registry: VariableRegistry::new(),
+            last_stage_visible_variables: HashMap::new(),
+            variable_optionalities: HashMap::new(),
+        }
     }
 
     pub fn new_function_pipeline(
@@ -66,8 +71,8 @@ impl PipelineTranslationContext {
         input_variable: (String, Option<Span>, (VariableCategory, VariableOptionality)),
     ) -> Result<Variable, Box<RepresentationError>> {
         let (name, source_span, (category, optionality)) = input_variable;
-        let variable =
-            self.variable_registry.register_input_variable(name.as_str(), category, optionality, source_span)?;
+        let variable = self.variable_registry.register_input_variable(name.as_str(), category, source_span)?;
+        self.variable_optionalities.insert(variable, optionality);
         self.last_stage_visible_variables.insert(name.clone(), variable);
         Ok(variable)
     }
@@ -76,8 +81,18 @@ impl PipelineTranslationContext {
         &'a mut self,
         parameters: &'a mut ParameterRegistry,
     ) -> BlockBuilderContext<'a> {
-        let Self { variable_registry, last_stage_visible_variables: visible_variables } = self;
-        BlockBuilderContext::new(variable_registry, visible_variables, parameters)
+        let Self { variable_registry, last_stage_visible_variables, variable_optionalities: variable_optionality } =
+            self;
+        BlockBuilderContext::new(variable_registry, last_stage_visible_variables, variable_optionality, parameters)
+    }
+
+    pub fn new_block_builder_context_for_writes<'a>(
+        &'a mut self,
+        parameters: &'a mut ParameterRegistry,
+    ) -> BlockBuilderContext<'a> {
+        let mut new_context = Self::new_block_builder_context(self, parameters);
+        new_context.is_write_stage = true;
+        new_context
     }
 
     pub(crate) fn register_reduced_variable(
@@ -98,16 +113,24 @@ impl PipelineTranslationContext {
         let variable = self.variable_registry.register_reduce_output_variable(
             name.to_owned(),
             variable_category,
-            is_optional,
             source_span,
             reducer,
         )?;
+        let optionality = if is_optional { VariableOptionality::Optional } else { VariableOptionality::Required };
+        self.variable_optionalities.insert(variable, optionality);
         self.last_stage_visible_variables.insert(name.to_owned(), variable);
         Ok(variable)
     }
 
     pub fn get_variable(&self, variable: &str) -> Option<Variable> {
         self.last_stage_visible_variables.get(variable).cloned()
+    }
+
+    pub fn is_variable_optional(&self, variable: Variable) -> bool {
+        match self.variable_optionalities.get(&variable).unwrap_or(&VariableOptionality::Required) {
+            VariableOptionality::Required => false,
+            VariableOptionality::Optional => true,
+        }
     }
 }
 

--- a/ir/translation/reduce.rs
+++ b/ir/translation/reduce.rs
@@ -52,12 +52,7 @@ pub fn translate_reduce(
             }),
         };
         if let Err(err) = optionality_mismatch_check {
-            // TODO: This has to wait till we finalize the spec
-            // use error::TypeDBError;
-            // tracing::warn!(
-            //     "The declared optionality of a variable assigned in a reduce stage did not match the optionality of the reducer result. This will fail in the next version:\n{}",
-            //     err.format_description()
-            // );
+            error::optional_usage_error!(err);
         }
         let assigned_var = context.register_reduced_variable(
             var_name,

--- a/ir/translation/writes.rs
+++ b/ir/translation/writes.rs
@@ -35,7 +35,7 @@ pub fn translate_insert(
     insert: &typeql::query::stage::Insert,
 ) -> Result<Block, Box<RepresentationError>> {
     validate_insert_patterns(&insert.patterns)?;
-    let mut builder = Block::builder(context.new_block_builder_context(value_parameters));
+    let mut builder = Block::builder(context.new_block_builder_context_for_writes(value_parameters));
     let function_index = HashMapFunctionSignatureIndex::empty();
     let mut conjunction = builder.conjunction_mut();
     add_patterns(&function_index, &mut conjunction, &insert.patterns)?;
@@ -78,6 +78,7 @@ fn validate_insert_pattern(pattern: &typeql::Pattern) -> Result<(), Box<Represen
                 }
             }
         }
+        typeql::Pattern::Statement(Statement::IsSet(_)) => (),
         typeql::Pattern::Statement(stmt) => {
             return Err(Box::new(RepresentationError::IllegalStatementForInsert { source_span: stmt.span() }));
         }
@@ -91,7 +92,7 @@ pub fn translate_update(
     update: &typeql::query::stage::Update,
 ) -> Result<Block, Box<RepresentationError>> {
     validate_update_patterns(context, &update.patterns)?;
-    let mut builder = Block::builder(context.new_block_builder_context(value_parameters));
+    let mut builder = Block::builder(context.new_block_builder_context_for_writes(value_parameters));
     let function_index = HashMapFunctionSignatureIndex::empty();
     let mut conjunction = builder.conjunction_mut();
     add_patterns(&function_index, &mut conjunction, &update.patterns)?;
@@ -104,7 +105,7 @@ pub fn translate_put(
     put: &Put,
 ) -> Result<Block, Box<RepresentationError>> {
     validate_insert_patterns(&put.patterns)?;
-    let mut builder = Block::builder(context.new_block_builder_context(value_parameters));
+    let mut builder = Block::builder(context.new_block_builder_context_for_writes(value_parameters));
     let function_index = HashMapFunctionSignatureIndex::empty();
     let mut conjunction = builder.conjunction_mut();
     add_patterns(&function_index, &mut conjunction, &put.patterns)?;
@@ -136,7 +137,7 @@ pub fn translate_delete(
 ) -> Result<Block, Box<RepresentationError>> {
     validate_delete(delete)?;
     validate_deleted_variables_availability(context, delete)?;
-    let mut builder = Block::builder(context.new_block_builder_context(value_parameters));
+    let mut builder = Block::builder(context.new_block_builder_context_for_writes(value_parameters));
     let mut deleted_concepts = HashSet::new();
     let mut conjunction = builder.conjunction_mut();
     add_deletables(&delete.deletables, &mut conjunction, &mut deleted_concepts)?;
@@ -187,6 +188,14 @@ fn add_deletables(
                 debug_assert!(deletables.iter().all(|d| !matches!(d.kind, DeletableKind::Optional { .. })));
                 let mut optional_builder = conjunction.add_optional(deletable.span())?;
                 add_deletables(deletables, &mut optional_builder, deleted_concepts_recursive)?;
+            }
+            DeletableKind::IsSet { variables } => {
+                let mut constraints = conjunction.constraints_mut();
+                let translated_variables = variables
+                    .iter()
+                    .map(|variable| constraints.get_or_declare_variable(variable.name().unwrap(), variable.span()))
+                    .collect::<Result<Vec<_>, _>>()?;
+                constraints.add_is_set(translated_variables, deletable.span())?;
             }
         }
     }
@@ -267,6 +276,8 @@ fn validate_update_pattern(
                         }
                     }
                 }
+            } else if let Statement::IsSet(_) = statement {
+                () // Is set is allowed. Do nothing.
             } else {
                 return Err(Box::new(RepresentationError::IllegalStatementForUpdate { source_span: statement.span() }));
             }
@@ -350,6 +361,11 @@ fn validate_deleted_variable_availability_deletable(
             for deletable in deletables {
                 debug_assert!(!matches!(deletable.kind, DeletableKind::Optional { .. }));
                 validate_deleted_variable_availability_deletable(context, deletable)?;
+            }
+        }
+        DeletableKind::IsSet { variables } => {
+            for variable in variables {
+                verify_variable_available!(context, variable => DeleteVariableUnavailable)?;
             }
         }
     };

--- a/query/analyse.rs
+++ b/query/analyse.rs
@@ -29,6 +29,7 @@ use concept::{
     type_::{OwnerAPI, TypeAPI, attribute_type::AttributeType, type_manager::TypeManager},
 };
 use encoding::value::value_type::ValueType;
+use error::todo_must_implement;
 use ir::{
     pattern::{
         ParameterID, Scope, Vertex, conjunction::Conjunction, nested_pattern::NestedPattern,
@@ -245,7 +246,7 @@ fn enrich_annotations(
 ) -> ConjunctionAnnotations {
     variable_annotations
         .map(|(variable, annotations)| {
-            let is_optional = variable_registry.is_variable_optional(variable);
+            let is_optional = todo_must_implement!("variable_registry.is_variable_optional(variable)");
             (StructureVariableId::from(variable), PipelineVariableAnnotationAndModifier { is_optional, annotations })
         })
         .collect()

--- a/server/service/grpc/analyze.rs
+++ b/server/service/grpc/analyze.rs
@@ -440,6 +440,13 @@ fn query_structure_constraint(
                 })),
             });
         }
+        Constraint::IsSet(is_set) => {
+            let variables = is_set.vertices().map(encode_structure_vertex_variable).collect::<Result<Vec<_>, _>>()?;
+            constraints.push(conjunction_proto::Constraint {
+                span,
+                constraint: Some(structure_constraint::Constraint::IsSet(structure_constraint::IsSet { variables })),
+            });
+        }
         Constraint::Iid(iid) => {
             let iid_bytes = Vec::from(context.get_parameter_iid(iid.iid().as_parameter().as_ref().unwrap()).unwrap());
             constraints.push(conjunction_proto::Constraint {

--- a/server/service/http/message/analyze/structure.rs
+++ b/server/service/http/message/analyze/structure.rs
@@ -132,6 +132,9 @@ pub enum StructureConstraint {
         lhs: StructureVertex,
         rhs: StructureVertex,
     },
+    IsSet {
+        variables: Vec<StructureVertex>,
+    },
     Iid {
         concept: StructureVertex,
         iid: String,
@@ -402,6 +405,10 @@ fn encode_structure_constraint(
                 rhs: encode_structure_vertex(context, is.rhs())?,
             }
         }),
+        Constraint::IsSet(isset) => push({
+            let variables = encode_structure_vertices(context, isset.ids())?;
+            StructureConstraint::IsSet { variables }
+        }),
         Constraint::Iid(iid) => push({
             let concept = encode_structure_vertex(context, iid.var())?;
             let iid_bytes = context.get_parameter_iid(iid.iid().as_parameter().as_ref().unwrap()).unwrap();
@@ -595,6 +602,7 @@ pub mod bdd {
         Plays { player, role, } |
         FunctionCall { name, assigned, arguments, } |
         Expression { text, assigned, arguments, } |
+        IsSet { variables, } |
         Is { lhs, rhs, } |
         Iid { concept, iid, } |
         Comparison { lhs, rhs, comparator, } |


### PR DESCRIPTION
## Product change and motivation
Introduces the `IsSet` constraint in TypeQL and propagates it throughout.

## Implementation
Ideally, we only have to validate that all the optional dereferences are safe (thanks to the user putting `IsSet` in the right places. Then we just have to run the `IsSet` check as soon as the variable is produced. 