### PR TITLE
Make CleanupIntervals pub in transaction

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5953,7 +5953,7 @@ checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 [[package]]
 name = "typeql"
 version = "0.0.0"
-source = "git+https://github.com/typedb/typeql?tag=3.12.2#7f4cac93fa8eee8643aa9f75eb60cacb5a454842"
+source = "git+https://github.com/typedb/typeql?tag=3.13.0-rc0#b1dffc04645bd3c74bdf71edd7f02b81ad440afc"
 dependencies = [
  "chrono",
  "itertools 0.14.0",

--- a/database/transaction.rs
+++ b/database/transaction.rs
@@ -9,10 +9,10 @@ use std::{
     sync::{Arc, mpsc::RecvTimeoutError},
 };
 
-pub use concept::thing::cleanup::CleanupRecord;
+pub use concept::thing::cleanup::{CleanupIntervals, CleanupRecord};
 use concept::{
     error::{ConceptReadError, ConceptWriteError},
-    thing::{cleanup::CleanupIntervals, statistics::StatisticsError, thing_manager::ThingManager},
+    thing::{statistics::StatisticsError, thing_manager::ThingManager},
     type_::type_manager::{
         TypeManager,
         type_cache::{TypeCache, TypeCacheCreateError},


### PR DESCRIPTION
## Product change and motivation

Use `pub use` for `CleanupIntervals` struct in `transaction` to expose this struct to the extensions of TypeDB.

This PR fixes the broken dependency introduced by the rename of `CleanupRecord` to `CleanupIntervals`: https://github.com/typedb/typedb/commit/83476cd0d9e8705a651b55532c6d6c111d606425

## Implementation

Export both cleanup-related structs (one for tests, one for extensions).