### PR TITLE
Support fully qualified names for builtin functions to emulate namespacing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5953,7 +5953,7 @@ checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 [[package]]
 name = "typeql"
 version = "0.0.0"
-source = "git+https://github.com/typedb/typeql?rev=a96735cc0d432a2c021f70a5bcf372ca5d4241ed#a96735cc0d432a2c021f70a5bcf372ca5d4241ed"
+source = "git+https://github.com/typedb/typeql?rev=5485e04a51c79ad1d29477db7532003c84983751#5485e04a51c79ad1d29477db7532003c84983751"
 dependencies = [
  "chrono",
  "itertools 0.14.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5953,7 +5953,7 @@ checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 [[package]]
 name = "typeql"
 version = "0.0.0"
-source = "git+https://github.com/typedb/typeql?tag=3.13.0#19f95d347288a9158e28603e4f9cc85181833109"
+source = "git+https://github.com/typedb/typeql?rev=a96735cc0d432a2c021f70a5bcf372ca5d4241ed#a96735cc0d432a2c021f70a5bcf372ca5d4241ed"
 dependencies = [
  "chrono",
  "itertools 0.14.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -222,7 +222,7 @@ features = {}
 
 		[workspace.dependencies.typeql]
 			features = []
-			rev = "a96735cc0d432a2c021f70a5bcf372ca5d4241ed"
+			rev = "74f11f52896677eef8ff142a86e4fd2da5c9df10"
 			git = "https://github.com/typedb/typeql"
 			default-features = false
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -222,8 +222,8 @@ features = {}
 
 		[workspace.dependencies.typeql]
 			features = []
+			rev = "a96735cc0d432a2c021f70a5bcf372ca5d4241ed"
 			git = "https://github.com/typedb/typeql"
-			tag = "3.13.0"
 			default-features = false
 
 		[workspace.dependencies.cache]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -222,7 +222,7 @@ features = {}
 
 		[workspace.dependencies.typeql]
 			features = []
-			rev = "74f11f52896677eef8ff142a86e4fd2da5c9df10"
+			rev = "5485e04a51c79ad1d29477db7532003c84983751"
 			git = "https://github.com/typedb/typeql"
 			default-features = false
 

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -110,7 +110,7 @@ workspace_refs(
     name = "typedb_workspace_refs",
     workspace_commit_dict = {
 #        "typedb_protocol+": "3a39f0b94fd7ea316ba5a4f74d44d5afc454cedf",
-        "typeql+": "a96735cc0d432a2c021f70a5bcf372ca5d4241ed",
+        "typeql+": "74f11f52896677eef8ff142a86e4fd2da5c9df10",
     },
     workspace_tag_dict = {
         "typedb_protocol+": "3.12.0",
@@ -179,7 +179,7 @@ bazel_dep(name = "typeql", version = "0.0.0")
 git_override(
     module_name = "typeql",
     remote = "https://github.com/krishnangovindraj/typeql",
-    commit = "a96735cc0d432a2c021f70a5bcf372ca5d4241ed",
+    commit = "74f11f52896677eef8ff142a86e4fd2da5c9df10",
 )
 
 bazel_dep(name = "typedb_protocol", version = "0.0.0")

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -110,7 +110,7 @@ workspace_refs(
     name = "typedb_workspace_refs",
     workspace_commit_dict = {
 #        "typedb_protocol+": "3a39f0b94fd7ea316ba5a4f74d44d5afc454cedf",
-        "typeql+": "74f11f52896677eef8ff142a86e4fd2da5c9df10",
+        "typeql+": "5485e04a51c79ad1d29477db7532003c84983751",
     },
     workspace_tag_dict = {
         "typedb_protocol+": "3.12.0",
@@ -178,8 +178,8 @@ git_override(
 bazel_dep(name = "typeql", version = "0.0.0")
 git_override(
     module_name = "typeql",
-    remote = "https://github.com/krishnangovindraj/typeql",
-    commit = "74f11f52896677eef8ff142a86e4fd2da5c9df10",
+    remote = "https://github.com/typedb/typeql",
+    commit = "5485e04a51c79ad1d29477db7532003c84983751",
 )
 
 bazel_dep(name = "typedb_protocol", version = "0.0.0")
@@ -192,8 +192,8 @@ git_override(
 bazel_dep(name = "typedb_behaviour", version = "0.0.0")
 git_override(
     module_name = "typedb_behaviour",
-    remote = "https://github.com/krishnangovindraj/typedb-behaviour",
-    commit = "e9c95511b576609e385978e94eff508f1e2a2ebe",
+    remote = "https://github.com/typedb/typedb-behaviour",
+    commit = "a428985711011ee5b9164bad65238a591f23e3ca",
 )
 
 http_file = use_repo_rule("@bazel_tools//tools/build_defs/repo:http.bzl", "http_file")

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -110,11 +110,11 @@ workspace_refs(
     name = "typedb_workspace_refs",
     workspace_commit_dict = {
 #        "typedb_protocol+": "3a39f0b94fd7ea316ba5a4f74d44d5afc454cedf",
-#        "typeql+": "9bd7d56a907e8bf60ac5a5a7ca609131bf1b24f3",
+        "typeql+": "a96735cc0d432a2c021f70a5bcf372ca5d4241ed",
     },
     workspace_tag_dict = {
         "typedb_protocol+": "3.12.0",
-        "typeql+": "3.13.0",
+#        "typeql+": "3.13.0",
     },
 )
 
@@ -178,8 +178,8 @@ git_override(
 bazel_dep(name = "typeql", version = "0.0.0")
 git_override(
     module_name = "typeql",
-    remote = "https://github.com/typedb/typeql",
-    tag = "3.13.0",
+    remote = "https://github.com/krishnangovindraj/typeql",
+    commit = "a96735cc0d432a2c021f70a5bcf372ca5d4241ed",
 )
 
 bazel_dep(name = "typedb_protocol", version = "0.0.0")
@@ -192,8 +192,8 @@ git_override(
 bazel_dep(name = "typedb_behaviour", version = "0.0.0")
 git_override(
     module_name = "typedb_behaviour",
-    remote = "https://github.com/typedb/typedb-behaviour",
-    commit = "888359942ccd234e64809215c0ff7c74343ff7ee",
+    remote = "https://github.com/krishnangovindraj/typedb-behaviour",
+    commit = "e9c95511b576609e385978e94eff508f1e2a2ebe",
 )
 
 http_file = use_repo_rule("@bazel_tools//tools/build_defs/repo:http.bzl", "http_file")

--- a/compiler/annotation/expression/builtin_resolution.rs
+++ b/compiler/annotation/expression/builtin_resolution.rs
@@ -18,7 +18,7 @@ use crate::annotation::expression::{
         },
         unary::{
             LenString, MathAbsDecimal, MathAbsDouble, MathAbsInteger, MathCeilDecimal, MathCeilDouble,
-            MathFloorDecimal, MathFloorDouble, MathRoundDecimal, MathRoundDouble,
+            MathFloorDecimal, MathFloorDouble, MathLog10Double, MathLog10Integer, MathRoundDecimal, MathRoundDouble,
         },
     },
 };
@@ -102,14 +102,15 @@ impl BinaryValueFunctionResolver for $fid {
     };
 }
 unary_builtin! {
-    Abs = MathAbs [ Integer, Double, Decimal, ]
-    Ceil = MathCeil [ Double, Decimal, ]
-    Floor = MathFloor [ Double, Decimal, ]
-    Round = MathRound [ Double, Decimal, ]
-    Len = Len [ String, ]
+    MathAbs = MathAbs [ Integer, Double, Decimal, ]
+    MathCeil = MathCeil [ Double, Decimal, ]
+    MathFloor = MathFloor [ Double, Decimal, ]
+    MathRound = MathRound [ Double, Decimal, ]
+    StringLen = Len [ String, ]
+    MathLog10 = MathLog10 [ Integer, Double, ]
 }
 
 binary_builtin! {
-    Max:true = MathMax [ (Integer, Integer), (Double, Double), (Decimal, Decimal), ]
-    Min:true = MathMin [ (Integer, Integer), (Double, Double), (Decimal, Decimal), ]
+    MathMax:true = MathMax [ (Integer, Integer), (Double, Double), (Decimal, Decimal), ]
+    MathMin:true = MathMin [ (Integer, Integer), (Double, Double), (Decimal, Decimal), ]
 }

--- a/compiler/annotation/expression/expression_compiler.rs
+++ b/compiler/annotation/expression/expression_compiler.rs
@@ -31,6 +31,11 @@ use crate::annotation::expression::{
         ExpressionInstruction, list_operations,
         load::{LoadConstant, LoadVariable},
         op_codes::ExpressionOpCode,
+        operators,
+        unary::{
+            LenString, MathAbsDecimal, MathAbsDouble, MathAbsInteger, MathCeilDecimal, MathCeilDouble,
+            MathFloorDecimal, MathFloorDouble, MathLog10Double, MathLog10Integer, MathRoundDecimal, MathRoundDouble,
+        },
     },
     operation_resolution,
 };
@@ -197,26 +202,29 @@ impl<'this> ExpressionCompilationContext<'this> {
 
     fn compile_value_builtin(&mut self, builtin: &BuiltinValueFunctionCall) -> Result<(), Box<ExpressionCompileError>> {
         match builtin.function_id() {
-            BuiltinValueFunctionID::Abs => {
-                UnaryValueFunctionResolverImpl::<builtin_resolution::Abs>::resolve_validate_append(builtin, self)
+            BuiltinValueFunctionID::MathAbs => {
+                UnaryValueFunctionResolverImpl::<builtin_resolution::MathAbs>::resolve_validate_append(builtin, self)
             }
-            BuiltinValueFunctionID::Ceil => {
-                UnaryValueFunctionResolverImpl::<builtin_resolution::Ceil>::resolve_validate_append(builtin, self)
+            BuiltinValueFunctionID::MathCeil => {
+                UnaryValueFunctionResolverImpl::<builtin_resolution::MathCeil>::resolve_validate_append(builtin, self)
             }
-            BuiltinValueFunctionID::Floor => {
-                UnaryValueFunctionResolverImpl::<builtin_resolution::Floor>::resolve_validate_append(builtin, self)
+            BuiltinValueFunctionID::MathFloor => {
+                UnaryValueFunctionResolverImpl::<builtin_resolution::MathFloor>::resolve_validate_append(builtin, self)
             }
-            BuiltinValueFunctionID::Round => {
-                UnaryValueFunctionResolverImpl::<builtin_resolution::Round>::resolve_validate_append(builtin, self)
+            BuiltinValueFunctionID::MathRound => {
+                UnaryValueFunctionResolverImpl::<builtin_resolution::MathRound>::resolve_validate_append(builtin, self)
             }
-            BuiltinValueFunctionID::Min => {
-                BinaryValueFunctionResolverImpl::<builtin_resolution::Min>::resolve_validate_append(builtin, self)
+            BuiltinValueFunctionID::MathMin => {
+                BinaryValueFunctionResolverImpl::<builtin_resolution::MathMin>::resolve_validate_append(builtin, self)
             }
-            BuiltinValueFunctionID::Max => {
-                BinaryValueFunctionResolverImpl::<builtin_resolution::Max>::resolve_validate_append(builtin, self)
+            BuiltinValueFunctionID::MathMax => {
+                BinaryValueFunctionResolverImpl::<builtin_resolution::MathMax>::resolve_validate_append(builtin, self)
             }
-            BuiltinValueFunctionID::Len => {
-                UnaryValueFunctionResolverImpl::<builtin_resolution::Len>::resolve_validate_append(builtin, self)
+            BuiltinValueFunctionID::StringLen => {
+                UnaryValueFunctionResolverImpl::<builtin_resolution::StringLen>::resolve_validate_append(builtin, self)
+            }
+            BuiltinValueFunctionID::MathLog10 => {
+                UnaryValueFunctionResolverImpl::<builtin_resolution::MathLog10>::resolve_validate_append(builtin, self)
             }
         }
     }

--- a/compiler/annotation/expression/instructions/op_codes.rs
+++ b/compiler/annotation/expression/instructions/op_codes.rs
@@ -64,8 +64,6 @@ macro_rules! for_each_opcode {
             MathAbsDecimal,
             MathAbsInteger,
 
-            MathRemainderInteger,
-
             MathRoundDouble,
             MathCeilDouble,
             MathFloorDouble,
@@ -81,6 +79,11 @@ macro_rules! for_each_opcode {
             MathMaxIntegerInteger,
             MathMaxDoubleDouble,
             MathMaxDecimalDecimal,
+
+            MathRemainderInteger,
+
+            MathLog10Integer,
+            MathLog10Double,
 
             LenString,
         }

--- a/compiler/annotation/expression/instructions/unary.rs
+++ b/compiler/annotation/expression/instructions/unary.rs
@@ -80,4 +80,7 @@ unary_instruction! { 'a
         let len = a1.chars().count();
         len.try_into().map_err(|_| ExpressionEvaluationError::OverlongString { len })
     }
+
+    MathLog10Integer(a1: i64) -> f64 { Ok((a1 as f64).log10()) }
+    MathLog10Double(a1: f64) -> f64 { Ok(a1.log10()) }
 }

--- a/executor/read/expression_executor.rs
+++ b/executor/read/expression_executor.rs
@@ -35,7 +35,8 @@ use compiler::{
             },
             unary::{
                 LenString, MathAbsDecimal, MathAbsDouble, MathAbsInteger, MathCeilDecimal, MathCeilDouble,
-                MathFloorDecimal, MathFloorDouble, MathRoundDecimal, MathRoundDouble, Unary, UnaryExpression,
+                MathFloorDecimal, MathFloorDouble, MathLog10Double, MathLog10Integer, MathRoundDecimal,
+                MathRoundDouble, Unary, UnaryExpression,
             },
         },
     },

--- a/ir/pattern/expression.rs
+++ b/ir/pattern/expression.rs
@@ -14,9 +14,10 @@ use std::{
 use answer::variable::Variable;
 use error::typedb_error;
 use structural_equality::StructuralEquality;
-use typeql::common::Span;
+use typeql::{common::Span, expression::NamespacedFunctionName};
 
 use crate::{
+    RepresentationError,
     pattern::{
         IrID, ParameterID,
         variable_category::{VariableCategory, VariableOptionality},
@@ -281,15 +282,47 @@ impl StructuralEquality for BuiltinValueFunctionCall {
     }
 }
 
-#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
-pub enum BuiltinValueFunctionID {
-    Abs,
-    Ceil,
-    Floor,
-    Round,
-    Max,
-    Min,
-    Len,
+macro_rules! function_id_enum {
+    ( $($id:ident = $name:literal,)* ) => {
+        #[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
+        pub enum BuiltinValueFunctionID {
+            $( $id, ) *
+        }
+
+        impl BuiltinValueFunctionID {
+            pub(crate) fn resolve_namespaced(name: &NamespacedFunctionName) -> Result<Self, Box<RepresentationError>> {
+                match name.name.as_str() {
+                    $( $name => Ok(Self::$id), )*
+                    other => Err(Box::new(RepresentationError::UnresolvedFunction {
+                        function_name: other.to_owned(),
+                        source_span: name.span.clone(),
+                    }))
+                }
+            }
+
+            fn name(&self) -> &'static str {
+                match self {
+                    $( Self::$id => $name, )*
+                }
+            }
+        }
+    };
+}
+
+function_id_enum! {
+    // math unary
+    MathAbs = "std::math::abs",
+    MathCeil = "std::math::ceil",
+    MathFloor = "std::math::floor",
+    MathRound = "std::math::round",
+    MathLog10 = "std::math::log10",
+
+    // math binary
+    MathMax = "std::math::max",
+    MathMin = "std::math::min",
+
+    // string
+    StringLen = "std::string::len",
 }
 
 impl StructuralEquality for BuiltinValueFunctionID {
@@ -304,15 +337,7 @@ impl StructuralEquality for BuiltinValueFunctionID {
 
 impl fmt::Display for BuiltinValueFunctionID {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Self::Abs => fmt::Display::fmt(&typeql::token::Function::Abs, f),
-            Self::Ceil => fmt::Display::fmt(&typeql::token::Function::Ceil, f),
-            Self::Floor => fmt::Display::fmt(&typeql::token::Function::Floor, f),
-            Self::Round => fmt::Display::fmt(&typeql::token::Function::Round, f),
-            Self::Max => fmt::Display::fmt(&typeql::token::Function::Max, f),
-            Self::Min => fmt::Display::fmt(&typeql::token::Function::Min, f),
-            Self::Len => fmt::Display::fmt(&typeql::token::Function::Len, f),
-        }
+        fmt::Display::fmt(self.name(), f)
     }
 }
 

--- a/ir/translation/constraints.rs
+++ b/ir/translation/constraints.rs
@@ -536,7 +536,8 @@ fn add_typeql_iterable_binding(
         typeql::Expression::Function(FunctionCall { name: FunctionName::Identifier(identifier), args, span }) => {
             add_function_call(function_index, constraints, checked_identifier(identifier)?, assigned, args, *span)
         }
-        typeql::Expression::Function(FunctionCall { name: FunctionName::Builtin(_), .. }) => {
+        typeql::Expression::Function(FunctionCall { name: FunctionName::Namespaced(_), .. })
+        | typeql::Expression::Function(FunctionCall { name: FunctionName::Builtin(_), .. }) => {
             Err(Box::new(RepresentationError::UnimplementedLanguageFeature {
                 feature: UnimplementedFeature::LetInBuiltinCall,
             }))

--- a/ir/translation/expression.rs
+++ b/ir/translation/expression.rs
@@ -8,7 +8,7 @@ use answer::variable::Variable;
 use encoding::value::value::Value;
 use typeql::{
     common::{Span, Spanned},
-    expression::{BuiltinFunctionName, FunctionName},
+    expression::{BuiltinFunctionName, FunctionName, NamespacedFunctionName},
     token::{ArithmeticOperator, Function},
 };
 
@@ -199,6 +199,18 @@ fn build_function(
     tree: &mut ExpressionTree<Variable>,
 ) -> Result<Expression<Variable>, Box<RepresentationError>> {
     match &function_call.name {
+        FunctionName::Namespaced(namespaced) => {
+            let args = function_call
+                .args
+                .iter()
+                .map(|expr| build_recursive(function_index, constraints, expr, tree))
+                .collect::<Result<Vec<_>, _>>()?;
+            Ok(Expression::BuiltinValueFunctionCall(BuiltinValueFunctionCall::new(
+                to_namespaced_value_function_id(namespaced, &args)?,
+                args,
+                namespaced.span(),
+            )))
+        }
         FunctionName::Builtin(builtin) if is_builtin_value_function(builtin) => {
             let args = function_call
                 .args
@@ -280,6 +292,13 @@ fn is_builtin_value_function(typeql_id: &BuiltinFunctionName) -> bool {
     )
 }
 
+fn to_namespaced_value_function_id(
+    name: &NamespacedFunctionName,
+    args: &[usize],
+) -> Result<BuiltinValueFunctionID, Box<RepresentationError>> {
+    BuiltinValueFunctionID::resolve_namespaced(name)
+}
+
 fn to_builtin_value_function_id(
     typeql_id: &BuiltinFunctionName,
     args: &[usize],
@@ -288,31 +307,31 @@ fn to_builtin_value_function_id(
     match token {
         Function::Abs => {
             check_builtin_arg_count(token, args.len(), 1, typeql_id.span())?;
-            Ok(BuiltinValueFunctionID::Abs)
+            Ok(BuiltinValueFunctionID::MathAbs)
         }
         Function::Ceil => {
             check_builtin_arg_count(token, args.len(), 1, typeql_id.span())?;
-            Ok(BuiltinValueFunctionID::Ceil)
+            Ok(BuiltinValueFunctionID::MathCeil)
         }
         Function::Floor => {
             check_builtin_arg_count(token, args.len(), 1, typeql_id.span())?;
-            Ok(BuiltinValueFunctionID::Floor)
+            Ok(BuiltinValueFunctionID::MathFloor)
         }
         Function::Round => {
             check_builtin_arg_count(token, args.len(), 1, typeql_id.span())?;
-            Ok(BuiltinValueFunctionID::Round)
+            Ok(BuiltinValueFunctionID::MathRound)
         }
         Function::Max => {
             check_builtin_arg_count(token, args.len(), 2, typeql_id.span())?;
-            Ok(BuiltinValueFunctionID::Max)
+            Ok(BuiltinValueFunctionID::MathMax)
         }
         Function::Min => {
             check_builtin_arg_count(token, args.len(), 2, typeql_id.span())?;
-            Ok(BuiltinValueFunctionID::Min)
+            Ok(BuiltinValueFunctionID::MathMin)
         }
         Function::Len => {
             check_builtin_arg_count(token, args.len(), 1, typeql_id.span())?;
-            Ok(BuiltinValueFunctionID::Len)
+            Ok(BuiltinValueFunctionID::StringLen)
         }
         _ => Err(Box::new(RepresentationError::InternalNotAValueBuiltin { token, source_span: typeql_id.span() })),
     }

--- a/ir/translation/fetch.rs
+++ b/ir/translation/fetch.rs
@@ -135,7 +135,7 @@ fn translate_fetch_list(
         }
         FetchStream::Function(call) => {
             match &call.name {
-                FunctionName::Builtin(name) => {
+                FunctionName::Namespaced(_) | FunctionName::Builtin(_) => {
                     // built-in functions always return single values, so should not be wrapped in a list (although we could allow it if it's something interesting)
                     Err(Box::new(FetchRepresentationError::BuiltinFunctionInList { declaration: call.clone() }))
                 }
@@ -219,7 +219,7 @@ fn translate_fetch_single(
                 translate_inline_expression_single(parent_context, value_parameters, function_index, expression)
             }
             Expression::Function(call) => match &call.name {
-                FunctionName::Builtin(_) => {
+                FunctionName::Namespaced(_) | FunctionName::Builtin(_) => {
                     translate_inline_expression_single(parent_context, value_parameters, function_index, expression)
                 }
                 FunctionName::Identifier(name) => {


### PR DESCRIPTION
## Product change and motivation
Support using fully qualified function names to invoke built-in functions (e.g. `let $rounded = std::math::round(1.5);`).
Using the name directly is still supported for existing functions, but most future functions will need to be invoked using fully qualified names till namespacing is fully supported.

## Implementation
Looks up fully qualified names as if they were normal names.
Older names are redirected to use the implementation of the namespaced functions.