### PR TITLE
Ignore internal variables of parent when seeding positions in subpattern

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -192,8 +192,8 @@ git_override(
 bazel_dep(name = "typedb_behaviour", version = "0.0.0")
 git_override(
     module_name = "typedb_behaviour",
-    remote = "https://github.com/typedb/typedb-behaviour",
-    commit = "c4004a7e787ac111ce83d35230deea60fb6f3eda",
+    remote = "https://github.com/krishnangovindraj/typedb-behaviour",
+    commit = "84ef85d25fe604d2fc0074308cccdb6cae8c5366",
 )
 
 http_file = use_repo_rule("@bazel_tools//tools/build_defs/repo:http.bzl", "http_file")

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -192,8 +192,8 @@ git_override(
 bazel_dep(name = "typedb_behaviour", version = "0.0.0")
 git_override(
     module_name = "typedb_behaviour",
-    remote = "https://github.com/krishnangovindraj/typedb-behaviour",
-    commit = "84ef85d25fe604d2fc0074308cccdb6cae8c5366",
+    remote = "https://github.com/typedb/typedb-behaviour",
+    commit = "888359942ccd234e64809215c0ff7c74343ff7ee",
 )
 
 http_file = use_repo_rule("@bazel_tools//tools/build_defs/repo:http.bzl", "http_file")

--- a/compiler/executable/match_/planner/mod.rs
+++ b/compiler/executable/match_/planner/mod.rs
@@ -329,7 +329,8 @@ impl ConjunctionExecutableBuilder {
         constraint_variables: HashSet<Variable>,
         planner_statistics: PlannerStatistics,
     ) -> Self {
-        let index = assigned_positions.clone();
+        let mut index = assigned_positions.clone();
+        index.retain(|variable, position| !matches!(position, ExecutorVariable::Internal(_)));
         let produced_so_far = HashSet::from_iter(input_variables.iter().copied());
         let current_outputs = produced_so_far.clone();
         let reverse_index = index.iter().map(|(&var, &pos)| (pos, var)).collect();


### PR DESCRIPTION
## Product change and motivation
Since a subpattern (may) extend the row from its parent pattern, it uses the same positions in the row for the shared/input variables as the parent pattern does. In certain cases such as disjunctions in negations: 
* a variable that is in all branches of the disjunction is considered visible to the parent. 
* If it is not used outside the disjunction, the parent pattern considers it "internal" to the disjunction.
* Since the parent passes positions down to the subpatterns, the disjunction branches wrongly assume "internal" to be the position of the variable, though it may be used in different constraints within the branch.


## Implementation
Ignore all assignments of "internal" positions when seeding the subpattern's variable positions.

This only became a problem after we promoted variables which are bound in all branches to be visible in the parent.
