### PR TITLE
Split impl of the embedded Checker which extracts from TupleIterator and the standalone Checker

### DIFF
--- a/executor/instruction/checker.rs
+++ b/executor/instruction/checker.rs
@@ -222,72 +222,6 @@ impl<T> Checker<T> {
         }
     }
 
-    pub(crate) fn filter(
-        &self,
-        context: &ExecutionContext<impl ReadableSnapshot + 'static>,
-        row: &MaybeOwnedRow<'_>,
-        source: T,
-        storage_counters: StorageCounters,
-    ) -> Result<bool, Box<ConceptReadError>> {
-        for check in &self.checks {
-            let passes = match check {
-                CheckInstruction::Iid { var, iid } => self.filter_iid(context, row, *var, &source, iid),
-                CheckInstruction::TypeList { type_var, types } => {
-                    self.filter_type_list(context, row, *type_var, &source, types)
-                }
-                CheckInstruction::ThingTypeList { thing_var, types } => {
-                    self.filter_thing_type_list(context, row, *thing_var, &source, types)
-                }
-                CheckInstruction::Sub { sub_kind, subtype, supertype } => {
-                    self.filter_sub(context, row, *sub_kind, &source, subtype, supertype)?
-                }
-                CheckInstruction::Owns { owner, attribute } => {
-                    self.filter_owns(context, row, &source, owner, attribute)?
-                }
-                CheckInstruction::Relates { relation, role_type } => {
-                    self.filter_relates(context, row, &source, relation, role_type)?
-                }
-                CheckInstruction::Plays { player, role_type } => {
-                    self.filter_plays(context, row, &source, player, role_type)?
-                }
-                CheckInstruction::Isa { isa_kind, type_, thing } => {
-                    self.filter_isa(context, row, &source, *isa_kind, type_, thing)?
-                }
-                CheckInstruction::Has { owner, attribute } => {
-                    self.filter_has(context, row, &source, owner, attribute, storage_counters.clone())?
-                }
-                CheckInstruction::Links { relation, player, role } => {
-                    self.filter_links(context, row, &source, relation, player, role, storage_counters.clone())?
-                }
-                CheckInstruction::IndexedRelation { start_player, end_player, relation, start_role, end_role } => self
-                    .filter_indexed_relation(
-                        context,
-                        row,
-                        &source,
-                        start_player,
-                        end_player,
-                        relation,
-                        start_role,
-                        end_role,
-                        storage_counters.clone(),
-                    )?,
-                CheckInstruction::Is { lhs, rhs } => self.filter_is(row, &source, *lhs, *rhs),
-                CheckInstruction::LinksDeduplication { role1, player1, role2, player2 } => {
-                    self.filter_links_dedup(row, &source, *role1, *player1, *role2, *player2)
-                }
-                CheckInstruction::Comparison { lhs, rhs, comparator } => {
-                    self.filter_comparison(context, row, &source, lhs, rhs, *comparator, storage_counters.clone())?
-                }
-                CheckInstruction::NotNone { variables } => Self::filter_not_none(row, variables),
-                CheckInstruction::Unsatisfiable => false,
-            };
-            if !passes {
-                return Ok(false);
-            }
-        }
-        Ok(true)
-    }
-
     pub(crate) fn filter_fn_for_row(
         &self,
         context: &ExecutionContext<impl ReadableSnapshot + 'static>,
@@ -337,10 +271,7 @@ impl<T> Checker<T> {
                 &CheckInstruction::LinksDeduplication { role1, player1, role2, player2 } => {
                     self.filter_links_dedup_fn(row, role1, player1, role2, player2)
                 }
-                CheckInstruction::NotNone { variables } => {
-                    todo!()
-                    // self.filter_not(context, row, check)
-                }
+                CheckInstruction::NotNone { variables } => self.filter_not_none_fn(context, row, variables),
                 &CheckInstruction::Is { lhs, rhs } => self.filter_is_fn(row, lhs, rhs),
                 CheckInstruction::Comparison { lhs, rhs, comparator } => {
                     self.filter_comparison_fn(context, row, lhs, rhs, *comparator, storage_counters.clone())
@@ -373,22 +304,6 @@ impl<T> Checker<T> {
         Box::new(move |value: &T| Ok(Self::check_iid(&iid, var(value))))
     }
 
-    fn filter_iid(
-        &self,
-        context: &ExecutionContext<impl ReadableSnapshot + 'static>,
-        row: &MaybeOwnedRow<'_>,
-        var: ExecutorVariable,
-        source: &T,
-        iid: &ir::pattern::ParameterID,
-    ) -> bool {
-        let extracted = match self.extractors.get(&var) {
-            Some(function) => function(source),
-            None => get_vertex_value(&CheckVertex::Variable(var), Some(row), &context.parameters),
-        };
-        let iid = context.parameters().iid(iid).unwrap();
-        Self::check_iid(iid, extracted)
-    }
-
     fn check_iid(iid: &ByteArray<{ THING_VERTEX_MAX_LENGTH }>, value: VariableValue<'_>) -> bool {
         match value {
             VariableValue::Thing(thing) => match thing {
@@ -415,21 +330,6 @@ impl<T> Checker<T> {
         Box::new(move |value: &T| Ok(types.contains(&unwrap_or_result_false!(type_(value) => Type))))
     }
 
-    fn filter_type_list(
-        &self,
-        context: &ExecutionContext<impl ReadableSnapshot + 'static>,
-        row: &MaybeOwnedRow<'_>,
-        type_var: ExecutorVariable,
-        source: &T,
-        types: &std::sync::Arc<std::collections::BTreeSet<Type>>,
-    ) -> bool {
-        let extracted = match self.extractors.get(&type_var) {
-            Some(function) => function(source),
-            None => get_vertex_value(&CheckVertex::Variable(type_var), Some(row), &context.parameters),
-        };
-        types.contains(&unwrap_or_return_false!(extracted => Type))
-    }
-
     fn filter_thing_type_list_fn(
         &self,
         context: &ExecutionContext<impl ReadableSnapshot + 'static>,
@@ -440,21 +340,6 @@ impl<T> Checker<T> {
         let thing = self.make_extractor(&CheckVertex::Variable(thing_var), row, context);
         let types = types.clone();
         Box::new(move |value: &T| Ok(types.contains(&unwrap_or_result_false!(thing(value) => Thing).type_())))
-    }
-
-    fn filter_thing_type_list(
-        &self,
-        context: &ExecutionContext<impl ReadableSnapshot + 'static>,
-        row: &MaybeOwnedRow<'_>,
-        thing_var: ExecutorVariable,
-        source: &T,
-        types: &std::sync::Arc<std::collections::BTreeSet<Type>>,
-    ) -> bool {
-        let extracted = match self.extractors.get(&thing_var) {
-            Some(function) => function(source),
-            None => get_vertex_value(&CheckVertex::Variable(thing_var), Some(row), &context.parameters),
-        };
-        types.contains(&unwrap_or_return_false!(extracted => Thing).type_())
     }
 
     fn filter_sub_fn(
@@ -474,32 +359,6 @@ impl<T> Checker<T> {
             let supertype = unwrap_or_result_false!(supertype(source) => Type);
             Self::check_sub(&*snapshot, &*thing_manager, sub_kind, subtype, supertype)
         })
-    }
-
-    fn filter_sub(
-        &self,
-        context: &ExecutionContext<impl ReadableSnapshot + 'static>,
-        row: &MaybeOwnedRow<'_>,
-        sub_kind: SubKind,
-        source: &T,
-        subtype: &CheckVertex<ExecutorVariable>,
-        supertype: &CheckVertex<ExecutorVariable>,
-    ) -> Result<bool, Box<ConceptReadError>> {
-        let subtype = match subtype.as_variable().and_then(|var| self.extractors.get(&var)) {
-            Some(function) => function(source),
-            None => get_vertex_value(subtype, Some(row), &context.parameters),
-        };
-        let supertype = match supertype.as_variable().and_then(|var| self.extractors.get(&var)) {
-            Some(function) => function(source),
-            None => get_vertex_value(supertype, Some(row), &context.parameters),
-        };
-        Self::check_sub(
-            context.snapshot.as_ref(),
-            context.thing_manager.as_ref(),
-            sub_kind,
-            unwrap_or_result_false!(subtype => Type),
-            unwrap_or_result_false!(supertype => Type),
-        )
     }
 
     fn check_sub(
@@ -533,29 +392,6 @@ impl<T> Checker<T> {
         })
     }
 
-    fn filter_owns(
-        &self,
-        context: &ExecutionContext<impl ReadableSnapshot + 'static>,
-        row: &MaybeOwnedRow<'_>,
-        source: &T,
-        owner: &CheckVertex<ExecutorVariable>,
-        attribute: &CheckVertex<ExecutorVariable>,
-    ) -> Result<bool, Box<ConceptReadError>> {
-        let owner = match owner.as_variable().and_then(|var| self.extractors.get(&var)) {
-            Some(&function) => function(source),
-            None => get_vertex_value(owner, Some(row), &context.parameters),
-        };
-        let attribute = match attribute.as_variable().and_then(|var| self.extractors.get(&var)) {
-            Some(&function) => function(source),
-            None => get_vertex_value(attribute, Some(row), &context.parameters),
-        };
-        let owner = unwrap_or_result_false!(owner => Type).as_object_type();
-        let attribute = unwrap_or_result_false!(attribute => Type).as_attribute_type();
-        owner
-            .get_owns_attribute(context.snapshot.as_ref(), context.thing_manager.clone().type_manager(), attribute)
-            .map(|owns| owns.is_some())
-    }
-
     fn filter_relates_fn(
         &self,
         context: &ExecutionContext<impl ReadableSnapshot + 'static>,
@@ -574,29 +410,6 @@ impl<T> Checker<T> {
                 .get_relates_role(&*snapshot, thing_manager.type_manager(), role_type)
                 .map(|relates| relates.is_some())
         })
-    }
-
-    fn filter_relates(
-        &self,
-        context: &ExecutionContext<impl ReadableSnapshot + 'static>,
-        row: &MaybeOwnedRow<'_>,
-        source: &T,
-        relation: &CheckVertex<ExecutorVariable>,
-        role_type: &CheckVertex<ExecutorVariable>,
-    ) -> Result<bool, Box<ConceptReadError>> {
-        let relation = match relation.as_variable().and_then(|var| self.extractors.get(&var)) {
-            Some(function) => function(source),
-            None => get_vertex_value(relation, Some(row), &context.parameters),
-        };
-        let role_type = match role_type.as_variable().and_then(|var| self.extractors.get(&var)) {
-            Some(function) => function(source),
-            None => get_vertex_value(role_type, Some(row), &context.parameters),
-        };
-        let relation_type = unwrap_or_result_false!(relation => Type).as_relation_type();
-        let role_type = unwrap_or_result_false!(role_type => Type).as_role_type();
-        relation_type
-            .get_relates_role(context.snapshot.as_ref(), context.thing_manager.type_manager(), role_type)
-            .map(|relates| relates.is_some())
     }
 
     fn filter_plays_fn(
@@ -619,29 +432,6 @@ impl<T> Checker<T> {
                     .map(|plays| plays.is_some())
             }
         })
-    }
-
-    fn filter_plays(
-        &self,
-        context: &ExecutionContext<impl ReadableSnapshot + 'static>,
-        row: &MaybeOwnedRow<'_>,
-        source: &T,
-        player: &CheckVertex<ExecutorVariable>,
-        role_type: &CheckVertex<ExecutorVariable>,
-    ) -> Result<bool, Box<ConceptReadError>> {
-        let player = match player.as_variable().and_then(|var| self.extractors.get(&var)) {
-            Some(function) => function(source),
-            None => get_vertex_value(player, Some(row), &context.parameters),
-        };
-        let role_type = match role_type.as_variable().and_then(|var| self.extractors.get(&var)) {
-            Some(&function) => function(source),
-            None => get_vertex_value(role_type, Some(row), &context.parameters),
-        };
-        let object_type = unwrap_or_result_false!(player => Type).as_object_type();
-        let role_type = unwrap_or_result_false!(role_type => Type).as_role_type();
-        object_type
-            .get_plays_role(context.snapshot.as_ref(), context.thing_manager.type_manager(), role_type)
-            .map(|plays| plays.is_some())
     }
 
     fn filter_isa_fn(
@@ -669,32 +459,6 @@ impl<T> Checker<T> {
         })
     }
 
-    fn filter_isa(
-        &self,
-        context: &ExecutionContext<impl ReadableSnapshot + 'static>,
-        row: &MaybeOwnedRow<'_>,
-        source: &T,
-        isa_kind: IsaKind,
-        type_: &CheckVertex<ExecutorVariable>,
-        thing: &CheckVertex<ExecutorVariable>,
-    ) -> Result<bool, Box<ConceptReadError>> {
-        let thing = match thing.as_variable().and_then(|var| self.extractors.get(&var)) {
-            Some(function) => function(source),
-            None => get_vertex_value(thing, Some(row), &context.parameters),
-        };
-        let type_ = match type_.as_variable().and_then(|var| self.extractors.get(&var)) {
-            Some(function) => function(source),
-            None => get_vertex_value(type_, Some(row), &context.parameters),
-        };
-        let actual = unwrap_or_result_false!(thing => Thing).type_();
-        let expected = unwrap_or_result_false!(type_ => Type);
-        if isa_kind == IsaKind::Exact {
-            Ok(actual == expected)
-        } else {
-            actual.is_transitive_subtype_of(expected, context.snapshot.as_ref(), context.thing_manager.type_manager())
-        }
-    }
-
     fn filter_has_fn(
         &self,
         context: &ExecutionContext<impl ReadableSnapshot + 'static>,
@@ -715,33 +479,6 @@ impl<T> Checker<T> {
                 owner.has_attribute(&*snapshot, &thing_manager, attribute, storage_counters.clone())
             }
         })
-    }
-
-    fn filter_has(
-        &self,
-        context: &ExecutionContext<impl ReadableSnapshot + 'static>,
-        row: &MaybeOwnedRow<'_>,
-        source: &T,
-        owner: &CheckVertex<ExecutorVariable>,
-        attribute: &CheckVertex<ExecutorVariable>,
-        storage_counters: StorageCounters,
-    ) -> Result<bool, Box<ConceptReadError>> {
-        let owner = match owner.as_variable().and_then(|var| self.extractors.get(&var)) {
-            Some(function) => function(source),
-            None => get_vertex_value(owner, Some(row), &context.parameters),
-        };
-        let attribute = match attribute.as_variable().and_then(|var| self.extractors.get(&var)) {
-            Some(function) => function(source),
-            None => get_vertex_value(attribute, Some(row), &context.parameters),
-        };
-        let owner = unwrap_or_result_false!(&owner => Thing).as_object();
-        let attribute = unwrap_or_result_false!(&attribute => Thing).as_attribute();
-        owner.has_attribute(
-            context.snapshot.as_ref(),
-            context.thing_manager.as_ref(),
-            attribute,
-            storage_counters.clone(),
-        )
     }
 
     fn filter_links_fn(
@@ -766,40 +503,6 @@ impl<T> Checker<T> {
                 relation.has_role_player(&*snapshot, &thing_manager, player, role, storage_counters.clone())
             }
         })
-    }
-
-    fn filter_links(
-        &self,
-        context: &ExecutionContext<impl ReadableSnapshot + 'static>,
-        row: &MaybeOwnedRow<'_>,
-        source: &T,
-        relation: &CheckVertex<ExecutorVariable>,
-        player: &CheckVertex<ExecutorVariable>,
-        role: &CheckVertex<ExecutorVariable>,
-        storage_counters: StorageCounters,
-    ) -> Result<bool, Box<ConceptReadError>> {
-        let relation = match relation.as_variable().and_then(|var| self.extractors.get(&var)) {
-            Some(function) => function(source),
-            None => get_vertex_value(relation, Some(row), &context.parameters),
-        };
-        let player = match player.as_variable().and_then(|var| self.extractors.get(&var)) {
-            Some(function) => function(source),
-            None => get_vertex_value(player, Some(row), &context.parameters),
-        };
-        let role = match role.as_variable().and_then(|var| self.extractors.get(&var)) {
-            Some(function) => function(source),
-            None => get_vertex_value(role, Some(row), &context.parameters),
-        };
-        let relation = unwrap_or_result_false!(relation => Thing).as_relation();
-        let player = unwrap_or_result_false!(player => Thing).as_object();
-        let role = unwrap_or_result_false!(role => Type).as_role_type();
-        relation.has_role_player(
-            context.snapshot.as_ref(),
-            context.thing_manager.as_ref(),
-            player,
-            role,
-            storage_counters.clone(),
-        )
     }
 
     fn filter_indexed_relation_fn(
@@ -840,54 +543,6 @@ impl<T> Checker<T> {
         })
     }
 
-    fn filter_indexed_relation(
-        &self,
-        context: &ExecutionContext<impl ReadableSnapshot + 'static>,
-        row: &MaybeOwnedRow<'_>,
-        source: &T,
-        start_player: &CheckVertex<ExecutorVariable>,
-        end_player: &CheckVertex<ExecutorVariable>,
-        relation: &CheckVertex<ExecutorVariable>,
-        start_role: &CheckVertex<ExecutorVariable>,
-        end_role: &CheckVertex<ExecutorVariable>,
-        storage_counters: StorageCounters,
-    ) -> Result<bool, Box<ConceptReadError>> {
-        let start_player_extractor = match start_player.as_variable().and_then(|var| self.extractors.get(&var)) {
-            Some(function) => function(source),
-            None => get_vertex_value(start_player, Some(row), &context.parameters),
-        };
-        let end_player_extractor = match end_player.as_variable().and_then(|var| self.extractors.get(&var)) {
-            Some(function) => function(source),
-            None => get_vertex_value(end_player, Some(row), &context.parameters),
-        };
-        let relation_extractor = match relation.as_variable().and_then(|var| self.extractors.get(&var)) {
-            Some(function) => function(source),
-            None => get_vertex_value(relation, Some(row), &context.parameters),
-        };
-        let start_role_extractor = match start_role.as_variable().and_then(|var| self.extractors.get(&var)) {
-            Some(function) => function(source),
-            None => get_vertex_value(start_role, Some(row), &context.parameters),
-        };
-        let end_role_extractor = match end_role.as_variable().and_then(|var| self.extractors.get(&var)) {
-            Some(function) => function(source),
-            None => get_vertex_value(end_role, Some(row), &context.parameters),
-        };
-        let object = unwrap_or_result_false!(start_player_extractor => Thing).as_object();
-        let end_player = unwrap_or_result_false!(end_player_extractor => Thing).as_object();
-        let relation = unwrap_or_result_false!(relation_extractor => Thing).as_relation();
-        let start_role = unwrap_or_result_false!(start_role_extractor => Type).as_role_type();
-        let end_role = unwrap_or_result_false!(end_role_extractor => Type).as_role_type();
-        object.has_indexed_relation_player(
-            context.snapshot.as_ref(),
-            context.thing_manager.as_ref(),
-            end_player,
-            relation,
-            start_role,
-            end_role,
-            storage_counters.clone(),
-        )
-    }
-
     fn filter_is_fn(
         &self,
         row: &MaybeOwnedRow<'_>,
@@ -914,24 +569,6 @@ impl<T> Checker<T> {
         };
         // NOTE: Empty is Empty matches
         Box::new(move |value: &T| Ok(lhs(value) == rhs(value)))
-    }
-
-    fn filter_is(&self, row: &MaybeOwnedRow<'_>, source: &T, lhs: ExecutorVariable, rhs: ExecutorVariable) -> bool {
-        let lhs = match self.extractors.get(&lhs) {
-            Some(function) => function(source),
-            None => {
-                let ExecutorVariable::RowPosition(pos) = lhs else { unreachable!() };
-                row.get(pos).as_reference()
-            }
-        };
-        let rhs = match self.extractors.get(&rhs) {
-            Some(function) => function(source),
-            None => {
-                let ExecutorVariable::RowPosition(pos) = rhs else { unreachable!() };
-                row.get(pos).as_reference()
-            }
-        };
-        lhs == rhs
     }
 
     fn filter_links_dedup_fn(
@@ -981,66 +618,15 @@ impl<T> Checker<T> {
         Box::new(move |value: &T| Ok(!(role1(value) == role2(value) && player1(value) == player2(value))))
     }
 
-    fn filter_links_dedup(
-        &self,
-        row: &MaybeOwnedRow<'_>,
-        source: &T,
-        role1: ExecutorVariable,
-        player1: ExecutorVariable,
-        role2: ExecutorVariable,
-        player2: ExecutorVariable,
-    ) -> bool {
-        let role1 = match self.extractors.get(&role1) {
-            Some(function) => function(source),
-            None => {
-                let ExecutorVariable::RowPosition(pos) = role1 else { unreachable!() };
-                row.get(pos).as_reference()
-            }
-        };
-        let player1 = match self.extractors.get(&player1) {
-            Some(function) => function(source),
-            None => {
-                let ExecutorVariable::RowPosition(pos) = player1 else { unreachable!() };
-                row.get(pos).as_reference()
-            }
-        };
-        let role2 = match self.extractors.get(&role2) {
-            Some(function) => function(source),
-            None => {
-                let ExecutorVariable::RowPosition(pos) = role2 else { unreachable!() };
-                row.get(pos).as_reference()
-            }
-        };
-        let player2 = match self.extractors.get(&player2) {
-            Some(function) => function(source),
-            None => {
-                let ExecutorVariable::RowPosition(pos) = player2 else { unreachable!() };
-                row.get(pos).as_reference()
-            }
-        };
-        !(role1 == role2 && player1 == player2)
-    }
-
     fn filter_not_none_fn(
+        &self,
+        context: &ExecutionContext<impl ReadableSnapshot + 'static>,
         row: &MaybeOwnedRow<'_>,
-        variables: Arc<Vec<ExecutorVariable>>,
+        variables: &[ExecutorVariable],
     ) -> Box<dyn Fn(&T) -> Result<bool, Box<ConceptReadError>>> {
-        let values: Vec<_> = variables
-            .iter()
-            .map(|var| {
-                let ExecutorVariable::RowPosition(pos) = var else { unreachable!() };
-                row.get(*pos).clone().into_owned()
-            })
-            .collect();
-        Box::new(move |_value: &T| Ok(values.iter().all(|value| !value.is_none())))
-    }
-
-    fn filter_not_none(row: &MaybeOwnedRow<'_>, variables: &[ExecutorVariable]) -> bool {
-        variables.iter().all(|var| {
-            let ExecutorVariable::RowPosition(pos) = var else { unreachable!() };
-            let value = row.get(*pos);
-            !value.is_none()
-        })
+        let extractors: Vec<_> =
+            variables.iter().map(|var| self.make_extractor(&CheckVertex::Variable(*var), row, context)).collect();
+        Box::new(move |value: &T| Ok(extractors.iter().all(|extractor| !extractor(value).is_none())))
     }
 
     fn filter_comparison_fn(
@@ -1084,28 +670,314 @@ impl<T> Checker<T> {
         })
     }
 
-    fn filter_comparison(
-        &self,
+    fn cmp_values_fn(comparator: &Comparator) -> fn(&Value<'_>, &Value<'_>) -> bool {
+        match comparator {
+            Comparator::Equal => |a, b| a == b,
+            Comparator::NotEqual => |a, b| a != b,
+            Comparator::Less => |a, b| a < b,
+            Comparator::Greater => |a, b| a > b,
+            Comparator::LessOrEqual => |a, b| a <= b,
+            Comparator::GreaterOrEqual => |a, b| a >= b,
+            Comparator::Like => |a, b| {
+                // TODO: Avoid recompiling the regex every time.
+                regex::Regex::new(b.unwrap_string_ref())
+                    .expect("Invalid regex should have been caught at compile time")
+                    .is_match(a.unwrap_string_ref())
+            },
+            Comparator::Contains => |a, b| {
+                let a_unicase = UniCase::new(a.unwrap_string_ref()).to_folded_case();
+                let b_unicase = UniCase::new(b.unwrap_string_ref()).to_folded_case();
+                a_unicase.contains(b_unicase.as_str())
+            },
+        }
+    }
+}
+
+impl Checker<()> {
+    pub(crate) fn filter(
+        checks: &[CheckInstruction<ExecutorVariable>],
         context: &ExecutionContext<impl ReadableSnapshot + 'static>,
         row: &MaybeOwnedRow<'_>,
-        source: &T,
+        storage_counters: StorageCounters,
+    ) -> Result<bool, Box<ConceptReadError>> {
+        for check in checks {
+            let passes = match check {
+                CheckInstruction::Iid { var, iid } => Self::filter_iid(context, row, *var, iid),
+                CheckInstruction::TypeList { type_var, types } => {
+                    Self::filter_type_list(context, row, *type_var, types)
+                }
+                CheckInstruction::ThingTypeList { thing_var, types } => {
+                    Self::filter_thing_type_list(context, row, *thing_var, types)
+                }
+                CheckInstruction::Sub { sub_kind, subtype, supertype } => {
+                    Self::filter_sub(context, row, *sub_kind, subtype, supertype)?
+                }
+                CheckInstruction::Owns { owner, attribute } => Self::filter_owns(context, row, owner, attribute)?,
+                CheckInstruction::Relates { relation, role_type } => {
+                    Self::filter_relates(context, row, relation, role_type)?
+                }
+                CheckInstruction::Plays { player, role_type } => Self::filter_plays(context, row, player, role_type)?,
+                CheckInstruction::Isa { isa_kind, type_, thing } => {
+                    Self::filter_isa(context, row, *isa_kind, type_, thing)?
+                }
+                CheckInstruction::Has { owner, attribute } => {
+                    Self::filter_has(context, row, owner, attribute, storage_counters.clone())?
+                }
+                CheckInstruction::Links { relation, player, role } => {
+                    Self::filter_links(context, row, relation, player, role, storage_counters.clone())?
+                }
+                CheckInstruction::IndexedRelation { start_player, end_player, relation, start_role, end_role } => {
+                    Self::filter_indexed_relation(
+                        context,
+                        row,
+                        start_player,
+                        end_player,
+                        relation,
+                        start_role,
+                        end_role,
+                        storage_counters.clone(),
+                    )?
+                }
+                CheckInstruction::Is { lhs, rhs } => Self::filter_is(row, *lhs, *rhs),
+                CheckInstruction::LinksDeduplication { role1, player1, role2, player2 } => {
+                    Self::filter_links_dedup(context, row, *role1, *player1, *role2, *player2)
+                }
+                CheckInstruction::Comparison { lhs, rhs, comparator } => {
+                    Self::filter_comparison(context, row, lhs, rhs, *comparator, storage_counters.clone())?
+                }
+                CheckInstruction::NotNone { variables } => Self::filter_not_none(row, variables),
+                CheckInstruction::Unsatisfiable => false,
+            };
+            if !passes {
+                return Ok(false);
+            }
+        }
+        Ok(true)
+    }
+
+    fn filter_iid(
+        context: &ExecutionContext<impl ReadableSnapshot + 'static>,
+        row: &MaybeOwnedRow<'_>,
+        var: ExecutorVariable,
+        iid: &ir::pattern::ParameterID,
+    ) -> bool {
+        let extracted = get_vertex_value(&CheckVertex::Variable(var), Some(row), &context.parameters);
+        let iid = context.parameters().iid(iid).unwrap();
+        Self::check_iid(iid, extracted)
+    }
+
+    fn filter_type_list(
+        context: &ExecutionContext<impl ReadableSnapshot + 'static>,
+        row: &MaybeOwnedRow<'_>,
+        type_var: ExecutorVariable,
+        types: &std::sync::Arc<std::collections::BTreeSet<Type>>,
+    ) -> bool {
+        let extracted = get_vertex_value(&CheckVertex::Variable(type_var), Some(row), &context.parameters);
+        types.contains(&unwrap_or_return_false!(extracted => Type))
+    }
+
+    fn filter_thing_type_list(
+        context: &ExecutionContext<impl ReadableSnapshot + 'static>,
+        row: &MaybeOwnedRow<'_>,
+        thing_var: ExecutorVariable,
+        types: &std::sync::Arc<std::collections::BTreeSet<Type>>,
+    ) -> bool {
+        let extracted = get_vertex_value(&CheckVertex::Variable(thing_var), Some(row), &context.parameters);
+        types.contains(&unwrap_or_return_false!(extracted => Thing).type_())
+    }
+
+    fn filter_sub(
+        context: &ExecutionContext<impl ReadableSnapshot + 'static>,
+        row: &MaybeOwnedRow<'_>,
+        sub_kind: SubKind,
+        subtype: &CheckVertex<ExecutorVariable>,
+        supertype: &CheckVertex<ExecutorVariable>,
+    ) -> Result<bool, Box<ConceptReadError>> {
+        let subtype = get_vertex_value(subtype, Some(row), &context.parameters);
+        let supertype = get_vertex_value(supertype, Some(row), &context.parameters);
+        Self::check_sub(
+            context.snapshot.as_ref(),
+            context.thing_manager.as_ref(),
+            sub_kind,
+            unwrap_or_result_false!(subtype => Type),
+            unwrap_or_result_false!(supertype => Type),
+        )
+    }
+
+    fn filter_owns(
+        context: &ExecutionContext<impl ReadableSnapshot + 'static>,
+        row: &MaybeOwnedRow<'_>,
+        owner: &CheckVertex<ExecutorVariable>,
+        attribute: &CheckVertex<ExecutorVariable>,
+    ) -> Result<bool, Box<ConceptReadError>> {
+        let owner = get_vertex_value(owner, Some(row), &context.parameters);
+        let attribute = get_vertex_value(attribute, Some(row), &context.parameters);
+        let owner = unwrap_or_result_false!(owner => Type).as_object_type();
+        let attribute = unwrap_or_result_false!(attribute => Type).as_attribute_type();
+        owner
+            .get_owns_attribute(context.snapshot.as_ref(), context.thing_manager.clone().type_manager(), attribute)
+            .map(|owns| owns.is_some())
+    }
+
+    fn filter_relates(
+        context: &ExecutionContext<impl ReadableSnapshot + 'static>,
+        row: &MaybeOwnedRow<'_>,
+        relation: &CheckVertex<ExecutorVariable>,
+        role_type: &CheckVertex<ExecutorVariable>,
+    ) -> Result<bool, Box<ConceptReadError>> {
+        let relation = get_vertex_value(relation, Some(row), &context.parameters);
+        let role_type = get_vertex_value(role_type, Some(row), &context.parameters);
+        let relation_type = unwrap_or_result_false!(relation => Type).as_relation_type();
+        let role_type = unwrap_or_result_false!(role_type => Type).as_role_type();
+        relation_type
+            .get_relates_role(context.snapshot.as_ref(), context.thing_manager.type_manager(), role_type)
+            .map(|relates| relates.is_some())
+    }
+
+    fn filter_plays(
+        context: &ExecutionContext<impl ReadableSnapshot + 'static>,
+        row: &MaybeOwnedRow<'_>,
+        player: &CheckVertex<ExecutorVariable>,
+        role_type: &CheckVertex<ExecutorVariable>,
+    ) -> Result<bool, Box<ConceptReadError>> {
+        let player = get_vertex_value(player, Some(row), &context.parameters);
+        let role_type = get_vertex_value(role_type, Some(row), &context.parameters);
+        let object_type = unwrap_or_result_false!(player => Type).as_object_type();
+        let role_type = unwrap_or_result_false!(role_type => Type).as_role_type();
+        object_type
+            .get_plays_role(context.snapshot.as_ref(), context.thing_manager.type_manager(), role_type)
+            .map(|plays| plays.is_some())
+    }
+
+    fn filter_isa(
+        context: &ExecutionContext<impl ReadableSnapshot + 'static>,
+        row: &MaybeOwnedRow<'_>,
+        isa_kind: IsaKind,
+        type_: &CheckVertex<ExecutorVariable>,
+        thing: &CheckVertex<ExecutorVariable>,
+    ) -> Result<bool, Box<ConceptReadError>> {
+        let thing = get_vertex_value(thing, Some(row), &context.parameters);
+        let type_ = get_vertex_value(type_, Some(row), &context.parameters);
+        let actual = unwrap_or_result_false!(thing => Thing).type_();
+        let expected = unwrap_or_result_false!(type_ => Type);
+        if isa_kind == IsaKind::Exact {
+            Ok(actual == expected)
+        } else {
+            actual.is_transitive_subtype_of(expected, context.snapshot.as_ref(), context.thing_manager.type_manager())
+        }
+    }
+
+    fn filter_has(
+        context: &ExecutionContext<impl ReadableSnapshot + 'static>,
+        row: &MaybeOwnedRow<'_>,
+        owner: &CheckVertex<ExecutorVariable>,
+        attribute: &CheckVertex<ExecutorVariable>,
+        storage_counters: StorageCounters,
+    ) -> Result<bool, Box<ConceptReadError>> {
+        let owner = get_vertex_value(owner, Some(row), &context.parameters);
+        let attribute = get_vertex_value(attribute, Some(row), &context.parameters);
+        let owner = unwrap_or_result_false!(&owner => Thing).as_object();
+        let attribute = unwrap_or_result_false!(&attribute => Thing).as_attribute();
+        owner.has_attribute(
+            context.snapshot.as_ref(),
+            context.thing_manager.as_ref(),
+            attribute,
+            storage_counters.clone(),
+        )
+    }
+
+    fn filter_links(
+        context: &ExecutionContext<impl ReadableSnapshot + 'static>,
+        row: &MaybeOwnedRow<'_>,
+        relation: &CheckVertex<ExecutorVariable>,
+        player: &CheckVertex<ExecutorVariable>,
+        role: &CheckVertex<ExecutorVariable>,
+        storage_counters: StorageCounters,
+    ) -> Result<bool, Box<ConceptReadError>> {
+        let relation = get_vertex_value(relation, Some(row), &context.parameters);
+        let player = get_vertex_value(player, Some(row), &context.parameters);
+        let role = get_vertex_value(role, Some(row), &context.parameters);
+        let relation = unwrap_or_result_false!(relation => Thing).as_relation();
+        let player = unwrap_or_result_false!(player => Thing).as_object();
+        let role = unwrap_or_result_false!(role => Type).as_role_type();
+        relation.has_role_player(
+            context.snapshot.as_ref(),
+            context.thing_manager.as_ref(),
+            player,
+            role,
+            storage_counters.clone(),
+        )
+    }
+
+    fn filter_indexed_relation(
+        context: &ExecutionContext<impl ReadableSnapshot + 'static>,
+        row: &MaybeOwnedRow<'_>,
+        start_player: &CheckVertex<ExecutorVariable>,
+        end_player: &CheckVertex<ExecutorVariable>,
+        relation: &CheckVertex<ExecutorVariable>,
+        start_role: &CheckVertex<ExecutorVariable>,
+        end_role: &CheckVertex<ExecutorVariable>,
+        storage_counters: StorageCounters,
+    ) -> Result<bool, Box<ConceptReadError>> {
+        let start_player_extractor = get_vertex_value(start_player, Some(row), &context.parameters);
+        let end_player_extractor = get_vertex_value(end_player, Some(row), &context.parameters);
+        let relation_extractor = get_vertex_value(relation, Some(row), &context.parameters);
+        let start_role_extractor = get_vertex_value(start_role, Some(row), &context.parameters);
+        let end_role_extractor = get_vertex_value(end_role, Some(row), &context.parameters);
+        let object = unwrap_or_result_false!(start_player_extractor => Thing).as_object();
+        let end_player = unwrap_or_result_false!(end_player_extractor => Thing).as_object();
+        let relation = unwrap_or_result_false!(relation_extractor => Thing).as_relation();
+        let start_role = unwrap_or_result_false!(start_role_extractor => Type).as_role_type();
+        let end_role = unwrap_or_result_false!(end_role_extractor => Type).as_role_type();
+        object.has_indexed_relation_player(
+            context.snapshot.as_ref(),
+            context.thing_manager.as_ref(),
+            end_player,
+            relation,
+            start_role,
+            end_role,
+            storage_counters.clone(),
+        )
+    }
+
+    fn filter_is(row: &MaybeOwnedRow<'_>, lhs: ExecutorVariable, rhs: ExecutorVariable) -> bool {
+        let lhs = get_variable_value(Some(row), &lhs);
+        let rhs = get_variable_value(Some(row), &rhs);
+        lhs == rhs
+    }
+
+    fn filter_links_dedup(
+        _context: &ExecutionContext<impl ReadableSnapshot + 'static>,
+        row: &MaybeOwnedRow<'_>,
+        role1: ExecutorVariable,
+        player1: ExecutorVariable,
+        role2: ExecutorVariable,
+        player2: ExecutorVariable,
+    ) -> bool {
+        let role1 = get_variable_value(Some(row), &role1);
+        let player1 = get_variable_value(Some(row), &player1);
+        let role2 = get_variable_value(Some(row), &role2);
+        let player2 = get_variable_value(Some(row), &player2);
+        !(role1 == role2 && player1 == player2)
+    }
+
+    fn filter_not_none(row: &MaybeOwnedRow<'_>, variables: &[ExecutorVariable]) -> bool {
+        variables.iter().all(|var| {
+            let value = get_variable_value(Some(row), var);
+            !value.is_none()
+        })
+    }
+
+    fn filter_comparison(
+        context: &ExecutionContext<impl ReadableSnapshot + 'static>,
+        row: &MaybeOwnedRow<'_>,
         lhs: &CheckVertex<ExecutorVariable>,
         rhs: &CheckVertex<ExecutorVariable>,
         comparator: Comparator,
         storage_counters: StorageCounters,
     ) -> Result<bool, Box<ConceptReadError>> {
-        let lhs = match lhs.as_variable().and_then(|var| self.extractors.get(&var)) {
-            Some(function) => function(source),
-            None => get_vertex_value(lhs, Some(row), &context.parameters),
-        };
-        let rhs = match rhs {
-            &CheckVertex::Variable(ExecutorVariable::RowPosition(pos)) => row.get(pos).as_reference(),
-            &CheckVertex::Variable(_) => unreachable!(),
-            CheckVertex::Parameter(param) => {
-                VariableValue::Value(context.parameters().value_unchecked(param).as_reference())
-            }
-            CheckVertex::Type(_) => unreachable!(),
-        };
+        let lhs = get_vertex_value(lhs, Some(row), &context.parameters);
+        let rhs = get_vertex_value(rhs, Some(row), &context.parameters);
         let rhs = match &rhs {
             VariableValue::Thing(Thing::Attribute(attr)) => {
                 attr.get_value(context.snapshot.as_ref(), context.thing_manager.as_ref(), storage_counters.clone())?
@@ -1130,28 +1002,6 @@ impl<T> Checker<T> {
             Ok(false)
         }
     }
-
-    fn cmp_values_fn(comparator: &Comparator) -> fn(&Value<'_>, &Value<'_>) -> bool {
-        match comparator {
-            Comparator::Equal => |a, b| a == b,
-            Comparator::NotEqual => |a, b| a != b,
-            Comparator::Less => |a, b| a < b,
-            Comparator::Greater => |a, b| a > b,
-            Comparator::LessOrEqual => |a, b| a <= b,
-            Comparator::GreaterOrEqual => |a, b| a >= b,
-            Comparator::Like => |a, b| {
-                // TODO: Avoid recompiling the regex every time.
-                regex::Regex::new(b.unwrap_string_ref())
-                    .expect("Invalid regex should have been caught at compile time")
-                    .is_match(a.unwrap_string_ref())
-            },
-            Comparator::Contains => |a, b| {
-                let a_unicase = UniCase::new(a.unwrap_string_ref()).to_folded_case();
-                let b_unicase = UniCase::new(b.unwrap_string_ref()).to_folded_case();
-                a_unicase.contains(b_unicase.as_str())
-            },
-        }
-    }
 }
 
 fn get_vertex_value<'a, 'b>(
@@ -1160,17 +1010,21 @@ fn get_vertex_value<'a, 'b>(
     parameters: &'b ParameterRegistry,
 ) -> VariableValue<'b> {
     match vertex {
-        CheckVertex::Variable(var) => match var {
-            ExecutorVariable::RowPosition(position) => {
-                row.expect("CheckVertex::Variable requires a row to take from").get(*position).as_reference()
-            }
-            ExecutorVariable::Internal(_) => {
-                unreachable!("Check variables without an extractor must have been recorded in the row.")
-            }
-        },
+        CheckVertex::Variable(var) => get_variable_value(row, &var),
         CheckVertex::Type(type_) => VariableValue::Type(*type_),
         CheckVertex::Parameter(parameter_id) => {
             VariableValue::Value(parameters.value_unchecked(parameter_id).as_reference())
+        }
+    }
+}
+
+fn get_variable_value<'a>(row: Option<&'a MaybeOwnedRow<'a>>, variable: &ExecutorVariable) -> VariableValue<'a> {
+    match variable {
+        ExecutorVariable::RowPosition(position) => {
+            row.expect("CheckVertex::Variable requires a row to take from").get(*position).as_reference()
+        }
+        ExecutorVariable::Internal(_) => {
+            unreachable!("Check variables without an extractor must have been recorded in the row.")
         }
     }
 }

--- a/executor/read/immediate_executor.rs
+++ b/executor/read/immediate_executor.rs
@@ -938,9 +938,7 @@ impl CheckExecutor {
 
         while let Some(row) = input.next() {
             let input_row = row.map_err(|err| err.clone())?;
-            if self
-                .checker
-                .filter(context, &input_row, (), self.profile.storage_counters())
+            if Checker::filter(&self.checker.checks, context, &input_row, self.profile.storage_counters())
                 .map_err(|err| ReadExecutionError::ConceptRead { typedb_source: err })?
             {
                 output.append(|mut row| {

--- a/executor/read/immediate_executor.rs
+++ b/executor/read/immediate_executor.rs
@@ -885,7 +885,7 @@ impl AssignExecutor {
 }
 
 pub(crate) struct CheckExecutor {
-    checker: Checker<()>,
+    checks: Vec<CheckInstruction<ExecutorVariable>>,
     selected_variables: Vec<VariablePosition>,
     output_width: u32,
     input: Option<FixedBatch>,
@@ -894,7 +894,7 @@ pub(crate) struct CheckExecutor {
 
 impl fmt::Debug for CheckExecutor {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "CheckExecutor (with checks {:?})", self.checker.checks)
+        write!(f, "CheckExecutor (with checks {:?})", self.checks)
     }
 }
 
@@ -905,8 +905,7 @@ impl CheckExecutor {
         output_width: u32,
         profile: Arc<StepProfile>,
     ) -> Self {
-        let checker = Checker::new(checks, HashMap::new());
-        Self { checker, selected_variables, output_width, input: None, profile }
+        Self { checks, selected_variables, output_width, input: None, profile }
     }
 
     fn reset(&mut self) {
@@ -938,7 +937,7 @@ impl CheckExecutor {
 
         while let Some(row) = input.next() {
             let input_row = row.map_err(|err| err.clone())?;
-            if Checker::filter(&self.checker.checks, context, &input_row, self.profile.storage_counters())
+            if Checker::filter(&self.checks, context, &input_row, self.profile.storage_counters())
                 .map_err(|err| ReadExecutionError::ConceptRead { typedb_source: err })?
             {
                 output.append(|mut row| {


### PR DESCRIPTION
## Implementation
Splitting the impl block and removing the `self` parameter clears us to execute a `Vec<CheckInstruction<_>>` without having to create a `Checker`
