### PR TITLE
Fix function calls copying row where input row is narrower output row

### DIFF
--- a/compiler/executable/match_/planner/mod.rs
+++ b/compiler/executable/match_/planner/mod.rs
@@ -161,7 +161,6 @@ struct FunctionCallBuilder {
     function_id: FunctionID,
     arguments: Vec<VariablePosition>,
     assigned: Vec<Option<VariablePosition>>,
-    output_width: u32,
 }
 
 #[derive(Debug)]
@@ -283,19 +282,15 @@ impl StepBuilder {
                 ))
             }
 
-            StepInstructionsBuilder::FunctionCall(FunctionCallBuilder {
-                function_id,
-                arguments,
-                assigned,
-                output_width,
-                ..
-            }) => ExecutionStep::FunctionCall(FunctionCallStep {
-                function_id,
-                arguments,
-                assigned,
-                selected_variables,
-                output_width,
-            }),
+            StepInstructionsBuilder::FunctionCall(FunctionCallBuilder { function_id, arguments, assigned, .. }) => {
+                ExecutionStep::FunctionCall(FunctionCallStep {
+                    function_id,
+                    arguments,
+                    assigned,
+                    selected_variables,
+                    output_width,
+                })
+            }
         }
     }
 }

--- a/compiler/executable/match_/planner/plan.rs
+++ b/compiler/executable/match_/planner/plan.rs
@@ -1468,7 +1468,6 @@ impl ConjunctionPlan<'_> {
                         function_id: call_binding.function_call().function_id(),
                         arguments,
                         assigned,
-                        output_width: conjunction_builder.next_output.position,
                     });
                     conjunction_builder.push_step(&HashMap::new(), step_builder.into())
                 }
@@ -1506,7 +1505,6 @@ impl ConjunctionPlan<'_> {
                     function_id: call_binding.function_call().function_id(),
                     arguments,
                     assigned,
-                    output_width: conjunction_builder.next_output.position,
                 });
                 conjunction_builder.push_step(&HashMap::new(), step_builder.into());
             }

--- a/executor/read/immediate_executor.rs
+++ b/executor/read/immediate_executor.rs
@@ -944,7 +944,7 @@ impl CheckExecutor {
                 .map_err(|err| ReadExecutionError::ConceptRead { typedb_source: err })?
             {
                 output.append(|mut row| {
-                    row.copy_mapped(input_row, self.selected_variables.iter().map(|pos| (*pos, *pos)));
+                    row.copy_selected_from_row(input_row, &self.selected_variables);
                 })
             }
         }
@@ -957,6 +957,7 @@ pub(crate) struct BuiltinCallExecutor {
     builtin_id: BuiltinConceptFunctionID,
     argument_positions: Vec<VariablePosition>,
     assignment_positions: Vec<Option<VariablePosition>>,
+    selected_variables: Vec<VariablePosition>,
     output_width: u32,
     input: Option<FixedBatch>,
     profile: Arc<StepProfile>,
@@ -973,10 +974,19 @@ impl BuiltinCallExecutor {
         builtin_id: BuiltinConceptFunctionID,
         argument_positions: Vec<VariablePosition>,
         assignment_positions: Vec<Option<VariablePosition>>,
+        selected_variables: Vec<VariablePosition>,
         output_width: u32,
         profile: Arc<StepProfile>,
     ) -> Self {
-        Self { builtin_id, argument_positions, assignment_positions, output_width, input: None, profile }
+        Self {
+            builtin_id,
+            argument_positions,
+            assignment_positions,
+            selected_variables,
+            output_width,
+            input: None,
+            profile,
+        }
     }
 
     pub(crate) fn output_width(&self) -> u32 {
@@ -1027,7 +1037,14 @@ impl BuiltinCallExecutor {
     ) -> Result<(), Box<ConceptReadError>> {
         macro_rules! execute {
             ($id:ident) => {
-                builtin_function::$id(&self.assignment_positions, &self.argument_positions, context, input_row, output)
+                builtin_function::$id(
+                    &self.assignment_positions,
+                    &self.argument_positions,
+                    &self.selected_variables,
+                    context,
+                    input_row,
+                    output,
+                )
             };
         }
 

--- a/executor/read/immediate_executor.rs
+++ b/executor/read/immediate_executor.rs
@@ -944,7 +944,7 @@ impl CheckExecutor {
                 .map_err(|err| ReadExecutionError::ConceptRead { typedb_source: err })?
             {
                 output.append(|mut row| {
-                    row.copy_input_and_extend(input_row, &self.selected_variables, [], 1);
+                    row.merge_selected(&self.selected_variables, input_row, [], 1);
                 })
             }
         }

--- a/executor/read/immediate_executor.rs
+++ b/executor/read/immediate_executor.rs
@@ -944,7 +944,7 @@ impl CheckExecutor {
                 .map_err(|err| ReadExecutionError::ConceptRead { typedb_source: err })?
             {
                 output.append(|mut row| {
-                    row.copy_selected_from_row(input_row, &self.selected_variables);
+                    row.copy_input_and_extend(input_row, &self.selected_variables, [], 1);
                 })
             }
         }

--- a/executor/read/immediate_executor/builtin_function.rs
+++ b/executor/read/immediate_executor/builtin_function.rs
@@ -38,13 +38,13 @@ pub(crate) fn iid(
     output: &mut FixedBatch,
 ) -> Result<(), Box<ConceptReadError>> {
     let Some(return_position) = assignment_positions[0] else {
-        output.append(|mut row| row.copy_input_and_extend(input_row.as_reference(), selected_variables, [], 1));
+        output.append(|mut row| row.merge_selected(selected_variables, input_row.as_reference(), [], 1));
         return Ok(()); // all concepts have IIDs
     };
     let iid = input_row[argument_positions[0].as_usize()].as_thing().iid();
     let iid_value = VariableValue::Value(Value::String(Cow::Owned(format!("{iid:x}"))));
     output.append(|mut row| {
-        row.copy_input_and_extend(input_row.as_reference(), selected_variables, [(return_position, iid_value)], 1);
+        row.merge_selected(selected_variables, input_row.as_reference(), [(return_position, iid_value)], 1);
     });
     Ok(())
 }
@@ -58,14 +58,14 @@ pub(crate) fn label(
     output: &mut FixedBatch,
 ) -> Result<(), Box<ConceptReadError>> {
     let Some(return_position) = assignment_positions[0] else {
-        output.append(|mut row| row.copy_input_and_extend(input_row.as_reference(), selected_variables, [], 1));
+        output.append(|mut row| row.merge_selected(selected_variables, input_row.as_reference(), [], 1));
         return Ok(()); // all types have labels
     };
     let ty = input_row[argument_positions[0].as_usize()].as_type();
     let label = ty.get_label(&**context.snapshot(), context.type_manager())?;
     let label_value = VariableValue::Value(Value::String(Cow::Owned(label.to_string())));
     output.append(|mut row| {
-        row.copy_input_and_extend(input_row.as_reference(), selected_variables, [(return_position, label_value)], 1);
+        row.merge_selected(selected_variables, input_row.as_reference(), [(return_position, label_value)], 1);
     });
     Ok(())
 }
@@ -79,12 +79,12 @@ pub(crate) fn get_doc(
     output: &mut FixedBatch,
 ) -> Result<(), Box<ConceptReadError>> {
     let Some(return_position) = assignment_positions[0] else {
-        output.append(|mut row| row.copy_input_and_extend(input_row.as_reference(), selected_variables, [], 1));
+        output.append(|mut row| row.merge_selected(selected_variables, input_row.as_reference(), [], 1));
         return Ok(()); // a missing doc is equivalent to @doc("")
     };
     let doc_value = get_type_doc(context, &input_row[argument_positions[0].as_usize()])?;
     output.append(|mut row| {
-        row.copy_input_and_extend(input_row.as_reference(), selected_variables, [(return_position, doc_value)], 1);
+        row.merge_selected(selected_variables, input_row.as_reference(), [(return_position, doc_value)], 1);
     });
     Ok(())
 }
@@ -98,7 +98,7 @@ pub(crate) fn get_owns_doc(
     output: &mut FixedBatch,
 ) -> Result<(), Box<ConceptReadError>> {
     let Some(return_position) = assignment_positions[0] else {
-        output.append(|mut row| row.copy_input_and_extend(input_row.as_reference(), selected_variables, [], 1));
+        output.append(|mut row| row.merge_selected(selected_variables, input_row.as_reference(), [], 1));
         return Ok(()); // a missing doc is equivalent to @doc("")
     };
     let owner = &input_row[argument_positions[0].as_usize()];
@@ -110,7 +110,7 @@ pub(crate) fn get_owns_doc(
             &AnnotationCategory::Doc,
         )?);
         output.append(|mut row| {
-            row.copy_input_and_extend(input_row.as_reference(), selected_variables, [(return_position, doc_value)], 1);
+            row.merge_selected(selected_variables, input_row.as_reference(), [(return_position, doc_value)], 1);
         });
     }
     Ok(())
@@ -125,7 +125,7 @@ pub(crate) fn get_plays_doc(
     output: &mut FixedBatch,
 ) -> Result<(), Box<ConceptReadError>> {
     let Some(return_position) = assignment_positions[0] else {
-        output.append(|mut row| row.copy_input_and_extend(input_row.as_reference(), selected_variables, [], 1));
+        output.append(|mut row| row.merge_selected(selected_variables, input_row.as_reference(), [], 1));
         return Ok(()); // a missing doc is equivalent to @doc("")
     };
     let player = &input_row[argument_positions[0].as_usize()];
@@ -137,7 +137,7 @@ pub(crate) fn get_plays_doc(
             &AnnotationCategory::Doc,
         )?);
         output.append(|mut row| {
-            row.copy_input_and_extend(input_row.as_reference(), selected_variables, [(return_position, doc_value)], 1);
+            row.merge_selected(selected_variables, input_row.as_reference(), [(return_position, doc_value)], 1);
         });
     }
     Ok(())
@@ -152,7 +152,7 @@ pub(crate) fn get_relates_doc(
     output: &mut FixedBatch,
 ) -> Result<(), Box<ConceptReadError>> {
     let Some(return_position) = assignment_positions[0] else {
-        output.append(|mut row| row.copy_input_and_extend(input_row.as_reference(), selected_variables, [], 1));
+        output.append(|mut row| row.merge_selected(selected_variables, input_row.as_reference(), [], 1));
         return Ok(()); // a missing doc is equivalent to @doc("")
     };
     let relation = &input_row[argument_positions[0].as_usize()];
@@ -164,7 +164,7 @@ pub(crate) fn get_relates_doc(
             &AnnotationCategory::Doc,
         )?);
         output.append(|mut row| {
-            row.copy_input_and_extend(input_row.as_reference(), selected_variables, [(return_position, doc_value)], 1);
+            row.merge_selected(selected_variables, input_row.as_reference(), [(return_position, doc_value)], 1);
         });
     }
     Ok(())
@@ -179,14 +179,14 @@ pub(crate) fn get_sub_doc(
     output: &mut FixedBatch,
 ) -> Result<(), Box<ConceptReadError>> {
     let Some(return_position) = assignment_positions[0] else {
-        output.append(|mut row| row.copy_input_and_extend(input_row.as_reference(), selected_variables, [], 1));
+        output.append(|mut row| row.merge_selected(selected_variables, input_row.as_reference(), [], 1));
         return Ok(()); // a missing doc is equivalent to @doc("")
     };
     let subtype = &input_row[argument_positions[0].as_usize()];
     let supertype = &input_row[argument_positions[1].as_usize()];
     if let Some(doc_value) = get_subtype_doc(context, subtype, supertype)? {
         output.append(|mut row| {
-            row.copy_input_and_extend(input_row.as_reference(), selected_variables, [(return_position, doc_value)], 1);
+            row.merge_selected(selected_variables, input_row.as_reference(), [(return_position, doc_value)], 1);
         });
     }
     Ok(())
@@ -201,7 +201,7 @@ pub(crate) fn get_meta(
     output: &mut FixedBatch,
 ) -> Result<(), Box<ConceptReadError>> {
     let Some(return_position) = assignment_positions[0] else {
-        output.append(|mut row| row.copy_input_and_extend(input_row.as_reference(), selected_variables, [], 1));
+        output.append(|mut row| row.merge_selected(selected_variables, input_row.as_reference(), [], 1));
         return Ok(()); // a missing metadata annotation for a key is treated as @meta("key", "")
     };
     let meta_value = get_type_meta(
@@ -210,7 +210,7 @@ pub(crate) fn get_meta(
         &input_row[argument_positions[1].as_usize()],
     )?;
     output.append(|mut row| {
-        row.copy_input_and_extend(input_row.as_reference(), selected_variables, [(return_position, meta_value)], 1);
+        row.merge_selected(selected_variables, input_row.as_reference(), [(return_position, meta_value)], 1);
     });
     Ok(())
 }
@@ -224,7 +224,7 @@ pub(crate) fn get_owns_meta(
     output: &mut FixedBatch,
 ) -> Result<(), Box<ConceptReadError>> {
     let Some(return_position) = assignment_positions[0] else {
-        output.append(|mut row| row.copy_input_and_extend(input_row.as_reference(), selected_variables, [], 1));
+        output.append(|mut row| row.merge_selected(selected_variables, input_row.as_reference(), [], 1));
         return Ok(()); // a missing metadata annotation for a key is treated as @meta("key", "")
     };
     let key = input_row[argument_positions[0].as_usize()].as_value().unwrap_string_ref().to_owned();
@@ -238,7 +238,7 @@ pub(crate) fn get_owns_meta(
             category,
         )?);
         output.append(|mut row| {
-            row.copy_input_and_extend(input_row.as_reference(), selected_variables, [(return_position, meta_value)], 1);
+            row.merge_selected(selected_variables, input_row.as_reference(), [(return_position, meta_value)], 1);
         });
     }
     Ok(())
@@ -253,7 +253,7 @@ pub(crate) fn get_plays_meta(
     output: &mut FixedBatch,
 ) -> Result<(), Box<ConceptReadError>> {
     let Some(return_position) = assignment_positions[0] else {
-        output.append(|mut row| row.copy_input_and_extend(input_row.as_reference(), selected_variables, [], 1));
+        output.append(|mut row| row.merge_selected(selected_variables, input_row.as_reference(), [], 1));
         return Ok(()); // a missing metadata annotation for a key is treated as @meta("key", "")
     };
     let key = input_row[argument_positions[0].as_usize()].as_value().unwrap_string_ref().to_owned();
@@ -267,7 +267,7 @@ pub(crate) fn get_plays_meta(
             category,
         )?);
         output.append(|mut row| {
-            row.copy_input_and_extend(input_row.as_reference(), selected_variables, [(return_position, meta_value)], 1);
+            row.merge_selected(selected_variables, input_row.as_reference(), [(return_position, meta_value)], 1);
         });
     }
     Ok(())
@@ -282,7 +282,7 @@ pub(crate) fn get_relates_meta(
     output: &mut FixedBatch,
 ) -> Result<(), Box<ConceptReadError>> {
     let Some(return_position) = assignment_positions[0] else {
-        output.append(|mut row| row.copy_input_and_extend(input_row.as_reference(), selected_variables, [], 1));
+        output.append(|mut row| row.merge_selected(selected_variables, input_row.as_reference(), [], 1));
         return Ok(()); // a missing metadata annotation for a key is treated as @meta("key", "")
     };
     let key = input_row[argument_positions[0].as_usize()].as_value().unwrap_string_ref().to_owned();
@@ -296,7 +296,7 @@ pub(crate) fn get_relates_meta(
             category,
         )?);
         output.append(|mut row| {
-            row.copy_input_and_extend(input_row.as_reference(), selected_variables, [(return_position, meta_value)], 1);
+            row.merge_selected(selected_variables, input_row.as_reference(), [(return_position, meta_value)], 1);
         });
     }
     Ok(())
@@ -311,7 +311,7 @@ pub(crate) fn get_sub_meta(
     output: &mut FixedBatch,
 ) -> Result<(), Box<ConceptReadError>> {
     let Some(return_position) = assignment_positions[0] else {
-        output.append(|mut row| row.copy_input_and_extend(input_row.as_reference(), selected_variables, [], 1));
+        output.append(|mut row| row.merge_selected(selected_variables, input_row.as_reference(), [], 1));
         return Ok(()); // a missing metadata annotation for a key is treated as @meta("key", "")
     };
     let key = &input_row[argument_positions[0].as_usize()];
@@ -319,7 +319,7 @@ pub(crate) fn get_sub_meta(
     let supertype = &input_row[argument_positions[2].as_usize()];
     if let Some(meta_value) = get_subtype_meta(context, key, subtype, supertype)? {
         output.append(|mut row| {
-            row.copy_input_and_extend(input_row.as_reference(), selected_variables, [(return_position, meta_value)], 1);
+            row.merge_selected(selected_variables, input_row.as_reference(), [(return_position, meta_value)], 1);
         });
     }
     Ok(())
@@ -442,7 +442,7 @@ pub(crate) fn get_fun_doc(
     output: &mut FixedBatch,
 ) -> Result<(), Box<ConceptReadError>> {
     let Some(return_position) = assignment_positions[0] else {
-        output.append(|mut row| row.copy_input_and_extend(input_row.as_reference(), selected_variables, [], 1));
+        output.append(|mut row| row.merge_selected(selected_variables, input_row.as_reference(), [], 1));
         return Ok(()); // a missing doc is equivalent to @doc("")
     };
     let function_name = input_row[argument_positions[0].as_usize()].as_value().unwrap_string_ref();
@@ -456,7 +456,7 @@ pub(crate) fn get_fun_doc(
         &AnnotationCategory::Doc,
     )?);
     output.append(|mut row| {
-        row.copy_input_and_extend(input_row.as_reference(), selected_variables, [(return_position, doc_value)], 1);
+        row.merge_selected(selected_variables, input_row.as_reference(), [(return_position, doc_value)], 1);
     });
     Ok(())
 }
@@ -470,7 +470,7 @@ pub(crate) fn get_fun_meta(
     output: &mut FixedBatch,
 ) -> Result<(), Box<ConceptReadError>> {
     let Some(return_position) = assignment_positions[0] else {
-        output.append(|mut row| row.copy_input_and_extend(input_row.as_reference(), selected_variables, [], 1));
+        output.append(|mut row| row.merge_selected(selected_variables, input_row.as_reference(), [], 1));
         return Ok(()); // a missing metadata annotation for a key is treated as @meta("key", "")
     };
     let key = input_row[argument_positions[0].as_usize()].as_value().unwrap_string_ref().to_owned();
@@ -486,7 +486,7 @@ pub(crate) fn get_fun_meta(
         category,
     )?);
     output.append(|mut row| {
-        row.copy_input_and_extend(input_row.as_reference(), selected_variables, [(return_position, meta_value)], 1);
+        row.merge_selected(selected_variables, input_row.as_reference(), [(return_position, meta_value)], 1);
     });
     Ok(())
 }
@@ -529,17 +529,17 @@ pub(crate) fn put_all_metas_into_batch(
     if metas.is_empty() {
         return Ok(());
     } else if key_return_position.is_none() && value_return_position.is_none() {
-        output.append(|mut row| row.copy_input_and_extend(input_row.as_reference(), selected_variables, [], 1));
+        output.append(|mut row| row.merge_selected(selected_variables, input_row.as_reference(), [], 1));
         return Ok(());
     }
 
     for anno in metas {
         let (key, value) = meta_to_tuple(anno);
         output.append(|mut row| {
-            let extension = [(key_return_position, key), (value_return_position, value)]
+            let meta_key_and_value = [(key_return_position, key), (value_return_position, value)]
                 .into_iter()
                 .filter_map(|(pos, value)| Some((pos?, value)));
-            row.copy_input_and_extend(input_row.as_reference(), selected_variables, extension, 1);
+            row.merge_selected(selected_variables, input_row.as_reference(), meta_key_and_value, 1);
         });
     }
     Ok(())

--- a/executor/read/immediate_executor/builtin_function.rs
+++ b/executor/read/immediate_executor/builtin_function.rs
@@ -117,7 +117,6 @@ pub(crate) fn get_owns_doc(
             row.copy_selected_from_row(input_row.as_reference(), selected_variables);
             row.set(return_position, doc_value);
         });
-        todo_must_implement!("Does the early-return has to be inside here?");
     }
     Ok(())
 }
@@ -146,7 +145,6 @@ pub(crate) fn get_plays_doc(
             row.copy_selected_from_row(input_row.as_reference(), selected_variables);
             row.set(return_position, doc_value);
         });
-        todo_must_implement!("Does the early-return has to be inside here?");
     }
     Ok(())
 }

--- a/executor/read/immediate_executor/builtin_function.rs
+++ b/executor/read/immediate_executor/builtin_function.rs
@@ -23,12 +23,11 @@ use concept::{
     },
 };
 use encoding::value::value::Value;
-use error::todo_must_implement;
 use ir::translation::function::FunctionAnnotation;
 use itertools::Itertools;
 use storage::snapshot::ReadableSnapshot;
 
-use crate::{Provenance, batch::FixedBatch, pipeline::stage::ExecutionContext, row::MaybeOwnedRow};
+use crate::{batch::FixedBatch, pipeline::stage::ExecutionContext, row::MaybeOwnedRow};
 
 pub(crate) fn iid(
     assignment_positions: &[Option<VariablePosition>],
@@ -39,14 +38,13 @@ pub(crate) fn iid(
     output: &mut FixedBatch,
 ) -> Result<(), Box<ConceptReadError>> {
     let Some(return_position) = assignment_positions[0] else {
-        output.append(|mut row| row.copy_selected_from_row(input_row.as_reference(), selected_variables));
+        output.append(|mut row| row.copy_input_and_extend(input_row.as_reference(), selected_variables, [], 1));
         return Ok(()); // all concepts have IIDs
     };
     let iid = input_row[argument_positions[0].as_usize()].as_thing().iid();
     let iid_value = VariableValue::Value(Value::String(Cow::Owned(format!("{iid:x}"))));
     output.append(|mut row| {
-        row.copy_selected_from_row(input_row.as_reference(), selected_variables);
-        row.set(return_position, iid_value);
+        row.copy_input_and_extend(input_row.as_reference(), selected_variables, [(return_position, iid_value)], 1);
     });
     Ok(())
 }
@@ -60,15 +58,14 @@ pub(crate) fn label(
     output: &mut FixedBatch,
 ) -> Result<(), Box<ConceptReadError>> {
     let Some(return_position) = assignment_positions[0] else {
-        output.append(|mut row| row.copy_selected_from_row(input_row.as_reference(), selected_variables));
+        output.append(|mut row| row.copy_input_and_extend(input_row.as_reference(), selected_variables, [], 1));
         return Ok(()); // all types have labels
     };
     let ty = input_row[argument_positions[0].as_usize()].as_type();
     let label = ty.get_label(&**context.snapshot(), context.type_manager())?;
     let label_value = VariableValue::Value(Value::String(Cow::Owned(label.to_string())));
     output.append(|mut row| {
-        row.copy_selected_from_row(input_row.as_reference(), selected_variables);
-        row.set(return_position, label_value);
+        row.copy_input_and_extend(input_row.as_reference(), selected_variables, [(return_position, label_value)], 1);
     });
     Ok(())
 }
@@ -82,13 +79,12 @@ pub(crate) fn get_doc(
     output: &mut FixedBatch,
 ) -> Result<(), Box<ConceptReadError>> {
     let Some(return_position) = assignment_positions[0] else {
-        output.append(|mut row| row.copy_selected_from_row(input_row.as_reference(), selected_variables));
+        output.append(|mut row| row.copy_input_and_extend(input_row.as_reference(), selected_variables, [], 1));
         return Ok(()); // a missing doc is equivalent to @doc("")
     };
     let doc_value = get_type_doc(context, &input_row[argument_positions[0].as_usize()])?;
     output.append(|mut row| {
-        row.copy_selected_from_row(input_row.as_reference(), selected_variables);
-        row.set(return_position, doc_value);
+        row.copy_input_and_extend(input_row.as_reference(), selected_variables, [(return_position, doc_value)], 1);
     });
     Ok(())
 }
@@ -102,7 +98,7 @@ pub(crate) fn get_owns_doc(
     output: &mut FixedBatch,
 ) -> Result<(), Box<ConceptReadError>> {
     let Some(return_position) = assignment_positions[0] else {
-        output.append(|mut row| row.copy_selected_from_row(input_row.as_reference(), selected_variables));
+        output.append(|mut row| row.copy_input_and_extend(input_row.as_reference(), selected_variables, [], 1));
         return Ok(()); // a missing doc is equivalent to @doc("")
     };
     let owner = &input_row[argument_positions[0].as_usize()];
@@ -114,8 +110,7 @@ pub(crate) fn get_owns_doc(
             &AnnotationCategory::Doc,
         )?);
         output.append(|mut row| {
-            row.copy_selected_from_row(input_row.as_reference(), selected_variables);
-            row.set(return_position, doc_value);
+            row.copy_input_and_extend(input_row.as_reference(), selected_variables, [(return_position, doc_value)], 1);
         });
     }
     Ok(())
@@ -130,7 +125,7 @@ pub(crate) fn get_plays_doc(
     output: &mut FixedBatch,
 ) -> Result<(), Box<ConceptReadError>> {
     let Some(return_position) = assignment_positions[0] else {
-        output.append(|mut row| row.copy_selected_from_row(input_row.as_reference(), selected_variables));
+        output.append(|mut row| row.copy_input_and_extend(input_row.as_reference(), selected_variables, [], 1));
         return Ok(()); // a missing doc is equivalent to @doc("")
     };
     let player = &input_row[argument_positions[0].as_usize()];
@@ -142,8 +137,7 @@ pub(crate) fn get_plays_doc(
             &AnnotationCategory::Doc,
         )?);
         output.append(|mut row| {
-            row.copy_selected_from_row(input_row.as_reference(), selected_variables);
-            row.set(return_position, doc_value);
+            row.copy_input_and_extend(input_row.as_reference(), selected_variables, [(return_position, doc_value)], 1);
         });
     }
     Ok(())
@@ -158,7 +152,7 @@ pub(crate) fn get_relates_doc(
     output: &mut FixedBatch,
 ) -> Result<(), Box<ConceptReadError>> {
     let Some(return_position) = assignment_positions[0] else {
-        output.append(|mut row| row.copy_selected_from_row(input_row.as_reference(), selected_variables));
+        output.append(|mut row| row.copy_input_and_extend(input_row.as_reference(), selected_variables, [], 1));
         return Ok(()); // a missing doc is equivalent to @doc("")
     };
     let relation = &input_row[argument_positions[0].as_usize()];
@@ -170,8 +164,7 @@ pub(crate) fn get_relates_doc(
             &AnnotationCategory::Doc,
         )?);
         output.append(|mut row| {
-            row.copy_selected_from_row(input_row.as_reference(), selected_variables);
-            row.set(return_position, doc_value);
+            row.copy_input_and_extend(input_row.as_reference(), selected_variables, [(return_position, doc_value)], 1);
         });
     }
     Ok(())
@@ -186,15 +179,14 @@ pub(crate) fn get_sub_doc(
     output: &mut FixedBatch,
 ) -> Result<(), Box<ConceptReadError>> {
     let Some(return_position) = assignment_positions[0] else {
-        output.append(|mut row| row.copy_selected_from_row(input_row.as_reference(), selected_variables));
+        output.append(|mut row| row.copy_input_and_extend(input_row.as_reference(), selected_variables, [], 1));
         return Ok(()); // a missing doc is equivalent to @doc("")
     };
     let subtype = &input_row[argument_positions[0].as_usize()];
     let supertype = &input_row[argument_positions[1].as_usize()];
     if let Some(doc_value) = get_subtype_doc(context, subtype, supertype)? {
         output.append(|mut row| {
-            row.copy_selected_from_row(input_row.as_reference(), selected_variables);
-            row.set(return_position, doc_value);
+            row.copy_input_and_extend(input_row.as_reference(), selected_variables, [(return_position, doc_value)], 1);
         });
     }
     Ok(())
@@ -209,7 +201,7 @@ pub(crate) fn get_meta(
     output: &mut FixedBatch,
 ) -> Result<(), Box<ConceptReadError>> {
     let Some(return_position) = assignment_positions[0] else {
-        output.append(|mut row| row.copy_selected_from_row(input_row.as_reference(), selected_variables));
+        output.append(|mut row| row.copy_input_and_extend(input_row.as_reference(), selected_variables, [], 1));
         return Ok(()); // a missing metadata annotation for a key is treated as @meta("key", "")
     };
     let meta_value = get_type_meta(
@@ -218,8 +210,7 @@ pub(crate) fn get_meta(
         &input_row[argument_positions[1].as_usize()],
     )?;
     output.append(|mut row| {
-        row.copy_selected_from_row(input_row.as_reference(), selected_variables);
-        row.set(return_position, meta_value);
+        row.copy_input_and_extend(input_row.as_reference(), selected_variables, [(return_position, meta_value)], 1);
     });
     Ok(())
 }
@@ -233,7 +224,7 @@ pub(crate) fn get_owns_meta(
     output: &mut FixedBatch,
 ) -> Result<(), Box<ConceptReadError>> {
     let Some(return_position) = assignment_positions[0] else {
-        output.append(|mut row| row.copy_selected_from_row(input_row.as_reference(), selected_variables));
+        output.append(|mut row| row.copy_input_and_extend(input_row.as_reference(), selected_variables, [], 1));
         return Ok(()); // a missing metadata annotation for a key is treated as @meta("key", "")
     };
     let key = input_row[argument_positions[0].as_usize()].as_value().unwrap_string_ref().to_owned();
@@ -247,8 +238,7 @@ pub(crate) fn get_owns_meta(
             category,
         )?);
         output.append(|mut row| {
-            row.copy_selected_from_row(input_row.as_reference(), selected_variables);
-            row.set(return_position, meta_value);
+            row.copy_input_and_extend(input_row.as_reference(), selected_variables, [(return_position, meta_value)], 1);
         });
     }
     Ok(())
@@ -263,7 +253,7 @@ pub(crate) fn get_plays_meta(
     output: &mut FixedBatch,
 ) -> Result<(), Box<ConceptReadError>> {
     let Some(return_position) = assignment_positions[0] else {
-        output.append(|mut row| row.copy_selected_from_row(input_row.as_reference(), selected_variables));
+        output.append(|mut row| row.copy_input_and_extend(input_row.as_reference(), selected_variables, [], 1));
         return Ok(()); // a missing metadata annotation for a key is treated as @meta("key", "")
     };
     let key = input_row[argument_positions[0].as_usize()].as_value().unwrap_string_ref().to_owned();
@@ -277,8 +267,7 @@ pub(crate) fn get_plays_meta(
             category,
         )?);
         output.append(|mut row| {
-            row.copy_selected_from_row(input_row.as_reference(), selected_variables);
-            row.set(return_position, meta_value);
+            row.copy_input_and_extend(input_row.as_reference(), selected_variables, [(return_position, meta_value)], 1);
         });
     }
     Ok(())
@@ -293,7 +282,7 @@ pub(crate) fn get_relates_meta(
     output: &mut FixedBatch,
 ) -> Result<(), Box<ConceptReadError>> {
     let Some(return_position) = assignment_positions[0] else {
-        output.append(|mut row| row.copy_selected_from_row(input_row.as_reference(), selected_variables));
+        output.append(|mut row| row.copy_input_and_extend(input_row.as_reference(), selected_variables, [], 1));
         return Ok(()); // a missing metadata annotation for a key is treated as @meta("key", "")
     };
     let key = input_row[argument_positions[0].as_usize()].as_value().unwrap_string_ref().to_owned();
@@ -307,8 +296,7 @@ pub(crate) fn get_relates_meta(
             category,
         )?);
         output.append(|mut row| {
-            row.copy_selected_from_row(input_row.as_reference(), selected_variables);
-            row.set(return_position, meta_value);
+            row.copy_input_and_extend(input_row.as_reference(), selected_variables, [(return_position, meta_value)], 1);
         });
     }
     Ok(())
@@ -323,7 +311,7 @@ pub(crate) fn get_sub_meta(
     output: &mut FixedBatch,
 ) -> Result<(), Box<ConceptReadError>> {
     let Some(return_position) = assignment_positions[0] else {
-        output.append(|mut row| row.copy_selected_from_row(input_row.as_reference(), selected_variables));
+        output.append(|mut row| row.copy_input_and_extend(input_row.as_reference(), selected_variables, [], 1));
         return Ok(()); // a missing metadata annotation for a key is treated as @meta("key", "")
     };
     let key = &input_row[argument_positions[0].as_usize()];
@@ -331,8 +319,7 @@ pub(crate) fn get_sub_meta(
     let supertype = &input_row[argument_positions[2].as_usize()];
     if let Some(meta_value) = get_subtype_meta(context, key, subtype, supertype)? {
         output.append(|mut row| {
-            row.copy_selected_from_row(input_row.as_reference(), selected_variables);
-            row.set(return_position, meta_value);
+            row.copy_input_and_extend(input_row.as_reference(), selected_variables, [(return_position, meta_value)], 1);
         });
     }
     Ok(())
@@ -455,7 +442,7 @@ pub(crate) fn get_fun_doc(
     output: &mut FixedBatch,
 ) -> Result<(), Box<ConceptReadError>> {
     let Some(return_position) = assignment_positions[0] else {
-        output.append(|mut row| row.copy_selected_from_row(input_row.as_reference(), selected_variables));
+        output.append(|mut row| row.copy_input_and_extend(input_row.as_reference(), selected_variables, [], 1));
         return Ok(()); // a missing doc is equivalent to @doc("")
     };
     let function_name = input_row[argument_positions[0].as_usize()].as_value().unwrap_string_ref();
@@ -469,8 +456,7 @@ pub(crate) fn get_fun_doc(
         &AnnotationCategory::Doc,
     )?);
     output.append(|mut row| {
-        row.copy_selected_from_row(input_row.as_reference(), selected_variables);
-        row.set(return_position, doc_value);
+        row.copy_input_and_extend(input_row.as_reference(), selected_variables, [(return_position, doc_value)], 1);
     });
     Ok(())
 }
@@ -484,7 +470,7 @@ pub(crate) fn get_fun_meta(
     output: &mut FixedBatch,
 ) -> Result<(), Box<ConceptReadError>> {
     let Some(return_position) = assignment_positions[0] else {
-        output.append(|mut row| row.copy_selected_from_row(input_row.as_reference(), selected_variables));
+        output.append(|mut row| row.copy_input_and_extend(input_row.as_reference(), selected_variables, [], 1));
         return Ok(()); // a missing metadata annotation for a key is treated as @meta("key", "")
     };
     let key = input_row[argument_positions[0].as_usize()].as_value().unwrap_string_ref().to_owned();
@@ -500,8 +486,7 @@ pub(crate) fn get_fun_meta(
         category,
     )?);
     output.append(|mut row| {
-        row.copy_selected_from_row(input_row.as_reference(), selected_variables);
-        row.set(return_position, meta_value);
+        row.copy_input_and_extend(input_row.as_reference(), selected_variables, [(return_position, meta_value)], 1);
     });
     Ok(())
 }
@@ -544,20 +529,17 @@ pub(crate) fn put_all_metas_into_batch(
     if metas.is_empty() {
         return Ok(());
     } else if key_return_position.is_none() && value_return_position.is_none() {
-        output.append(|mut row| row.copy_selected_from_row(input_row.as_reference(), selected_variables));
+        output.append(|mut row| row.copy_input_and_extend(input_row.as_reference(), selected_variables, [], 1));
         return Ok(());
     }
 
     for anno in metas {
         let (key, value) = meta_to_tuple(anno);
         output.append(|mut row| {
-            row.copy_selected_from_row(input_row.as_reference(), selected_variables);
-            if let Some(key_return_position) = key_return_position {
-                row.set(key_return_position, key);
-            }
-            if let Some(value_return_position) = value_return_position {
-                row.set(value_return_position, value);
-            }
+            let extension = [(key_return_position, key), (value_return_position, value)]
+                .into_iter()
+                .filter_map(|(pos, value)| Some((pos?, value)));
+            row.copy_input_and_extend(input_row.as_reference(), selected_variables, extension, 1);
         });
     }
     Ok(())

--- a/executor/read/immediate_executor/builtin_function.rs
+++ b/executor/read/immediate_executor/builtin_function.rs
@@ -23,6 +23,7 @@ use concept::{
     },
 };
 use encoding::value::value::Value;
+use error::todo_must_implement;
 use ir::translation::function::FunctionAnnotation;
 use itertools::Itertools;
 use storage::snapshot::ReadableSnapshot;
@@ -32,82 +33,91 @@ use crate::{Provenance, batch::FixedBatch, pipeline::stage::ExecutionContext, ro
 pub(crate) fn iid(
     assignment_positions: &[Option<VariablePosition>],
     argument_positions: &[VariablePosition],
+    selected_variables: &[VariablePosition],
     _context: &ExecutionContext<impl ReadableSnapshot>,
     input_row: &MaybeOwnedRow<'_>,
     output: &mut FixedBatch,
 ) -> Result<(), Box<ConceptReadError>> {
     let Some(return_position) = assignment_positions[0] else {
-        output.append(|mut row| row.copy_from_row(input_row.as_reference()));
+        output.append(|mut row| row.copy_selected_from_row(input_row.as_reference(), selected_variables));
         return Ok(()); // all concepts have IIDs
     };
-    let (mut row, multiplicity, provenance) = row_into_parts_widened(input_row, return_position);
     let iid = input_row[argument_positions[0].as_usize()].as_thing().iid();
-    row[return_position.as_usize()] = VariableValue::Value(Value::String(Cow::Owned(format!("{iid:x}"))));
-    let output_row = MaybeOwnedRow::new_owned(row, multiplicity, provenance);
-    output.append(|mut row| row.copy_from_row(output_row));
+    let iid_value = VariableValue::Value(Value::String(Cow::Owned(format!("{iid:x}"))));
+    output.append(|mut row| {
+        row.copy_selected_from_row(input_row.as_reference(), selected_variables);
+        row.set(return_position, iid_value);
+    });
     Ok(())
 }
 
 pub(crate) fn label(
     assignment_positions: &[Option<VariablePosition>],
     argument_positions: &[VariablePosition],
+    selected_variables: &[VariablePosition],
     context: &ExecutionContext<impl ReadableSnapshot>,
     input_row: &MaybeOwnedRow<'_>,
     output: &mut FixedBatch,
 ) -> Result<(), Box<ConceptReadError>> {
     let Some(return_position) = assignment_positions[0] else {
-        output.append(|mut row| row.copy_from_row(input_row.as_reference()));
+        output.append(|mut row| row.copy_selected_from_row(input_row.as_reference(), selected_variables));
         return Ok(()); // all types have labels
     };
-    let (mut row, multiplicity, provenance) = row_into_parts_widened(input_row, return_position);
     let ty = input_row[argument_positions[0].as_usize()].as_type();
     let label = ty.get_label(&**context.snapshot(), context.type_manager())?;
-    row[return_position.as_usize()] = VariableValue::Value(Value::String(Cow::Owned(label.to_string())));
-    let output_row = MaybeOwnedRow::new_owned(row, multiplicity, provenance);
-    output.append(|mut row| row.copy_from_row(output_row));
+    let label_value = VariableValue::Value(Value::String(Cow::Owned(label.to_string())));
+    output.append(|mut row| {
+        row.copy_selected_from_row(input_row.as_reference(), selected_variables);
+        row.set(return_position, label_value);
+    });
     Ok(())
 }
 
 pub(crate) fn get_doc(
     assignment_positions: &[Option<VariablePosition>],
     argument_positions: &[VariablePosition],
+    selected_variables: &[VariablePosition],
     context: &ExecutionContext<impl ReadableSnapshot>,
     input_row: &MaybeOwnedRow<'_>,
     output: &mut FixedBatch,
 ) -> Result<(), Box<ConceptReadError>> {
     let Some(return_position) = assignment_positions[0] else {
-        output.append(|mut row| row.copy_from_row(input_row.as_reference()));
+        output.append(|mut row| row.copy_selected_from_row(input_row.as_reference(), selected_variables));
         return Ok(()); // a missing doc is equivalent to @doc("")
     };
-    let (mut row, multiplicity, provenance) = row_into_parts_widened(input_row, return_position);
-    row[return_position.as_usize()] = get_type_doc(context, &input_row[argument_positions[0].as_usize()])?;
-    let output_row = MaybeOwnedRow::new_owned(row, multiplicity, provenance);
-    output.append(|mut row| row.copy_from_row(output_row));
+    let doc_value = get_type_doc(context, &input_row[argument_positions[0].as_usize()])?;
+    output.append(|mut row| {
+        row.copy_selected_from_row(input_row.as_reference(), selected_variables);
+        row.set(return_position, doc_value);
+    });
     Ok(())
 }
 
 pub(crate) fn get_owns_doc(
     assignment_positions: &[Option<VariablePosition>],
     argument_positions: &[VariablePosition],
+    selected_variables: &[VariablePosition],
     context: &ExecutionContext<impl ReadableSnapshot>,
     input_row: &MaybeOwnedRow<'_>,
     output: &mut FixedBatch,
 ) -> Result<(), Box<ConceptReadError>> {
     let Some(return_position) = assignment_positions[0] else {
-        output.append(|mut row| row.copy_from_row(input_row.as_reference()));
+        output.append(|mut row| row.copy_selected_from_row(input_row.as_reference(), selected_variables));
         return Ok(()); // a missing doc is equivalent to @doc("")
     };
-    let (mut row, multiplicity, provenance) = row_into_parts_widened(input_row, return_position);
     let owner = &input_row[argument_positions[0].as_usize()];
     let attribute = &input_row[argument_positions[1].as_usize()];
     if let Some(owns) = get_owns(context, owner, attribute)? {
-        row[return_position.as_usize()] = unwrap_doc(context.type_manager().get_owns_annotation_declared_by_category(
+        let doc_value = unwrap_doc(context.type_manager().get_owns_annotation_declared_by_category(
             &**context.snapshot(),
             owns,
             &AnnotationCategory::Doc,
         )?);
-        let output_row = MaybeOwnedRow::new_owned(row, multiplicity, provenance);
-        output.append(|mut row| row.copy_from_row(output_row));
+        output.append(|mut row| {
+            row.copy_selected_from_row(input_row.as_reference(), selected_variables);
+            row.set(return_position, doc_value);
+        });
+        todo_must_implement!("Does the early-return has to be inside here?");
     }
     Ok(())
 }
@@ -115,26 +125,28 @@ pub(crate) fn get_owns_doc(
 pub(crate) fn get_plays_doc(
     assignment_positions: &[Option<VariablePosition>],
     argument_positions: &[VariablePosition],
+    selected_variables: &[VariablePosition],
     context: &ExecutionContext<impl ReadableSnapshot>,
     input_row: &MaybeOwnedRow<'_>,
     output: &mut FixedBatch,
 ) -> Result<(), Box<ConceptReadError>> {
     let Some(return_position) = assignment_positions[0] else {
-        output.append(|mut row| row.copy_from_row(input_row.as_reference()));
+        output.append(|mut row| row.copy_selected_from_row(input_row.as_reference(), selected_variables));
         return Ok(()); // a missing doc is equivalent to @doc("")
     };
-    let (mut row, multiplicity, provenance) = row_into_parts_widened(input_row, return_position);
     let player = &input_row[argument_positions[0].as_usize()];
     let role = &input_row[argument_positions[1].as_usize()];
     if let Some(plays) = get_plays(context, player, role)? {
-        row[return_position.as_usize()] =
-            unwrap_doc(context.type_manager().get_plays_annotation_declared_by_category(
-                &**context.snapshot(),
-                plays,
-                &AnnotationCategory::Doc,
-            )?);
-        let output_row = MaybeOwnedRow::new_owned(row, multiplicity, provenance);
-        output.append(|mut row| row.copy_from_row(output_row));
+        let doc_value = unwrap_doc(context.type_manager().get_plays_annotation_declared_by_category(
+            &**context.snapshot(),
+            plays,
+            &AnnotationCategory::Doc,
+        )?);
+        output.append(|mut row| {
+            row.copy_selected_from_row(input_row.as_reference(), selected_variables);
+            row.set(return_position, doc_value);
+        });
+        todo_must_implement!("Does the early-return has to be inside here?");
     }
     Ok(())
 }
@@ -142,26 +154,27 @@ pub(crate) fn get_plays_doc(
 pub(crate) fn get_relates_doc(
     assignment_positions: &[Option<VariablePosition>],
     argument_positions: &[VariablePosition],
+    selected_variables: &[VariablePosition],
     context: &ExecutionContext<impl ReadableSnapshot>,
     input_row: &MaybeOwnedRow<'_>,
     output: &mut FixedBatch,
 ) -> Result<(), Box<ConceptReadError>> {
     let Some(return_position) = assignment_positions[0] else {
-        output.append(|mut row| row.copy_from_row(input_row.as_reference()));
+        output.append(|mut row| row.copy_selected_from_row(input_row.as_reference(), selected_variables));
         return Ok(()); // a missing doc is equivalent to @doc("")
     };
-    let (mut row, multiplicity, provenance) = row_into_parts_widened(input_row, return_position);
     let relation = &input_row[argument_positions[0].as_usize()];
     let role = &input_row[argument_positions[1].as_usize()];
     if let Some(relates) = get_relates(context, relation, role)? {
-        row[return_position.as_usize()] =
-            unwrap_doc(context.type_manager().get_relates_annotation_declared_by_category(
-                &**context.snapshot(),
-                relates,
-                &AnnotationCategory::Doc,
-            )?);
-        let output_row = MaybeOwnedRow::new_owned(row, multiplicity, provenance);
-        output.append(|mut row| row.copy_from_row(output_row));
+        let doc_value = unwrap_doc(context.type_manager().get_relates_annotation_declared_by_category(
+            &**context.snapshot(),
+            relates,
+            &AnnotationCategory::Doc,
+        )?);
+        output.append(|mut row| {
+            row.copy_selected_from_row(input_row.as_reference(), selected_variables);
+            row.set(return_position, doc_value);
+        });
     }
     Ok(())
 }
@@ -169,21 +182,22 @@ pub(crate) fn get_relates_doc(
 pub(crate) fn get_sub_doc(
     assignment_positions: &[Option<VariablePosition>],
     argument_positions: &[VariablePosition],
+    selected_variables: &[VariablePosition],
     context: &ExecutionContext<impl ReadableSnapshot>,
     input_row: &MaybeOwnedRow<'_>,
     output: &mut FixedBatch,
 ) -> Result<(), Box<ConceptReadError>> {
     let Some(return_position) = assignment_positions[0] else {
-        output.append(|mut row| row.copy_from_row(input_row.as_reference()));
+        output.append(|mut row| row.copy_selected_from_row(input_row.as_reference(), selected_variables));
         return Ok(()); // a missing doc is equivalent to @doc("")
     };
-    let (mut row, multiplicity, provenance) = row_into_parts_widened(input_row, return_position);
     let subtype = &input_row[argument_positions[0].as_usize()];
     let supertype = &input_row[argument_positions[1].as_usize()];
-    if let Some(a) = get_subtype_doc(context, subtype, supertype)? {
-        row[return_position.as_usize()] = a;
-        let output_row = MaybeOwnedRow::new_owned(row, multiplicity, provenance);
-        output.append(|mut row| row.copy_from_row(output_row));
+    if let Some(doc_value) = get_subtype_doc(context, subtype, supertype)? {
+        output.append(|mut row| {
+            row.copy_selected_from_row(input_row.as_reference(), selected_variables);
+            row.set(return_position, doc_value);
+        });
     }
     Ok(())
 }
@@ -191,47 +205,53 @@ pub(crate) fn get_sub_doc(
 pub(crate) fn get_meta(
     assignment_positions: &[Option<VariablePosition>],
     argument_positions: &[VariablePosition],
+    selected_variables: &[VariablePosition],
     context: &ExecutionContext<impl ReadableSnapshot>,
     input_row: &MaybeOwnedRow<'_>,
     output: &mut FixedBatch,
 ) -> Result<(), Box<ConceptReadError>> {
     let Some(return_position) = assignment_positions[0] else {
-        output.append(|mut row| row.copy_from_row(input_row.as_reference()));
+        output.append(|mut row| row.copy_selected_from_row(input_row.as_reference(), selected_variables));
         return Ok(()); // a missing metadata annotation for a key is treated as @meta("key", "")
     };
-    let (mut row, multiplicity, provenance) = row_into_parts_widened(input_row, return_position);
-    row[return_position.as_usize()] = get_type_meta(
+    let meta_value = get_type_meta(
         context,
         &input_row[argument_positions[0].as_usize()],
         &input_row[argument_positions[1].as_usize()],
     )?;
-    let output_row = MaybeOwnedRow::new_owned(row, multiplicity, provenance);
-    output.append(|mut row| row.copy_from_row(output_row));
+    output.append(|mut row| {
+        row.copy_selected_from_row(input_row.as_reference(), selected_variables);
+        row.set(return_position, meta_value);
+    });
     Ok(())
 }
 
 pub(crate) fn get_owns_meta(
     assignment_positions: &[Option<VariablePosition>],
     argument_positions: &[VariablePosition],
+    selected_variables: &[VariablePosition],
     context: &ExecutionContext<impl ReadableSnapshot>,
     input_row: &MaybeOwnedRow<'_>,
     output: &mut FixedBatch,
 ) -> Result<(), Box<ConceptReadError>> {
     let Some(return_position) = assignment_positions[0] else {
-        output.append(|mut row| row.copy_from_row(input_row.as_reference()));
+        output.append(|mut row| row.copy_selected_from_row(input_row.as_reference(), selected_variables));
         return Ok(()); // a missing metadata annotation for a key is treated as @meta("key", "")
     };
-    let (mut row, multiplicity, provenance) = row_into_parts_widened(input_row, return_position);
     let key = input_row[argument_positions[0].as_usize()].as_value().unwrap_string_ref().to_owned();
     let category = &AnnotationCategory::Meta(key);
     let owner = &input_row[argument_positions[1].as_usize()];
     let attribute = &input_row[argument_positions[2].as_usize()];
     if let Some(owns) = get_owns(context, owner, attribute)? {
-        row[return_position.as_usize()] = unwrap_meta_value(
-            context.type_manager().get_owns_annotation_declared_by_category(&**context.snapshot(), owns, category)?,
-        );
-        let output_row = MaybeOwnedRow::new_owned(row, multiplicity, provenance);
-        output.append(|mut row| row.copy_from_row(output_row));
+        let meta_value = unwrap_meta_value(context.type_manager().get_owns_annotation_declared_by_category(
+            &**context.snapshot(),
+            owns,
+            category,
+        )?);
+        output.append(|mut row| {
+            row.copy_selected_from_row(input_row.as_reference(), selected_variables);
+            row.set(return_position, meta_value);
+        });
     }
     Ok(())
 }
@@ -239,25 +259,29 @@ pub(crate) fn get_owns_meta(
 pub(crate) fn get_plays_meta(
     assignment_positions: &[Option<VariablePosition>],
     argument_positions: &[VariablePosition],
+    selected_variables: &[VariablePosition],
     context: &ExecutionContext<impl ReadableSnapshot>,
     input_row: &MaybeOwnedRow<'_>,
     output: &mut FixedBatch,
 ) -> Result<(), Box<ConceptReadError>> {
     let Some(return_position) = assignment_positions[0] else {
-        output.append(|mut row| row.copy_from_row(input_row.as_reference()));
+        output.append(|mut row| row.copy_selected_from_row(input_row.as_reference(), selected_variables));
         return Ok(()); // a missing metadata annotation for a key is treated as @meta("key", "")
     };
-    let (mut row, multiplicity, provenance) = row_into_parts_widened(input_row, return_position);
     let key = input_row[argument_positions[0].as_usize()].as_value().unwrap_string_ref().to_owned();
     let category = &AnnotationCategory::Meta(key);
     let player = &input_row[argument_positions[1].as_usize()];
     let role = &input_row[argument_positions[2].as_usize()];
     if let Some(plays) = get_plays(context, player, role)? {
-        row[return_position.as_usize()] = unwrap_meta_value(
-            context.type_manager().get_plays_annotation_declared_by_category(&**context.snapshot(), plays, category)?,
-        );
-        let output_row = MaybeOwnedRow::new_owned(row, multiplicity, provenance);
-        output.append(|mut row| row.copy_from_row(output_row));
+        let meta_value = unwrap_meta_value(context.type_manager().get_plays_annotation_declared_by_category(
+            &**context.snapshot(),
+            plays,
+            category,
+        )?);
+        output.append(|mut row| {
+            row.copy_selected_from_row(input_row.as_reference(), selected_variables);
+            row.set(return_position, meta_value);
+        });
     }
     Ok(())
 }
@@ -265,28 +289,29 @@ pub(crate) fn get_plays_meta(
 pub(crate) fn get_relates_meta(
     assignment_positions: &[Option<VariablePosition>],
     argument_positions: &[VariablePosition],
+    selected_variables: &[VariablePosition],
     context: &ExecutionContext<impl ReadableSnapshot>,
     input_row: &MaybeOwnedRow<'_>,
     output: &mut FixedBatch,
 ) -> Result<(), Box<ConceptReadError>> {
     let Some(return_position) = assignment_positions[0] else {
-        output.append(|mut row| row.copy_from_row(input_row.as_reference()));
+        output.append(|mut row| row.copy_selected_from_row(input_row.as_reference(), selected_variables));
         return Ok(()); // a missing metadata annotation for a key is treated as @meta("key", "")
     };
-    let (mut row, multiplicity, provenance) = row_into_parts_widened(input_row, return_position);
     let key = input_row[argument_positions[0].as_usize()].as_value().unwrap_string_ref().to_owned();
     let category = &AnnotationCategory::Meta(key);
     let relation = &input_row[argument_positions[1].as_usize()];
     let role = &input_row[argument_positions[2].as_usize()];
     if let Some(relates) = get_relates(context, relation, role)? {
-        row[return_position.as_usize()] =
-            unwrap_meta_value(context.type_manager().get_relates_annotation_declared_by_category(
-                &**context.snapshot(),
-                relates,
-                category,
-            )?);
-        let output_row = MaybeOwnedRow::new_owned(row, multiplicity, provenance);
-        output.append(|mut row| row.copy_from_row(output_row));
+        let meta_value = unwrap_meta_value(context.type_manager().get_relates_annotation_declared_by_category(
+            &**context.snapshot(),
+            relates,
+            category,
+        )?);
+        output.append(|mut row| {
+            row.copy_selected_from_row(input_row.as_reference(), selected_variables);
+            row.set(return_position, meta_value);
+        });
     }
     Ok(())
 }
@@ -294,22 +319,23 @@ pub(crate) fn get_relates_meta(
 pub(crate) fn get_sub_meta(
     assignment_positions: &[Option<VariablePosition>],
     argument_positions: &[VariablePosition],
+    selected_variables: &[VariablePosition],
     context: &ExecutionContext<impl ReadableSnapshot>,
     input_row: &MaybeOwnedRow<'_>,
     output: &mut FixedBatch,
 ) -> Result<(), Box<ConceptReadError>> {
     let Some(return_position) = assignment_positions[0] else {
-        output.append(|mut row| row.copy_from_row(input_row.as_reference()));
+        output.append(|mut row| row.copy_selected_from_row(input_row.as_reference(), selected_variables));
         return Ok(()); // a missing metadata annotation for a key is treated as @meta("key", "")
     };
-    let (mut row, multiplicity, provenance) = row_into_parts_widened(input_row, return_position);
     let key = &input_row[argument_positions[0].as_usize()];
     let subtype = &input_row[argument_positions[1].as_usize()];
     let supertype = &input_row[argument_positions[2].as_usize()];
-    if let Some(variable_value) = get_subtype_meta(context, key, subtype, supertype)? {
-        row[return_position.as_usize()] = variable_value;
-        let output_row = MaybeOwnedRow::new_owned(row, multiplicity, provenance);
-        output.append(|mut row| row.copy_from_row(output_row));
+    if let Some(meta_value) = get_subtype_meta(context, key, subtype, supertype)? {
+        output.append(|mut row| {
+            row.copy_selected_from_row(input_row.as_reference(), selected_variables);
+            row.set(return_position, meta_value);
+        });
     }
     Ok(())
 }
@@ -317,6 +343,7 @@ pub(crate) fn get_sub_meta(
 pub(crate) fn get_all_meta(
     assignment_positions: &[Option<VariablePosition>],
     argument_positions: &[VariablePosition],
+    selected_variables: &[VariablePosition],
     context: &ExecutionContext<impl ReadableSnapshot>,
     input_row: &MaybeOwnedRow<'_>,
     output: &mut FixedBatch,
@@ -324,12 +351,13 @@ pub(crate) fn get_all_meta(
     let key_return_position = assignment_positions[0];
     let value_return_position = assignment_positions[1];
     let metas = get_type_all_meta(context, &input_row[argument_positions[0].as_usize()])?;
-    put_all_metas_into_batch(input_row, output, key_return_position, value_return_position, metas)
+    put_all_metas_into_batch(input_row, output, key_return_position, value_return_position, selected_variables, metas)
 }
 
 pub(crate) fn get_owns_all_meta(
     assignment_positions: &[Option<VariablePosition>],
     argument_positions: &[VariablePosition],
+    selected_variables: &[VariablePosition],
     context: &ExecutionContext<impl ReadableSnapshot>,
     input_row: &MaybeOwnedRow<'_>,
     output: &mut FixedBatch,
@@ -340,7 +368,14 @@ pub(crate) fn get_owns_all_meta(
     let attribute = &input_row[argument_positions[1].as_usize()];
     if let Some(owns) = get_owns(context, owner, attribute)? {
         let metas = get_owns_meta_annotations(context, owns)?;
-        put_all_metas_into_batch(input_row, output, key_return_position, value_return_position, metas)?;
+        put_all_metas_into_batch(
+            input_row,
+            output,
+            key_return_position,
+            value_return_position,
+            selected_variables,
+            metas,
+        )?;
     }
     Ok(())
 }
@@ -348,6 +383,7 @@ pub(crate) fn get_owns_all_meta(
 pub(crate) fn get_plays_all_meta(
     assignment_positions: &[Option<VariablePosition>],
     argument_positions: &[VariablePosition],
+    selected_variables: &[VariablePosition],
     context: &ExecutionContext<impl ReadableSnapshot>,
     input_row: &MaybeOwnedRow<'_>,
     output: &mut FixedBatch,
@@ -358,7 +394,14 @@ pub(crate) fn get_plays_all_meta(
     let role = &input_row[argument_positions[1].as_usize()];
     if let Some(plays) = get_plays(context, player, role)? {
         let metas = get_plays_meta_annotations(context, plays)?;
-        put_all_metas_into_batch(input_row, output, key_return_position, value_return_position, metas)?;
+        put_all_metas_into_batch(
+            input_row,
+            output,
+            key_return_position,
+            value_return_position,
+            selected_variables,
+            metas,
+        )?;
     }
     Ok(())
 }
@@ -366,6 +409,7 @@ pub(crate) fn get_plays_all_meta(
 pub(crate) fn get_relates_all_meta(
     assignment_positions: &[Option<VariablePosition>],
     argument_positions: &[VariablePosition],
+    selected_variables: &[VariablePosition],
     context: &ExecutionContext<impl ReadableSnapshot>,
     input_row: &MaybeOwnedRow<'_>,
     output: &mut FixedBatch,
@@ -376,7 +420,14 @@ pub(crate) fn get_relates_all_meta(
     let role = &input_row[argument_positions[1].as_usize()];
     if let Some(relates) = get_relates(context, relation, role)? {
         let metas = get_relates_meta_annotations(context, relates)?;
-        put_all_metas_into_batch(input_row, output, key_return_position, value_return_position, metas)?;
+        put_all_metas_into_batch(
+            input_row,
+            output,
+            key_return_position,
+            value_return_position,
+            selected_variables,
+            metas,
+        )?;
     }
     Ok(())
 }
@@ -384,6 +435,7 @@ pub(crate) fn get_relates_all_meta(
 pub(crate) fn get_sub_all_meta(
     assignment_positions: &[Option<VariablePosition>],
     argument_positions: &[VariablePosition],
+    selected_variables: &[VariablePosition],
     context: &ExecutionContext<impl ReadableSnapshot>,
     input_row: &MaybeOwnedRow<'_>,
     output: &mut FixedBatch,
@@ -393,48 +445,50 @@ pub(crate) fn get_sub_all_meta(
     let subtype = &input_row[argument_positions[0].as_usize()];
     let supertype = &input_row[argument_positions[1].as_usize()];
     let metas = get_subtype_all_meta(context, subtype, supertype)?;
-    put_all_metas_into_batch(input_row, output, key_return_position, value_return_position, metas)
+    put_all_metas_into_batch(input_row, output, key_return_position, value_return_position, selected_variables, metas)
 }
 
 pub(crate) fn get_fun_doc(
     assignment_positions: &[Option<VariablePosition>],
     argument_positions: &[VariablePosition],
+    selected_variables: &[VariablePosition],
     context: &ExecutionContext<impl ReadableSnapshot>,
     input_row: &MaybeOwnedRow<'_>,
     output: &mut FixedBatch,
 ) -> Result<(), Box<ConceptReadError>> {
     let Some(return_position) = assignment_positions[0] else {
-        output.append(|mut row| row.copy_from_row(input_row.as_reference()));
+        output.append(|mut row| row.copy_selected_from_row(input_row.as_reference(), selected_variables));
         return Ok(()); // a missing doc is equivalent to @doc("")
     };
-    let (mut row, multiplicity, provenance) = row_into_parts_widened(input_row, return_position);
     let function_name = input_row[argument_positions[0].as_usize()].as_value().unwrap_string_ref();
     let function = context.function_manager().get_function_key(&**context.snapshot(), function_name).unwrap();
     let Some(function) = function else {
         return Err(Box::new(ConceptReadError::FunctionNotFound { function_name: function_name.to_owned() }));
     };
-    row[return_position.as_usize()] = unwrap_doc(context.function_manager().get_function_annotation_by_category(
+    let doc_value = unwrap_doc(context.function_manager().get_function_annotation_by_category(
         &**context.snapshot(),
         function,
         &AnnotationCategory::Doc,
     )?);
-    let output_row = MaybeOwnedRow::new_owned(row, multiplicity, provenance);
-    output.append(|mut row| row.copy_from_row(output_row));
+    output.append(|mut row| {
+        row.copy_selected_from_row(input_row.as_reference(), selected_variables);
+        row.set(return_position, doc_value);
+    });
     Ok(())
 }
 
 pub(crate) fn get_fun_meta(
     assignment_positions: &[Option<VariablePosition>],
     argument_positions: &[VariablePosition],
+    selected_variables: &[VariablePosition],
     context: &ExecutionContext<impl ReadableSnapshot>,
     input_row: &MaybeOwnedRow<'_>,
     output: &mut FixedBatch,
 ) -> Result<(), Box<ConceptReadError>> {
     let Some(return_position) = assignment_positions[0] else {
-        output.append(|mut row| row.copy_from_row(input_row.as_reference()));
+        output.append(|mut row| row.copy_selected_from_row(input_row.as_reference(), selected_variables));
         return Ok(()); // a missing metadata annotation for a key is treated as @meta("key", "")
     };
-    let (mut row, multiplicity, provenance) = row_into_parts_widened(input_row, return_position);
     let key = input_row[argument_positions[0].as_usize()].as_value().unwrap_string_ref().to_owned();
     let category = &AnnotationCategory::Meta(key);
     let function_name = input_row[argument_positions[1].as_usize()].as_value().unwrap_string_ref();
@@ -442,17 +496,22 @@ pub(crate) fn get_fun_meta(
     let Some(function) = function else {
         return Err(Box::new(ConceptReadError::FunctionNotFound { function_name: function_name.to_owned() }));
     };
-    row[return_position.as_usize()] = unwrap_meta_value(
-        context.function_manager().get_function_annotation_by_category(&**context.snapshot(), function, category)?,
-    );
-    let output_row = MaybeOwnedRow::new_owned(row, multiplicity, provenance);
-    output.append(|mut row| row.copy_from_row(output_row));
+    let meta_value = unwrap_meta_value(context.function_manager().get_function_annotation_by_category(
+        &**context.snapshot(),
+        function,
+        category,
+    )?);
+    output.append(|mut row| {
+        row.copy_selected_from_row(input_row.as_reference(), selected_variables);
+        row.set(return_position, meta_value);
+    });
     Ok(())
 }
 
 pub(crate) fn get_fun_all_meta(
     assignment_positions: &[Option<VariablePosition>],
     argument_positions: &[VariablePosition],
+    selected_variables: &[VariablePosition],
     context: &ExecutionContext<impl ReadableSnapshot>,
     input_row: &MaybeOwnedRow<'_>,
     output: &mut FixedBatch,
@@ -473,7 +532,7 @@ pub(crate) fn get_fun_all_meta(
             _ => None,
         })
         .collect_vec();
-    put_all_metas_into_batch(input_row, output, key_return_position, value_return_position, metas)
+    put_all_metas_into_batch(input_row, output, key_return_position, value_return_position, selected_variables, metas)
 }
 
 pub(crate) fn put_all_metas_into_batch(
@@ -481,27 +540,27 @@ pub(crate) fn put_all_metas_into_batch(
     output: &mut FixedBatch,
     key_return_position: Option<VariablePosition>,
     value_return_position: Option<VariablePosition>,
+    selected_variables: &[VariablePosition],
     metas: Vec<AnnotationMeta>,
 ) -> Result<(), Box<ConceptReadError>> {
     if metas.is_empty() {
         return Ok(());
     } else if key_return_position.is_none() && value_return_position.is_none() {
-        output.append(|mut row| row.copy_from_row(input_row.as_reference()));
+        output.append(|mut row| row.copy_selected_from_row(input_row.as_reference(), selected_variables));
         return Ok(());
     }
 
-    let (mut row, multiplicity, provenance) =
-        row_into_parts_widened(input_row, Ord::max(key_return_position, value_return_position).unwrap());
     for anno in metas {
         let (key, value) = meta_to_tuple(anno);
-        if let Some(key_return_position) = key_return_position {
-            row[key_return_position.as_usize()] = key;
-        }
-        if let Some(value_return_position) = value_return_position {
-            row[value_return_position.as_usize()] = value;
-        }
-        let output_row = MaybeOwnedRow::new_owned(row.clone(), multiplicity, provenance);
-        output.append(|mut row| row.copy_from_row(output_row));
+        output.append(|mut row| {
+            row.copy_selected_from_row(input_row.as_reference(), selected_variables);
+            if let Some(key_return_position) = key_return_position {
+                row.set(key_return_position, key);
+            }
+            if let Some(value_return_position) = value_return_position {
+                row.set(value_return_position, value);
+            }
+        });
     }
     Ok(())
 }

--- a/executor/read/immediate_executor/builtin_function.rs
+++ b/executor/read/immediate_executor/builtin_function.rs
@@ -565,17 +565,6 @@ pub(crate) fn put_all_metas_into_batch(
     Ok(())
 }
 
-pub(crate) fn row_into_parts_widened(
-    input_row: &MaybeOwnedRow<'_>,
-    index: VariablePosition,
-) -> (Vec<VariableValue<'static>>, u64, Provenance) {
-    let (mut row, multiplicity, provenance) = input_row.clone().into_owned_parts();
-    if row.len() <= index.as_usize() {
-        row.resize(index.as_usize() + 1, VariableValue::None);
-    }
-    (row, multiplicity, provenance)
-}
-
 pub(crate) fn get_owns(
     context: &ExecutionContext<impl ReadableSnapshot>,
     owner: &VariableValue<'_>,

--- a/executor/read/nested_pattern_executor.rs
+++ b/executor/read/nested_pattern_executor.rs
@@ -127,6 +127,7 @@ pub struct InlinedCallExecutor {
     pub inner: PatternExecutor,
     pub arg_mapping: Vec<VariablePosition>,
     pub assignment_positions: Vec<Option<VariablePosition>>,
+    pub selected_variables: Vec<VariablePosition>,
     pub output_width: u32,
     pub parameter_registry: Arc<ParameterRegistry>,
 }
@@ -141,6 +142,7 @@ impl InlinedCallExecutor {
             inner,
             arg_mapping: function_call.arguments.clone(),
             assignment_positions: function_call.assigned.clone(),
+            selected_variables: function_call.selected_variables.clone(),
             output_width: function_call.output_width,
             parameter_registry,
         }
@@ -167,7 +169,7 @@ impl InlinedCallExecutor {
             let returned_row = batch.get_row(return_index);
             if check_indices.iter().all(|(src, dst)| returned_row.get(*src) == input.get(*dst)) {
                 output_batch.append(|mut output_row| {
-                    output_row.copy_from_row(input.as_reference());
+                    output_row.copy_mapped(input.as_reference(), self.selected_variables.iter().map(|&p| (p, p)));
                     output_row.copy_mapped(
                         returned_row.as_reference(),
                         self.assignment_positions

--- a/executor/read/nested_pattern_executor.rs
+++ b/executor/read/nested_pattern_executor.rs
@@ -47,7 +47,7 @@ impl DisjunctionExecutor {
         let mut uniform_batch = FixedBatch::new(self.output_width);
         unmapped.into_iter().for_each(|row| {
             uniform_batch.append(|mut output_row| {
-                output_row.copy_mapped(row, self.selected_variables.iter().map(|&pos| (pos, pos)));
+                output_row.copy_input_and_extend(row, &self.selected_variables, [], 1);
                 output_row.set_branch_id_in_provenance(self.branch_ids[*source_branch_index]);
             })
         });
@@ -95,9 +95,7 @@ impl OptionalExecutor {
     pub(crate) fn map_as_failed_output(&self, unmapped_input: MaybeOwnedRow<'_>) -> FixedBatch {
         let mut output = FixedBatch::new(self.output_width);
         output.append(|mut output_row| {
-            output_row
-                .copy_mapped(unmapped_input.as_reference(), self.selected_variables.iter().map(|&pos| (pos, pos)));
-            output_row.set_provenance(unmapped_input.provenance()); // Pass through old provenance
+            output_row.copy_input_and_extend(unmapped_input.as_reference(), &self.selected_variables, [], 1);
         });
         output
     }
@@ -169,16 +167,17 @@ impl InlinedCallExecutor {
             let returned_row = batch.get_row(return_index);
             if check_indices.iter().all(|(src, dst)| returned_row.get(*src) == input.get(*dst)) {
                 output_batch.append(|mut output_row| {
-                    output_row.copy_selected_from_row(input.as_reference(), &self.selected_variables);
-                    output_row.copy_mapped(
-                        returned_row.as_reference(),
-                        self.assignment_positions
-                            .iter()
-                            .enumerate()
-                            .filter_map(|(src, &dst)| Some((VariablePosition::new(src as u32), dst?))),
+                    let extension = self
+                        .assignment_positions
+                        .iter()
+                        .enumerate()
+                        .filter_map(|(index, &dst)| Some((dst?, returned_row[index].clone())));
+                    output_row.copy_input_and_extend(
+                        input.as_reference(),
+                        &self.selected_variables,
+                        extension,
+                        returned_row.multiplicity(),
                     );
-                    // Fix provenance:
-                    output_row.set_provenance(input.provenance());
                 });
             }
         }

--- a/executor/read/nested_pattern_executor.rs
+++ b/executor/read/nested_pattern_executor.rs
@@ -169,7 +169,7 @@ impl InlinedCallExecutor {
             let returned_row = batch.get_row(return_index);
             if check_indices.iter().all(|(src, dst)| returned_row.get(*src) == input.get(*dst)) {
                 output_batch.append(|mut output_row| {
-                    output_row.copy_mapped(input.as_reference(), self.selected_variables.iter().map(|&p| (p, p)));
+                    output_row.copy_selected_from_row(input.as_reference(), &self.selected_variables);
                     output_row.copy_mapped(
                         returned_row.as_reference(),
                         self.assignment_positions

--- a/executor/read/nested_pattern_executor.rs
+++ b/executor/read/nested_pattern_executor.rs
@@ -47,7 +47,7 @@ impl DisjunctionExecutor {
         let mut uniform_batch = FixedBatch::new(self.output_width);
         unmapped.into_iter().for_each(|row| {
             uniform_batch.append(|mut output_row| {
-                output_row.copy_input_and_extend(row, &self.selected_variables, [], 1);
+                output_row.merge_selected(&self.selected_variables, row, [], 1);
                 output_row.set_branch_id_in_provenance(self.branch_ids[*source_branch_index]);
             })
         });
@@ -95,7 +95,7 @@ impl OptionalExecutor {
     pub(crate) fn map_as_failed_output(&self, unmapped_input: MaybeOwnedRow<'_>) -> FixedBatch {
         let mut output = FixedBatch::new(self.output_width);
         output.append(|mut output_row| {
-            output_row.copy_input_and_extend(unmapped_input.as_reference(), &self.selected_variables, [], 1);
+            output_row.merge_selected(&self.selected_variables, unmapped_input.as_reference(), [], 1);
         });
         output
     }
@@ -172,9 +172,9 @@ impl InlinedCallExecutor {
                         .iter()
                         .enumerate()
                         .filter_map(|(index, &dst)| Some((dst?, returned_row[index].clone())));
-                    output_row.copy_input_and_extend(
-                        input.as_reference(),
+                    output_row.merge_selected(
                         &self.selected_variables,
+                        input.as_reference(),
                         extension,
                         returned_row.multiplicity(),
                     );

--- a/executor/read/step_executor.rs
+++ b/executor/read/step_executor.rs
@@ -217,6 +217,7 @@ pub(crate) fn create_executors_for_conjunction(
                             function_call.function_id.clone(),
                             function_call.arguments.clone(),
                             function_call.assigned.clone(),
+                            function_call.selected_variables.clone(),
                             function_call.output_width,
                         );
                         steps.push(StepExecutors::TabledCall(executor))

--- a/executor/read/step_executor.rs
+++ b/executor/read/step_executor.rs
@@ -204,6 +204,7 @@ pub(crate) fn create_executors_for_conjunction(
                         builtin_id,
                         function_call.arguments.clone(),
                         function_call.assigned.clone(),
+                        function_call.selected_variables.clone(),
                         function_call.output_width,
                         builtin_profile,
                     );

--- a/executor/read/tabled_call_executor.rs
+++ b/executor/read/tabled_call_executor.rs
@@ -28,6 +28,7 @@ pub(crate) struct TabledCallExecutor {
     argument_positions: Vec<VariablePosition>,
     assignment_positions: Vec<Option<VariablePosition>>,
     output_width: u32,
+    selected_variables: Vec<VariablePosition>,
     active_executor: Option<TabledCallExecutorState>,
 }
 
@@ -54,9 +55,17 @@ impl TabledCallExecutor {
         function_id: FunctionID,
         argument_positions: Vec<VariablePosition>,
         assignment_positions: Vec<Option<VariablePosition>>,
+        selected_variables: Vec<VariablePosition>,
         output_width: u32,
     ) -> Self {
-        Self { function_id, argument_positions, assignment_positions, output_width, active_executor: None }
+        Self {
+            function_id,
+            argument_positions,
+            assignment_positions,
+            output_width,
+            selected_variables,
+            active_executor: None,
+        }
     }
 
     pub(crate) fn output_width(&self) -> u32 {

--- a/executor/read/tabled_call_executor.rs
+++ b/executor/read/tabled_call_executor.rs
@@ -103,21 +103,28 @@ impl TabledCallExecutor {
             .filter_map(|(src, &dst)| Some((VariablePosition::new(src as u32), dst?)))
             .filter(|(_, dst)| dst.as_usize() < input.len() && input.get(*dst) != &VariableValue::None)
             .collect(); // TODO: Can we move this to compilation?
-
+        eprintln!("Selected positions is: {:?}; Input width is: {}", self.assignment_positions, input.row().len());
         for return_index in 0..returned_batch.len() {
             // TODO: Deduplicate?
             let returned_row = returned_batch.get_row(return_index);
+            eprintln!(
+                "Assignment positions is: {:?}; Returns width is {}",
+                self.assignment_positions,
+                returned_row.row().len()
+            );
             if check_indices.iter().all(|(src, dst)| returned_row.get(*src) == input.get(*dst)) {
                 output_batch.append(|mut output_row| {
-                    output_row.copy_selected_from_row(input.as_reference(), &self.selected_variables);
-                    output_row.copy_mapped(
-                        returned_row,
-                        self.assignment_positions
-                            .iter()
-                            .enumerate()
-                            .filter_map(|(src, &dst)| Some((VariablePosition::new(src as u32), dst?))),
+                    let extension = self
+                        .assignment_positions
+                        .iter()
+                        .enumerate()
+                        .filter_map(|(index, &dst)| Some((dst?, returned_row[index].clone())));
+                    output_row.copy_input_and_extend(
+                        input.as_reference(),
+                        &self.selected_variables,
+                        extension,
+                        returned_row.multiplicity(),
                     );
-                    output_row.set_provenance(input.provenance())
                 });
             }
         }

--- a/executor/read/tabled_call_executor.rs
+++ b/executor/read/tabled_call_executor.rs
@@ -109,7 +109,7 @@ impl TabledCallExecutor {
             let returned_row = returned_batch.get_row(return_index);
             if check_indices.iter().all(|(src, dst)| returned_row.get(*src) == input.get(*dst)) {
                 output_batch.append(|mut output_row| {
-                    output_row.copy_mapped(input.as_reference(), self.selected_variables.iter().map(|&p| (p, p)));
+                    output_row.copy_selected_from_row(input.as_reference(), &self.selected_variables);
                     output_row.copy_mapped(
                         returned_row,
                         self.assignment_positions

--- a/executor/read/tabled_call_executor.rs
+++ b/executor/read/tabled_call_executor.rs
@@ -106,22 +106,17 @@ impl TabledCallExecutor {
         for return_index in 0..returned_batch.len() {
             // TODO: Deduplicate?
             let returned_row = returned_batch.get_row(return_index);
-            eprintln!(
-                "Assignment positions is: {:?}; Returns width is {}",
-                self.assignment_positions,
-                returned_row.row().len()
-            );
             if check_indices.iter().all(|(src, dst)| returned_row.get(*src) == input.get(*dst)) {
                 output_batch.append(|mut output_row| {
-                    let extension = self
+                    let assignments = self
                         .assignment_positions
                         .iter()
                         .enumerate()
                         .filter_map(|(index, &dst)| Some((dst?, returned_row[index].clone())));
-                    output_row.copy_input_and_extend(
-                        input.as_reference(),
+                    output_row.merge_selected(
                         &self.selected_variables,
-                        extension,
+                        input.as_reference(),
+                        assignments,
                         returned_row.multiplicity(),
                     );
                 });

--- a/executor/read/tabled_call_executor.rs
+++ b/executor/read/tabled_call_executor.rs
@@ -109,7 +109,7 @@ impl TabledCallExecutor {
             let returned_row = returned_batch.get_row(return_index);
             if check_indices.iter().all(|(src, dst)| returned_row.get(*src) == input.get(*dst)) {
                 output_batch.append(|mut output_row| {
-                    output_row.copy_from_row(input.as_reference());
+                    output_row.copy_mapped(input.as_reference(), self.selected_variables.iter().map(|&p| (p, p)));
                     output_row.copy_mapped(
                         returned_row,
                         self.assignment_positions

--- a/executor/read/tabled_call_executor.rs
+++ b/executor/read/tabled_call_executor.rs
@@ -103,7 +103,6 @@ impl TabledCallExecutor {
             .filter_map(|(src, &dst)| Some((VariablePosition::new(src as u32), dst?)))
             .filter(|(_, dst)| dst.as_usize() < input.len() && input.get(*dst) != &VariableValue::None)
             .collect(); // TODO: Can we move this to compilation?
-        eprintln!("Selected positions is: {:?}; Input width is: {}", self.assignment_positions, input.row().len());
         for return_index in 0..returned_batch.len() {
             // TODO: Deduplicate?
             let returned_row = returned_batch.get_row(return_index);

--- a/executor/row.rs
+++ b/executor/row.rs
@@ -66,9 +66,10 @@ impl<'a> Row<'a> {
         extension: impl IntoIterator<Item = (VariablePosition, VariableValue<'static>)>,
         extension_multiplicity: u64,
     ) {
-        self.copy_mapped(input, selected.iter().map(|&p| (p, p)));
+        self.copy_mapped(input, selected.iter().map(|&pos| (pos, pos)));
         for (pos, value) in extension {
             // TODO: Should this check `selected.contains(pos)` instead?
+            debug_assert!(pos.as_usize() < self.len() || !selected.contains(&pos));
             if pos.as_usize() < self.len() {
                 self.set(pos, value);
             }

--- a/executor/row.rs
+++ b/executor/row.rs
@@ -59,8 +59,21 @@ impl<'a> Row<'a> {
         *self.provenance = row.provenance()
     }
 
-    pub(crate) fn copy_selected_from_row(&mut self, row: MaybeOwnedRow<'_>, selected: &[VariablePosition]) {
-        self.copy_mapped(row, selected.iter().map(|&p| (p, p)))
+    pub(crate) fn copy_input_and_extend(
+        &mut self,
+        input: MaybeOwnedRow<'_>,
+        selected: &[VariablePosition],
+        extension: impl IntoIterator<Item = (VariablePosition, VariableValue<'static>)>,
+        extension_multiplicity: u64,
+    ) {
+        self.copy_mapped(input, selected.iter().map(|&p| (p, p)));
+        for (pos, value) in extension {
+            // TODO: Should this check `selected.contains(pos)` instead?
+            if pos.as_usize() < self.len() {
+                self.set(pos, value);
+            }
+        }
+        *self.multiplicity *= extension_multiplicity;
     }
 
     pub(crate) fn copy_mapped(

--- a/executor/row.rs
+++ b/executor/row.rs
@@ -59,18 +59,17 @@ impl<'a> Row<'a> {
         *self.provenance = row.provenance()
     }
 
-    pub(crate) fn copy_input_and_extend(
+    pub(crate) fn merge_selected(
         &mut self,
-        input: MaybeOwnedRow<'_>,
         selected: &[VariablePosition],
+        input: MaybeOwnedRow<'_>,
         extension: impl IntoIterator<Item = (VariablePosition, VariableValue<'static>)>,
         extension_multiplicity: u64,
     ) {
         self.copy_mapped(input, selected.iter().map(|&pos| (pos, pos)));
         for (pos, value) in extension {
             // TODO: Should this check `selected.contains(pos)` instead?
-            debug_assert!(pos.as_usize() < self.len() || !selected.contains(&pos));
-            if pos.as_usize() < self.len() {
+            if selected.contains(&pos) {
                 self.set(pos, value);
             }
         }

--- a/executor/row.rs
+++ b/executor/row.rs
@@ -59,11 +59,8 @@ impl<'a> Row<'a> {
         *self.provenance = row.provenance()
     }
 
-    pub(crate) fn copy_from(&mut self, row: &[VariableValue<'static>], multiplicity: u64, provenance: Provenance) {
-        debug_assert!(self.len() == row.len());
-        self.row.clone_from_slice(row);
-        *self.multiplicity = multiplicity;
-        *self.provenance = provenance
+    pub(crate) fn copy_selected_from_row(&mut self, row: MaybeOwnedRow<'_>, selected: &[VariablePosition]) {
+        self.copy_mapped(row, selected.iter().map(|&p| (p, p)))
     }
 
     pub(crate) fn copy_mapped(


### PR DESCRIPTION
## Product change and motivation
This can happen when a function call is the first instruction after a stage that may narrow a row, such as select or delete. fixes #7930