### PR TITLE
Disable implicit init py file creation for bazel python targets

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5953,7 +5953,7 @@ checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 [[package]]
 name = "typeql"
 version = "0.0.0"
-source = "git+https://github.com/typedb/typeql?tag=3.12.2#7f4cac93fa8eee8643aa9f75eb60cacb5a454842"
+source = "git+https://github.com/typedb/typeql?tag=3.13.0-rc0#b1dffc04645bd3c74bdf71edd7f02b81ad440afc"
 dependencies = [
  "chrono",
  "itertools 0.14.0",

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -57,6 +57,9 @@ bazel_dep(name = "rules_python", version = "2.3.2")
 python = use_extension("@rules_python//python/extensions:python.bzl", "python")
 python.toolchain(is_default = True, python_version = "3.11", ignore_root_user_error = True)
 
+rules_python_config = use_extension("@rules_python//python/extensions:config.bzl", "config")
+rules_python_config.explicit_init_py(default = True)
+
 # Java
 bazel_dep(name = "rules_java", version = "8.6.2")
 
@@ -161,15 +164,15 @@ use_repo(
 bazel_dep(name = "typedb_bazel_distribution", version = "0.0.0")
 git_override(
     module_name = "typedb_bazel_distribution",
-    remote = "https://github.com/typedb/bazel-distribution",
-    commit = "c98429250c448e7bd940062584c3ebd6a2368faf",
+    remote = "https://github.com/krishnangovindraj/bazel-distribution",
+    commit = "f783fde1160f33412a959b60cbf4caa851720811",
 )
 
 bazel_dep(name = "typedb_dependencies", version = "0.0.0")
 git_override(
     module_name = "typedb_dependencies",
-    remote = "https://github.com/typedb/dependencies",
-    commit = "b137ccdae216d144bb5efc07a0bb42a662f17116",
+    remote = "https://github.com/krishnangovindraj/dependencies",
+    commit = "e4cfec76ebee4166d4ed4765c2068c798987c424",
 )
 
 bazel_dep(name = "typeql", version = "0.0.0")

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -164,15 +164,15 @@ use_repo(
 bazel_dep(name = "typedb_bazel_distribution", version = "0.0.0")
 git_override(
     module_name = "typedb_bazel_distribution",
-    remote = "https://github.com/krishnangovindraj/bazel-distribution",
-    commit = "f783fde1160f33412a959b60cbf4caa851720811",
+    remote = "https://github.com/typedb/bazel-distribution",
+    commit = "87a2092926b36a5c82cada9d21e1c3a6d6e32859",
 )
 
 bazel_dep(name = "typedb_dependencies", version = "0.0.0")
 git_override(
     module_name = "typedb_dependencies",
-    remote = "https://github.com/krishnangovindraj/dependencies",
-    commit = "e4cfec76ebee4166d4ed4765c2068c798987c424",
+    remote = "https://github.com/typedb/dependencies",
+    commit = "bf924ef788fd605224383a2ea7f59599862c6bab",
 )
 
 bazel_dep(name = "typeql", version = "0.0.0")


### PR DESCRIPTION
## Usage and product changes
Disable implicit init py file creation for bazel python targets, as advised by: bazel-contrib/rules_python#2945 

## Implementation
Configures this repo to disable the behaviour, as advised by the error message: 
```
rules_python_config = use_extension("@rules_python//python/extensions:config.bzl", "config")
rules_python_config.explicit_init_py(default = True)
```

Note this only influences targets in this repository, so we still get warnings from other dependencies such as `bazel_tools` and `rules_pkg`.
