### PR TITLE
Use old brew install script from before deprecation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -658,42 +658,42 @@ workflows:
       - test-deploy-snapshot-linux-x86_64:
           filters:
             branches:
-              only: [ master, old-brew-best-brew  ]
+              only: [ master ]
 
       - test-deploy-snapshot-linux-arm64:
           filters:
             branches:
-              only: [ master, old-brew-best-brew  ]
+              only: [ master ]
 
       - test-deploy-snapshot-mac-x86_64:
           filters:
             branches:
-              only: [ master, old-brew-best-brew  ]
+              only: [ master ]
 
       - test-deploy-snapshot-mac-arm64:
           filters:
             branches:
-              only: [ master, old-brew-best-brew  ]
+              only: [ master ]
 
       - test-deploy-snapshot-windows-x86_64:
           filters:
             branches:
-              only: [ master, old-brew-best-brew  ]
+              only: [ master ]
 
       - deploy-docker-snapshot-x86_64:
           filters:
             branches:
-              only: [ master, old-brew-best-brew  ]
+              only: [ master ]
 
       - deploy-docker-snapshot-arm64:
           filters:
             branches:
-              only: [ master, old-brew-best-brew  ]
+              only: [ master ]
 
       - deploy-docker-snapshot-multiarch:
           filters:
             branches:
-              only: [ master, old-brew-best-brew  ]
+              only: [ master ]
           requires:
             - deploy-docker-snapshot-x86_64
             - deploy-docker-snapshot-arm64
@@ -701,17 +701,17 @@ workflows:
       - deploy-snapshot-apt-x86_64:
           filters:
             branches:
-              only: [ master, old-brew-best-brew  ]
+              only: [ master ]
 
       - deploy-snapshot-apt-arm64:
           filters:
             branches:
-              only: [ master, old-brew-best-brew  ]
+              only: [ master ]
 
       - deploy-snapshot-brew:
           filters:
             branches:
-              only: [ master, old-brew-best-brew  ]
+              only: [ master ]
           requires:
             - test-deploy-snapshot-mac-arm64
             - test-deploy-snapshot-mac-x86_64
@@ -719,63 +719,63 @@ workflows:
       - deploy-snapshot-installer-mac-arm64:
           filters:
             branches:
-              only: [ master, old-brew-best-brew  ]
+              only: [ master ]
           requires:
             - test-deploy-snapshot-mac-arm64
 
       - deploy-snapshot-installer-mac-x86_64:
           filters:
             branches:
-              only: [ master, old-brew-best-brew  ]
+              only: [ master ]
           requires:
             - test-deploy-snapshot-mac-x86_64
 
       - test-distribution-apt-snapshot-x86_64:
           filters:
             branches:
-              only: [ master, old-brew-best-brew  ]
+              only: [ master ]
           requires:
             - deploy-snapshot-apt-x86_64
 
       - test-distribution-apt-snapshot-arm64:
           filters:
             branches:
-              only: [ master, old-brew-best-brew  ]
+              only: [ master ]
           requires:
             - deploy-snapshot-apt-arm64
 
       - test-distribution-brew-snapshot-arm64:
           filters:
             branches:
-              only: [ master, old-brew-best-brew  ]
+              only: [ master ]
           requires:
             - deploy-snapshot-brew
 
       - test-distribution-brew-snapshot-x86_64:
           filters:
             branches:
-              only: [ master, old-brew-best-brew  ]
+              only: [ master ]
           requires:
             - deploy-snapshot-brew
 
       - test-distribution-docker-snapshot-x86_64:
           filters:
             branches:
-              only: [ master, old-brew-best-brew  ]
+              only: [ master ]
           requires:
             - deploy-docker-snapshot-multiarch
 
       - test-distribution-docker-snapshot-arm64:
           filters:
             branches:
-              only: [ master, old-brew-best-brew  ]
+              only: [ master ]
           requires:
             - deploy-docker-snapshot-multiarch
 
       - sync-to-typedb-benchmark:
           filters:
             branches:
-              only: [ master, old-brew-best-brew  ]
+              only: [ master ]
           requires:
             - test-deploy-snapshot-linux-x86_64
 


### PR DESCRIPTION
## Product change and motivation
Use old brew install script from before deprecation so that our CI chugs along.
see Homebrew/install#1140 